### PR TITLE
Update: Bump webdriver version to 0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "futures-util",
  "log",
  "openssl",
- "pin-project 1.0.2",
+ "pin-project",
  "tokio 0.2.24",
  "tokio-openssl 0.4.0",
  "tungstenite",
@@ -302,6 +302,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "binary-space-partition"
@@ -645,7 +651,7 @@ dependencies = [
  "surfman",
  "surfman-chains",
  "surfman-chains-api",
- "time",
+ "time 0.1.45",
  "webrender",
  "webrender_api",
  "webrender_surfman",
@@ -671,7 +677,7 @@ dependencies = [
  "servo_config",
  "sparkle",
  "style",
- "time",
+ "time 0.1.45",
  "webrender_api",
  "webxr-api",
 ]
@@ -754,7 +760,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -886,7 +892,7 @@ dependencies = [
  "servo_geometry",
  "servo_url",
  "style_traits",
- "time",
+ "time 0.1.45",
  "toml",
  "webrender",
  "webrender_api",
@@ -963,7 +969,17 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "time",
+ "time 0.1.45",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "time 0.3.21",
+ "version_check",
 ]
 
 [[package]]
@@ -1340,7 +1356,7 @@ dependencies = [
  "servo_config",
  "servo_rand",
  "servo_url",
- "time",
+ "time 0.1.45",
  "uuid",
 ]
 
@@ -1357,7 +1373,7 @@ dependencies = [
  "msg",
  "serde",
  "servo_url",
- "time",
+ "time 0.1.45",
  "uuid",
 ]
 
@@ -1668,7 +1684,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "pin-project 1.0.2",
+ "pin-project",
  "spin",
 ]
 
@@ -1985,7 +2001,7 @@ dependencies = [
  "servo_url",
  "smallvec",
  "style",
- "time",
+ "time 0.1.45",
  "truetype",
  "ucd",
  "unicode-bidi",
@@ -2559,26 +2575,6 @@ checksum = "b1334b94d8ce67319ddc44663daef53d8c1538629a11562530c981dbd9085b9a"
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.2.24",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
@@ -2721,16 +2717,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-dependencies = [
- "bytes 0.5.6",
- "http",
-]
-
-[[package]]
-name = "http-body"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
@@ -2766,30 +2752,6 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.2.7",
- "http",
- "http-body 0.3.1",
- "httparse",
- "httpdate 0.3.2",
- "itoa 0.4.8",
- "pin-project 1.0.2",
- "socket2 0.3.19",
- "tokio 0.2.24",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
@@ -2798,14 +2760,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.9",
+ "h2",
  "http",
- "http-body 0.4.4",
+ "http-body",
  "httparse",
  "httpdate 0.3.2",
  "itoa 0.4.8",
- "pin-project 1.0.2",
- "socket2 0.4.7",
+ "pin-project",
+ "socket2",
  "tokio 1.25.0",
  "tower-service",
  "tracing",
@@ -2819,7 +2781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
 dependencies = [
  "http",
- "hyper 0.14.5",
+ "hyper",
  "linked_hash_set",
  "once_cell",
  "openssl",
@@ -2836,14 +2798,14 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4193ebe2b9ecb7d04dd1a777c25f3294e10310fe5583e1006a3f47779d6c6a01"
 dependencies = [
- "cookie",
+ "cookie 0.12.0",
  "headers",
  "http",
- "hyper 0.14.5",
+ "hyper",
  "mime",
  "serde",
  "serde_bytes",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -3222,7 +3184,7 @@ dependencies = [
  "servo_url",
  "style",
  "style_traits",
- "time",
+ "time 0.1.45",
  "webrender_api",
 ]
 
@@ -3569,7 +3531,7 @@ dependencies = [
  "smallvec",
  "string_cache",
  "thin-slice",
- "time",
+ "time 0.1.45",
  "tokio 1.25.0",
  "url",
  "uuid",
@@ -3705,7 +3667,7 @@ dependencies = [
  "script_traits",
  "servo_config",
  "servo_url",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -3718,7 +3680,7 @@ dependencies = [
  "msg",
  "profile_traits",
  "servo_url",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -3878,7 +3840,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 dependencies = [
- "time",
+ "time 0.1.45",
  "winapi",
 ]
 
@@ -3982,7 +3944,7 @@ dependencies = [
  "brotli",
  "bytes 1.1.0",
  "content-security-policy",
- "cookie",
+ "cookie 0.12.0",
  "crossbeam-channel 0.4.4",
  "data-url",
  "devtools_traits",
@@ -3993,7 +3955,7 @@ dependencies = [
  "generic-array 0.14.4",
  "headers",
  "http",
- "hyper 0.14.5",
+ "hyper",
  "hyper-openssl",
  "hyper_serde",
  "immeta",
@@ -4021,7 +3983,7 @@ dependencies = [
  "servo_url",
  "sha2",
  "std_test_override",
- "time",
+ "time 0.1.45",
  "tokio 0.2.24",
  "tokio 1.25.0",
  "tokio-openssl 0.6.3",
@@ -4049,11 +4011,11 @@ name = "net_traits"
 version = "0.0.1"
 dependencies = [
  "content-security-policy",
- "cookie",
+ "cookie 0.12.0",
  "embedder_traits",
  "headers",
  "http",
- "hyper 0.14.5",
+ "hyper",
  "hyper_serde",
  "image 0.24.6",
  "ipc-channel",
@@ -4071,7 +4033,7 @@ dependencies = [
  "servo_rand",
  "servo_url",
  "std_test_override",
- "time",
+ "time 0.1.45",
  "url",
  "uuid",
  "webrender_api",
@@ -4688,31 +4650,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
-dependencies = [
- "pin-project-internal 0.4.29",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.2",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -4881,7 +4823,7 @@ dependencies = [
  "serde",
  "servo_config",
  "signpost",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -5200,6 +5142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,7 +5201,7 @@ dependencies = [
  "canvas_traits",
  "chrono",
  "content-security-policy",
- "cookie",
+ "cookie 0.12.0",
  "crossbeam-channel 0.4.4",
  "cssparser",
  "data-url",
@@ -5322,7 +5273,7 @@ dependencies = [
  "swapper",
  "tempfile",
  "tendril",
- "time",
+ "time 0.1.45",
  "unicode-bidi",
  "unicode-segmentation",
  "url",
@@ -5395,7 +5346,7 @@ dependencies = [
  "bitflags",
  "bluetooth_traits",
  "canvas_traits",
- "cookie",
+ "cookie 0.12.0",
  "crossbeam-channel 0.4.4",
  "devtools_traits",
  "embedder_traits",
@@ -5420,7 +5371,7 @@ dependencies = [
  "servo_url",
  "smallvec",
  "style_traits",
- "time",
+ "time 0.1.45",
  "uuid",
  "webdriver",
  "webgpu",
@@ -5502,9 +5453,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -5520,9 +5471,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5542,14 +5493,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "dtoa",
- "itoa 0.4.8",
+ "form_urlencoded",
+ "itoa 1.0.1",
+ "ryu",
  "serde",
- "url",
 ]
 
 [[package]]
@@ -6088,17 +6039,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
@@ -6259,7 +6199,7 @@ dependencies = [
  "style_derive",
  "style_traits",
  "thin-slice",
- "time",
+ "time 0.1.45",
  "to_shmem",
  "to_shmem_derive",
  "toml",
@@ -6535,6 +6475,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+dependencies = [
+ "itoa 1.0.1",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "time-point"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6622,10 +6589,8 @@ checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures-core",
  "iovec",
  "lazy_static",
- "memchr",
  "mio 0.6.22",
  "num_cpus",
  "pin-project-lite 0.1.11",
@@ -6646,7 +6611,7 @@ dependencies = [
  "mio 0.8.6",
  "num_cpus",
  "pin-project-lite 0.2.8",
- "socket2 0.4.7",
+ "socket2",
  "tokio-macros 1.7.0",
  "windows-sys 0.42.0",
 ]
@@ -6721,20 +6686,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.11",
- "tokio 0.2.24",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
@@ -6743,6 +6694,19 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
+ "pin-project-lite 0.2.8",
+ "tokio 1.25.0",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite 0.2.8",
  "tokio 1.25.0",
 ]
@@ -6787,16 +6751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project 1.0.2",
- "tracing",
 ]
 
 [[package]]
@@ -6966,12 +6920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
-
-[[package]]
 name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7001,9 +6949,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -7034,28 +6982,31 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.5"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
+checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
 dependencies = [
- "bytes 0.5.6",
- "futures 0.3.5",
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-util",
  "headers",
  "http",
- "hyper 0.13.10",
+ "hyper",
  "log",
  "mime",
  "mime_guess",
- "pin-project 0.4.29",
+ "percent-encoding",
+ "pin-project",
+ "rustls-pemfile",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.24",
+ "tokio 1.25.0",
+ "tokio-stream",
+ "tokio-util 0.7.8",
  "tower-service",
  "tracing",
- "tracing-futures",
- "urlencoding",
 ]
 
 [[package]]
@@ -7227,22 +7178,21 @@ dependencies = [
 
 [[package]]
 name = "webdriver"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3484940751923901dc09b362740cad90bcfb62ec93d8abf38add2c3ac728c596"
+checksum = "cf9ae70f0cb12332fe144def990a9e62b20db2361b8784f879bb2814aad6c763"
 dependencies = [
- "base64 0.12.0",
- "bytes 0.5.6",
- "cookie",
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "cookie 0.16.2",
  "http",
  "log",
- "once_cell",
- "regex",
  "serde",
  "serde_derive",
  "serde_json",
- "time",
- "tokio 0.2.24",
+ "time 0.3.21",
+ "tokio 1.25.0",
+ "tokio-stream",
  "unicode-segmentation",
  "url",
  "warp",
@@ -7254,7 +7204,7 @@ version = "0.0.1"
 dependencies = [
  "base64 0.10.1",
  "compositing",
- "cookie",
+ "cookie 0.12.0",
  "crossbeam-channel 0.4.4",
  "euclid",
  "headers",
@@ -7331,7 +7281,7 @@ dependencies = [
  "sig",
  "smallvec",
  "svg_fmt",
- "time",
+ "time 0.1.45",
  "tracy-rs",
  "webrender_api",
  "webrender_build",
@@ -7356,7 +7306,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "time",
+ "time 0.1.45",
  "wr_malloc_size_of",
 ]
 
@@ -7403,7 +7353,7 @@ dependencies = [
  "sparkle",
  "surfman",
  "surfman-chains",
- "time",
+ "time 0.1.45",
  "webxr-api",
  "winapi",
  "wio",
@@ -7418,7 +7368,7 @@ dependencies = [
  "ipc-channel",
  "log",
  "serde",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -7761,7 +7711,7 @@ dependencies = [
  "flate2",
  "msdos_time",
  "podio",
- "time",
+ "time 0.1.45",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ unicode-bidi = "0.3.4"
 unicode-script = "0.5"
 url = "2.0"
 uuid = { version = "0.8", features = ["v4"] }
-webdriver = "0.44"
+webdriver = "0.48.0"
 winapi = "0.3"
 xi-unicode = "0.1.0"
 xml5ever = "0.17"

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -77,6 +77,7 @@ fn compute_tick_duration(tick_actions: &ActionSequence) -> u64 {
             }
         },
         ActionsType::Key { actions: _ } => (),
+        ActionsType::Wheel { actions } => todo!("Not implemented."),
     }
     duration
 }
@@ -188,6 +189,7 @@ impl Handler {
                     }
                 }
             },
+            ActionsType::Wheel { actions } => todo!("Not implemented."),
         }
 
         Ok(())
@@ -282,6 +284,7 @@ impl Handler {
                 actions: vec![PointerActionItem::Pointer(PointerAction::Up(
                     PointerUpAction {
                         button: action.button,
+                        ..Default::default()
                     },
                 ))],
             },
@@ -328,6 +331,7 @@ impl Handler {
                 actions: vec![PointerActionItem::Pointer(PointerAction::Down(
                     PointerDownAction {
                         button: action.button,
+                        ..Default::default()
                     },
                 ))],
             },
@@ -356,8 +360,8 @@ impl Handler {
         let tick_start = Instant::now();
 
         // Steps 1 - 2
-        let x_offset = action.x.unwrap_or(0);
-        let y_offset = action.y.unwrap_or(0);
+        let x_offset = action.x;
+        let y_offset = action.y;
 
         // Steps 3 - 4
         let (start_x, start_y) = match self

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -115,8 +115,9 @@ pub fn start_server(port: u16, constellation_chan: Sender<ConstellationMsg>) {
         .spawn(move || {
             let address = SocketAddrV4::new("0.0.0.0".parse().unwrap(), port);
             match server::start(
-                "localhost".to_owned(),
                 SocketAddr::V4(address),
+                vec![],
+                vec![],
                 handler,
                 extension_routes(),
             ) {
@@ -1510,15 +1511,22 @@ impl Handler {
                     let pointer_move_action = PointerMoveAction {
                         duration: None,
                         origin: PointerOrigin::Element(WebElement(element_id)),
-                        x: Some(0),
-                        y: Some(0),
+                        x: 0,
+                        y: 0,
+                        ..Default::default()
                     };
 
                     // Steps 8.7 - 8.8
-                    let pointer_down_action = PointerDownAction { button: 1 };
+                    let pointer_down_action = PointerDownAction {
+                        button: 1,
+                        ..Default::default()
+                    };
 
                     // Steps 8.9 - 8.10
-                    let pointer_up_action = PointerUpAction { button: 1 };
+                    let pointer_up_action = PointerUpAction {
+                        button: 1,
+                        ..Default::default()
+                    };
 
                     // Step 8.11
                     if let Err(error) =

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -2,12 +2,8 @@
 skip-check-length = false
 skip-check-licenses = false
 check-alphabetical-order = true
-check-ordered-json-keys = [
-  "./resources/prefs.json",
-]
-lint-scripts = [
-  "./python/servo/lints/wpt_lint.py",
-]
+check-ordered-json-keys = ["./resources/prefs.json"]
+lint-scripts = ["./python/servo/lints/wpt_lint.py"]
 
 # Packages which we avoid using in Servo.
 # For each blocked package, we can list the exceptions,
@@ -15,10 +11,10 @@ lint-scripts = [
 [blocked-packages]
 num = []
 rand = [
-  "hashglobe", # Only used in tests
+  "hashglobe",     # Only used in tests
   "ipc-channel",
   "phf_generator",
-  "quickcheck", # Only used in tests
+  "quickcheck",    # Only used in tests
   "servo_rand",
   "tungstenite",
   "ws",
@@ -27,6 +23,8 @@ rand = [
 [ignore]
 # Ignored packages with duplicated versions
 packages = [
+  "time",
+  "cookie",
   "arrayvec",
   "base64",
   "cfg-if",
@@ -34,7 +32,7 @@ packages = [
   "crossbeam-utils",
   "fixedbitset",
   "getrandom",
-  "h2",
+  # "h2",
   "half",
   "image",
   "itoa",
@@ -65,14 +63,14 @@ packages = [
   "tokio",
   "tokio-macros",
   "tokio-util",
-  "http-body",
+  # "http-body",
   "httpdate",
-  "hyper",
+  # "hyper",
   "bytes",
-  "pin-project",
+  # "pin-project",
   "pin-project-lite",
-  "pin-project-internal",
-  "socket2",
+  # "pin-project-internal",
+  # "socket2",
 
   # https://github.com/servo/servo/pull/23288#issuecomment-494687746
   "gl_generator",

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -32,7 +32,6 @@ packages = [
   "crossbeam-utils",
   "fixedbitset",
   "getrandom",
-  # "h2",
   "half",
   "image",
   "itoa",
@@ -63,14 +62,9 @@ packages = [
   "tokio",
   "tokio-macros",
   "tokio-util",
-  # "http-body",
   "httpdate",
-  # "hyper",
   "bytes",
-  # "pin-project",
   "pin-project-lite",
-  # "pin-project-internal",
-  # "socket2",
 
   # https://github.com/servo/servo/pull/23288#issuecomment-494687746
   "gl_generator",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

These changes bump the `webdriver` crate from version 0.44 to 0.48. There are compilation issues which will need to be addressed accordingly.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29742 (GitHub issue number if applicable)

<!-- Either: -->
- [X] These changes may require some additional tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
