### PR TITLE
Handle floats in BlockContainer::inline_content_sizes

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -690,12 +690,7 @@ impl FloatBox {
             .floats
             .lower_ceiling(sequential_layout_state.current_block_position_including_margins());
 
-        let style = match self.contents {
-            IndependentFormattingContext::Replaced(ref replaced) => replaced.style.clone(),
-            IndependentFormattingContext::NonReplaced(ref non_replaced) => {
-                non_replaced.style.clone()
-            },
-        };
+        let style = self.contents.style().clone();
         let float_context = &mut sequential_layout_state.floats;
         let box_fragment = positioning_context.layout_maybe_position_relative_fragment(
             layout_context,

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -33,10 +33,17 @@ impl ContentSizes {
         }
     }
 
-    pub fn max(self, other: Self) -> Self {
+    pub fn max(&self, other: Self) -> Self {
         Self {
             min_content: self.min_content.max(other.min_content),
             max_content: self.max_content.max(other.max_content),
+        }
+    }
+
+    pub fn add(&self, other: &Self) -> Self {
+        Self {
+            min_content: self.min_content.max(other.min_content),
+            max_content: self.max_content + other.max_content,
         }
     }
 

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-intrinsics-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-intrinsics-001.html.ini
@@ -1,4 +1,7 @@
 [flex-basis-intrinsics-001.html]
+  [.flex-item 1]
+    expected: FAIL
+
   [.flex-item 2]
     expected: FAIL
 
@@ -18,12 +21,6 @@
     expected: FAIL
 
   [.flex-item 6]
-    expected: FAIL
-
-  [.flex-item 7]
-    expected: FAIL
-
-  [.flex-item 9]
     expected: FAIL
 
   [.flex-item 11]


### PR DESCRIPTION
Typically, block-level contents are stacked vertically, so this was just taking the maximum size among all contents. However, floats can be stacked horizontally, so we need to sum their sizes.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29874

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
