### PR TITLE
layout_2020: Implement automatic minimum size of flex items

### DIFF
--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -138,7 +138,7 @@ impl IndependentFormattingContext {
         }
     }
 
-    pub fn inline_content_sizes(&mut self, layout_context: &LayoutContext) -> ContentSizes {
+    pub fn inline_content_sizes(&self, layout_context: &LayoutContext) -> ContentSizes {
         match self {
             Self::NonReplaced(inner) => inner
                 .contents

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -201,7 +201,7 @@ impl ReplacedContent {
         Vec2::from_physical_size(&intrinsic_size, style.writing_mode)
     }
 
-    fn inline_size_over_block_size_intrinsic_ratio(
+    pub fn inline_size_over_block_size_intrinsic_ratio(
         &self,
         style: &ComputedValues,
     ) -> Option<CSSFloat> {

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-factor-less-than-one.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-factor-less-than-one.html.ini
@@ -22,6 +22,3 @@
 
   [.flexbox 12]
     expected: FAIL
-
-  [.flexbox 19]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-024.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-024.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-024.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-size-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-size-001.html.ini
@@ -1,14 +1,5 @@
 [flex-minimum-size-001.html]
-  [.flexbox, .inline-flexbox 1]
-    expected: FAIL
-
   [.flexbox, .inline-flexbox 6]
-    expected: FAIL
-
-  [.flexbox, .inline-flexbox 5]
-    expected: FAIL
-
-  [.flexbox, .inline-flexbox 4]
     expected: FAIL
 
   [.flexbox, .inline-flexbox 2]

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-001.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-002.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-003.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-003.html.ini
@@ -1,0 +1,2 @@
+[flex-wrap-003.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-004.html.ini
@@ -1,0 +1,2 @@
+[flex-wrap-004.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-align-self-stretch-vert-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-align-self-stretch-vert-001.html.ini
@@ -1,2 +1,2 @@
 [flexbox-align-self-stretch-vert-001.html]
-  expected: FAIL
+  expected: TIMEOUT

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-min-width-auto-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-min-width-auto-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-min-width-auto-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-min-width-auto-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-min-width-auto-003.html.ini
@@ -1,2 +1,0 @@
-[flexbox-min-width-auto-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-min-width-auto-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-min-width-auto-004.html.ini
@@ -1,2 +1,0 @@
-[flexbox-min-width-auto-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-0-0-unitless.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-0-0-unitless.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-0-0-unitless.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-0-0.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-0-0.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-0-0.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-0.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-0.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-0.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-1-0-unitless.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-1-0-unitless.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-1-0-unitless.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-1-0.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-1-0.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-1-0.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-1.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-1.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-1.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-N-0-unitless.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-N-0-unitless.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-N-0-unitless.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-N-0.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-N-0.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-N-0.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-N.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-0-N.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-0-N.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/radiobutton-min-size.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/radiobutton-min-size.html.ini
@@ -1,4 +1,0 @@
-[radiobutton-min-size.html]
-  [two radio button widths are identical]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/relayout-image-load.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/relayout-image-load.html.ini
@@ -1,3 +1,0 @@
-[relayout-image-load.html]
-  [#test 1]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/table-as-item-stretch-cross-size-4.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/table-as-item-stretch-cross-size-4.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-stretch-cross-size-4.html]
-  expected: FAIL


### PR DESCRIPTION
Implement the algorithm described in
https://drafts.csswg.org/css-flexbox/#min-size-auto.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
