### PR TITLE
layout_2020: fix target main size not get clamped in flexbox

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -943,6 +943,8 @@ impl FlexLine<'_> {
                 //  it’s a min violation.”
                 for (item_and_target_main_size, frozen) in items() {
                     if violation(item_and_target_main_size) > Length::zero() {
+                        let (item, target_main_size) = item_and_target_main_size;
+                        target_main_size.set(item.content_min_size.main);
                         frozen_count.set(frozen_count.get() + 1);
                         frozen.set(true);
                     }
@@ -954,6 +956,11 @@ impl FlexLine<'_> {
                 //  it’s a max violation.”
                 for (item_and_target_main_size, frozen) in items() {
                     if violation(item_and_target_main_size) < Length::zero() {
+                        let (item, target_main_size) = item_and_target_main_size;
+                        let Some(max_size) = item.content_max_size.main else {
+                            unreachable!()
+                        };
+                        target_main_size.set(max_size);
                         frozen_count.set(frozen_count.get() + 1);
                         frozen.set(true);
                     }

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-008.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-008.html.ini
@@ -1,2 +1,0 @@
-[flex-grow-008.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-center.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-center.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-center.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-flex-end.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-flex-end.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-flex-end.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-flex-start.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-flex-start.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-flex-start.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacearound-only.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacearound-only.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-spacearound-only.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacearound.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacearound.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-spacearound.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacebetween-only.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacebetween-only.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-spacebetween-only.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacebetween.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacebetween.html.ini
@@ -1,2 +1,0 @@
-[flexbox_justifycontent-spacebetween.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/image-as-flexitem-size-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/image-as-flexitem-size-005.html.ini
@@ -1,7 +1,4 @@
 [image-as-flexitem-size-005.html]
-  [.flexbox > img 11]
-    expected: FAIL
-
   [.flexbox > img 18]
     expected: FAIL
 
@@ -24,16 +21,4 @@
     expected: FAIL
 
   [.flexbox > img 2]
-    expected: FAIL
-
-  [.flexbox > img 14]
-    expected: FAIL
-
-  [.flexbox > img 17]
-    expected: FAIL
-
-  [.flexbox > img 12]
-    expected: FAIL
-
-  [.flexbox > img 9]
     expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/image-as-flexitem-size-005v.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/image-as-flexitem-size-005v.html.ini
@@ -1,19 +1,4 @@
 [image-as-flexitem-size-005v.html]
-  [.flexbox > img 9]
-    expected: FAIL
-
-  [.flexbox > img 12]
-    expected: FAIL
-
-  [.flexbox > img 14]
-    expected: FAIL
-
-  [.flexbox > img 17]
-    expected: FAIL
-
-  [.flexbox > img 11]
-    expected: FAIL
-
   [.flexbox > img 18]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/percentage-heights-012.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/percentage-heights-012.html.ini
@@ -1,6 +1,3 @@
 [percentage-heights-012.html]
   [.flexbox 9]
     expected: FAIL
-
-  [.flexbox 10]
-    expected: FAIL


### PR DESCRIPTION
When Resolving flexible lengths, the clamp result of item's target main size is not actually saved when it should.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
