### PR TITLE
Use Python 3.9 on linux workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,6 +61,10 @@ jobs:
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
+      - name: Select Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip virtualenv
       - name: Bootstrap dependencies


### PR DESCRIPTION
It looks like the system python 3.8 has older 'ssl' module which is now causing [recent Linux nightly builds](https://github.com/servo/servo/actions/runs/5010809452/jobs/8981025230) to fail:

```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'

  File "/home/runner/work/servo/servo/python/servo/package_commands.py", line 559, in upload_nightly
    import boto3
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/boto3/__init__.py", line 17, in <module>
    from boto3.session import Session
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/client.py", line 15, in <module>
    from botocore import waiter, xform_name
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/waiter.py", line 18, in <module>
    from botocore.docs.docstring import WaiterDocstring
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/docs/__init__.py", line 15, in <module>
    from botocore.docs.service import ServiceDocumenter
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/docs/service.py", line 14, in <module>
    from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/docs/client.py", line 17, in <module>
    from botocore.docs.example import ResponseExampleDocumenter
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/docs/example.py", line 13, in <module>
    from botocore.docs.shape import ShapeDocumenter
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/docs/shape.py", line 19, in <module>
    from botocore.utils import is_json_value_header
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/utils.py", line 37, in <module>
    import botocore.httpsession
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/botocore/httpsession.py", line 45, in <module>
    from urllib3.contrib.pyopenssl import (
  File "/home/runner/work/servo/servo/python/_virtualenv3.8/lib/python3.8/site-packages/urllib3/contrib/pyopenssl.py", line 43, in <module>
    import OpenSSL.SSL  # type: ignore[import]
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
```

This PR upgrades to python 3.9 from 3.8 (default on 20.04) as upgrading 'ssl' using pip doesn't  work.  ssl on PyPi only works with Python 2 (ssl is now a builtin module since Python 3).  

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the change was validated with a [manual run](https://github.com/servo/servo/actions/runs/5014885132)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
