### PR TITLE
layout_2020: Fix divide by zero error when resolving flexible lengths

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -905,9 +905,13 @@ impl FlexLine<'_> {
         for ((item, target_main_size), frozen) in items() {
             let is_inflexible = flex_factor(item) == 0. ||
                 if grow {
-                    item.flex_base_size > item.hypothetical_main_size
+                    item.flex_base_size > item.hypothetical_main_size ||
+                        item.content_max_size
+                            .main
+                            .map_or(false, |l| l == item.flex_base_size)
                 } else {
-                    item.flex_base_size < item.hypothetical_main_size
+                    item.flex_base_size < item.hypothetical_main_size ||
+                        item.flex_base_size == item.content_min_size.main
                 };
             if is_inflexible {
                 frozen_count.set(frozen_count.get() + 1);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29852 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
