### PR TITLE
Layout 2020: Fix issues with float implementation documentation

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -523,8 +523,9 @@ fn layout_in_flow_non_replaced_block_level(
                 inline_start,
                 inline_end: inline_start + inline_size,
             };
-            parent_containing_block_position_info =
-                Some(sequential_layout_state.update_all_containing_block_offsets(new_cb_offsets));
+            parent_containing_block_position_info = Some(
+                sequential_layout_state.replace_containing_block_position_info(new_cb_offsets),
+            );
         },
     };
 
@@ -595,7 +596,7 @@ fn layout_in_flow_non_replaced_block_level(
         // Now that we're done laying out our children, we can restore the
         // parent's containing block position information.
         sequential_layout_state
-            .update_all_containing_block_offsets(parent_containing_block_position_info.unwrap());
+            .replace_containing_block_position_info(parent_containing_block_position_info.unwrap());
 
         // Account for padding and border. We also might have to readjust the
         // `bfc_relative_block_position` if it was different from the content size (i.e. was


### PR DESCRIPTION
Fix some rustdoc comments which won't process properly unless they start with three '/' characters. In addition, improve the name of a function and add some missing documentation.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
