### PR TITLE
Don't pass float stacking containers up to parent stacking contexts

### DIFF
--- a/tests/wpt/metadata-layout-2020/css/CSS2/css1/c414-flt-wrap-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/css1/c414-flt-wrap-001.xht.ini
@@ -1,0 +1,2 @@
+[c414-flt-wrap-001.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/clear-clearance-calculation-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/clear-clearance-calculation-003.xht.ini
@@ -1,2 +1,0 @@
-[clear-clearance-calculation-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-001.html.ini
@@ -1,2 +1,0 @@
-[floats-placement-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-002.html.ini
@@ -1,2 +1,0 @@
-[floats-placement-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-003.html.ini
@@ -1,2 +1,0 @@
-[floats-placement-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-008.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-008.html.ini
@@ -1,2 +1,0 @@
-[floats-placement-008.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-001.html.ini
@@ -1,0 +1,3 @@
+[hit-test-floats-001.html]
+  [hit-test-floats-001]
+    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-001.xht.ini
@@ -1,2 +1,0 @@
-[stack-floats-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-002.xht.ini
@@ -1,2 +1,0 @@
-[stack-floats-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-004.xht.ini
@@ -1,2 +1,0 @@
-[stack-floats-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-center.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-center.html.ini
@@ -1,2 +1,0 @@
-[flex-align-content-center.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-end.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-end.html.ini
@@ -1,2 +1,0 @@
-[flex-align-content-end.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-space-around.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-space-around.html.ini
@@ -1,2 +1,0 @@
-[flex-align-content-space-around.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-space-between.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-space-between.html.ini
@@ -1,2 +1,0 @@
-[flex-align-content-space-between.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-start.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-align-content-start.html.ini
@@ -1,2 +1,0 @@
-[flex-align-content-start.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-formatting-interop.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_flex-formatting-interop.html.ini
@@ -1,0 +1,2 @@
+[flexbox_flex-formatting-interop.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-position/position-absolute-dynamic-static-position-floats-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-position/position-absolute-dynamic-static-position-floats-004.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-dynamic-static-position-floats-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-position/static-position/inline-level-absolute-in-block-level-context-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-position/static-position/inline-level-absolute-in-block-level-context-004.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-position/static-position/inline-level-absolute-in-block-level-context-009.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-position/static-position/inline-level-absolute-in-block-level-context-009.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-009.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-position/static-position/inline-level-absolute-in-block-level-context-010.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-position/static-position/inline-level-absolute-in-block-level-context-010.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-010.html]
-  expected: FAIL


### PR DESCRIPTION
Don't pass up float stacking containers to parent stacking contexts

Instead of passing up stacking containers created by floated content,
keep them in their original parent stacking containers. This is in in
line with specification text for stacking containers:

> To paint a stacking container, given a box root and a canvas canvas:
>
>   1.  Paint a stacking context given root and canvas, treating root as
>       if it created a new stacking context, but omitting any positioned
>       descendants or descendants that actually create a stacking context
>       (letting the parent stacking context paint them, instead).



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
