### PR TITLE
Fix `mach test-wpt` to make crash tests work

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1484,11 +1484,10 @@ where
             // Panic a top level browsing context.
             FromCompositorMsg::SendError(top_level_browsing_context_id, error) => {
                 debug!("constellation got SendError message");
-                if let Some(id) = top_level_browsing_context_id {
-                    self.handle_panic(id, error, None);
-                } else {
+                if top_level_browsing_context_id.is_none() {
                     warn!("constellation got a SendError message without top level id");
                 }
+                self.handle_panic(top_level_browsing_context_id, error, None);
             },
             // Send frame tree to WebRender. Make it visible.
             FromCompositorMsg::SelectBrowser(top_level_browsing_context_id) => {
@@ -2753,15 +2752,13 @@ where
             .pipelines
             .get(&pipeline_id)
             .map(|pipeline| pipeline.top_level_browsing_context_id);
-        if let Some(top_level_browsing_context_id) = top_level_browsing_context_id {
-            let reason = format!("Send failed ({})", err);
-            self.handle_panic(top_level_browsing_context_id, reason, None);
-        }
+        let reason = format!("Send failed ({})", err);
+        self.handle_panic(top_level_browsing_context_id, reason, None);
     }
 
     fn handle_panic(
         &mut self,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
+        top_level_browsing_context_id: Option<TopLevelBrowsingContextId>,
         reason: String,
         backtrace: Option<String>,
     ) {
@@ -2771,6 +2768,11 @@ where
             println!("Pipeline failed in hard-fail mode.  Crashing!");
             process::exit(1);
         }
+
+        let top_level_browsing_context_id = match top_level_browsing_context_id {
+            Some(id) => id,
+            None => return,
+        };
 
         debug!(
             "Panic handler for top-level browsing context {}: {}.",
@@ -2853,13 +2855,16 @@ where
         entry: LogEntry,
     ) {
         debug!("Received log entry {:?}.", entry);
-        match (entry, top_level_browsing_context_id) {
-            (LogEntry::Panic(reason, backtrace), Some(top_level_browsing_context_id)) => {
-                self.handle_panic(top_level_browsing_context_id, reason, Some(backtrace));
-            },
-            (LogEntry::Panic(reason, _), _) |
-            (LogEntry::Error(reason), _) |
-            (LogEntry::Warn(reason), _) => {
+        if let LogEntry::Panic(ref reason, ref backtrace) = entry {
+            self.handle_panic(
+                top_level_browsing_context_id,
+                reason.clone(),
+                Some(backtrace.clone()),
+            );
+        }
+
+        match entry {
+            LogEntry::Panic(reason, _) | LogEntry::Error(reason) | LogEntry::Warn(reason) => {
                 // VecDeque::truncate is unstable
                 if WARNINGS_BUFFER_SIZE <= self.handled_warnings.len() {
                     self.handled_warnings.pop_front();

--- a/ports/winit/main2.rs
+++ b/ports/winit/main2.rs
@@ -117,11 +117,11 @@ pub fn main() {
         };
         let current_thread = thread::current();
         let name = current_thread.name().unwrap_or("<unnamed>");
-        let stdout = std::io::stdout();
-        let mut stdout = stdout.lock();
+        let stderr = std::io::stderr();
+        let mut stderr = stderr.lock();
         if let Some(location) = info.location() {
             let _ = writeln!(
-                &mut stdout,
+                &mut stderr,
                 "{} (thread {}, at {}:{})",
                 msg,
                 name,
@@ -129,12 +129,16 @@ pub fn main() {
                 location.line()
             );
         } else {
-            let _ = writeln!(&mut stdout, "{} (thread {})", msg, name);
+            let _ = writeln!(&mut stderr, "{} (thread {})", msg, name);
         }
         if env::var("RUST_BACKTRACE").is_ok() {
-            let _ = backtrace::print(&mut stdout);
+            let _ = backtrace::print(&mut stderr);
         }
-        drop(stdout);
+        drop(stderr);
+
+        if opts::get().hard_fail && !opts::get().multiprocess {
+            std::process::exit(1);
+        }
 
         error!("{}", msg);
     }));

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -216,10 +216,8 @@ class ServoHandler(mozlog.reader.LogHandler):
         ))
 
     def process_output(self, data):
-        if data['thread'] not in self.running_tests:
-            return
-        test_name = self.running_tests[data['thread']]
-        self.test_output[test_name] += data['data'] + "\n"
+        if 'test' in data:
+            self.test_output[data['test']] += data['data'] + "\n"
 
     def log(self, _):
         pass

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -86,7 +86,7 @@ def run_tests(default_binary_path: str, **kwargs):
 
     if not kwargs.get("no_default_test_types"):
         test_types = {
-            "servo": ["testharness", "reftest", "wdspec"],
+            "servo": ["testharness", "reftest", "wdspec", "crashtest"],
             "servodriver": ["testharness", "reftest"],
         }
         product = kwargs.get("product") or "servo"

--- a/tests/wpt/meta-legacy-layout/css/css-flexbox/contain-size-layout-abspos-flex-container-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-flexbox/contain-size-layout-abspos-flex-container-crash.html.ini
@@ -1,0 +1,2 @@
+[contain-size-layout-abspos-flex-container-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-alpha.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-alpha.https.html.ini
@@ -1,0 +1,2 @@
+[background-image-alpha.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-multiple.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-multiple.https.html.ini
@@ -1,0 +1,2 @@
+[background-image-multiple.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-repeat-x.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-repeat-x.https.html.ini
@@ -1,0 +1,2 @@
+[background-repeat-x.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/column-count-crash.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/column-count-crash.https.html.ini
@@ -1,0 +1,2 @@
+[column-count-crash.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/custom-property-animation-on-main-thread.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/custom-property-animation-on-main-thread.https.html.ini
@@ -1,2 +1,2 @@
 [custom-property-animation-on-main-thread.https.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-001.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-background-image-001.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-002.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-background-image-002.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-001.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-background-image-tiled-001.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-002.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-background-image-tiled-002.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-003.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-background-image-tiled-003.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-001.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-border-image-001.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-002.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-border-image-002.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-003.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-border-image-003.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-004.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-004.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-border-image-004.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-005.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-005.https.html.ini
@@ -1,0 +1,2 @@
+[geometry-border-image-005.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-with-float-size.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-with-float-size.https.html.ini
@@ -1,3 +1,3 @@
 [geometry-with-float-size.https.html]
   type: reftest
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/canvas-transform.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/canvas-transform.https.html.ini
@@ -1,2 +1,2 @@
 [canvas-transform.https.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/device-pixel-ratio.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/device-pixel-ratio.https.html.ini
@@ -1,3 +1,3 @@
 [device-pixel-ratio.https.html]
   type: reftest
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-constructor-error.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-constructor-error.https.html.ini
@@ -1,0 +1,2 @@
+[invalid-image-constructor-error.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-paint-error.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-paint-error.https.html.ini
@@ -1,0 +1,2 @@
+[invalid-image-paint-error.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-pending-script.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-pending-script.https.html.ini
@@ -1,0 +1,2 @@
+[invalid-image-pending-script.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/non-registered-property-value.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/non-registered-property-value.https.html.ini
@@ -1,0 +1,2 @@
+[non-registered-property-value.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/overdraw.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/overdraw.https.html.ini
@@ -1,0 +1,2 @@
+[overdraw.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-arguments.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-arguments.https.html.ini
@@ -1,0 +1,2 @@
+[paint-arguments.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments-var.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments-var.https.html.ini
@@ -1,2 +1,2 @@
 [paint-function-arguments-var.https.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments.https.html.ini
@@ -1,0 +1,2 @@
+[paint-function-arguments.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-this-value.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-this-value.https.html.ini
@@ -1,0 +1,2 @@
+[paint-function-this-value.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-canvasFilter.tentative.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-canvasFilter.tentative.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-canvasFilter.tentative.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-composite.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-composite.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-composite.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-conicGradient.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-conicGradient.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-conicGradient.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-filter.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-filter.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-filter.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-gradient.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-gradient.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-gradient.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-image.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-image.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-image.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-paths.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-paths.https.html.ini
@@ -1,4 +1,4 @@
 [paint2d-paths.https.html]
   type: reftest
-  expected: FAIL
   bug: https://github.com/servo/servo/issues/17597
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-rects.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-rects.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-rects.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-reset.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-reset.https.html.ini
@@ -1,2 +1,2 @@
 [paint2d-reset.https.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-roundRect.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-roundRect.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-roundRect.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-shadows.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-shadows.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-shadows.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-transform.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-transform.https.html.ini
@@ -1,0 +1,2 @@
+[paint2d-transform.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-001.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-001.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-002.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-002.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-003.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-003.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-004.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-004.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-004.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-005.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-005.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-005.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-006.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-006.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-006.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-007.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-007.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-007.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-008.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-008.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-008.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-009.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-009.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-009.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-010.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-010.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-010.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-011.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-011.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-011.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-012.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-012.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-012.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-013.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-013.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-013.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-014.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-014.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-014.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-015.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-015.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-015.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-016.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-016.https.html.ini
@@ -1,3 +1,4 @@
 [parse-input-arguments-016.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-017.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-017.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-017.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-018.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-018.https.html.ini
@@ -1,3 +1,3 @@
 [parse-input-arguments-018.https.html]
   type: reftest
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-019.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-019.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-019.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-020.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-020.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-020.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-021.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-021.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-021.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-022.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-022.https.html.ini
@@ -1,0 +1,2 @@
+[parse-input-arguments-022.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/roundrect.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/roundrect.https.html.ini
@@ -1,0 +1,2 @@
+[roundrect.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-001.https.html.ini
@@ -1,0 +1,2 @@
+[setTransform-001.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-002.https.html.ini
@@ -1,0 +1,2 @@
+[setTransform-002.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-003.https.html.ini
@@ -1,0 +1,2 @@
+[setTransform-003.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-004.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-004.https.html.ini
@@ -1,0 +1,2 @@
+[setTransform-004.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/style-background-image.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/style-background-image.https.html.ini
@@ -1,4 +1,4 @@
 [style-background-image.https.html]
   type: reftest
-  expected: FAIL
   bug: https://github.com/servo/servo/issues/17378
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/style-before-pseudo.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/style-before-pseudo.https.html.ini
@@ -1,4 +1,4 @@
 [style-before-pseudo.https.html]
   type: reftest
-  expected: FAIL
   bug: https://github.com/servo/servo/issues/17854
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/style-first-letter-pseudo.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/style-first-letter-pseudo.https.html.ini
@@ -1,4 +1,4 @@
 [style-first-letter-pseudo.https.html]
   type: reftest
-  expected: FAIL
   bug: https://github.com/servo/servo/issues/17854
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-after-load.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-after-load.https.html.ini
@@ -1,0 +1,2 @@
+[valid-image-after-load.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-before-load.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-before-load.https.html.ini
@@ -1,0 +1,2 @@
+[valid-image-before-load.https.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/overlay/overlay-popover-backdrop-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/overlay/overlay-popover-backdrop-crash.html.ini
@@ -1,0 +1,2 @@
+[overlay-popover-backdrop-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/css/css-text/ellisize-rtl-text-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/ellisize-rtl-text-crash.html.ini
@@ -1,0 +1,2 @@
+[ellisize-rtl-text-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/cssom-view/client-props-root-display-none-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/cssom-view/client-props-root-display-none-crash.html.ini
@@ -1,0 +1,2 @@
+[client-props-root-display-none-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/crashtests/broken-reference-crash-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/crashtests/broken-reference-crash-001.html.ini
@@ -1,0 +1,2 @@
+[broken-reference-crash-001.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/custom-elements/when-defined-reentry-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/custom-elements/when-defined-reentry-crash.html.ini
@@ -1,2 +1,0 @@
-[when-defined-reentry-crash.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/custom-elements/when-defined-reentry-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/custom-elements/when-defined-reentry-crash.html.ini
@@ -1,0 +1,2 @@
+[when-defined-reentry-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/fullscreen/crashtests/chrome-1312699.html.ini
+++ b/tests/wpt/meta-legacy-layout/fullscreen/crashtests/chrome-1312699.html.ini
@@ -1,0 +1,2 @@
+[chrome-1312699.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/html/semantics/forms/the-input-element/input-form-detach-style-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/forms/the-input-element/input-form-detach-style-crash.html.ini
@@ -1,0 +1,2 @@
+[input-form-detach-style-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/html/semantics/popovers/popover-dialog-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/popovers/popover-dialog-crash.html.ini
@@ -1,0 +1,2 @@
+[popover-dialog-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/html/semantics/popovers/popover-hint-crash.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/popovers/popover-hint-crash.tentative.html.ini
@@ -1,0 +1,2 @@
+[popover-hint-crash.tentative.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/html/semantics/popovers/popover-manual-crash.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/popovers/popover-manual-crash.html.ini
@@ -1,0 +1,2 @@
+[popover-manual-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/webaudio/the-audio-api/processing-model/cycle-without-delay.html.ini
+++ b/tests/wpt/meta-legacy-layout/webaudio/the-audio-api/processing-model/cycle-without-delay.html.ini
@@ -1,0 +1,2 @@
+[cycle-without-delay.html]
+  expected: CRASH

--- a/tests/wpt/meta/css/css-position/overlay/overlay-popover-backdrop-crash.html.ini
+++ b/tests/wpt/meta/css/css-position/overlay/overlay-popover-backdrop-crash.html.ini
@@ -1,0 +1,2 @@
+[overlay-popover-backdrop-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-text/ellisize-rtl-text-crash.html.ini
+++ b/tests/wpt/meta/css/css-text/ellisize-rtl-text-crash.html.ini
@@ -1,0 +1,2 @@
+[ellisize-rtl-text-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-001.html.ini
@@ -1,0 +1,2 @@
+[preserve3d-scene-001.html]
+  expected: CRASH

--- a/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-002.html.ini
@@ -1,0 +1,2 @@
+[preserve3d-scene-002.html]
+  expected: CRASH

--- a/tests/wpt/meta/css/filter-effects/crashtests/broken-reference-crash-001.html.ini
+++ b/tests/wpt/meta/css/filter-effects/crashtests/broken-reference-crash-001.html.ini
@@ -1,0 +1,2 @@
+[broken-reference-crash-001.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/custom-elements/when-defined-reentry-crash.html.ini
+++ b/tests/wpt/meta/custom-elements/when-defined-reentry-crash.html.ini
@@ -1,2 +1,0 @@
-[when-defined-reentry-crash.html]
-  expected: CRASH

--- a/tests/wpt/meta/custom-elements/when-defined-reentry-crash.html.ini
+++ b/tests/wpt/meta/custom-elements/when-defined-reentry-crash.html.ini
@@ -1,0 +1,2 @@
+[when-defined-reentry-crash.html]
+  expected: CRASH

--- a/tests/wpt/meta/fetch/metadata/generated/element-img-environment-change.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/element-img-environment-change.sub.html.ini
@@ -1,8 +1,5 @@
 [element-img-environment-change.sub.html]
   expected: TIMEOUT
-  [sec-fetch-site - Not sent to non-trustworthy same-origin destination, no attributes]
-    expected: FAIL
-
   [sec-fetch-site - Not sent to non-trustworthy same-site destination, no attributes]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fullscreen/crashtests/chrome-1312699.html.ini
+++ b/tests/wpt/meta/fullscreen/crashtests/chrome-1312699.html.ini
@@ -1,0 +1,2 @@
+[chrome-1312699.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/popovers/popover-dialog-crash.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-dialog-crash.html.ini
@@ -1,0 +1,2 @@
+[popover-dialog-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/popovers/popover-hint-crash.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-hint-crash.tentative.html.ini
@@ -1,0 +1,2 @@
+[popover-hint-crash.tentative.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/popovers/popover-manual-crash.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-manual-crash.html.ini
@@ -1,0 +1,2 @@
+[popover-manual-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/streams/readable-streams/crashtests/strategy-worker-terminate.html.ini
+++ b/tests/wpt/meta/streams/readable-streams/crashtests/strategy-worker-terminate.html.ini
@@ -1,0 +1,2 @@
+[strategy-worker-terminate.html]
+  expected: CRASH

--- a/tests/wpt/meta/streams/readable-streams/crashtests/strategy-worker-terminate.html.ini
+++ b/tests/wpt/meta/streams/readable-streams/crashtests/strategy-worker-terminate.html.ini
@@ -1,2 +1,0 @@
-[strategy-worker-terminate.html]
-  expected: CRASH

--- a/tests/wpt/meta/webaudio/the-audio-api/processing-model/cycle-without-delay.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/processing-model/cycle-without-delay.html.ini
@@ -1,0 +1,2 @@
+[cycle-without-delay.html]
+  expected: CRASH

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet.html.ini
@@ -1,0 +1,2 @@
+[test_paint_worklet.html]
+  expected: CRASH

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_size.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_size.html.ini
@@ -1,3 +1,3 @@
 [test_paint_worklet_size.html]
   type: reftest
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_timeout.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_timeout.html.ini
@@ -1,3 +1,4 @@
 [test_paint_worklet_timeout.html]
   type: testharness
   prefs: [dom.worklet.timeout_ms:10]
+  expected: CRASH


### PR DESCRIPTION
The first commit fixes two issues related to crash tests:
1. test-wpt is unable to find existing crash tests even when called with --test-types=crashtests. The fix here is to add crashtests to the default test suite types to python/wpt/run.py
2. When running in headless mode, crashes in style threads don't cause servo to crash because the logic in constellation.rs currently calls handle_panic only when the top-level browsing context id is some value. Since style pool threads are shared, they always generate Panic messages with None as top-level browsing context id.

The second commit addresses issues with generating and capturing backtrace and stderr for crash tests.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
