### PR TITLE
layout_2020: Allow end margin to collapse with children if height is set to 0

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -482,7 +482,7 @@ fn layout_in_flow_non_replaced_block_level(
     let end_margin_can_collapse_with_children = block_is_same_formatting_context &&
         pbm.padding.block_end == Length::zero() &&
         pbm.border.block_end == Length::zero() &&
-        block_size == LengthOrAuto::Auto &&
+        block_size.auto_is(|| Length::zero()) == Length::zero() &&
         min_box_size.block == Length::zero();
 
     let mut clearance = Length::zero();

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-016.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-019.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-019.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-019.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/margin-collapse-through-zero-height-block.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/margin-collapse-through-zero-height-block.html.ini
@@ -1,2 +1,0 @@
-[margin-collapse-through-zero-height-block.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Previously, end margin was allowed to collapse only when block size is not set.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
