### PR TITLE
Fix the rustdoc build after recent changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compile docs
         run: python3 ./mach doc
         env:
-          RUSTDOCFLAGS: --disable-minification
+          RUSTDOCFLAGS: -Z unstable-options --disable-minification
       - name: Upload docs
         run: |
           cd target/doc


### PR DESCRIPTION
If passing --disable-minification, we must also enable unstable-options. This was happening before, but by accident.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a build fix.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
