### PR TITLE
Fix slowness in macos copy_dependencies

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -557,8 +557,6 @@ class MachCommands(CommandBase):
             features=features, **kwargs
         )
 
-        elapsed = time() - build_start
-
         # Do some additional things if the build succeeded
         if status == 0:
             if android and not no_package:
@@ -656,6 +654,7 @@ class MachCommands(CommandBase):
 
         # Generate Desktop Notification if elapsed-time > some threshold value
 
+        elapsed = time() - build_start
         elapsed_delta = datetime.timedelta(seconds=int(elapsed))
         build_message = f"{'Succeeded' if status == 0 else 'Failed'} in {elapsed_delta}"
         self.notify("Servo build", build_message)

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -858,8 +858,8 @@ def copy_dependencies(binary_path, lib_path, gst_root):
 
     # Update binary libraries
     binary_dependencies = set(otool(binary_path))
-    binary_dependencies = binary_dependencies.union(macos_plugins())
     change_non_system_libraries_path(binary_dependencies, relative_path, binary_path)
+    binary_dependencies = binary_dependencies.union(macos_plugins())
 
     # Update dependencies libraries
     need_checked = binary_dependencies

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -631,6 +631,7 @@ class MachCommands(CommandBase):
 
                 if has_media_stack:
                     gst_root = gstreamer_root(target, env)
+                    print("Packaging gstreamer dylibs")
                     if not package_gstreamer_dylibs(gst_root, servo_path):
                         return 1
 


### PR DESCRIPTION
The `copy_dependencies` logic is invoking `change_non_system_libraries_path` with absolute paths to gstreamer *plugin dylibs*.
`change_non_system_libraries_path` skips editing links in servo binary to relocatable dylibs, but the since the plugins have absolute paths, they are treated as 'non-relocable' and it will try to edit the *non-existent* link (since plugins are loaded dynamically) in servo bin . These unnecessary calls to change_link_name is the cause of the slowness identified in #29764 

This PR fixes the issue by ensuring plugin dylibs are not passed to the first call to change_non_system_libraries_path that patches the links in the main servo binary.

With this fix, the time taken by copy_dependencies is reduced to ~3 seconds on my system.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29764 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix slowness in build step
