### PR TITLE
Layout 2020: Correct rendering of floated root

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -429,11 +429,12 @@ impl StackingContext {
         };
 
         let fragment = first_stacking_context_fragment.fragment.borrow();
-        let box_fragment = if let Fragment::Box(box_fragment) = &*fragment {
-            box_fragment
-        } else {
-            debug_panic!("Expected a box-generated fragment");
-            return;
+        let box_fragment = match &*fragment {
+            Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => box_fragment,
+            _ => {
+                debug_panic!("Expected a box-generated fragment");
+                return;
+            },
         };
 
         // The `StackingContextFragment` we found is for the root DOM element:

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -61,23 +61,13 @@ pub struct ContainingBlockPositionInfo {
     pub inline_end: Length,
 }
 
-impl Default for ContainingBlockPositionInfo {
-    fn default() -> Self {
-        Self {
-            block_start: Length::zero(),
-            block_start_margins_not_collapsed: CollapsedMargin::zero(),
-            inline_start: Length::zero(),
-            inline_end: Length::new(f32::INFINITY),
-        }
-    }
-}
-
 impl ContainingBlockPositionInfo {
     pub fn new_with_inline_offsets(inline_start: Length, inline_end: Length) -> Self {
         Self {
+            block_start: Length::zero(),
+            block_start_margins_not_collapsed: CollapsedMargin::zero(),
             inline_start,
             inline_end,
-            ..Default::default()
         }
     }
 }
@@ -109,7 +99,7 @@ pub struct FloatContext {
 impl FloatContext {
     /// Returns a new float context representing a containing block with the given content
     /// inline-size.
-    pub fn new() -> Self {
+    pub fn new(max_inline_size: Length) -> Self {
         let mut bands = FloatBandTree::new();
         bands = bands.insert(FloatBand {
             top: Length::zero(),
@@ -124,7 +114,10 @@ impl FloatContext {
         FloatContext {
             bands,
             ceiling: Length::zero(),
-            containing_block_info: Default::default(),
+            containing_block_info: ContainingBlockPositionInfo::new_with_inline_offsets(
+                Length::zero(),
+                max_inline_size,
+            ),
             clear_left_position: Length::zero(),
             clear_right_position: Length::zero(),
         }
@@ -827,9 +820,9 @@ pub(crate) struct SequentialLayoutState {
 
 impl SequentialLayoutState {
     /// Creates a new empty `SequentialLayoutState`.
-    pub(crate) fn new() -> SequentialLayoutState {
+    pub(crate) fn new(max_inline_size: Length) -> SequentialLayoutState {
         SequentialLayoutState {
-            floats: FloatContext::new(),
+            floats: FloatContext::new(max_inline_size),
             current_margin: CollapsedMargin::zero(),
             bfc_relative_block_position: Length::zero(),
         }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -80,7 +80,7 @@ impl BlockFormattingContext {
         tree_rank: usize,
     ) -> IndependentLayout {
         let mut sequential_layout_state = if self.contains_floats || !layout_context.use_rayon {
-            Some(SequentialLayoutState::new())
+            Some(SequentialLayoutState::new(containing_block.inline_size))
         } else {
             None
         };

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -464,7 +464,7 @@ impl PlacedFloat {
 
 impl FloatPlacement {
     fn place(floats: Vec<FloatInput>) -> FloatPlacement {
-        let mut float_context = FloatContext::new();
+        let mut float_context = FloatContext::new(Length::new(f32::INFINITY));
         let mut placed_floats = vec![];
         for float in floats {
             let ceiling = Length::new(float.ceiling as f32);

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/clear-on-child-with-margins-2.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/clear-on-child-with-margins-2.html.ini
@@ -1,2 +1,0 @@
-[clear-on-child-with-margins-2.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/adjoining-floats-dynamic.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/adjoining-floats-dynamic.html.ini
@@ -1,2 +1,0 @@
-[adjoining-floats-dynamic.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-rule3-outside-left-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-rule3-outside-left-002.xht.ini
@@ -1,2 +1,0 @@
-[floats-rule3-outside-left-002.xht]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_float_placement_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_float_placement_a.html.ini
@@ -1,2 +1,0 @@
-[block_formatting_context_float_placement_a.html]
-  expected: FAIL


### PR DESCRIPTION
Fix two issues around floating a root element:

1. In the StackingContext code handle the case where a root element is a Float fragment and not a Box fragment. This fixes a debug assertion failure in the css/CSS2/float/float-root.html test.
2. When initializing the SequentialLayoutState, use the containing block width as the maximum inline float placement position instead of infinity. This fixes the rendering of css/CSS2/float/float-root.html.

Note that css/CSS2/float/float-root.html was passing before, because both the test and reference were subject to the same bug. This fixes a couple other tests as well.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
