### PR TITLE
Support mac wpt builds

### DIFF
--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -16,11 +16,11 @@ jobs:
     name: WPT ${{ inputs.layout }}
     runs-on: macos-13
     env:
-      max_chunk_id: 20
+      max_chunk_id: 5
     strategy:
       fail-fast: false
       matrix:
-        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        chunk_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'issue_comment'

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -1,0 +1,98 @@
+---
+name: Mac WPT Tests
+on:
+  workflow_call:
+    inputs:
+      layout:
+        required: true
+        type: string
+
+env:
+  RUST_BACKTRACE: 1
+  SHELL: /bin/bash
+
+jobs:
+  mac-wpt:
+    name: WPT ${{ inputs.layout }}
+    runs-on: macos-13
+    env:
+      max_chunk_id: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    steps:
+      - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment'
+        with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 2
+      - uses: actions/download-artifact@v3
+        with:
+          name: release-binary-macos
+      - name: Prep test environment
+        run: |
+          gtar -xzf target.tar.gz
+          python3 -m pip install --upgrade pip virtualenv
+          python3 ./mach bootstrap
+      - name: Smoketest
+        run: python3 ./mach smoketest
+      - name: Run tests
+        run: |
+          python3 ./mach test-wpt --with-${{ inputs.layout }} \
+            --release --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
+            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
+            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
+            --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
+            --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
+      - name: Archive filtered results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: wpt-filtered-results-mac-${{ inputs.layout }}
+          path: |
+            filtered-test-wpt.${{ matrix.chunk_id }}.json
+            unexpected-test-wpt.${{ matrix.chunk_id }}.log
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: wpt-logs-mac-${{ inputs.layout }}
+          path: |
+            test-wpt.${{ matrix.chunk_id }}.log
+            filtered-wpt-results.${{ matrix.chunk_id }}.json
+
+  report-test-results:
+    name: Reporting test results
+    runs-on: ubuntu-latest
+    if: ${{ always() && !cancelled() }}
+    needs: [ mac-wpt ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/download-artifact@v3
+        with:
+          name: wpt-filtered-results-mac-${{ inputs.layout }}
+          path: wpt-filtered-results-mac
+      - name: Create aggregated unexpected results
+        run: cat wpt-filtered-results-mac/*.log > unexpected-test-wpt.log
+      - name: Archive aggregate results
+        uses: actions/upload-artifact@v3
+        with:
+          name: wpt-filtered-results-mac-${{ inputs.layout }}
+          path: |
+            unexpected-test-wpt.log
+      - name: Comment on PR with results
+        run: etc/ci/report_aggregated_expected_results.py --tag="mac-wpt-${{ inputs.layout }}"
+          wpt-filtered-results-mac/*.json
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RESULTS: ${{ toJson(needs.*.result) }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -3,6 +3,9 @@ name: Mac
 on:
   workflow_call:
     inputs:
+      wpt-layout:
+        required: false
+        type: string
       unit-tests:
         required: false
         default: false
@@ -16,6 +19,10 @@ on:
         type: string
   workflow_dispatch:
     inputs:
+      wpt-layout:
+        required: false
+        type: choice
+        options: ["none", "2013", "2020", "all"]
       unit-tests:
         required: false
         default: false
@@ -25,7 +32,7 @@ on:
         default: false
         type: boolean
   push:
-    branches: ["try-mac"]
+    branches: ["try-mac", "try-wpt-mac", "try-wpt-mac-2020"]
 
 env:
   RUST_BACKTRACE: 1
@@ -38,7 +45,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'issue_comment'
@@ -96,68 +103,28 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Package binary
-        run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib resources
+        run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib target/release/lib/*.dylib resources
       - name: Archive binary
         uses: actions/upload-artifact@v3
         with:
           name: release-binary-macos
           path: target.tar.gz
 
-  # mac-wpt:
-  #   name: Mac WPT Tests
-  #   runs-on: macos-12
-  #   needs: ["build-mac"]
-  #   env:
-  #     max_chunk_id: 20
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #     if: github.event_name != 'issue_comment'
-  #     with:
-  #       fetch-depth: 2
-  #   # This is necessary to checkout the pull request if this run was triggered
-  #   # via an `issue_comment` action on a pull request.
-  #   - uses: actions/checkout@v3
-  #     if: github.event_name == 'issue_comment'
-  #     with:
-  #       ref: refs/pull/${{ github.event.issue.number }}/head
-  #       fetch-depth: 2
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: release-binary-macos
-  #     # TODO: Remove this step when the compatibility issue between mozjs and
-  #     #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
-  #     - name: Select Python 3.9
-  #       run: |
-  #         brew install python@3.9
-  #         cd $(dirname $(which python3.9))
-  #         rm -f python3 pip3
-  #         ln -s python3.9 python3
-  #         ln -s pip3.9 pip3
-  #     - name: Prep test environment
-  #       run: |
-  #         gtar -xzf target.tar.gz
-  #         python3 -m pip install --upgrade pip virtualenv
-  #     - name: Smoketest
-  #       run: python3 ./mach smoketest
-  #     - name: Run tests
-  #       run: |
-  #         python3 ./mach test-wpt \
-  #           --release --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
-  #           --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-  #           --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-  #           --filter-intermittents=filtered-wpt-summary.${{ matrix.chunk_id }}.log
-  #     - name: Archive logs
-  #       uses: actions/upload-artifact@v3
-  #       if: ${{ failure() }}
-  #       with:
-  #         name: wpt${{ matrix.chunk_id }}-logs-macos
-  #         path: |
-  #           test-wpt.${{ matrix.chunk_id }}.log
-  #           filtered-wpt-summary.${{ matrix.chunk_id }}.log
+  wpt-2020:
+    if: ${{ github.ref_name == 'try-wpt-mac-2020' || inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
+    name: Mac WPT Tests 2020
+    needs: ["build"]
+    uses: ./.github/workflows/mac-wpt.yml
+    with:
+      layout: "layout-2020"
+
+  wpt-2013:
+    if: ${{ github.ref_name == 'try-wpt-mac' || inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
+    name: Mac WPT Tests 2013
+    needs: ["build"]
+    uses: ./.github/workflows/mac-wpt.yml
+    with:
+      layout: "layout-2013"
 
   result:
     name: Result
@@ -166,6 +133,8 @@ jobs:
     # needs all build to detect cancellation
     needs:
       - "build"
+      - "wpt-2020"
+      - "wpt-2013"
 
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -4,8 +4,8 @@
 name: Quick check
 on:
   push:
-    branches:
-      ["**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!try-wpt-2020", "!dependabot/**"]
+    branches-ignore:
+      ["master", "auto", "try", "try-*", "dependabot/**"]
 
 jobs:
   build-linux:

--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -229,7 +229,7 @@ def main():
     results = get_results(filenames, args.tag)
     if not results:
         print("Did not find any unexpected results.")
-        create_check_run("Did not find any unexpected results.")
+        create_check_run("Did not find any unexpected results.", args.tag)
         return
 
     print(results.to_string())

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -24,6 +24,17 @@ from mach.decorators import (
 
 from servo.command_base import CommandBase, cd, call
 
+VALID_TRY_BRACHES = [
+    "try",
+    "try-linux",
+    "try-mac",
+    "try-windows",
+    "try-wpt",
+    "try-wpt-2020",
+    "try-wpt-mac",
+    "try-wpt-mac-2020"
+]
+
 
 @CommandProvider
 class MachCommands(CommandBase):
@@ -282,7 +293,6 @@ class MachCommands(CommandBase):
     def try_jobs(self, jobs):
         branches = []
         # we validate branches because force pushing is destructive
-        VALID_TRY_BRACHES = ["try", "try-linux", "try-mac", "try-windows", "try-wpt", "try-wpt-2020"]
         for job in jobs:
             # branches must start with try-
             if "try" not in job:


### PR DESCRIPTION
There used to be mac wpt runners but it was comment out due to slowness. Now that we have optional workflows it could be useful to have it working but not enabled (available only via `try-wpt-mac` builds)

Currently [failing](https://github.com/sagudev/servo/actions/runs/5224662042/jobs/9434201525) with:
```console
Run python3 ./mach smoketest
Error initializing GStreamer: ErrorLoadingPlugins(["libgstcoreelements.dylib", "libgstnice.dylib", "libgstapp.dylib", "libgstaudioconvert.dylib", "libgstaudioresample.dylib", "libgstgio.dylib", "libgstogg.dylib", "libgstopengl.dylib", "libgstopus.dylib", "libgstplayback.dylib", "libgsttheora.dylib", "libgsttypefindfunctions.dylib", "libgstvolume.dylib", "libgstvorbis.dylib", "libgstaudiofx.dylib", "libgstaudioparsers.dylib", "libgstautodetect.dylib", "libgstdeinterlace.dylib", "libgstid3demux.dylib", "libgstinterleave.dylib", "libgstisomp4.dylib", "libgstmatroska.dylib", "libgstrtp.dylib", "libgstrtpmanager.dylib", "libgstvideofilter.dylib", "libgstvpx.dylib", "libgstaudiobuffersplit.dylib", "libgstdtls.dylib", "libgstid3tag.dylib", "libgstproxy.dylib", "libgstvideoparsersbad.dylib", "libgstwebrtc.dylib", "libgstlibav.dylib", "libgstosxaudio.dylib", "libgstosxvideo.dylib", "libgstapplemedia.dylib", "libgstvideoconvertscale.dylib"])
Servo exited with non-zero status 1
```
even though `./mach bootstrap-gstreamer` is run beforehand.