### PR TITLE
Convert some comments into rustdoc

### DIFF
--- a/components/layout_2020/fragment_tree/containing_block.rs
+++ b/components/layout_2020/fragment_tree/containing_block.rs
@@ -10,40 +10,40 @@ use style::computed_values::position::T as ComputedPosition;
 /// blocks (for all descendants, for absolute and fixed position
 /// descendants, and for fixed position descendants).
 pub(crate) struct ContainingBlockManager<'a, T> {
-    // The containing block for all non-absolute descendants. "...if the element's
-    // position is 'relative' or 'static', the containing block is formed by the
-    // content edge of the nearest block container ancestor box." This is also
-    // the case for 'position: sticky' elements.
-    // https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
+    /// The containing block for all non-absolute descendants. "...if the element's
+    /// position is 'relative' or 'static', the containing block is formed by the
+    /// content edge of the nearest block container ancestor box." This is also
+    /// the case for 'position: sticky' elements.
+    /// https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
     pub for_non_absolute_descendants: &'a T,
 
-    // The containing block for absolute descendants. "If the element has
-    // 'position: absolute', the containing block is
-    // established by the nearest ancestor with a 'position' of 'absolute',
-    // 'relative' or 'fixed', in the following way:
-    //   1. In the case that the ancestor is an inline element, the containing
-    //      block is the bounding box around the padding boxes of the first and the
-    //      last inline boxes generated for that element. In CSS 2.1, if the inline
-    //      element is split across multiple lines, the containing block is
-    //      undefined.
-    //   2. Otherwise, the containing block is formed by the padding edge of the
-    //      ancestor."
-    // https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
-    // If the ancestor forms a containing block for all descendants (see below),
-    // this value will be None and absolute descendants will use the containing
-    // block for fixed descendants.
+    /// The containing block for absolute descendants. "If the element has
+    /// 'position: absolute', the containing block is
+    /// established by the nearest ancestor with a 'position' of 'absolute',
+    /// 'relative' or 'fixed', in the following way:
+    ///   1. In the case that the ancestor is an inline element, the containing
+    ///      block is the bounding box around the padding boxes of the first and the
+    ///      last inline boxes generated for that element. In CSS 2.1, if the inline
+    ///      element is split across multiple lines, the containing block is
+    ///      undefined.
+    ///   2. Otherwise, the containing block is formed by the padding edge of the
+    ///      ancestor."
+    /// https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
+    /// If the ancestor forms a containing block for all descendants (see below),
+    /// this value will be None and absolute descendants will use the containing
+    /// block for fixed descendants.
     pub for_absolute_descendants: Option<&'a T>,
 
-    // The containing block for fixed and absolute descendants.
-    // "For elements whose layout is governed by the CSS box model, any value
-    // other than none for the transform property also causes the element to
-    // establish a containing block for all descendants. Its padding box will be
-    // used to layout for all of its absolute-position descendants,
-    // fixed-position descendants, and descendant fixed background attachments."
-    // https://w3c.github.io/csswg-drafts/css-transforms-1/#containing-block-for-all-descendants
-    // See `ComputedValues::establishes_containing_block_for_all_descendants`
-    // for a list of conditions where an element forms a containing block for
-    // all descendants.
+    /// The containing block for fixed and absolute descendants.
+    /// "For elements whose layout is governed by the CSS box model, any value
+    /// other than none for the transform property also causes the element to
+    /// establish a containing block for all descendants. Its padding box will be
+    /// used to layout for all of its absolute-position descendants,
+    /// fixed-position descendants, and descendant fixed background attachments."
+    /// https://w3c.github.io/csswg-drafts/css-transforms-1/#containing-block-for-all-descendants
+    /// See `ComputedValues::establishes_containing_block_for_all_descendants`
+    /// for a list of conditions where an element forms a containing block for
+    /// all descendants.
     pub for_absolute_and_fixed_descendants: &'a T,
 }
 


### PR DESCRIPTION
These were always meant to be rustdoc and converting them makes them show up in the IDE in a more helpful way.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
