### PR TITLE
Fix layout 2020 crashes

### DIFF
--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -32,7 +32,13 @@ use rayon;
 use smallvec::SmallVec;
 
 /// The minimum stack size for a thread in the styling pool, in kilobytes.
+#[cfg(feature = "gecko")]
 pub const STYLE_THREAD_STACK_SIZE_KB: usize = 256;
+
+/// The minimum stack size for a thread in the styling pool, in kilobytes.
+/// Servo requires a bigger stack in debug builds.
+#[cfg(feature = "servo")]
+pub const STYLE_THREAD_STACK_SIZE_KB: usize = 512;
 
 /// The stack margin. If we get this deep in the stack, we will skip recursive
 /// optimizations to ensure that there is sufficient room for non-recursive work.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR contains (temporary) fixes for two issues discovered in layout-2020.

1. servo crashing due to 'already mutably borrowed' error when loading 'https://mozdevs.github.io/servo-experiments/experiments/bookshelf/'
2. Dev builds crashing when loading servo.org, but not in release mode.

For the first issue, when rendering a page containing an iframe, layout 2020 creates parallel 'Layout' threads which share workers in the stylo thread pool. Because of the way the 'StyleSharingCache' structures are designed using TLS for storage of LRU cache, this leads to a double borrow of the cache when both layout threads run concurrently.

More details about the issue can be found here: https://gist.github.com/mukilan/ed57eb61b83237a05fbf6360ec5e33b0

This PR is a workaround until we find a more elegant/optimal design that also can work for gecko. The fix for now is simply to not allow multiple layouts in parallel.

For the second issue, it seems like the style pool threads overrun their allocated stack space more quickly in debug mode than in release mode. Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1376883 it seems the stack size was chosen after several experiments. It is possible the results of those experiments are no longer valid.

The temporary workaround is to increase the stack size of the worker threads to avoid layout 2020 builds from crashing when servo.org is loaded, until we can confirm the theory and implement a more robust solution.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix crashing behaviour

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
