### PR TITLE
Run the Layout 2020 tests in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2020'
+      wpt: 'test'
 
   build_result:
     name: homu build finished

--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -105,8 +105,11 @@ class Item:
 def get_results(filenames: list[str], tag: str = "") -> Optional[Item]:
     unexpected = []
     for filename in filenames:
-        with open(filename, encoding="utf-8") as file:
-            unexpected += json.load(file)
+        try:
+            with open(filename, encoding="utf-8") as file:
+                unexpected += json.load(file)
+        except FileNotFoundError as exception:
+            print(exception)
     unexpected.sort(key=lambda result: result["path"])
 
     def is_flaky(result):


### PR DESCRIPTION
Also fix report_aggregated_expected_results.py which was reporting an error when there were no failing tests. This is more commonly an issue with Layout 2020 because if runs fewer tests and was causing builds to show up as failing even when they were not.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they change the build infrastructure.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
