### PR TITLE
Use layout 2020 by default

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -252,7 +252,7 @@ class CommandBase(object):
         self.config["build"].setdefault("mode", "")
         self.config["build"].setdefault("debug-assertions", False)
         self.config["build"].setdefault("debug-mozjs", False)
-        self.config["build"].setdefault("layout-2020", False)
+        self.config["build"].setdefault("layout-2020", True)
         self.config["build"].setdefault("media-stack", "auto")
         self.config["build"].setdefault("ccache", "")
         self.config["build"].setdefault("rustflags", "")

--- a/servobuild.example
+++ b/servobuild.example
@@ -44,7 +44,7 @@ webgl-backtrace = false
 dom-backtrace = false
 
 # Default to the “2020” implementation of CSS layout instead of the “2013” one.
-layout-2020 = false
+layout-2020 = true
 
 # Pick a media stack based on the target. Other values are "gstreamer" and "dummy"
 media-stack = "auto"


### PR DESCRIPTION
This PR switches `./mach build` to use layout 2020 by default. It doesn't switch the nightly builds served from download.servo.org to layout 2020. I can add that change to this PR if we are ready to make the switch in nightly builds as well.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29843 
- [x] These changes do not require tests because modify mach build configuration.