### PR TITLE
Add initial support for css-text-3 whitespace handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ dependencies = [
  "style_traits",
  "unicode-script",
  "webrender_api",
+ "xi-unicode",
 ]
 
 [[package]]

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -44,6 +44,7 @@ style = { path = "../style", features = ["servo"] }
 style_traits = { path = "../style_traits" }
 unicode-script = { workspace = true }
 webrender_api = { workspace = true }
+xi-unicode = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -150,6 +150,7 @@ where
                             base_fragment_info: (&run.info).into(),
                             text: run.text.into(),
                             parent_style: run.info.style,
+                            has_uncollapsible_content: false,
                         }),
                         self.text_decoration_line,
                     ),

--- a/tests/wpt/meta/css/CSS2/abspos/remove-block-between-inline-and-abspos.html.ini
+++ b/tests/wpt/meta/css/CSS2/abspos/remove-block-between-inline-and-abspos.html.ini
@@ -1,0 +1,2 @@
+[remove-block-between-inline-and-abspos.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-019.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-019.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-019.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-020.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-020.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-020.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-021.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-021.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-021.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-023.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-023.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-023.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-024.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-024.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-024.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-025.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-025.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-025.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-026.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-026.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-026.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-027.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-027.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-027.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-037.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-037.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-037.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-038.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-038.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-038.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-039.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-039.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-039.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-041.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-041.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-041.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-042.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-042.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-042.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-043.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-043.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-043.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-044.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-044.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-044.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-045.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-box-model-045.xht.ini
@@ -1,2 +1,0 @@
-[bidi-box-model-045.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-012.xht.ini
@@ -1,2 +1,0 @@
-[border-color-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/anonymous-box-generation-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/anonymous-box-generation-001.xht.ini
@@ -1,2 +1,0 @@
-[anonymous-box-generation-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/insert-inline-in-blocks-n-inlines-begin-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/insert-inline-in-blocks-n-inlines-begin-001.xht.ini
@@ -1,2 +1,0 @@
-[insert-inline-in-blocks-n-inlines-begin-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/insert-inline-in-blocks-n-inlines-end-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/insert-inline-in-blocks-n-inlines-end-001.xht.ini
@@ -1,2 +1,0 @@
-[insert-inline-in-blocks-n-inlines-end-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/insert-inline-in-blocks-n-inlines-middle-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/insert-inline-in-blocks-n-inlines-middle-001.xht.ini
@@ -1,2 +1,0 @@
-[insert-inline-in-blocks-n-inlines-middle-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-002.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-fit-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-003.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-fit-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-004.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-fit-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-005.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-fit-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c542-letter-sp-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c542-letter-sp-001.xht.ini
@@ -1,0 +1,2 @@
+[c542-letter-sp-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c547-indent-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c547-indent-001.xht.ini
@@ -1,2 +1,0 @@
-[c547-indent-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5501-imrgn-t-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5501-imrgn-t-000.xht.ini
@@ -1,2 +1,0 @@
-[c5501-imrgn-t-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5502-mrgn-r-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5502-mrgn-r-000.xht.ini
@@ -1,2 +1,0 @@
-[c5502-mrgn-r-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5503-imrgn-b-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5503-imrgn-b-000.xht.ini
@@ -1,2 +1,0 @@
-[c5503-imrgn-b-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5506-ipadn-t-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5506-ipadn-t-000.xht.ini
@@ -1,2 +1,0 @@
-[c5506-ipadn-t-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5506-ipadn-t-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5506-ipadn-t-001.xht.ini
@@ -1,2 +1,0 @@
-[c5506-ipadn-t-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5507-padn-r-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5507-padn-r-000.xht.ini
@@ -1,2 +1,0 @@
-[c5507-padn-r-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5508-ipadn-b-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5508-ipadn-b-000.xht.ini
@@ -1,2 +1,0 @@
-[c5508-ipadn-b-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5508-ipadn-b-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5508-ipadn-b-001.xht.ini
@@ -1,2 +1,0 @@
-[c5508-ipadn-b-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5509-padn-l-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5509-padn-l-000.xht.ini
@@ -1,2 +1,0 @@
-[c5509-padn-l-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5525-fltwidth-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5525-fltwidth-003.xht.ini
@@ -1,2 +1,0 @@
-[c5525-fltwidth-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-124.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-124.xht.ini
@@ -1,2 +1,0 @@
-[floats-124.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-125.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-125.xht.ini
@@ -1,2 +1,0 @@
-[floats-125.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-143.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-143.xht.ini
@@ -1,2 +1,0 @@
-[floats-143.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/float-no-content-beside-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/float-no-content-beside-001.html.ini
@@ -1,2 +1,0 @@
-[float-no-content-beside-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-right-overflow.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-right-overflow.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-002-right-overflow.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-right-table.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-right-table.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-002-right-table.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-applies-to-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-applies-to-017.xht.ini
@@ -1,2 +1,0 @@
-[font-applies-to-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-variant-applies-to-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-variant-applies-to-017.xht.ini
@@ -1,2 +1,0 @@
-[font-variant-applies-to-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-017.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/after-content-display-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/after-content-display-001.xht.ini
@@ -1,2 +1,0 @@
-[after-content-display-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/after-content-display-018.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/after-content-display-018.xht.ini
@@ -1,2 +1,0 @@
-[after-content-display-018.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/content-173.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/content-173.xht.ini
@@ -1,2 +1,0 @@
-[content-173.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/content-white-space-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/content-white-space-001.xht.ini
@@ -1,2 +1,0 @@
-[content-white-space-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/border-padding-bleed-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/border-padding-bleed-001.xht.ini
@@ -1,2 +1,0 @@
-[border-padding-bleed-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/border-padding-bleed-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/border-padding-bleed-002.xht.ini
@@ -1,2 +1,0 @@
-[border-padding-bleed-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/border-padding-bleed-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/border-padding-bleed-003.xht.ini
@@ -1,2 +1,0 @@
-[border-padding-bleed-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/inline-formatting-context-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/inline-formatting-context-007.xht.ini
@@ -1,2 +1,0 @@
-[inline-formatting-context-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/inline-formatting-context-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/inline-formatting-context-013.xht.ini
@@ -1,2 +1,0 @@
-[inline-formatting-context-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/inline-negative-margin-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/inline-negative-margin-001.html.ini
@@ -34,3 +34,9 @@
 
   [[data-expected-height\] 13]
     expected: FAIL
+
+  [[data-expected-height\] 3]
+    expected: FAIL
+
+  [[data-expected-height\] 4]
+    expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-align-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-align-001.html.ini
@@ -1,2 +1,0 @@
-[block-in-inline-align-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-001.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-empty-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-first-line-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-first-line-001.html.ini
@@ -1,2 +1,0 @@
-[block-in-inline-first-line-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-nosplit-ref.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-insert-006-nosplit-ref.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-ref.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-insert-006-ref.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-insert-006.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-margins-003.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-margins-003.html.ini
@@ -1,2 +1,0 @@
-[block-in-inline-margins-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-nested-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-nested-002.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-nested-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001a.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-whitespace-001a.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001b.xht.ini
@@ -1,0 +1,2 @@
+[block-in-inline-whitespace-001b.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-001.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-replaced-width-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-006.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-replaced-width-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-001a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-001a.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-width-001a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-001b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-001b.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-width-001b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-002a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-002a.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-width-002a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-002b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-width-002b.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-width-002b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-width-percentage-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-width-percentage-001.xht.ini
@@ -1,2 +1,0 @@
-[max-width-percentage-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-width-percentage-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-width-percentage-001.xht.ini
@@ -1,2 +1,0 @@
-[min-width-percentage-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/replaced-intrinsic-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/replaced-intrinsic-002.xht.ini
@@ -1,2 +1,0 @@
-[replaced-intrinsic-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-percentage-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-percentage-001.xht.ini
@@ -1,2 +1,0 @@
-[width-percentage-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-percentage-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-percentage-002.xht.ini
@@ -1,2 +1,0 @@
-[width-percentage-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/abspos-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/abspos-008.xht.ini
@@ -1,2 +1,0 @@
-[abspos-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/position-relative-029.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/position-relative-029.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-029.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/position-relative-030.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/position-relative-030.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-030.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/position-relative-031.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/position-relative-031.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-031.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-014.xht.ini
@@ -1,2 +1,0 @@
-[text-indent-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-on-blank-line-rtl-left-align.html.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-on-blank-line-rtl-left-align.html.ini
@@ -1,0 +1,2 @@
+[text-indent-on-blank-line-rtl-left-align.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-007.xht.ini
@@ -1,2 +1,0 @@
-[white-space-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-008.xht.ini
@@ -1,0 +1,2 @@
+[white-space-008.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-collapsing-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-collapsing-003.xht.ini
@@ -1,2 +1,0 @@
-[white-space-collapsing-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-collapsing-breaks-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-collapsing-breaks-001.xht.ini
@@ -1,2 +1,0 @@
-[white-space-collapsing-breaks-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-normal-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-normal-008.xht.ini
@@ -1,2 +1,0 @@
-[white-space-normal-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-processing-043.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-processing-043.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-043.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-processing-044.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-processing-044.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-044.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-processing-045.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-processing-045.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-045.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-processing-053.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-processing-053.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-053.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visudet/inline-block-baseline-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/visudet/inline-block-baseline-001.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-baseline-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visudet/inline-block-baseline-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/visudet/inline-block-baseline-003.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-baseline-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visudet/inline-block-baseline-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/visudet/inline-block-baseline-004.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-baseline-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/emptyspan-1.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/emptyspan-1.html.ini
@@ -1,0 +1,2 @@
+[emptyspan-1.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/split-inner-inline-2.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/split-inner-inline-2.html.ini
@@ -1,0 +1,2 @@
+[split-inner-inline-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1a.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1a.html.ini
@@ -1,0 +1,2 @@
+[whitespace-present-1a.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1b.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1b.html.ini
@@ -1,0 +1,2 @@
+[whitespace-present-1b.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/css-box-justify-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/css-box-justify-content.html.ini
@@ -1,2 +1,0 @@
-[css-box-justify-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/fieldset-baseline-alignment.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/fieldset-baseline-alignment.html.ini
@@ -1,2 +1,0 @@
-[fieldset-baseline-alignment.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-wrap-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-wrap-003.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-wrap-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-wrap-004.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-anonymous-items-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-anonymous-items-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-anonymous-items-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-min-width-auto-005.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-min-width-auto-005.html.ini
@@ -1,2 +1,0 @@
-[flexbox-min-width-auto-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-with-multi-column-property.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-with-multi-column-property.html.ini
@@ -1,2 +1,0 @@
-[flexbox-with-multi-column-property.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_fbfc.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_fbfc.html.ini
@@ -1,2 +1,0 @@
-[flexbox_fbfc.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_flex-none-wrappable-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_flex-none-wrappable-content.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-none-wrappable-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-size-quirks-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-size-quirks-002.html.ini
@@ -1,3 +1,6 @@
 [percentage-size-quirks-002.html]
   [.pct 2]
     expected: FAIL
+
+  [.pct 1]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-subelements-001.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-subelements-001.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-subelements-001.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/inline_absolute_hypothetical_baseline_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/inline_absolute_hypothetical_baseline_a.html.ini
@@ -1,2 +1,0 @@
-[inline_absolute_hypothetical_baseline_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/inline_absolute_hypothetical_metrics_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/inline_absolute_hypothetical_metrics_a.html.ini
@@ -1,2 +1,0 @@
-[inline_absolute_hypothetical_metrics_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/input_whitespace.html.ini
+++ b/tests/wpt/mozilla/meta/css/input_whitespace.html.ini
@@ -1,0 +1,2 @@
+[input_whitespace.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/line_break_nowrap.html.ini
+++ b/tests/wpt/mozilla/meta/css/line_break_nowrap.html.ini
@@ -1,2 +1,0 @@
-[line_break_nowrap.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/linebreak_inline_span_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/linebreak_inline_span_a.html.ini
@@ -1,2 +1,0 @@
-[linebreak_inline_span_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/linebreak_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/linebreak_simple_a.html.ini
@@ -1,2 +1,0 @@
-[linebreak_simple_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/position_fixed_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/position_fixed_a.html.ini
@@ -1,2 +1,0 @@
-[position_fixed_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/pseudo_element_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/pseudo_element_a.html.ini
@@ -1,2 +1,0 @@
-[pseudo_element_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/text_overflow_basic_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/text_overflow_basic_a.html.ini
@@ -1,2 +1,0 @@
-[text_overflow_basic_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/white-space-pre-line.htm.ini
+++ b/tests/wpt/mozilla/meta/css/white-space-pre-line.htm.ini
@@ -1,2 +1,0 @@
-[white-space-pre-line.htm]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/white-space-pre-wrap.htm.ini
+++ b/tests/wpt/mozilla/meta/css/white-space-pre-wrap.htm.ini
@@ -1,2 +1,0 @@
-[white-space-pre-wrap.htm]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/word-break-keep-all-006.htm.ini
+++ b/tests/wpt/mozilla/meta/css/word-break-keep-all-006.htm.ini
@@ -1,0 +1,2 @@
+[word-break-keep-all-006.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/word-break-keep-all-007.htm.ini
+++ b/tests/wpt/mozilla/meta/css/word-break-keep-all-007.htm.ini
@@ -1,0 +1,2 @@
+[word-break-keep-all-007.htm]
+  expected: FAIL


### PR DESCRIPTION
This adds initial support for whitespace handling from the CSS
specification for Layout 2020. In general, the basics are covered. Since
test output is very sensitive to whitespace handling, this change
incorporates several fixes:

1. Whitespace is collapsed according to the Phase 1 rules of the
   specification, though language-specific unbreaking rules are not
   handled properly yet.
2. Whitespace is mostly trimmed and positioned according to the Phase 2
   rules, but full support for removing whitespace at the end of lines
   is pending on a temporary data structure to hold lines under
   construction.
3. Completely empty box fragments left over immediately after line
   breaks are now trimmed from the fragment tree.
4. This change tries to detect when an inline formatting context
   collapses through.

Fixes #29994.
Fixes #29590.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29590, #29994.
- [x] There are tests for these changes
