### PR TITLE
layout_2020: Only count for content size for height of non-replaced inline elements

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -461,7 +461,7 @@ impl InlineBox {
             margin.inline_start = Length::zero();
         }
         let mut start_corner = Vec2 {
-            block: padding.block_start + border.block_start + margin.block_start,
+            block: Length::zero(),
             inline: ifc.inline_position - ifc.current_nesting_level.inline_start,
         };
         if style.clone_position().is_relative() {
@@ -533,12 +533,7 @@ impl<'box_tree> PartialInlineBoxFragment<'box_tree> {
         }
         self.parent_nesting_level
             .max_block_size_of_fragments_so_far
-            .max_assign(
-                fragment.content_rect.size.block +
-                    fragment.padding.block_sum() +
-                    fragment.border.block_sum() +
-                    fragment.margin.block_sum(),
-            );
+            .max_assign(fragment.content_rect.size.block);
 
         if let Some(context) = nesting_level.positioning_context.as_mut() {
             context.layout_collected_children(layout_context, &mut fragment);

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-017.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-017.xht.ini
@@ -1,2 +1,0 @@
-[background-root-017.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-width-applies-to-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-width-applies-to-008.xht.ini
@@ -1,2 +1,0 @@
-[border-width-applies-to-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/css1/c5506-ipadn-t-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/css1/c5506-ipadn-t-002.xht.ini
@@ -1,2 +1,0 @@
-[c5506-ipadn-t-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/linebox/vertical-align-top-bottom-padding.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/linebox/vertical-align-top-bottom-padding.html.ini
@@ -1,2 +1,0 @@
-[vertical-align-top-bottom-padding.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-bottom-applies-to-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-bottom-applies-to-008.xht.ini
@@ -1,2 +1,0 @@
-[margin-bottom-applies-to-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-001.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-inline-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-inline-001.xht.ini
@@ -1,2 +1,0 @@
-[margin-inline-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-inline-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-inline-002.xht.ini
@@ -1,2 +1,0 @@
-[margin-inline-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-top-applies-to-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-top-applies-to-008.xht.ini
@@ -1,2 +1,0 @@
-[margin-top-applies-to-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-empty-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-empty-001.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-empty-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inlines-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inlines-002.xht.ini
@@ -1,2 +1,0 @@
-[inlines-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/table-visual-layout-018.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/table-visual-layout-018.xht.ini
@@ -1,2 +1,0 @@
-[table-visual-layout-018.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visuren/emptyspan-1.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visuren/emptyspan-1.html.ini
@@ -1,2 +1,0 @@
-[emptyspan-1.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/item-with-table-with-infinite-max-intrinsic-width.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/item-with-table-with-infinite-max-intrinsic-width.html.ini
@@ -1,0 +1,2 @@
+[item-with-table-with-infinite-max-intrinsic-width.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/table-with-infinite-max-intrinsic-width.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/table-with-infinite-max-intrinsic-width.html.ini
@@ -1,0 +1,2 @@
+[table-with-infinite-max-intrinsic-width.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-ui/outline-020.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-ui/outline-020.html.ini
@@ -1,2 +1,0 @@
-[outline-020.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_border_baseline_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_border_baseline_a.html.ini
@@ -1,2 +1,0 @@
-[inline_border_baseline_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_element_padding_margin.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_element_padding_margin.html.ini
@@ -1,2 +1,0 @@
-[inline_element_padding_margin.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Accorinding to https://drafts.csswg.org/css2/#inline-non-replaced, The vertical padding, border and margin of an inline, non-replaced box start at the top and bottom of the content area, and has nothing to do with the line-height. But only the line-height is used when calculating the height of the line box.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
