### PR TITLE
Fix interaction of clearance with margin collapse

### DIFF
--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/adjoining-float-nested-forced-clearance-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/adjoining-float-nested-forced-clearance-002.html.ini
@@ -1,2 +1,0 @@
-[adjoining-float-nested-forced-clearance-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-033.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-033.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-033.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-034.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-034.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-034.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-035.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-035.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-035.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-clear-012.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-clear-012.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-012.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-clear-013.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/margin-collapse-clear-013.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-013.xht]
-  expected: FAIL


### PR DESCRIPTION
In #29897 I did the simple naive thing, but it wasn't entirely correct. This patch tries to address the problems. In particular:

 - Clearance should prevent margins from collapsing through if it happens between them, as opposed to on the element that owns them.
 - The margins of an element with clearance can still collapse through, and collapse with other siblings as normal, but the resulting margin can't collapse with the bottom margin of the parent.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29896
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
