### PR TITLE
Simplify the build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,253 +10,45 @@ for help getting started.
 
 Visit the [Servo Project page](https://servo.org/) for news and guides.
 
-## Setting up your environment
+## Build Setup
 
-### Rustup.rs
-
-Building servo requires [rustup](https://rustup.rs/), version 1.8.0 or more recent.
-If you have an older version, run `rustup self update`.
-
-To install on Windows, download and run [`rustup-init.exe`](https://win.rustup.rs/)
-then follow the onscreen instructions.
-
-To install on other systems, run:
-
-```sh
-curl https://sh.rustup.rs -sSf | sh
-```
-
-This will also download the current stable version of Rust, which Servo won’t use.
-To skip that step, run instead:
-
-```
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none
-```
-
-See also [Other installation methods](
-https://rust-lang.github.io/rustup/installation/other.html)
-
-### Other dependencies
-
-Please select your operating system:
 * [macOS](#macos)
-* [Debian-based distros](#on-debian-based-distros)
-* [Fedora](#on-fedora)
-* [Arch Linux](#on-arch-linux)
-* [openSUSE](#on-opensuse-linux)
-* [Gentoo Linux](#on-gentoo-linux)
-* [Microsoft Windows](#on-windows-msvc)
-* [Android](#cross-compilation-for-android)
+* [Linux](#Linux)
+* [Windows](#windows)
+* [Android](https://github.com/servo/servo/wiki/Building-for-Android)
 
-#### macOS
+If these instructions fail or you would like to install dependencies
+manually, try the [manual build setup][manual-build].
 
-- Install Xcode (version 10.2 or above is recommended)
-- Run `./mach bootstrap-gstreamer`. This will install the recommended version of GStreamer globally on your system.
+### macOS
+
+- Install [Xcode](https://developer.apple.com/xcode/)
+- Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- Run `./mach bootstrap-gstreamer`.
+  *This will install the recommended version of GStreamer globally on your system.*
 - Run `brew bundle install --file=etc/homebrew/Brewfile`
 - Run `pip install virtualenv`
 
-#### On Debian-based distros
 
-``` sh
-sudo apt install python3-virtualenv python3-pip
-./mach bootstrap
-```
+### Linux
 
-If `./mach bootstrap` doesn't work, file a bug, and, run the commands below:
+- Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- Install Python and virtualenv
+    - **Debian-like:** Run `sudo apt install python3-virtualenv python3-pip`
+    - **Fedora:** Run `sudo dnf install python3 python3-virtualenv python3-pip python3-devel`
+    - **Arch:** Run `sudo pacman -S --needed python python-virtualenv python-pip`
+    - **Gentoo:** Run `sudo emerge dev-python/virtualenv dev-python/pip`
+- Run `./mach bootstrap`
 
-``` sh
-sudo apt install git curl autoconf libx11-dev libfreetype6-dev libgl1-mesa-dri \
-    libglib2.0-dev xorg-dev gperf g++ build-essential cmake libssl-dev \
-    liblzma-dev libxmu6 libxmu-dev \
-    libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
-    libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libharfbuzz-dev ccache \
-    clang libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-    libgstreamer-plugins-bad1.0-dev autoconf2.13 llvm-dev
-```
+### Windows
 
-You will also need GStreamer which you can install in two ways:
+ - Download and run [`rustup-init.exe`](https://win.rustup.rs/) then follow the onscreen instructions.
+ - Install [chocolatey](https://chocolatey.org/)
+ - Run `choco install support\windows\chocolatey.config`
+   *This will install CMake, Git, LLVM, Ninja, NuGet, Python and the Visual Studio 2019 Build Tools.*
+ - Run `mach bootstrap-gstreamer`
 
-1. On **Ubuntu 20.04 LTS or greater**:  The system version of GStreamer is sufficient if you install the necessary plugins:
-
-   ```
-    sudo apt install gstreamer1.0-nice gstreamer1.0-plugins-bad
-   ```
-
-2. Run `./mach bootstrap-gstreamer` to install the prepackaged binaries into the `target` directory.
-
-If you are using **Ubuntu 16.04** or **Linux Mint 18**, run `export HARFBUZZ_SYS_NO_PKG_CONFIG=1` before building to avoid an error with harfbuzz.
-
-If you get an undefined symbol error on `gst_player_get_config` try removing `gir1.2-gst-plugins-bad-1.0` and all old versions of clang, see [#22016](https://github.com/servo/servo/issues/22016).
-
-#### On Fedora
-
-``` sh
-sudo dnf install python3 python3-virtualenv python3-pip python3-devel
-python3 ./mach bootstrap
-```
-
-If `python3 ./mach bootstrap` doesn't work, file a bug, and, run the commands below:
-
-``` sh
-sudo dnf install curl libtool gcc-c++ libXi-devel libunwind-devel \
-    freetype-devel mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel \
-    libXrandr-devel gperf fontconfig-devel cabextract ttmkfdir  expat-devel \
-    rpm-build openssl-devel cmake libX11-devel libXcursor-devel \
-    libXmu-devel dbus-devel ncurses-devel harfbuzz-devel \
-    ccache clang clang-libs python3-devel gstreamer1-devel \
-    gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel autoconf213 \
-    libjpeg-turbo-devel zlib libjpeg
-```
-
-#### On CentOS
-
-``` sh
-sudo yum install python-virtualenv python-pip
-./mach bootstrap
-```
-
-If `./mach bootstrap` doesn't work, file a bug, and, run the commands below:
-
-``` sh
-sudo yum install curl libtool gcc-c++ libXi-devel freetype-devel \
-    mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel libXrandr-devel \
-    gperf fontconfig-devel cabextract ttmkfdir python expat-devel rpm-build \
-    openssl-devel cmake3 libXcursor-devel libXmu-devel \
-    dbus-devel ncurses-devel python34 harfbuzz-devel \
-    ccache clang clang-libs llvm-toolset-7
-```
-
-Build inside `llvm-toolset` and `devtoolset`:
-
-```sh
-scl enable devtoolset-7 llvm-toolset-7 bash
-```
-
-with the following environmental variables set:
-
-```sh
-export CMAKE=cmake3
-export LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64
-```
-
-#### On openSUSE
-
-``` sh
-sudo zypper install libX11-devel libexpat-devel Mesa-libEGL-devel Mesa-libGL-devel cabextract cmake \
-    dbus-1-devel fontconfig-devel freetype-devel gcc-c++ git glib2-devel gperf \
-    harfbuzz-devel libXcursor-devel libXi-devel libXmu-devel libXrandr-devel libopenssl-devel \
-    python3-pip python3-virtualenv rpm-build ccache llvm-clang libclang autoconf213 gstreamer-devel \
-    gstreamer-plugins-base-devel gstreamer-plugins-bad-devel
-```
-
-#### On Arch Linux
-
-``` sh
-sudo pacman -S --needed base-devel git python python-virtualenv python-pip mesa cmake libxmu \
-    pkg-config ttf-fira-sans harfbuzz ccache llvm clang autoconf2.13 gstreamer gstreamer-vaapi \
-    gst-plugins-base gst-plugins-good gst-plugins-bad
-```
-
-#### On Gentoo Linux
-
-```sh
-sudo emerge net-misc/curl \
-    media-libs/freetype media-libs/mesa dev-util/gperf \
-    dev-python/virtualenv dev-python/pip dev-libs/openssl \
-    media-libs/harfbuzz dev-util/ccache sys-libs/libunwind \
-    x11-libs/libXmu x11-base/xorg-server sys-devel/clang \
-    media-libs/gstreamer media-libs/gst-plugins-bad media-libs/gst-plugins-base
-```
-
-With the following environment variable set:
-```sh
-export LIBCLANG_PATH=$(llvm-config --prefix)/lib64
-```
-
-#### On NixOS Linux
-
-```sh
-nix-shell etc/shell.nix
-```
-
-You will need to run this in every shell before running mach.
-
-#### On Windows (MSVC)
-
-1. Install Python 3.9 for Windows (https://www.python.org/downloads/release/python-392/). The Windows x86-64 MSI installer is fine. This is required in order to build the JavaScript engine, SpiderMonkey.
-
-   You will also need to set the `PYTHON3` environment variable, e.g., to 'C:\Python39\python.exe' by doing:
-   ```
-   setx PYTHON3 "C:\Python39\python.exe" /m
-   ```
-   The `/m` will set it system-wide for all future command windows.
-
-2. Install virtualenv. In a normal Windows Shell (cmd), do:
-     ```
-    pip install virtualenv
-    ```
-     If this does not work, you may need to reboot for the changed PATH settings (by the python installer) to take effect.
-
-3. Install GStreamer:
-    ```
-    mach bootstrap-gstreamer
-    ```
-   You can also install GStreamer manually using the MSVC (**not MingGW**) binaries from the [GStreamer](https://gstreamer.freedesktop.org/data/pkg/windows/) site. The currently recommended version is 1.16.0. i.e:
-
-    - [gstreamer-1.0-msvc-x86_64-1.16.0.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.16.0/gstreamer-1.0-msvc-x86_64-1.16.0.msi)
-    - [gstreamer-1.0-devel-msvc-x86_64-1.16.0.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.16.0/gstreamer-1.0-devel-msvc-x86_64-1.16.0.msi)
-
-
-   Note that you should ensure that _all_ components are installed from gstreamer, as we require many of the optional libraries that are not installed by default.
-
-4. Install Git for Windows (https://git-scm.com/download/win). DO allow it to add git.exe to the PATH (default
-settings for the installer are fine).
-
-5. Install Visual Studio Build Tools 2019 (https://visualstudio.microsoft.com/de/downloads/#build-tools-for-visual-studio-2019). It is easiest to install via [Chocolatey](https://chocolatey.org/install#installing-chocolatey) with:
-   ```
-   choco install -y visualstudio2019buildtools --package-parameters="--add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.VCTools"
-   ```
-   If you really need to use the Visual Studio Installer (UI), choose "Desktop development with C++" and add the optional "MSVC", "C++-ATL" and "C++-MFC" (latest).
-
-   The Visual Studio 2019 Build Tools MUST be installed to the default location or mach.bat will not find them.
-
-##### [Optional] Install LLVM for faster link times
-
-You may experience much faster builds on Windows by following these steps. (Related Rust issue: https://github.com/rust-lang/rust/issues/37543)
-
-1. Download the latest version of LLVM (https://releases.llvm.org/).
-2. Run the installer and choose to add LLVM to the system PATH.
-3. Add the following to your Cargo config (Found at `%USERPROFILE%\.cargo\config`). You may need to change the triple to match your environment.
-
-```
-[target.x86_64-pc-windows-msvc]
-linker = "lld-link.exe"
-```
-
-##### Troubleshooting a Windows environment
-
->If you have troubles with `x64 type` prompt as `mach.bat` set by default:
-> 1. You may need to choose and launch the type manually, such as `x86_x64 Cross Tools Command Prompt for VS 2019` in the Windows menu.)
-> 2. `cd to/the/path/servo`
-> 3. `python mach build -d`
-
-> If you got the error `Cannot run mach in a path on a case-sensitive file system on Windows`:
-> 1. Open Command Prompt or PowerShell as administrator.
-> 2. Disable case-sensitive for servo path, `fsutil.exe file SetCaseSensitiveInfo X:\path\to\servo disable`
-
-> If you got the error `DLL file `api-ms-win-crt-runtime-l1-1-0.dll` not found!` then set
-> the `WindowsSdkDir` environment variable to an appropriate `Windows Kit` directory containing
-> `Redist\ucrt\DLLs\x64\api-ms-win-crt-runtime-l1-1-0.dll`, for example
-> `C:\Program Files (x86)\Windows Kits\10`.
-
-> If you get the error `thread 'main' panicked at 'Unable to find libclang: "couldn\'t find any valid shared libraries matching: [\'clang.dll\', \'libclang.dll\'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: ... invalid DLL (64-bit))])"'`
-> then `rustup` may have installed the 32-bit default target rather than the 64-bit one.
-> You can find the configuration with `rustup show`, and set the default with `rustup set default-host x86_64-pc-windows-msvc`.
-
-#### Cross-compilation for Android
-
-Run `./mach bootstrap-android --build` to get Android-specific tools. See wiki for
-[details](https://github.com/servo/servo/wiki/Building-for-Android).
+See also [Windows Troubleshooting Tips][windows-tips].
 
 ### Cloning the Repo
 Your CARGO_HOME needs to point to (or be in) the same drive as your Servo repository (See [#28530](https://github.com/servo/servo/issues/28530)).
@@ -381,3 +173,6 @@ There are lots of mach commands you can use. You can list them with `./mach
 
 
 The generated documentation can be found on https://doc.servo.org/servo/index.html
+
+[manual-build]: https://github.com/servo/servo/wiki/Building#manual-build-setup
+[windows-tips]: https://github.com/servo/servo/wiki/Building#troubleshooting-the-windows-build

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -1067,8 +1067,8 @@ def find_highest_msvc_version():
 
     versions = sorted(find_highest_msvc_version_ext(), key=lambda tup: float(tup[1]))
     if not versions:
-        print("Can't find MSBuild.exe installation under %s. Please set the VSINSTALLDIR and VisualStudioVersion"
-              + " environment variables" % base_vs_path)
+        print(f"Can't find MSBuild.exe installation under {base_vs_path}. "
+              "Please set the VSINSTALLDIR and VisualStudioVersion environment variables")
         sys.exit(1)
     return versions[0]
 

--- a/support/windows/chocolatey.config
+++ b/support/windows/chocolatey.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="cmake" version="3.26.4" />
+  <package id="git"/>
+  <package id="llvm"/>
+  <package id="ninja"/>
+  <package id="nuget.commandline" version="6.6.0" />
+  <package id="python"/>
+  <package id="python3-virtualenv"/>
+  <package id="visualstudio2019buildtools" packageParameters="--add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Component.Windows10SDK  --add Microsoft.VisualStudio.Component.Windows10SDK.20348 --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.VCTools" />
+</packages>


### PR DESCRIPTION
- Add a chocolatey configuration that installs all dependencies and split
  the instructions into a normal and manual installation section. In
  addition fix a warning print statement for the Windows build that would
  trigger a Python exception.
- Simplify the build instructions in the README and move all manual
  setup details to: https://github.com/servo/servo/wiki/Building


<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
