### PR TITLE
layout_2020: Do linebreak for atomic inline-level elements

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -23,6 +23,7 @@ use app_units::Au;
 use atomic_refcell::AtomicRef;
 use gfx::text::text_run::GlyphRun;
 use servo_arc::Arc;
+use style::computed_values::white_space::T as WhiteSpace;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
 use style::values::computed::{Length, LengthPercentage, Percentage};
@@ -74,6 +75,7 @@ struct InlineNestingLevelState<'box_tree> {
     inline_start: Length,
     max_block_size_of_fragments_so_far: Length,
     positioning_context: Option<PositioningContext>,
+    white_space: WhiteSpace,
     /// Indicates whether this nesting level have text decorations in effect.
     /// From https://drafts.csswg.org/css-text-decor/#line-decoration
     // "When specified on or propagated to a block container that establishes
@@ -297,6 +299,7 @@ impl InlineFormattingContext {
                 inline_start: Length::zero(),
                 max_block_size_of_fragments_so_far: Length::zero(),
                 positioning_context: None,
+                white_space: containing_block.style.clone_inherited_text().white_space,
                 text_decoration_line: self.text_decoration_line,
             },
             sequential_layout_state,
@@ -503,6 +506,7 @@ impl InlineBox {
             start_corner += &relative_adjustement(&style, ifc.containing_block)
         }
         let positioning_context = PositioningContext::new_for_style(&style);
+        let white_space = style.clone_inherited_text().white_space;
         let text_decoration_line =
             ifc.current_nesting_level.text_decoration_line | style.clone_text_decoration_line();
         PartialInlineBoxFragment {
@@ -523,6 +527,7 @@ impl InlineBox {
                     inline_start: ifc.inline_position,
                     max_block_size_of_fragments_so_far: Length::zero(),
                     positioning_context,
+                    white_space,
                     text_decoration_line: text_decoration_line,
                 },
             ),

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-026.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-026.xht.ini
@@ -1,2 +1,0 @@
-[floats-026.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-027.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-027.xht.ini
@@ -1,2 +1,0 @@
-[floats-027.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-014.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-003.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-004.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-005.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-006.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-010.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-010.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-011.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-011.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-011.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-height-012.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-004.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-max-height-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-005.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-max-height-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-006.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-max-height-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-010.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-max-height-010.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-non-replaced-max-height-012.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-max-height-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-on-blank-line-rtl-left-align.html.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-on-blank-line-rtl-left-align.html.ini
@@ -1,2 +1,0 @@
-[text-indent-on-blank-line-rtl-left-align.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size-026.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size-026.html.ini
@@ -1,2 +1,0 @@
-[background-size-026.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-default.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-default.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-direction-default.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-row-reverse.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-row-reverse.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-direction-row-reverse.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-row.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-row.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-direction-row.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-wrap-wrap-reverse.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-wrap-wrap-reverse.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-wrap-wrap-reverse.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-wrap-wrap.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-wrap-wrap.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-wrap-wrap.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_first-line.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_first-line.html.ini
@@ -1,2 +1,0 @@
-[flexbox_first-line.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-001.html.ini
@@ -1,2 +1,0 @@
-[stretch-obeys-min-max-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-ui/text-overflow-ruby.html.ini
+++ b/tests/wpt/meta/css/css-ui/text-overflow-ruby.html.ini
@@ -1,0 +1,2 @@
+[text-overflow-ruby.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/percentage_width_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/percentage_width_inline_block_a.html.ini
@@ -1,2 +1,0 @@
-[percentage_width_inline_block_a.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29591 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
