### PR TITLE
Workaround bug in gstreamer binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ NOTE: run these steps after you've cloned the project locally.
 ``` sh
 cd servo 
 bash etc/install_macos_gstreamer.sh
+brew bundle install --file=etc/homebrew/Brewfile
 pip install virtualenv
 ```
 

--- a/etc/homebrew/Brewfile
+++ b/etc/homebrew/Brewfile
@@ -1,0 +1,3 @@
+# Runtime dependencies
+
+brew "xz"

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -872,6 +872,17 @@ def copy_dependencies(binary_path, lib_path, gst_root):
             if is_system_library(f):
                 continue
             full_path = resolve_rpath(f, gst_root)
+            # fixme(mukilan): this is a temporary solution to a bug
+            # in the official gstreamer packages. Few gstreamer dylibs
+            # like 'libavcodec.59.dylib' have absolute paths to liblzma
+            # instead of @rpath based to be relocatable. The homebrew
+            # prefix is configurable in general and is /opt/homebrew
+            # on Apple Silicon
+            if full_path == "/usr/local/opt/xz/lib/liblzma.5.dylib" and (
+                    not path.exists("/usr/local/opt/xz")
+                    and path.exists("/opt/homebrew/")):
+                full_path = "/opt/homebrew/lib/liblzma.5.dylib"
+
             need_relinked = set(otool(full_path))
             new_path = path.join(lib_path, path.basename(full_path))
             if not path.exists(new_path):


### PR DESCRIPTION
The official gstreamer .pkg distribution should contain 'relocatable' dylibs, but as discovered in #29732, some dylibs have absolute links to liblzma.5.dylib ("/usr/local/opt/xz/lib/liblzma.5.dylib")

Since /opt/homebrew is the default install location on Apple Silicion, this will cause the packaging & build steps to fail, even if 'xz' package is installed via homebrew.

This is a temporary fix until upstream fixes the bug and makes the package truly 'relocatable'. Users
with non-default homebrew prefixes will still have the issue.

Thanks to @atbrakhi  for helping me debug and test the patch on her mac.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29732 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix the broken build process.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
