### PR TITLE
Run unit tests on the main Linux workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
     with:
       layout: '2013'
       wpt: 'test'
+      unit-tests: true
 
   build-linux-layout-2020:
     name: Linux (layout-2020)
@@ -60,6 +61,7 @@ jobs:
     with:
       layout: '2020'
       wpt: 'test'
+      unit-tests: true
 
   build_result:
     name: homu build finished


### PR DESCRIPTION
Not running unit tests on the main Linux workflow makes it faster, but also allows merging changes that break the unit tests. This change fixes that.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are CI changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
