### PR TITLE
Add value argument to URLSearchParams's has() and delete()

### DIFF
--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -105,9 +105,14 @@ impl URLSearchParamsMethods for URLSearchParams {
     }
 
     // https://url.spec.whatwg.org/#dom-urlsearchparams-delete
-    fn Delete(&self, name: USVString) {
+    fn Delete(&self, name: USVString, value: Option<USVString>) {
         // Step 1.
-        self.list.borrow_mut().retain(|&(ref k, _)| k != &name.0);
+        self.list
+            .borrow_mut()
+            .retain(|&(ref k, ref v)| match &value {
+                Some(value) => !(k == &name.0 && v == &value.0),
+                None => k != &name.0,
+            });
         // Step 2.
         self.update_steps();
     }
@@ -135,9 +140,12 @@ impl URLSearchParamsMethods for URLSearchParams {
     }
 
     // https://url.spec.whatwg.org/#dom-urlsearchparams-has
-    fn Has(&self, name: USVString) -> bool {
+    fn Has(&self, name: USVString, value: Option<USVString>) -> bool {
         let list = self.list.borrow();
-        list.iter().any(|&(ref k, _)| k == &name.0)
+        list.iter().any(|&(ref k, ref v)| match &value {
+            Some(value) => k == &name.0 && v == &value.0,
+            None => k == &name.0,
+        })
     }
 
     // https://url.spec.whatwg.org/#dom-urlsearchparams-set

--- a/components/script/dom/webidls/URLSearchParams.webidl
+++ b/components/script/dom/webidls/URLSearchParams.webidl
@@ -11,10 +11,10 @@ interface URLSearchParams {
   [Throws] constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = "");
   readonly attribute unsigned long size;
   undefined append(USVString name, USVString value);
-  undefined delete(USVString name);
+  undefined delete(USVString name, optional USVString value);
   USVString? get(USVString name);
   sequence<USVString> getAll(USVString name);
-  boolean has(USVString name);
+  boolean has(USVString name, optional USVString value);
   undefined set(USVString name, USVString value);
 
   undefined sort();

--- a/tests/wpt/metadata/url/urlsearchparams-delete.any.js.ini
+++ b/tests/wpt/metadata/url/urlsearchparams-delete.any.js.ini
@@ -2,13 +2,7 @@
   [Changing the query of a URL with an opaque path can impact the path]
     expected: FAIL
 
-  [Two-argument delete()]
-    expected: FAIL
-
 
 [urlsearchparams-delete.any.html]
   [Changing the query of a URL with an opaque path can impact the path]
-    expected: FAIL
-
-  [Two-argument delete()]
     expected: FAIL

--- a/tests/wpt/metadata/url/urlsearchparams-has.any.js.ini
+++ b/tests/wpt/metadata/url/urlsearchparams-has.any.js.ini
@@ -1,8 +1,0 @@
-[urlsearchparams-has.any.html]
-  [Two-argument has()]
-    expected: FAIL
-
-
-[urlsearchparams-has.any.worker.html]
-  [Two-argument has()]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
My first attempt at contributing Rust code!
Add the value argument to `has()` and `done()` as in [the spec](https://url.spec.whatwg.org/#dom-urlsearchparams-delete).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #29725 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
