### PR TITLE
Set sensible defaults for cargo without mach

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,12 +27,29 @@ linker = "lld-link.exe"
 
 [target.x86_64-uwp-windows-msvc]
 linker = "lld-link.exe"
+rustflags = ["-W", "unused-extern-crates", "-C", "link-arg=-fuse-ld=gold"]
 
 [target.i686-pc-windows-msvc]
 linker = "lld-link.exe"
+rustflags = ["-W", "unused-extern-crates", "-C", "link-arg=-fuse-ld=gold"]
 
 [target.aarch64-pc-windows-msvc]
 linker = "lld-link.exe"
 
 [target.aarch64-uwp-windows-msvc]
 linker = "lld-link.exe"
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-W", "unused-extern-crates", "-C", "link-arg=-fuse-ld=gold"]
+
+[target.i686-unknown-linux-gnu]
+rustflags = ["-W", "unused-extern-crates", "-C", "link-arg=-fuse-ld=gold"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-W", "unused-extern-crates", "-C", "link-arg=-fuse-ld=gold"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-W", "unused-extern-crates", "-C", "link-arg=-fuse-ld=gold"]
+
+[build]
+rustflags = ["-W", "unused-extern-crates"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "ports/libsimpleservo/jniapi/",
     "tests/unit/*",
 ]
+default-members = ["ports/winit"]
 exclude = [".cargo"]
 
 [workspace.dependencies]

--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -77,6 +77,11 @@ fn main() {
         (true, false, false, false) => "gecko",
         (false, true, true, false) => "servo-2013",
         (false, true, false, true) => "servo-2020",
+        (false, true, false, false) => {
+            println!("cargo:warning=Using servo-layout-2020 for style eventhough no layout was selected.");
+            println!("cargo:rustc-cfg=feature=\"servo-layout-2020\"");
+            "servo-2020"
+        }
         _ => panic!(
             "\n\n\
              The style crate requires enabling one of its 'servo' or 'gecko' feature flags \

--- a/ports/winit/Cargo.toml
+++ b/ports/winit/Cargo.toml
@@ -27,7 +27,7 @@ ProductName = "Servo"
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]
-default = ["webdriver", "max_log_level"]
+default = ["webdriver", "max_log_level", "media-gstreamer", "native-bluetooth", "egl", "layout-2020"]
 egl = ["libservo/egl"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -851,6 +851,11 @@ class CommandBase(object):
             if self.config["build"]["debug-mozjs"] or debug_mozjs:
                 features.append("debugmozjs")
 
+            if path.join(self.context.topdir, "ports", "winit", "Cargo.toml") not in cargo_args:
+                cargo_args += ["--no-default-features"]
+                features.append("webdriver")
+                features.append("max_log_level")
+
             features.append("native-bluetooth")
 
             if self.is_uwp_build:


### PR DESCRIPTION
Implemented what was talked about on [zulip](https://servo.zulipchat.com/#narrow/stream/263398-general/topic/sensible.20default.20feature.20on.20winit.20port).

It's not very nice change but it is convenient to use.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
