### PR TITLE
Improve margin collapse in layout-2020

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -483,8 +483,7 @@ fn layout_in_flow_non_replaced_block_level(
     let end_margin_can_collapse_with_children = block_is_same_formatting_context &&
         pbm.padding.block_end == Length::zero() &&
         pbm.border.block_end == Length::zero() &&
-        block_size.auto_is(|| Length::zero()) == Length::zero() &&
-        min_box_size.block == Length::zero();
+        block_size == LengthOrAuto::Auto;
 
     let mut clearance = Length::zero();
     let parent_containing_block_position_info;
@@ -570,9 +569,11 @@ fn layout_in_flow_non_replaced_block_level(
                 content_block_size += collapsible_margins_in_children.end.solve();
             }
             block_margins_collapsed_with_children.collapsed_through =
-                start_margin_can_collapse_with_children &&
-                    end_margin_can_collapse_with_children &&
-                    collapsible_margins_in_children.collapsed_through;
+                collapsible_margins_in_children.collapsed_through &&
+                    block_is_same_formatting_context &&
+                    pbm.padding_border_sums.block == Length::zero() &&
+                    block_size.auto_is(|| Length::zero()) == Length::zero() &&
+                    min_box_size.block == Length::zero();
         },
         NonReplacedContents::EstablishesAnIndependentFormattingContext(non_replaced) => {
             let independent_layout = non_replaced.layout(

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-025.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-025.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-025.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-037.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-037.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-037.xht]
-  expected: FAIL


### PR DESCRIPTION
According to https://drafts.csswg.org/css2/#collapsing-margins, bottom
margins should only collapse with the last child if `height` is `auto`.
Also, the note mentions `min-height: 0`, but the normative text doesn't
have such requirement, so I'm dropping it, matching WebKit.

The previous logic is moved into the case of collapsing the top and
bottom margins of the same element, since this can happen either with
`height: auto` or `height: 0`, and requires `min-height: 0`.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29858
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
