### PR TITLE
Thread panics should be a hard-fail in smoketests

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -835,6 +835,9 @@ testing/web-platform/mozilla/tests for Servo-only tests""" % reference_path)
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Servo")
     def smoketest(self, params):
-        params = params + ['tests/html/close-on-load.html']
+        # We pass `-f` here so that any thread panic will cause Servo to exit,
+        # preventing a panic from hanging execution. This means that these kind
+        # of panics won't cause timeouts on CI.
+        params = params + ['-f', 'tests/html/close-on-load.html']
         return self.context.commands.dispatch(
             'run', self.context, params=params)


### PR DESCRIPTION
This prevents, for instance, a script thread panic from hanging Servo and means those kind of panics won't cause CI to hang.

Fixes #29749.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29749.
- [x] These changes do not require tests because they fix a test issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
