### PR TITLE
Propagate status on `build_like_command_arguments`

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -789,7 +789,7 @@ class CommandBase(object):
 
             self.features = kwargs.get("features", None) or []
             self.configure_media_stack(kwargs['media_stack'])
-            original_function(self, *args, **kwargs)
+            return original_function(self, *args, **kwargs)
 
         decorators.reverse()
         decorated_function = configuration_decorator


### PR DESCRIPTION
As observed in #29805 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29806 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
