### PR TITLE
Fix servo crate name confliction on documentation

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [lib]
-name = "servo"
+name = "libservo"
 path = "lib.rs"
 crate-type = ["rlib"]
 

--- a/ports/gstplugin/Cargo.toml
+++ b/ports/gstplugin/Cargo.toml
@@ -25,7 +25,7 @@ gstreamer-gl-sys = { version = "0.8", features = ["wayland"] }
 gstreamer-sys = "0.8"
 gstreamer-video = "0.15"
 lazy_static = { workspace = true }
-libservo = { path = "../../components/servo" }
+servo = { package = "libservo", path = "../../components/servo" }
 log = { workspace = true }
 servo-media = { git = "https://github.com/servo/media" }
 sparkle = { workspace = true }

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 getopts = { workspace = true }
 ipc-channel = { workspace = true }
-libservo = { path = "../../../components/servo" }
+servo = { package = "libservo", path = "../../../components/servo" }
 log = { workspace = true }
 servo-media = { git = "https://github.com/servo/media" }
 surfman = { workspace = true, features = ["sm-angle-default"] }
@@ -33,23 +33,23 @@ gl_generator = "0.14"
 serde_json = { workspace = true }
 
 [features]
-debugmozjs = ["libservo/debugmozjs"]
+debugmozjs = ["servo/debugmozjs"]
 default = ["webdriver", "max_log_level"]
-egl = ["libservo/egl"]
-googlevr = ["libservo/googlevr"]
-jitspew = ["libservo/jitspew"]
-js_backtrace = ["libservo/js_backtrace"]
-layout-2013 = ["libservo/layout-2013"]
-layout-2020 = ["libservo/layout-2020"]
+egl = ["servo/egl"]
+googlevr = ["servo/googlevr"]
+jitspew = ["servo/jitspew"]
+js_backtrace = ["servo/js_backtrace"]
+layout-2013 = ["servo/layout-2013"]
+layout-2020 = ["servo/layout-2020"]
 max_log_level = ["log/release_max_level_info"]
-media-dummy = ["libservo/media-dummy"]
-media-gstreamer = ["libservo/media-gstreamer"]
-native-bluetooth = ["libservo/native-bluetooth"]
-no_static_freetype = ["libservo/no_static_freetype"]
-no-wgl = ["libservo/no-wgl"]
-profilemozjs = ["libservo/profilemozjs"]
-refcell_backtrace = ["libservo/refcell_backtrace"]
-uwp = ["libservo/uwp", "webxr/openxr-api"]
-webdriver = ["libservo/webdriver"]
-webgl_backtrace = ["libservo/webgl_backtrace"]
-xr-profile = ["libservo/xr-profile"]
+media-dummy = ["servo/media-dummy"]
+media-gstreamer = ["servo/media-gstreamer"]
+native-bluetooth = ["servo/native-bluetooth"]
+no_static_freetype = ["servo/no_static_freetype"]
+no-wgl = ["servo/no-wgl"]
+profilemozjs = ["servo/profilemozjs"]
+refcell_backtrace = ["servo/refcell_backtrace"]
+uwp = ["servo/uwp", "webxr/openxr-api"]
+webdriver = ["servo/webdriver"]
+webgl_backtrace = ["servo/webgl_backtrace"]
+xr-profile = ["servo/xr-profile"]

--- a/ports/winit/Cargo.toml
+++ b/ports/winit/Cargo.toml
@@ -26,24 +26,24 @@ OriginalFilename = "servo.exe"
 ProductName = "Servo"
 
 [features]
-debugmozjs = ["libservo/debugmozjs"]
+debugmozjs = ["servo/debugmozjs"]
 default = ["webdriver", "max_log_level"]
-egl = ["libservo/egl"]
-jitspew = ["libservo/jitspew"]
-js_backtrace = ["libservo/js_backtrace"]
-layout-2013 = ["libservo/layout-2013"]
-layout-2020 = ["libservo/layout-2020"]
+egl = ["servo/egl"]
+jitspew = ["servo/jitspew"]
+js_backtrace = ["servo/js_backtrace"]
+layout-2013 = ["servo/layout-2013"]
+layout-2020 = ["servo/layout-2020"]
 max_log_level = ["log/release_max_level_info"]
-media-dummy = ["libservo/media-dummy"]
-media-gstreamer = ["libservo/media-gstreamer"]
-native-bluetooth = ["libservo/native-bluetooth"]
-no-wgl = ["libservo/no-wgl"]
-profilemozjs = ["libservo/profilemozjs"]
-refcell_backtrace = ["libservo/refcell_backtrace"]
-webdriver = ["libservo/webdriver"]
-webgl_backtrace = ["libservo/webgl_backtrace"]
-webrender_debugger = ["libservo/webrender_debugger"]
-xr-profile = ["libservo/xr-profile"]
+media-dummy = ["servo/media-dummy"]
+media-gstreamer = ["servo/media-gstreamer"]
+native-bluetooth = ["servo/native-bluetooth"]
+no-wgl = ["servo/no-wgl"]
+profilemozjs = ["servo/profilemozjs"]
+refcell_backtrace = ["servo/refcell_backtrace"]
+webdriver = ["servo/webdriver"]
+webgl_backtrace = ["servo/webgl_backtrace"]
+webrender_debugger = ["servo/webrender_debugger"]
+xr-profile = ["servo/xr-profile"]
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 backtrace = { workspace = true }
@@ -53,7 +53,7 @@ getopts = { workspace = true }
 keyboard-types = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
-libservo = { path = "../../components/servo" }
+servo = { package = "libservo", path = "../../components/servo" }
 log = { workspace = true }
 servo-media = { git = "https://github.com/servo/media" }
 shellwords = "1.0.0"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32412

<!-- Either: -->
- [x] There are tests for these changes OR it should be able to build all ports
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
The name of winit binary is conflicted with servo crate.
We can't read [documentation of servo library](https://doc.servo.org/servo/index.html) crate at the moment.
It's actually the winit binary documentation.