### PR TITLE
layout_2020: Check blocks for whether they will establish a formatting context

### DIFF
--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -11,7 +11,7 @@ use crate::flow::inline::{InlineBox, InlineFormattingContext, InlineLevelBox, Te
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::positioned::AbsolutelyPositionedBox;
-use crate::style_ext::{DisplayGeneratingBox, DisplayInside, DisplayOutside};
+use crate::style_ext::{ComputedValuesExt, DisplayGeneratingBox, DisplayInside, DisplayOutside};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_croissant::ParallelIteratorExt;
 use servo_arc::Arc;
@@ -591,7 +591,9 @@ where
 
         let kind = match contents.try_into() {
             Ok(contents) => match display_inside {
-                DisplayInside::Flow { is_list_item } => {
+                DisplayInside::Flow { is_list_item }
+                    if !info.style.establishes_block_formatting_context() =>
+                {
                     BlockLevelCreator::SameFormattingContextBlock(
                         IntermediateBlockContainer::Deferred {
                             contents,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -11,6 +11,7 @@ use style::computed_values::transform_style::T as ComputedTransformStyle;
 use style::logical_geometry::WritingMode;
 use style::properties::longhands::backface_visibility::computed_value::T as BackfaceVisiblity;
 use style::properties::longhands::box_sizing::computed_value::T as BoxSizing;
+use style::properties::longhands::column_span::computed_value::T as ColumnSpan;
 use style::properties::ComputedValues;
 use style::values::computed::image::Image as ComputedImageLayer;
 use style::values::computed::{Length, LengthPercentage};
@@ -112,6 +113,7 @@ pub(crate) trait ComputedValuesExt {
     ) -> flow_relative::Sides<LengthPercentageOrAuto<'_>>;
     fn has_transform_or_perspective(&self) -> bool;
     fn effective_z_index(&self) -> i32;
+    fn establishes_block_formatting_context(&self) -> bool;
     fn establishes_stacking_context(&self) -> bool;
     fn establishes_containing_block_for_absolute_descendants(&self) -> bool;
     fn establishes_containing_block_for_all_descendants(&self) -> bool;
@@ -363,6 +365,25 @@ impl ComputedValuesExt for ComputedValues {
             ComputedPosition::Static => 0,
             _ => self.get_position().z_index.integer_or(0),
         }
+    }
+
+    /// Return true if this style is a normal block and establishes
+    /// a new block formatting context.
+    fn establishes_block_formatting_context(&self) -> bool {
+        if self.get_box().overflow_x.is_scrollable() {
+            return true;
+        }
+
+        if self.get_column().is_multicol() {
+            return true;
+        }
+
+        if self.get_column().column_span == ColumnSpan::All {
+            return true;
+        }
+
+        // TODO: We need to handle CSS Contain here.
+        false
     }
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.

--- a/components/style/properties/longhands/column.mako.rs
+++ b/components/style/properties/longhands/column.mako.rs
@@ -67,7 +67,8 @@ ${helpers.predefined_type(
 ${helpers.single_keyword(
     "column-span",
     "none all",
-    engines="gecko",
+    engines="gecko servo-2020",
+    servo_2020_pref="layout.2020.unimplemented",
     animation_value_type="discrete",
     gecko_enum_prefix="StyleColumnSpan",
     spec="https://drafts.csswg.org/css-multicol/#propdef-column-span",

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-009.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-009.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-009.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/containing-block-percent-margin-bottom.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/containing-block-percent-margin-bottom.html.ini
@@ -1,3 +1,0 @@
-[containing-block-percent-margin-bottom.html]
-  [#container 1]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/containing-block-percent-margin-top.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/containing-block-percent-margin-top.html.ini
@@ -1,3 +1,0 @@
-[containing-block-percent-margin-top.html]
-  [#container 1]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html.ini
@@ -1,2 +1,0 @@
-[margin-collapse-through-percentage-height-block.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/negative-margin-shrinking-container-size-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/negative-margin-shrinking-container-size-002.html.ini
@@ -1,2 +1,0 @@
-[negative-margin-shrinking-container-size-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-definite-sizes-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-definite-sizes-003.html.ini
@@ -1,0 +1,2 @@
+[flexbox-definite-sizes-003.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-definite-sizes-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-definite-sizes-004.html.ini
@@ -1,0 +1,2 @@
+[flexbox-definite-sizes-004.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_fbfc2.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_fbfc2.html.ini
@@ -1,2 +1,0 @@
-[flexbox_fbfc2.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_item-clear.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_item-clear.html.ini
@@ -1,2 +1,0 @@
-[flexbox_item-clear.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-ui/outline-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-ui/outline-005.html.ini
@@ -1,2 +1,0 @@
-[outline-005.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-ui/outline-023.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-ui/outline-023.html.ini
@@ -1,2 +1,0 @@
-[outline-023.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_margin_collapse_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_margin_collapse_a.html.ini
@@ -1,2 +1,0 @@
-[block_formatting_context_margin_collapse_a.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
According to spec
https://drafts.csswg.org/css-overflow-3/#overflow-control, If the computed value of overflow on a block box is neither visible nor clip nor a combination thereof, it establishes an independent formatting context for its contents.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
