### PR TITLE
Clean up cross-compilation and features

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -147,19 +147,20 @@ class PackageCommands(CommandBase):
                      action='append',
                      help='Create an APPX package')
     @CommandArgument('--ms-app-store', default=None, action='store_true')
-    def package(self, release=False, dev=False, android=None, debug=False,
-                debugger=None, target=None, flavor=None, maven=False, uwp=None, ms_app_store=False):
+    def package(self, release=False, dev=False, android=None, target=None,
+                flavor=None, maven=False, uwp=None, ms_app_store=False):
         if android is None:
             android = self.config["build"]["android"]
         if target and android:
             print("Please specify either --target or --android.")
             sys.exit(1)
         if not android:
-            android = self.handle_android_target(target)
+            android = self.setup_configuration_for_android_target(target)
         else:
             target = self.config["android"]["target"]
 
-        env = self.build_env(target=target)
+        self.cross_compile_target = target
+        env = self.build_env()
         binary_path = self.get_binary_path(
             release, dev, target=target, android=android,
             simpleservo=uwp is not None
@@ -423,9 +424,10 @@ class PackageCommands(CommandBase):
             print("Please specify either --target or --android.")
             sys.exit(1)
         if not android:
-            android = self.handle_android_target(target)
+            android = self.setup_configuration_for_android_target(target)
+        self.cross_compile_target = target
 
-        env = self.build_env(target=target)
+        env = self.build_env()
         try:
             binary_path = self.get_binary_path(release, dev, android=android)
         except BuildNotFound:

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -242,8 +242,7 @@ class PostBuildCommands(CommandBase):
         'params', nargs='...',
         help="Command-line arguments to be passed through to cargo doc")
     @CommandBase.build_like_command_arguments
-    def doc(self, params, features, target=None, android=False,
-            media_stack=None, **kwargs):
+    def doc(self, params, **kwargs):
         self.ensure_bootstrapped(rustup_components=["rust-docs"])
         rustc_path = check_output(
             ["rustup" + BIN_SUFFIX, "which", "--toolchain", self.rust_toolchain(), "rustc"]
@@ -271,15 +270,8 @@ class PostBuildCommands(CommandBase):
                     else:
                         copy2(full_name, destination)
 
-        features = features or []
-
-        target, android = self.pick_target_triple(target, android)
-
-        features += self.pick_media_stack(media_stack, target)
-
-        env = self.build_env(target=target, is_build=True, features=features)
-
-        returncode = self.run_cargo_build_like_command("doc", params, features=features, env=env, **kwargs)
+        env = self.build_env(is_build=True)
+        returncode = self.run_cargo_build_like_command("doc", params, env=env, **kwargs)
         if returncode:
             return returncode
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -470,10 +470,11 @@ class MachCommands(CommandBase):
         avd = "servo-x86"
         target = "i686-linux-android"
         print("Assuming --target " + target)
+        self.cross_compile_target = target
 
-        env = self.build_env(target=target)
+        env = self.build_env()
         os.environ["PATH"] = env["PATH"]
-        assert self.handle_android_target(target)
+        assert self.setup_configuration_for_android_target(target)
         apk = self.get_apk_path(release)
 
         py = path.join(self.context.topdir, "etc", "run_in_headless_android_emulator.py")


### PR DESCRIPTION
Integrate cross-compilation and media-stack handling into the
`build_like_command_arguments` decorator. This removes a lot of
repetition in the code and standardizes how targets are selected for all
similar commands.

Now cross compilation targets, feature flags, and helper variables are
stored in the CommandBase instance. This also avoids having to
continuously pass these arguments down to functions called by the
commands.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
