### PR TITLE
Fix infinite loop in flexbox algorithm

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -976,10 +976,12 @@ impl FlexLine<'_> {
                     let scaled_shrink_factors_sum: Length = unfrozen_items()
                         .map(|(item, _)| scaled_shrink_factor(item))
                         .sum();
-                    for (item, target_main_size) in unfrozen_items() {
-                        let ratio = scaled_shrink_factor(item) / scaled_shrink_factors_sum;
-                        target_main_size
-                            .set(item.flex_base_size - remaining_free_space.abs() * ratio);
+                    if scaled_shrink_factors_sum > Length::zero() {
+                        for (item, target_main_size) in unfrozen_items() {
+                            let ratio = scaled_shrink_factor(item) / scaled_shrink_factors_sum;
+                            target_main_size
+                                .set(item.flex_base_size - remaining_free_space.abs() * ratio);
+                        }
                     }
                 }
             }

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-013.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-013.html.ini
@@ -1,5 +1,4 @@
 [flex-aspect-ratio-img-row-013.html]
-  expected: TIMEOUT
   [img 1]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-item-compressible-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-item-compressible-002.html.ini
@@ -1,5 +1,4 @@
 [flex-item-compressible-002.html]
-  expected: TIMEOUT
   [.flexbox 14]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-031.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-031.html.ini
@@ -1,5 +1,4 @@
 [flex-minimum-height-flex-items-031.html]
-  expected: TIMEOUT
   [.flex 1]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-align-self-stretch-vert-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-align-self-stretch-vert-001.html.ini
@@ -1,2 +1,2 @@
 [flexbox-align-self-stretch-vert-001.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-overflow-vert-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-overflow-vert-002.html.ini
@@ -1,2 +1,2 @@
 [flexbox-overflow-vert-002.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/percentage-padding-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/percentage-padding-002.html.ini
@@ -1,2 +1,2 @@
 [percentage-padding-002.html]
-  expected: TIMEOUT
+  expected: FAIL


### PR DESCRIPTION
Only apply step 5c of "resolve flexible lengths" if sum of scaled flexible shrink factors > 0
Probably fixes #29852 (but speculative as I can't get mach to run).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
