### PR TITLE
Implement BlockLevelBox::inline_content_sizes for floats

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -388,10 +388,9 @@ impl BlockLevelBox {
             Self::Independent(independent) => independent
                 .outer_inline_content_sizes(layout_context, containing_block_writing_mode),
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(_) => ContentSizes::zero(),
-            BlockLevelBox::OutOfFlowFloatBox(_box_) => {
-                // TODO: Actually implement that.
-                ContentSizes::zero()
-            },
+            BlockLevelBox::OutOfFlowFloatBox(float_box) => float_box
+                .contents
+                .outer_inline_content_sizes(layout_context, containing_block_writing_mode),
         }
     }
 }

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-001.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-002.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-004.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-005.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-012.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-012.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-012.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-013.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-013.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-013.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-015.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-015.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-015.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-016.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-023.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-023.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-023.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-024.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-024.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-024.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-026.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-026.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-026.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-027.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-027.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-027.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-034.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-034.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-034.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-035.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-035.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-035.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-037.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-037.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-037.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-038.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-038.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-038.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-045.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-045.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-045.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-046.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-046.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-046.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-048.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-048.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-048.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-049.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-049.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-049.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-056.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-056.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-056.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-057.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-057.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-057.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-059.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-059.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-059.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-060.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-060.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-060.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-067.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-067.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-067.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-068.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-068.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-068.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-070.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-070.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-070.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-071.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-071.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-071.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-078.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-078.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-078.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-079.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-079.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-079.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-081.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-081.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-081.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-082.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-082.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-082.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-100.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-100.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-100.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-101.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-101.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-101.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-102.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-right-102.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-102.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-intrinsics-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-intrinsics-001.html.ini
@@ -28,6 +28,3 @@
 
   [.flex-item 11]
     expected: FAIL
-
-  [.flex-item 1]
-    expected: FAIL


### PR DESCRIPTION
This improves #29874, but `BlockContainer::inline_content_sizes` will still need more changes in order to correctly handle sequences of floats.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
