### PR TITLE
Remove more Python 2 compatibility code

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -131,31 +131,11 @@ def archive_deterministically(dir_to_archive, dest_archive, prepend_path=None):
         os.rename(temp_file, dest_archive)
 
 
-def normalize_env(env):
-    # There is a bug in Py2 subprocess where it doesn't like unicode types in
-    # environment variables. Here, ensure all unicode are converted to
-    # native string type. utf-8 is our globally assumed default. If the caller
-    # doesn't want UTF-8, they shouldn't pass in a unicode instance.
-    normalized_env = {}
-    for k, v in env.items():
-        if isinstance(k, six.text_type):
-            k = six.ensure_str(k, 'utf-8', 'strict')
-
-        if isinstance(v, six.text_type):
-            v = six.ensure_str(v, 'utf-8', 'strict')
-
-        normalized_env[k] = v
-
-    return normalized_env
-
-
 def call(*args, **kwargs):
     """Wrap `subprocess.call`, printing the command if verbose=True."""
     verbose = kwargs.pop('verbose', False)
     if verbose:
         print(' '.join(args[0]))
-    if 'env' in kwargs:
-        kwargs['env'] = normalize_env(kwargs['env'])
     # we have to use shell=True in order to get PATH handling
     # when looking for the binary on Windows
     return subprocess.call(*args, shell=sys.platform == 'win32', **kwargs)
@@ -166,8 +146,6 @@ def check_output(*args, **kwargs):
     verbose = kwargs.pop('verbose', False)
     if verbose:
         print(' '.join(args[0]))
-    if 'env' in kwargs:
-        kwargs['env'] = normalize_env(kwargs['env'])
     # we have to use shell=True in order to get PATH handling
     # when looking for the binary on Windows
     return subprocess.check_output(*args, shell=sys.platform == 'win32', **kwargs)
@@ -178,9 +156,6 @@ def check_call(*args, **kwargs):
 
     Also fix any unicode-containing `env`, for subprocess """
     verbose = kwargs.pop('verbose', False)
-
-    if 'env' in kwargs:
-        kwargs['env'] = normalize_env(kwargs['env'])
 
     if verbose:
         print(' '.join(args[0]))

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -13,7 +13,6 @@ import tempfile
 from typing import Optional, Tuple
 
 import distro
-import six
 from .. import util
 from .base import Base
 
@@ -65,8 +64,8 @@ class Linux(Base):
 
     @staticmethod
     def get_distro_and_version() -> Tuple[str, str]:
-        distrib = six.ensure_str(distro.name())
-        version = six.ensure_str(distro.version())
+        distrib = distro.name()
+        version = distro.version()
 
         if distrib in ['LinuxMint', 'Linux Mint', 'KDE neon', 'Pop!_OS']:
             if '.' in version:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -20,7 +20,6 @@ import time
 import shutil
 import subprocess
 from xml.etree.ElementTree import XML
-from six import iteritems
 
 import wpt
 import wpt.manifestupdate
@@ -62,7 +61,7 @@ TEST_SUITES = OrderedDict([
               "include_arg": "test_name"}),
 ])
 
-TEST_SUITES_BY_PREFIX = {path: k for k, v in iteritems(TEST_SUITES) if "paths" in v for path in v["paths"]}
+TEST_SUITES_BY_PREFIX = {path: k for k, v in TEST_SUITES.items() if "paths" in v for path in v["paths"]}
 
 
 @CommandProvider
@@ -133,7 +132,7 @@ class MachCommands(CommandBase):
                 return 1
 
         test_start = time.time()
-        for suite, tests in iteritems(selected_suites):
+        for suite, tests in selected_suites.items():
             props = suites[suite]
             kwargs = props.get("kwargs", {})
             if tests:
@@ -149,7 +148,7 @@ class MachCommands(CommandBase):
     def suite_for_path(self, path_arg):
         if os.path.exists(path.abspath(path_arg)):
             abs_path = path.abspath(path_arg)
-            for prefix, suite in iteritems(TEST_SUITES_BY_PREFIX):
+            for prefix, suite in TEST_SUITES_BY_PREFIX.items():
                 if abs_path.startswith(prefix):
                     return suite
         return None

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -20,12 +20,10 @@ import subprocess
 import sys
 
 import colorama
-import six
 import toml
 import voluptuous
 import yaml
 from .licenseck import OLD_MPL, MPL, APACHE, COPYRIGHT, licenses_toml, licenses_dep_toml
-from six import iteritems
 topdir = os.path.abspath(os.path.dirname(sys.argv[0]))
 wpt = os.path.join(topdir, "tests", "wpt")
 
@@ -121,7 +119,7 @@ def is_iter_empty(iterator):
 
 
 def normilize_paths(paths):
-    if isinstance(paths, six.string_types):
+    if isinstance(paths, str):
         return os.path.join(*paths.split('/'))
     else:
         return [os.path.join(*path.split('/')) for path in paths]
@@ -374,7 +372,7 @@ def check_lock(file_name, contents):
         if name not in packages_by_name:
             yield (1, "duplicates are allowed for `{}` but it is not a dependency".format(name))
 
-    for (name, packages) in iteritems(packages_by_name):
+    for (name, packages) in packages_by_name.items():
         has_duplicates = len(packages) > 1
         duplicates_allowed = name in exceptions
 
@@ -419,7 +417,7 @@ def check_lock(file_name, contents):
                     visited_whitelisted_packages[dependency_name][package_name] = True
 
     # Check if all the exceptions to blocked packages actually depend on the blocked package
-    for dependency_name, package_names in iteritems(blocked_packages):
+    for dependency_name, package_names in blocked_packages.items():
         for package_name in package_names:
             if not visited_whitelisted_packages[dependency_name].get(package_name):
                 fmt = "Package {} is not required to be an exception of blocked package {}."


### PR DESCRIPTION
- os.environ is always `str` in Python 3.
- The only string type is `str` so we can stop using `six.str_types`.
- `iteritems()` isn't necessary because dicts have the `items()` method.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
