### PR TITLE
Set `id_hash` as default wpt chunker

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -73,6 +73,9 @@ def run_tests(**kwargs):
     set_if_none(
         kwargs, "host_cert_path", os.path.join(CERTS_PATH, "web-platform.test.pem")
     )
+    # Set `id_hash` as the default chunk, as this better distributes testing across different
+    # chunks and leads to more consistent timing on GitHub Actions.
+    set_if_none(kwargs, "chunk_type", "id_hash")
 
     kwargs["user_stylesheets"].append(os.path.join(SERVO_ROOT, "resources", "ahem.css"))
 


### PR DESCRIPTION
This PR sets [new `id_hash` chunker](https://github.com/web-platform-tests/wpt/pull/40020) as default chunker when running wpt tests via mach.

Fixes #29844, and as a bonus flattens wpt test times for chunks (for layout-2013: [10 min, 30 min] -> [20 min, 25 min])

Test run available [here](https://github.com/sagudev/servo/actions/runs/5207427141).
