### PR TITLE
Fix 29741 by extending request builder

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1978,6 +1978,7 @@ async fn cors_preflight_fetch(
         .destination(request.destination.clone())
         .referrer_policy(request.referrer_policy)
         .mode(RequestMode::CorsMode)
+        .response_tainting(ResponseTainting::CorsTainting)
         .build();
 
     // Step 2

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -93,7 +93,7 @@ pub enum RedirectMode {
 }
 
 /// [Response tainting](https://fetch.spec.whatwg.org/#concept-request-response-tainting)
-#[derive(Clone, Copy, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum ResponseTainting {
     Basic,
     CorsTainting,
@@ -253,6 +253,7 @@ pub struct RequestBuilder {
     pub parser_metadata: ParserMetadata,
     pub initiator: Initiator,
     pub https_state: HttpsState,
+    pub response_tainting: ResponseTainting,
 }
 
 impl RequestBuilder {
@@ -282,6 +283,7 @@ impl RequestBuilder {
             initiator: Initiator::None,
             csp_list: None,
             https_state: HttpsState::None,
+            response_tainting: ResponseTainting::Basic,
         }
     }
 
@@ -375,6 +377,11 @@ impl RequestBuilder {
         self
     }
 
+    pub fn response_tainting(mut self, response_tainting: ResponseTainting) -> RequestBuilder {
+        self.response_tainting = response_tainting;
+        self
+    }
+
     pub fn build(self) -> Request {
         let mut request = Request::new(
             self.url.clone(),
@@ -407,6 +414,7 @@ impl RequestBuilder {
         request.integrity_metadata = self.integrity_metadata;
         request.parser_metadata = self.parser_metadata;
         request.csp_list = self.csp_list;
+        request.response_tainting = self.response_tainting;
         request
     }
 }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -127,6 +127,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
         initiator: request.initiator,
         csp_list: None,
         https_state: request.https_state,
+        response_tainting: request.response_tainting,
     }
 }
 


### PR DESCRIPTION
Extend RequestBuilder to include ResponseTainting and used said functionality to set response_tainting to `::CorsTainting` in `cors_preflight_fetch()`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29741
<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
