### PR TITLE
windows workflow use C drive as target directory

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ env:
   LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
   PACKAGE: "${{ contains(inputs.layout, '2020') && 'windows-msvc-layout2020' || 'windows-msvc' }}"
   CCACHE: "ccache"
-  CARGO_INCREMENTAL: 0
+  CARGO_TARGET_DIR: C:\\a\\servo\\servo\\target
 
 jobs:
   build-win:
@@ -50,8 +50,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
       - name: wix311-binaries
         shell: powershell
         run: |
@@ -61,23 +59,20 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
       - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: |
           python -m pip install --upgrade pip virtualenv
           python mach fetch
           python mach bootstrap-gstreamer
       - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: python mach build --release --with-${{ env.LAYOUT }}
+      - name: Copy resources
+        run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: python mach smoketest --angle
       - name: Unit tests
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         if: ${{ inputs.unit-tests }}
         run: python mach test-unit --release --with-${{ env.LAYOUT }}
       - name: Package
-        working-directory: "C:\\a\\servo\\servo"
         run: python mach package --release
       - name: Upload Package
         uses: actions/upload-artifact@v3
@@ -90,7 +85,6 @@ jobs:
           path: C:\\a\\servo\\servo\\target/release/msi/Servo.exe
       - name: Upload
         if: ${{ inputs.upload }}
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: |
           python mach upload-nightly ${{ env.PACKAGE }} --secret-from-environment `
             --github-release-id ${{ inputs.github-release-id }}


### PR DESCRIPTION
Currently we clone to drive D (default drive in GitHub Actions), then copy to drive C, then build from there (due to low disk space on D drive). In this PR instead of copying to C drive we only set `CARGO_TARGET_DIR` to C drive, the build is reading source files from D and writing target files to C drive. This gets us approx. -20min.

Try-windows build available [here](https://github.com/sagudev/servo/actions/runs/5219706997/jobs/9421863750).

What do we lose? Well copying step was good benchmarker for GitHub runner machines, fast windows machines spend ~5min in copying step while slow machines ~8min.

For the future: I do believe that D drive may be faster for writing, so switching roles could benefit us, but it will require slow (like copying step) clone.
