### PR TITLE
Allow building on paths with Unicode characters

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -266,16 +266,6 @@ def bootstrap(topdir):
 
     topdir = os.path.abspath(topdir)
 
-    # We don't support paths with Unicode characters for now
-    # https://github.com/servo/servo/issues/10002
-    try:
-        # Trick to support both python2 and python3
-        topdir.encode().decode('ascii')
-    except UnicodeDecodeError:
-        print('Cannot run mach in a path with Unicode characters.')
-        print('Current path:', topdir)
-        sys.exit(1)
-
     # We don't support paths with spaces for now
     # https://github.com/servo/servo/issues/9442
     if ' ' in topdir:


### PR DESCRIPTION
This now works since the upgrade to Python 3, so we can remove
this code which prevents mach from running in these situations.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #10002.
- [x] These changes do not require tests because they just change build scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
