### PR TITLE
Use mozjs tracing infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3704,7 +3704,7 @@ checksum = "903970ae2f248d7275214cf8f387f8ba0c4ea7e3d87a320e85493db60ce28616"
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#98b678283d1b0c6d263302ca2aff770aece0cb8e"
+source = "git+https://github.com/servo/mozjs#64711ec2e6dc4595df691bffc7f1e5052ab86c8d"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.68.2"
-source = "git+https://github.com/servo/mozjs#98b678283d1b0c6d263302ca2aff770aece0cb8e"
+source = "git+https://github.com/servo/mozjs#64711ec2e6dc4595df691bffc7f1e5052ab86c8d"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/dom/bindings/record.rs
+++ b/components/script/dom/bindings/record.rs
@@ -81,6 +81,7 @@ impl RecordKey for ByteString {
 /// The `Record` (open-ended dictionary) type.
 #[derive(Clone, JSTraceable)]
 pub struct Record<K: RecordKey, V> {
+    #[custom_trace]
     map: IndexMap<K, V>,
 }
 

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -17,13 +17,12 @@ use js::typedarray::ArrayBufferView;
 use servo_rand::{RngCore, ServoRng};
 use std::ptr::NonNull;
 
-unsafe_no_jsmanaged_fields!(ServoRng);
-
 // https://developer.mozilla.org/en-US/docs/Web/API/Crypto
 #[dom_struct]
 pub struct Crypto {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "Defined in rand"]
+    #[no_trace]
     rng: DomRefCell<ServoRng>,
 }
 

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -25,8 +25,6 @@ use style::stylesheets::{
 
 unsafe_no_jsmanaged_fields!(RulesSource);
 
-unsafe_no_jsmanaged_fields!(CssRules);
-
 impl From<RulesMutateError> for Error {
     fn from(other: RulesMutateError) -> Self {
         match other {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -269,6 +269,7 @@ pub struct Document {
     #[no_trace]
     style_shared_lock: StyleSharedRwLock,
     /// List of stylesheets associated with nodes in this document. |None| if the list needs to be refreshed.
+    #[custom_trace]
     stylesheets: DomRefCell<DocumentStylesheetSet<StyleSheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     ready_state: Cell<DocumentReadyState>,

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -19,16 +19,15 @@ use js::rust::HandleObject;
 use keyboard_types::{Key, Modifiers};
 use std::cell::Cell;
 
-unsafe_no_jsmanaged_fields!(Key);
-unsafe_no_jsmanaged_fields!(Modifiers);
-
 #[dom_struct]
 pub struct KeyboardEvent {
     uievent: UIEvent,
     key: DomRefCell<DOMString>,
+    #[no_trace]
     typed_key: DomRefCell<Key>,
     code: DomRefCell<DOMString>,
     location: Cell<u32>,
+    #[no_trace]
     modifiers: Cell<Modifiers>,
     repeat: Cell<bool>,
     is_composing: Cell<bool>,

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -312,22 +312,6 @@ macro_rules! unsafe_no_jsmanaged_fields(
     );
 );
 
-macro_rules! jsmanaged_array(
-    ($count:expr) => (
-        #[allow(unsafe_code)]
-        unsafe impl<T> $crate::dom::bindings::trace::JSTraceable for [T; $count]
-            where T: $crate::dom::bindings::trace::JSTraceable
-        {
-            #[inline]
-            unsafe fn trace(&self, tracer: *mut ::js::jsapi::JSTracer) {
-                for v in self.iter() {
-                    v.trace(tracer);
-                }
-            }
-        }
-    );
-);
-
 /// These are used to generate a event handler which has no special case.
 macro_rules! define_event_handler(
     ($handler: ty, $event_type: ident, $getter: ident, $setter: ident, $setter_fn: ident) => (

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -7,7 +7,7 @@
 use crate::dom::bindings::codegen::Bindings::HTMLTemplateElementBinding::HTMLTemplateElementMethods;
 use crate::dom::bindings::inheritance::{Castable, CharacterDataTypeId, NodeTypeId};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::trace::JSTraceable;
+use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
@@ -101,7 +101,7 @@ impl Tokenizer {
 }
 
 #[allow(unsafe_code)]
-unsafe impl JSTraceable for HtmlTokenizer<TreeBuilder<Dom<Node>, Sink>> {
+unsafe impl CustomTraceable for HtmlTokenizer<TreeBuilder<Dom<Node>, Sink>> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         struct Tracer(*mut JSTracer);
         let tracer = Tracer(trc);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1381,6 +1381,7 @@ fn create_element_for_token(
 #[derive(JSTraceable, MallocSizeOf)]
 struct NetworkDecoder {
     #[ignore_malloc_size_of = "Defined in tendril"]
+    #[custom_trace]
     decoder: LossyDecoder<NetworkSink>,
 }
 

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::trace::JSTraceable;
+use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};
 use crate::dom::document::{determine_policy_for_token, Document};
 use crate::dom::htmlimageelement::{image_fetch_request, FromPictureOrSrcSet};
 use crate::dom::htmlscriptelement::script_fetch_request;
@@ -42,7 +42,7 @@ pub struct Tokenizer {
 }
 
 #[allow(unsafe_code)]
-unsafe impl JSTraceable for HtmlTokenizer<PrefetchSink> {
+unsafe impl CustomTraceable for HtmlTokenizer<PrefetchSink> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         self.sink.trace(trc)
     }

--- a/components/script/dom/servoparser/xml.rs
+++ b/components/script/dom/servoparser/xml.rs
@@ -5,7 +5,7 @@
 #![allow(unrooted_must_root)]
 
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::trace::JSTraceable;
+use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};
 use crate::dom::document::Document;
 use crate::dom::htmlscriptelement::HTMLScriptElement;
 use crate::dom::node::Node;
@@ -59,7 +59,7 @@ impl Tokenizer {
 }
 
 #[allow(unsafe_code)]
-unsafe impl JSTraceable for XmlTokenizer<XmlTreeBuilder<Dom<Node>, Sink>> {
+unsafe impl CustomTraceable for XmlTokenizer<XmlTreeBuilder<Dom<Node>, Sink>> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         struct Tracer(*mut JSTracer);
         let tracer = Tracer(trc);

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -42,6 +42,7 @@ pub struct ShadowRoot {
     document: Dom<Document>,
     host: MutNullableDom<Element>,
     /// List of author styles associated with nodes in this shadow tree.
+    #[custom_trace]
     author_styles: DomRefCell<AuthorStyles<StyleSheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     window: Dom<Window>,

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -43,8 +43,6 @@ enum WebGLTextureOwner {
 const MAX_LEVEL_COUNT: usize = 31;
 const MAX_FACE_COUNT: usize = 6;
 
-jsmanaged_array!(MAX_LEVEL_COUNT * MAX_FACE_COUNT);
-
 #[dom_struct]
 pub struct WebGLTexture {
     webgl_object: WebGLObject,

--- a/components/script/dom/xrhand.rs
+++ b/components/script/dom/xrhand.rs
@@ -17,6 +17,7 @@ pub struct XRHand {
     #[ignore_malloc_size_of = "defined in webxr"]
     source: Dom<XRInputSource>,
     #[ignore_malloc_size_of = "partially defind in webxr"]
+    #[custom_trace]
     spaces: Hand<Dom<XRJointSpace>>,
 }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -178,6 +178,7 @@ pub struct ModuleTree {
     // By default all maps in web specs are ordered maps
     // (https://infra.spec.whatwg.org/#ordered-map), however we can usually get away with using
     // stdlib maps and sets because we rarely iterate over them.
+    #[custom_trace]
     parent_identities: DomRefCell<IndexSet<ModuleIdentity>>,
     #[no_trace]
     descendant_urls: DomRefCell<IndexSet<ServoUrl>>,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -22,7 +22,7 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::trace_roots;
 use crate::dom::bindings::settings_stack;
-use crate::dom::bindings::trace::{trace_traceables, JSTraceable};
+use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::bindings::utils::DOM_CALLBACKS;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::eventtarget::EventTarget;
@@ -825,7 +825,6 @@ unsafe extern "C" fn trace_rust_roots(tr: *mut JSTracer, _data: *mut os::raw::c_
     }
     debug!("starting custom root handler");
     trace_thread(tr);
-    trace_traceables(tr);
     trace_roots(tr);
     trace_refcounted_objects(tr);
     settings_stack::trace(tr);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -521,8 +521,6 @@ impl<'a> Iterator for DocumentsIter<'a> {
 pub struct IncompleteParserContexts(RefCell<Vec<(PipelineId, ParserContext)>>);
 
 unsafe_no_jsmanaged_fields!(TaskQueue<MainThreadScriptMsg>);
-unsafe_no_jsmanaged_fields!(dyn BackgroundHangMonitorRegister);
-unsafe_no_jsmanaged_fields!(dyn BackgroundHangMonitor);
 
 #[derive(JSTraceable)]
 // ScriptThread instances are rooted on creation, so this is okay
@@ -552,8 +550,10 @@ pub struct ScriptThread {
     task_queue: TaskQueue<MainThreadScriptMsg>,
 
     /// A handle to register associated layout threads for hang-monitoring.
+    #[no_trace]
     background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
     /// The dedicated means of communication with the background-hang-monitor for this script-thread.
+    #[no_trace]
     background_hang_monitor: Box<dyn BackgroundHangMonitor>,
     /// A flag set to `true` by the BHM on exit, and checked from within the interrupt handler.
     closing: Arc<AtomicBool>,

--- a/components/script_plugins/trace_in_no_trace.rs
+++ b/components/script_plugins/trace_in_no_trace.rs
@@ -98,9 +98,7 @@ fn get_must_not_have_traceable(sym: &Symbols, attrs: &[Attribute]) -> Option<usi
 
 fn is_jstraceable<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>) -> bool {
     // TODO(sagudev): get_trait_def_id is expensive, use lazy and cache it for whole pass
-    if let Some(trait_id) =
-        get_trait_def_id(cx, &["script", "dom", "bindings", "trace", "JSTraceable"])
-    {
+    if let Some(trait_id) = get_trait_def_id(cx, &["mozjs", "gc", "Traceable"]) {
         return implements_trait(cx, ty, trait_id, &[]);
     }
     // when running tests


### PR DESCRIPTION
Servos tracing infrastructure was mainly copied to mozjs in https://github.com/servo/mozjs/pull/352. Now this PR tries to switch to it.

Due to moving `JSTraceable` trait to mozjs we can no longer implement trait directly on foreign types (of script crate) due to Rust's orphan rules. This PR resolves the problem with building on top of https://github.com/servo/servo/pull/29926 and introducing `CustomTraceable` trait where custom trace implementations on foreign types are necessary with limitation that they only work inside of Dom objects (those types that use `derive(JSTraceable)`). The final code now looks like this:

```rust
#[derive(JSTraceable)]
struct S {
  js_managed: JSManagedType,

  #[no_trace] // this field will be skipped in tracing
              // SAFETY: Trait shenanigans assures that the type is not JSTraceable
  non_js: NonJSManagedType,

  #[custom_trace] // Extern type implements CustomTraceable that is from servo => no problem with orphan rules
  extern_composed_type: Extern<JSManagedType>,
}
```

Needs https://github.com/servo/mozjs/pull/359.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
