### PR TITLE
Get clang-format from pip and upgrade to version 16

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -36,4 +36,7 @@ six == 1.15
 # For sending build notifications.
 notify-py == 0.3.42
 
+# For formatting C++ files.
+clang-format ~= 16.0.0
+
 -e python/tidy


### PR DESCRIPTION
This allows relying on a specific version of clang-format and no longer use any version checks. In addition, we can use --dry-run -Werror in order to avoid having to run against every file individually.

Fix #29847.
Fix #29846.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29847 and fix #29846.
- [x] These changes do not require tests because they update dev infrastructure.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
