### PR TITLE
Upload nightly builds for layout2020 variant

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload
         if: ${{ inputs.upload }}
         run: |
-          python3 ./mach upload-nightly mac --secret-from-environment \
+          python3 ./mach upload-nightly ${{ env.PACKAGE }} --secret-from-environment \
             --github-release-id ${{ inputs.github-release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,8 +59,11 @@ jobs:
     needs:
       - create-draft-release
       - upload-linux
+      - upload-linux-2020
       - upload-win
+      - upload-win-2020
       - upload-mac
+      - upload-mac-2020
 
   upload-win:
     # This job is only useful when run on upstream servo.
@@ -75,6 +78,19 @@ jobs:
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
 
+  upload-win-2020:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    name: Upload nightly (Windows layout-2020)
+    needs:
+      - create-draft-release
+    uses: ./.github/workflows/windows.yml
+    with:
+      layout: '2020'
+      upload: true
+      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+    secrets: inherit
+
   upload-mac:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
@@ -84,6 +100,19 @@ jobs:
     uses: ./.github/workflows/mac.yml
     with:
       layout: '2013'
+      upload: true
+      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+    secrets: inherit
+
+  upload-mac-2020:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    name: Upload nightly (macOS layout-2020)
+    needs:
+      - create-draft-release
+    uses: ./.github/workflows/mac.yml
+    with:
+      layout: '2020'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
@@ -104,7 +133,7 @@ jobs:
   upload-linux-2020:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (Linux layout2020)
+    name: Upload nightly (Linux layout-2020)
     needs:
       - create-draft-release
     uses: ./.github/workflows/linux.yml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,7 +98,7 @@ jobs:
         if: ${{ inputs.upload }}
         working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: |
-          python mach upload-nightly windows-msvc --secret-from-environment `
+          python mach upload-nightly ${{ env.PACKAGE }} --secret-from-environment `
             --github-release-id ${{ inputs.github-release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -61,6 +61,9 @@ PACKAGES = {
     'mac': [
         'target/release/servo-tech-demo.dmg',
     ],
+    'mac-layout2020': [
+        'target/release/servo-tech-demo.dmg',
+    ],
     'macbrew': [
         'target/release/brew/servo.tar.gz',
     ],
@@ -69,6 +72,10 @@ PACKAGES = {
         'target/android/gradle/servoview/maven/org/mozilla/servoview/servoview-x86/',
     ],
     'windows-msvc': [
+        r'target\release\msi\Servo.exe',
+        r'target\release\msi\Servo.zip',
+    ],
+    'windows-msvc-layout2020': [
         r'target\release\msi\Servo.exe',
         r'target\release\msi\Servo.zip',
     ],


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We'd like to start offering servo nightly builds with layout 2020 engine so that users can test the new layout without building servo. These new builds will be offered in addition to the current 2013 builds until we switch over to 2020 as the default.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they extend nightly CI job.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
