### PR TITLE
Simplify our setup for font metric queries from style

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -856,7 +856,7 @@ where
         if element.has_data() {
             node.to_threadsafe().as_element().unwrap().resolved_style()
         } else {
-            let mut tlc = ThreadLocalStyleContext::new(&context.style_context);
+            let mut tlc = ThreadLocalStyleContext::new();
             let mut context = StyleContext {
                 shared: &context.style_context,
                 thread_local: &mut tlc,
@@ -911,7 +911,7 @@ pub fn process_resolved_style_request<'dom>(
         return String::new();
     }
 
-    let mut tlc = ThreadLocalStyleContext::new(&context.style_context);
+    let mut tlc = ThreadLocalStyleContext::new();
     let mut context = StyleContext {
         shared: &context.style_context,
         thread_local: &mut tlc,

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -46,7 +46,6 @@ impl<'a, 'dom, E> DomTraversal<E> for RecalcStyleAndConstructFlows<'a>
 where
     E: TElement,
     E::ConcreteNode: LayoutNode<'dom>,
-    E::FontMetricsProvider: Send,
 {
     fn process_preorder<F>(
         &self,

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -356,7 +356,7 @@ pub fn process_resolved_style_request_for_unstyled_node<'dom>(
         return String::new();
     }
 
-    let mut tlc = ThreadLocalStyleContext::new(&context.style_context);
+    let mut tlc = ThreadLocalStyleContext::new();
     let mut context = StyleContext {
         shared: &context.style_context,
         thread_local: &mut tlc,

--- a/components/layout_2020/traversal.rs
+++ b/components/layout_2020/traversal.rs
@@ -34,7 +34,6 @@ impl<'a, 'dom, E> DomTraversal<E> for RecalcStyle<'a>
 where
     E: TElement,
     E::ConcreteNode: LayoutNode<'dom>,
-    E::FontMetricsProvider: Send,
 {
     fn process_preorder<F>(
         &self,

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -33,7 +33,6 @@ use style::context::SharedStyleContext;
 use style::data::ElementData;
 use style::dom::{DomChildren, LayoutIterator, TDocument, TElement, TNode, TShadowRoot};
 use style::element_state::*;
-use style::font_metrics::ServoMetricsProvider;
 use style::properties::PropertyDeclarationBlock;
 use style::selector_parser::{
     extended_filtering, AttrValue as SelectorAttrValue, Lang, NonTSPseudoClass, PseudoElement,
@@ -168,8 +167,6 @@ impl<'dom, LayoutDataType: LayoutDataTrait> style::dom::TElement
 {
     type ConcreteNode = ServoLayoutNode<'dom, LayoutDataType>;
     type TraversalChildrenIterator = DomChildren<Self::ConcreteNode>;
-
-    type FontMetricsProvider = ServoMetricsProvider;
 
     fn as_node(&self) -> ServoLayoutNode<'dom, LayoutDataType> {
         ServoLayoutNode::from_layout_js(self.element.upcast())

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -25,7 +25,6 @@ use style::context::SharedStyleContext;
 use style::data::ElementData;
 use style::dom::OpaqueNode;
 use style::dom::{LayoutIterator, NodeInfo, TElement, TNode};
-use style::font_metrics::ServoMetricsProvider;
 use style::properties::ComputedValues;
 use style::selector_parser::{PseudoElement, PseudoElementCascadeType, SelectorImpl};
 use style::stylist::RuleInclusion;
@@ -439,7 +438,6 @@ pub trait ThreadSafeLayoutElement<'dom>:
                             &context.guards,
                             &style_pseudo,
                             Some(data.styles.primary()),
-                            &ServoMetricsProvider,
                         ),
                     PseudoElementCascadeType::Lazy => {
                         context
@@ -451,7 +449,6 @@ pub trait ThreadSafeLayoutElement<'dom>:
                                 RuleInclusion::All,
                                 data.styles.primary(),
                                 /* is_probe = */ false,
-                                &ServoMetricsProvider,
                                 /* matching_func = */ None,
                             )
                             .unwrap()

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -9,7 +9,6 @@ use crate::animation::DocumentAnimationSet;
 use crate::bloom::StyleBloom;
 use crate::data::{EagerPseudoStyles, ElementData};
 use crate::dom::{SendElement, TElement};
-use crate::font_metrics::FontMetricsProvider;
 #[cfg(feature = "gecko")]
 use crate::gecko_bindings::structs;
 use crate::parallel::{STACK_SAFETY_MARGIN_KB, STYLE_THREAD_STACK_SIZE_KB};
@@ -720,9 +719,6 @@ pub struct ThreadLocalStyleContext<E: TElement> {
     pub selector_flags: SelectorFlagsMap<E>,
     /// Statistics about the traversal.
     pub statistics: PerThreadTraversalStatistics,
-    /// The struct used to compute and cache font metrics from style
-    /// for evaluation of the font-relative em/ch units and font-size
-    pub font_metrics_provider: E::FontMetricsProvider,
     /// A checker used to ensure that parallel.rs does not recurse indefinitely
     /// even on arbitrarily deep trees.  See Gecko bug 1376883.
     pub stack_limit_checker: StackLimitChecker,
@@ -731,9 +727,8 @@ pub struct ThreadLocalStyleContext<E: TElement> {
 }
 
 impl<E: TElement> ThreadLocalStyleContext<E> {
-    /// Creates a new `ThreadLocalStyleContext` from a shared one.
-    #[cfg(feature = "servo")]
-    pub fn new(shared: &SharedStyleContext) -> Self {
+    /// Creates a new `ThreadLocalStyleContext`
+    pub fn new() -> Self {
         ThreadLocalStyleContext {
             sharing_cache: StyleSharingCache::new(),
             rule_cache: RuleCache::new(),
@@ -741,25 +736,6 @@ impl<E: TElement> ThreadLocalStyleContext<E> {
             tasks: SequentialTaskList(Vec::new()),
             selector_flags: SelectorFlagsMap::new(),
             statistics: PerThreadTraversalStatistics::default(),
-            font_metrics_provider: E::FontMetricsProvider::create_from(shared),
-            stack_limit_checker: StackLimitChecker::new(
-                (STYLE_THREAD_STACK_SIZE_KB - STACK_SAFETY_MARGIN_KB) * 1024,
-            ),
-            nth_index_cache: NthIndexCache::default(),
-        }
-    }
-
-    #[cfg(feature = "gecko")]
-    /// Creates a new `ThreadLocalStyleContext` from a shared one.
-    pub fn new(shared: &SharedStyleContext) -> Self {
-        ThreadLocalStyleContext {
-            sharing_cache: StyleSharingCache::new(),
-            rule_cache: RuleCache::new(),
-            bloom_filter: StyleBloom::new(),
-            tasks: SequentialTaskList(Vec::new()),
-            selector_flags: SelectorFlagsMap::new(),
-            statistics: PerThreadTraversalStatistics::default(),
-            font_metrics_provider: E::FontMetricsProvider::create_from(shared),
             stack_limit_checker: StackLimitChecker::new(
                 (STYLE_THREAD_STACK_SIZE_KB - STACK_SAFETY_MARGIN_KB) * 1024,
             ),

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -13,7 +13,6 @@ use crate::context::SharedStyleContext;
 use crate::context::{PostAnimationTasks, UpdateAnimationsTasks};
 use crate::data::ElementData;
 use crate::element_state::ElementState;
-use crate::font_metrics::FontMetricsProvider;
 use crate::media_queries::Device;
 use crate::properties::{AnimationDeclarations, ComputedValues, PropertyDeclarationBlock};
 use crate::selector_parser::{AttrValue, Lang, PseudoElement, SelectorImpl};
@@ -362,12 +361,6 @@ pub trait TElement:
     /// TODO(emilio): We should eventually replace this with the `impl Trait`
     /// syntax.
     type TraversalChildrenIterator: Iterator<Item = Self::ConcreteNode>;
-
-    /// Type of the font metrics provider
-    ///
-    /// XXXManishearth It would be better to make this a type parameter on
-    /// ThreadLocalStyleContext and StyleContext
-    type FontMetricsProvider: FontMetricsProvider + Send;
 
     /// Get this element as a node.
     fn as_node(&self) -> Self::ConcreteNode;

--- a/components/style/driver.rs
+++ b/components/style/driver.rs
@@ -91,7 +91,7 @@ where
     //     ThreadLocalStyleContext has not released its TLS borrow by that point,
     //     we'll panic on double-borrow.
     let mut tls_slots = None;
-    let mut tlc = ThreadLocalStyleContext::new(traversal.shared_context());
+    let mut tlc = ThreadLocalStyleContext::new();
     let mut context = StyleContext {
         shared: traversal.shared_context(),
         thread_local: &mut tlc,

--- a/components/style/font_metrics.rs
+++ b/components/style/font_metrics.rs
@@ -6,9 +6,7 @@
 
 #![deny(missing_docs)]
 
-use crate::context::SharedStyleContext;
 use crate::values::computed::Length;
-use crate::Atom;
 
 /// Represents the font metrics that style needs from a font to compute the
 /// value of certain CSS units like `ex`.
@@ -46,65 +44,4 @@ pub enum FontMetricsOrientation {
     MatchContextPreferVertical,
     /// Force getting horizontal metrics.
     Horizontal,
-}
-
-/// A trait used to represent something capable of providing us font metrics.
-pub trait FontMetricsProvider {
-    /// Obtain the metrics for given font family.
-    fn query(
-        &self,
-        _context: &crate::values::computed::Context,
-        _base_size: crate::values::specified::length::FontBaseSize,
-        _orientation: FontMetricsOrientation,
-    ) -> FontMetrics {
-        Default::default()
-    }
-
-    /// Get default size of a given language and generic family.
-    fn get_size(
-        &self,
-        font_name: &Atom,
-        font_family: crate::values::computed::font::GenericFontFamily,
-    ) -> Length;
-
-    /// Construct from a shared style context
-    fn create_from(context: &SharedStyleContext) -> Self
-    where
-        Self: Sized;
-}
-
-// TODO: Servo's font metrics provider will probably not live in this crate, so this will
-// have to be replaced with something else (perhaps a trait method on TElement)
-// when we get there
-#[derive(Debug)]
-#[cfg(feature = "servo")]
-/// Dummy metrics provider for Servo. Knows nothing about fonts and does not provide
-/// any metrics.
-pub struct ServoMetricsProvider;
-
-#[cfg(feature = "servo")]
-impl FontMetricsProvider for ServoMetricsProvider {
-    fn create_from(_: &SharedStyleContext) -> Self {
-        ServoMetricsProvider
-    }
-
-    fn get_size(&self, _: &Atom, _: crate::values::computed::font::GenericFontFamily) -> Length {
-        unreachable!("Dummy provider should never be used to compute font size")
-    }
-}
-
-// Servo's font metrics provider will probably not live in this crate, so this will
-// have to be replaced with something else (perhaps a trait method on TElement)
-// when we get there
-
-#[cfg(feature = "gecko")]
-/// Construct a font metrics provider for the current product
-pub fn get_metrics_provider_for_product() -> crate::gecko::wrapper::GeckoFontMetricsProvider {
-    crate::gecko::wrapper::GeckoFontMetricsProvider::new()
-}
-
-#[cfg(feature = "servo")]
-/// Construct a font metrics provider for the current product
-pub fn get_metrics_provider_for_product() -> ServoMetricsProvider {
-    ServoMetricsProvider
 }

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -75,14 +75,11 @@ type WorkUnit<N> = ArrayVec<SendNode<N>, WORK_UNIT_MAX>;
 /// out of line so we don't allocate stack space for the entire struct
 /// in the caller.
 #[inline(never)]
-fn create_thread_local_context<'scope, E, D>(
-    traversal: &'scope D,
-    slot: &mut Option<ThreadLocalStyleContext<E>>,
-) where
+fn create_thread_local_context<'scope, E>(slot: &mut Option<ThreadLocalStyleContext<E>>)
+where
     E: TElement + 'scope,
-    D: DomTraversal<E>,
 {
-    *slot = Some(ThreadLocalStyleContext::new(traversal.shared_context()));
+    *slot = Some(ThreadLocalStyleContext::new());
 }
 
 /// A parallel top-down DOM traversal.
@@ -127,7 +124,7 @@ fn top_down_dom<'a, 'scope, E, D>(
         // Scope the borrow of the TLS so that the borrow is dropped before
         // a potential recursive call when we pass TailCall.
         let mut tlc = tls.ensure(|slot: &mut Option<ThreadLocalStyleContext<E>>| {
-            create_thread_local_context(traversal, slot)
+            create_thread_local_context(slot)
         });
 
         // Check that we're not in danger of running out of stack.

--- a/components/style/properties/cascade.rs
+++ b/components/style/properties/cascade.rs
@@ -7,7 +7,6 @@
 use crate::context::QuirksMode;
 use crate::custom_properties::CustomPropertiesBuilder;
 use crate::dom::TElement;
-use crate::font_metrics::FontMetricsProvider;
 use crate::logical_geometry::WritingMode;
 use crate::media_queries::Device;
 use crate::properties::{
@@ -82,7 +81,6 @@ pub fn cascade<E>(
     parent_style_ignoring_first_line: Option<&ComputedValues>,
     layout_parent_style: Option<&ComputedValues>,
     visited_rules: Option<&StrongRuleNode>,
-    font_metrics_provider: &dyn FontMetricsProvider,
     quirks_mode: QuirksMode,
     rule_cache: Option<&RuleCache>,
     rule_cache_conditions: &mut RuleCacheConditions,
@@ -99,7 +97,6 @@ where
         parent_style,
         parent_style_ignoring_first_line,
         layout_parent_style,
-        font_metrics_provider,
         CascadeMode::Unvisited { visited_rules },
         quirks_mode,
         rule_cache,
@@ -197,7 +194,6 @@ fn cascade_rules<E>(
     parent_style: Option<&ComputedValues>,
     parent_style_ignoring_first_line: Option<&ComputedValues>,
     layout_parent_style: Option<&ComputedValues>,
-    font_metrics_provider: &dyn FontMetricsProvider,
     cascade_mode: CascadeMode,
     quirks_mode: QuirksMode,
     rule_cache: Option<&RuleCache>,
@@ -220,7 +216,6 @@ where
         parent_style,
         parent_style_ignoring_first_line,
         layout_parent_style,
-        font_metrics_provider,
         cascade_mode,
         quirks_mode,
         rule_cache,
@@ -256,7 +251,6 @@ pub fn apply_declarations<'a, E, I>(
     parent_style: Option<&ComputedValues>,
     parent_style_ignoring_first_line: Option<&ComputedValues>,
     layout_parent_style: Option<&ComputedValues>,
-    font_metrics_provider: &dyn FontMetricsProvider,
     cascade_mode: CascadeMode,
     quirks_mode: QuirksMode,
     rule_cache: Option<&RuleCache>,
@@ -317,7 +311,6 @@ where
         in_media_query: false,
         for_smil_animation: false,
         for_non_inherited_property: None,
-        font_metrics_provider,
         quirks_mode,
         rule_cache_conditions: RefCell::new(rule_cache_conditions),
     };
@@ -762,7 +755,6 @@ impl<'a, 'b: 'a> Cascade<'a, 'b> {
             visited_parent!(parent_style),
             visited_parent!(parent_style_ignoring_first_line),
             visited_parent!(layout_parent_style),
-            self.context.font_metrics_provider,
             CascadeMode::Visited { writing_mode },
             self.context.quirks_mode,
             // The rule cache doesn't care about caching :visited

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -6,6 +6,7 @@
 
 use crate::context::QuirksMode;
 use crate::custom_properties::CssEnvironment;
+use crate::font_metrics::FontMetrics;
 use crate::media_queries::media_feature::{AllowsRanges, ParsingRequirements};
 use crate::media_queries::media_feature::{Evaluator, MediaFeatureDescription};
 use crate::media_queries::media_feature_expression::RangeOrOperator;
@@ -154,6 +155,22 @@ impl Device {
     /// Returns the device pixel ratio.
     pub fn device_pixel_ratio(&self) -> Scale<f32, CSSPixel, DevicePixel> {
         self.device_pixel_ratio
+    }
+
+    /// Queries dummy font metrics for Servo. Knows nothing about fonts and does not provide
+    /// any metrics.
+    /// TODO: Servo's font metrics provider will probably not live in this crate, so this will
+    /// have to be replaced with something else (perhaps a trait method on TElement)
+    /// when we get there
+    pub fn query_font_metrics(
+        &self,
+        _vertical: bool,
+        _font: &crate::properties::style_structs::Font,
+        _base_size: CSSPixelLength,
+        _in_media_query: bool,
+        _retrieve_math_scales: bool,
+    ) -> FontMetrics {
+        Default::default()
     }
 
     /// Take into account a viewport rule taken from the stylesheets.

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -351,7 +351,6 @@ where
             parent_style,
             parent_style,
             layout_parent_style,
-            &self.context.thread_local.font_metrics_provider,
             Some(&self.context.thread_local.rule_cache),
             &mut conditions,
         );

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -9,7 +9,6 @@
 
 use crate::context::QuirksMode;
 use crate::error_reporting::ContextualParseError;
-use crate::font_metrics::get_metrics_provider_for_product;
 use crate::media_queries::Device;
 use crate::parser::{Parse, ParserContext};
 use crate::properties::StyleBuilder;
@@ -673,14 +672,11 @@ impl MaybeNew for ViewportConstraints {
         // DEVICE-ADAPT § 6.2.3 Resolve non-auto lengths to pixel lengths
         let initial_viewport = device.au_viewport_size();
 
-        let provider = get_metrics_provider_for_product();
-
         let mut conditions = RuleCacheConditions::default();
         let context = Context {
             // Note: DEVICE-ADAPT § 5. states that relative length values are
             // resolved against initial values
             builder: StyleBuilder::for_inheritance(device, None, None),
-            font_metrics_provider: &provider,
             cached_system_font: None,
             in_media_query: false,
             quirks_mode: quirks_mode,


### PR DESCRIPTION
This is a backport of https://phabricator.services.mozilla.com/D157589,
by Emilio Cobos Álvarez, plus some additions so that Servo compiles,
and some parts from https://phabricator.services.mozilla.com/D144455.

Should have no change in behavior.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there should be no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
