### PR TITLE
Disable formatting for components/style/

### DIFF
--- a/components/style/rustfmt.toml
+++ b/components/style/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
Gecko doesn't enforce proper formatting, so disabling it will make it easier to backport changes from there.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
