### PR TITLE
Update README and HACKING_QUICKSTART to build Layout 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ To build Servo in development mode.
 This is useful for development, but the resulting binary is very slow:
 
 ``` sh
-./mach build --dev
+./mach build --dev --with-layout-2020
 ./mach run tests/html/about-mozilla.html
 ```
 
@@ -304,7 +304,7 @@ For benchmarking, performance testing, or real-world use.
 Add the `--release` flag to create an optimized build:
 
 ``` sh
-./mach build --release
+./mach build --release --with-layout-2020
 ./mach run --release tests/html/about-mozilla.html
 ```
 
@@ -329,14 +329,14 @@ though of course it doesn’t produce a binary you can run.
 For ARM (`armv7-linux-androideabi`, most phones):
 
 ``` sh
-./mach build --release --android
+./mach build --release --with-layout-2020 --android
 ./mach package --release --android
 ```
 
 For x86 (typically for the emulator):
 
 ```sh
-./mach build --release --target i686-linux-android
+./mach build --release --with-layout-2020 --target i686-linux-android
 ./mach package --release --target i686-linux-android
 ```
 

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -12,7 +12,7 @@ on the [Github Workflow](https://github.com/servo/servo/wiki/Github-workflow) an
 Building Servo is quite easy. Install the prerequisites described in the [README](../README.md) file, then type:
 
 ```shell
-./mach build -d
+./mach build -d --with-layout-2020
 ```
 
 *Note: on Mac, you might run into an SSL issue while compiling. You'll find a solution to this problem [here](https://github.com/sfackler/rust-openssl/issues/255).*
@@ -20,6 +20,8 @@ Building Servo is quite easy. Install the prerequisites described in the [README
 The `-d` option means "debug build". You can also build with the `-r` option which means "release build". Building with `-d` will allow you to use a debugger (lldb). A `-r` build is more performant. Release builds are slower to build.
 
 You can use and build a release build and a debug build in parallel.
+
+The `--with-layout-2020` option will build with Layout 2020 as the layout engine. Current work on the project is focused in this new layout engine, that's why this is the recommended build by default.
 
 ## Running Servo
 


### PR DESCRIPTION
Given that current work is around Layout 2020, this patch modifies the documentation so people pass `--with-layout-2020` when following the instructions.
