### PR TITLE
Remove some unused python code

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -82,24 +82,6 @@ PACKAGES = {
 }
 
 
-TemporaryDirectory = None
-if sys.version_info >= (3, 2):
-    TemporaryDirectory = tempfile.TemporaryDirectory
-else:
-    import contextlib
-
-    # Not quite as robust as tempfile.TemporaryDirectory,
-    # but good enough for most purposes
-    @contextlib.contextmanager
-    def TemporaryDirectory(**kwargs):
-        dir_name = tempfile.mkdtemp(**kwargs)
-        try:
-            yield dir_name
-        except Exception as e:
-            shutil.rmtree(dir_name)
-            raise e
-
-
 def listfiles(directory):
     return [f for f in os.listdir(directory)
             if path.isfile(path.join(directory, f))]
@@ -683,7 +665,7 @@ class PackageCommands(CommandBase):
 
             brew_version = timestamp.strftime('%Y.%m.%d')
 
-            with TemporaryDirectory(prefix='homebrew-servo') as tmp_dir:
+            with tempfile.TemporaryDirectory(prefix='homebrew-servo') as tmp_dir:
                 def call_git(cmd, **kwargs):
                     subprocess.check_call(
                         ['git', '-C', tmp_dir] + cmd,


### PR DESCRIPTION
This change removes:
 - The custom `--dry-run` support for `cargo-update`. The real cargo command now has `--dry-run` support and this code was broken for Python 3.
- The Python 2 version of TemporaryDirectory. This is no longer needed as we require Python 3.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
