### PR TITLE
Clean up and document the `send_display_list` interface

### DIFF
--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -28,6 +28,12 @@ impl Epoch {
     }
 }
 
+impl Into<webrender_api::Epoch> for Epoch {
+    fn into(self) -> webrender_api::Epoch {
+        webrender_api::Epoch(self.0)
+    }
+}
+
 /// A unique ID for every stacking context.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct StackingContextId(

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -70,6 +70,7 @@ impl DisplayList {
         viewport_size: units::LayoutSize,
         content_size: units::LayoutSize,
         pipeline_id: wr::PipelineId,
+        epoch: wr::Epoch,
     ) -> Self {
         Self {
             wr: wr::DisplayListBuilder::new(pipeline_id, content_size),
@@ -77,6 +78,7 @@ impl DisplayList {
                 viewport_size,
                 content_size,
                 pipeline_id,
+                epoch,
             ),
         }
     }

--- a/components/script_traits/compositor.rs
+++ b/components/script_traits/compositor.rs
@@ -7,7 +7,7 @@
 use embedder_traits::Cursor;
 use webrender_api::{
     units::{LayoutSize, LayoutVector2D},
-    ExternalScrollId, ScrollLocation, ScrollSensitivity, SpatialId,
+    Epoch, ExternalScrollId, PipelineId, ScrollLocation, ScrollSensitivity, SpatialId,
 };
 
 /// Information that Servo keeps alongside WebRender display items
@@ -213,6 +213,15 @@ impl ScrollTree {
 /// display lists sent to the compositor.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CompositorDisplayListInfo {
+    /// The WebRender [PipelineId] of this display list.
+    pub pipeline_id: PipelineId,
+
+    /// The size of the viewport that this display list renders into.
+    pub viewport_size: LayoutSize,
+
+    /// The epoch of the display list.
+    pub epoch: Epoch,
+
     /// An array of `HitTestInfo` which is used to store information
     /// to assist the compositor to take various actions (set the cursor,
     /// scroll without layout) using a WebRender hit test result.
@@ -237,7 +246,8 @@ impl CompositorDisplayListInfo {
     pub fn new(
         viewport_size: LayoutSize,
         content_size: LayoutSize,
-        pipeline_id: webrender_api::PipelineId,
+        pipeline_id: PipelineId,
+        epoch: Epoch,
     ) -> Self {
         let mut scroll_tree = ScrollTree::default();
         let root_reference_frame_id = scroll_tree.add_scroll_tree_node(
@@ -257,6 +267,9 @@ impl CompositorDisplayListInfo {
         );
 
         CompositorDisplayListInfo {
+            pipeline_id,
+            viewport_size,
+            epoch,
             hit_test_info: Default::default(),
             scroll_tree,
             root_reference_frame_id,


### PR DESCRIPTION
This moves more members to the CompositorDisplayListInfo struct, which now holds all miscellaneous, non-WebRender data when sending display lists. It also documents what each things sent with a display list does.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
