### PR TITLE
Fix compile on Fedora 38 (cargo upgrade mozangle to v0.3.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -3721,9 +3721,9 @@ checksum = "eeb5a94c61e12e2cfc16ee3e2b6eca8f126a43c888586626337544a7e824a1af"
 
 [[package]]
 name = "mozangle"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef98797da14500fb5eaabc90dc91cf7c42710c11330351521d72f4aa268d689c"
+checksum = "abe944fd6e85e054436f598b5fb12f492da8cf9554981bd4a23a91982f72657c"
 dependencies = [
  "cc",
  "gl_generator 0.13.1",


### PR DESCRIPTION

The changeset upgrades the Cargo.lock file to use mozangle v0.3.4. This also requires to upgrade the 'cc' dependency to v1.0.79.

I was unable to compile the servo/servo main branch. The fix for the compile error was already provided with servo/mozangle v0.3.4. The Cargo.lock file locked the version to v0.3.3.

After applying these changes my Fedora 38 box builds the servo debug binary successfully.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it solves a build issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
