### PR TITLE
Default nightly builds to layout 2020

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,11 +59,11 @@ jobs:
     needs:
       - create-draft-release
       - upload-linux
-      - upload-linux-2020
+      - upload-linux-2013
       - upload-win
-      - upload-win-2020
+      - upload-win-2013
       - upload-mac
-      - upload-mac-2020
+      - upload-mac-2013
 
   upload-win:
     # This job is only useful when run on upstream servo.
@@ -73,20 +73,20 @@ jobs:
       - create-draft-release
     uses: ./.github/workflows/windows.yml
     with:
-      layout: '2013'
+      layout: '2020'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
 
-  upload-win-2020:
+  upload-win-2013:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (Windows layout-2020)
+    name: Upload nightly (Windows layout-2013)
     needs:
       - create-draft-release
     uses: ./.github/workflows/windows.yml
     with:
-      layout: '2020'
+      layout: '2013'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
@@ -99,20 +99,20 @@ jobs:
       - create-draft-release
     uses: ./.github/workflows/mac.yml
     with:
-      layout: '2013'
+      layout: '2020'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
 
-  upload-mac-2020:
+  upload-mac-2013:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (macOS layout-2020)
+    name: Upload nightly (macOS layout-2013)
     needs:
       - create-draft-release
     uses: ./.github/workflows/mac.yml
     with:
-      layout: '2020'
+      layout: '2013'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
@@ -125,20 +125,20 @@ jobs:
       - create-draft-release
     uses: ./.github/workflows/linux.yml
     with:
-      layout: '2013'
+      layout: '2020'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
 
-  upload-linux-2020:
+  upload-linux-2013:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (Linux layout-2020)
+    name: Upload nightly (Linux layout-2013)
     needs:
       - create-draft-release
     uses: ./.github/workflows/linux.yml
     with:
-      layout: '2020'
+      layout: '2013'
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -518,9 +518,9 @@ class PackageCommands(CommandBase):
             package_hash_fileobj = io.BytesIO(package_hash.encode('utf-8'))
 
             if '2020' in platform:
-                asset_name = f'servo-latest-layout-2020.{extension}'
-            else:
                 asset_name = f'servo-latest.{extension}'
+            else:
+                asset_name = f'servo-latest-legacy-layout.{extension}'
 
             release.upload_asset(package, name=asset_name)
             release.upload_asset_from_memory(
@@ -545,7 +545,11 @@ class PackageCommands(CommandBase):
             BUCKET = 'servo-builds2'
             DISTRIBUTION_ID = 'EJ8ZWSJKFCJS2'
 
-            nightly_dir = 'nightly/{}'.format(platform)
+            if '2020' in platform:
+                nightly_dir = 'nightly/{}'.format(platform.replace('-layout2020', ''))
+            else:
+                nightly_dir = 'nightly/{}-legacy-layout'.format(platform)
+
             filename = nightly_filename(package, timestamp)
             package_upload_key = '{}/{}'.format(nightly_dir, filename)
             extension = path.basename(package).partition('.')[2]


### PR DESCRIPTION
This PR switches the filenames used by nightly builds so that the default `servo-latest.{ext}` packages use the 2020 engine and the 'servo-latest-legacy-layout.{ext}` packages use the 2013 engine.

Since the platform workflows are reused by  the main, quick-check, PR and WPT import flows and since the 2013/2020 flags are also controlled by try branches, I've kept the changes isolated to  `nightly.yml` and `package_commands.py` and have avoided changing the input parameters. If we want to deault all the workflows to 2020, I can decline this PR and raise a new one.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they modify packaging logic.
