### PR TITLE
Remove outdated note on README (fix #29786)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,6 @@ Add the `--release` flag to create an optimized build:
 ./mach run --release tests/html/about-mozilla.html
 ```
 
-**Note:** `mach build ` will build both `servo` and `libsimpleservo`. To make compilation a bit faster, it's possible to only compile the servo binary: `./mach build --dev -p servo`.
-
 ### Checking for build errors, without building
 
 If you’re making changes to one crate that cause build errors in another crate,


### PR DESCRIPTION
This patch just removes a note about building only servo vs libsimpleservo binaries, as that's no longer working.
