### PR TITLE
Only check the GStreamer installation when building

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -113,7 +113,7 @@ class MachCommands(CommandBase):
         if very_verbose:
             opts += ["-vv"]
 
-        env = self.build_env(is_build=True, features=self.features)
+        env = self.build_env(is_build=True)
         self.ensure_bootstrapped()
         self.ensure_clobbered()
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -522,13 +522,14 @@ class CommandBase(object):
             'vcdir': vcinstalldir,
         }
 
-    def build_env(self, hosts_file_path=None, is_build=False, test_unit=False, features=None):
+    def build_env(self, hosts_file_path=None, is_build=False, test_unit=False):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
 
-        if not features or "media-dummy" not in features:
+        if "media-dummy" not in self.features:
             servo.platform.get().set_gstreamer_environment_variables_if_necessary(
-                env, cross_compilation_target=self.cross_compile_target)
+                env, cross_compilation_target=self.cross_compile_target,
+                check_installation=is_build)
 
         if sys.platform == "win32" and type(env['PATH']) == six.text_type:
             # On win32, the virtualenv's activate_this.py script sometimes ends up


### PR DESCRIPTION
Instead of always checking whether GStreamer is installed in mach's `build_env`, only do this when actually building. Also, use the instance variable to find features and look for the "media-gstreamer" feature instead of looking for !"media-dummy."

Fixes #29797.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29797
- [x] These changes do not require tests because they are changes to the build scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
