### PR TITLE
Remove the DOMToTexture feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "gleam"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdef5b9df6d3a261b80a5ac55e13bf93945725df2463c1b0a2e5a527dce0d37"
+checksum = "a6da1b0a7e3f0833efe2c59f11c0e196d6208735018693c340eded4bd7aacb49"
 dependencies = [
  "gl_generator 0.14.0",
 ]
@@ -2214,9 +2214,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glslopt"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c6fe80551c01b577d6f63f2227c485c0cb6827defeaa13dacbf84b42012853"
+checksum = "74a3f5c04450dfdadb4b08f6e5ee6f5110f674de1acbd6199bfec68392a8cbaf"
 dependencies = [
  "cc",
 ]
@@ -2617,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2775,16 +2775,17 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.10"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985fc06b1304d19c28d5c562ed78ef5316183f2b0053b46763a0b94862373c34"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
 dependencies = [
  "bytemuck",
  "byteorder",
+ "color_quant",
  "num-iter",
- "num-rational 0.3.0",
+ "num-rational 0.3.2",
  "num-traits",
- "png 0.16.6",
+ "png 0.16.8",
 ]
 
 [[package]]
@@ -3688,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "mio-extras"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
  "log",
@@ -4043,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.40"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -4065,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -4571,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.6"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c150bf7479fafe3dd8740dbe48cc33b2a3efb7b0fe3483aced8bbc39f6d0238d"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -4630,9 +4631,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -5296,11 +5297,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -6619,9 +6620,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -6999,7 +7000,7 @@ dependencies = [
  "fxhash",
  "gleam",
  "glslopt",
- "image 0.23.10",
+ "image 0.23.14",
  "lazy_static",
  "libc",
  "log",
@@ -7318,9 +7319,9 @@ dependencies = [
 
 [[package]]
 name = "ws"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
+checksum = "25fe90c75f236a0a00247d5900226aea4f2d7b05ccc34da9e7a8880ff59b5848"
 dependencies = [
  "byteorder",
  "bytes 0.4.12",

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -7,12 +7,8 @@ use canvas_traits::webgl::webgl_channel;
 use canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLThreads};
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
-use gleam;
-use servo_config::pref;
-use sparkle::gl;
 use sparkle::gl::GlType;
 use std::default::Default;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use surfman::Device;
 use surfman::SurfaceInfo;
@@ -30,7 +26,6 @@ use webxr_api::LayerGrandManager as WebXRLayerGrandManager;
 pub struct WebGLComm {
     pub webgl_threads: WebGLThreads,
     pub image_handler: Box<dyn WebrenderExternalImageApi>,
-    pub output_handler: Option<Box<dyn webrender_api::OutputImageHandler>>,
     pub webxr_layer_grand_manager: WebXRLayerGrandManager<WebXRSurfman>,
 }
 
@@ -38,7 +33,6 @@ impl WebGLComm {
     /// Creates a new `WebGLComm` object.
     pub fn new(
         surfman: WebrenderSurfman,
-        webrender_gl: Rc<dyn gleam::gl::Gl>,
         webrender_api_sender: webrender_api::RenderApiSender,
         webrender_doc: webrender_api::DocumentId,
         external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
@@ -64,12 +58,6 @@ impl WebGLComm {
             webxr_init,
         };
 
-        let output_handler = if pref!(dom.webgl.dom_to_texture.enabled) {
-            Some(Box::new(OutputHandler::new(webrender_gl.clone())))
-        } else {
-            None
-        };
-
         let external = WebGLExternalImages::new(surfman, webrender_swap_chains);
 
         WebGLThread::run_on_own_thread(init);
@@ -77,7 +65,6 @@ impl WebGLComm {
         WebGLComm {
             webgl_threads: WebGLThreads(sender),
             image_handler: Box::new(external),
-            output_handler: output_handler.map(|b| b as Box<_>),
             webxr_layer_grand_manager: webxr_layer_grand_manager,
         }
     }
@@ -142,45 +129,5 @@ impl WebrenderExternalImageApi for WebGLExternalImages {
     fn unlock(&mut self, id: u64) {
         let id = WebGLContextId(id);
         self.unlock_swap_chain(id);
-    }
-}
-
-/// struct used to implement DOMToTexture feature and webrender::OutputImageHandler trait.
-struct OutputHandler {
-    webrender_gl: Rc<dyn gleam::gl::Gl>,
-    sync_objects: FnvHashMap<webrender_api::PipelineId, gleam::gl::GLsync>,
-}
-
-impl OutputHandler {
-    fn new(webrender_gl: Rc<dyn gleam::gl::Gl>) -> Self {
-        OutputHandler {
-            webrender_gl,
-            sync_objects: Default::default(),
-        }
-    }
-}
-
-/// Bridge between the WR frame outputs and WebGL to implement DOMToTexture synchronization.
-impl webrender_api::OutputImageHandler for OutputHandler {
-    fn lock(
-        &mut self,
-        id: webrender_api::PipelineId,
-    ) -> Option<(u32, webrender_api::units::FramebufferIntSize)> {
-        // Insert a fence in the WR command queue
-        let gl_sync = self
-            .webrender_gl
-            .fence_sync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
-        self.sync_objects.insert(id, gl_sync);
-        // https://github.com/servo/servo/issues/24615
-        None
-    }
-
-    fn unlock(&mut self, id: webrender_api::PipelineId) {
-        if let Some(gl_sync) = self.sync_objects.remove(&id) {
-            // Flush the Sync object into the GPU's command queue to guarantee that it it's signaled.
-            self.webrender_gl.flush();
-            // Mark the sync object for deletion.
-            self.webrender_gl.delete_sync(gl_sync);
-        }
     }
 }

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Deref;
-use webrender_api::{DocumentId, ImageKey, PipelineId};
+use webrender_api::ImageKey;
 use webxr_api::ContextId as WebXRContextId;
 use webxr_api::Error as WebXRError;
 use webxr_api::LayerId as WebXRLayerId;
@@ -76,8 +76,6 @@ pub enum WebGLMsg {
     /// Runs a WebXRCommand (WebXR layers need to be created in the WebGL
     /// thread, as they may have thread affinity).
     WebXRCommand(WebXRCommand),
-    /// Commands used for the DOMToTexture feature.
-    DOMToTextureCommand(DOMToTextureCommand),
     /// Performs a buffer swap.
     ///
     /// The third field contains the time (in ns) when the request
@@ -173,10 +171,6 @@ impl WebGLMsgSender {
     #[inline]
     pub fn send_remove(&self) -> WebGLSendResult {
         self.sender.send(WebGLMsg::RemoveContext(self.ctx_id))
-    }
-
-    pub fn send_dom_to_texture(&self, command: DOMToTextureCommand) -> WebGLSendResult {
-        self.sender.send(WebGLMsg::DOMToTextureCommand(command))
     }
 }
 
@@ -661,23 +655,6 @@ pub enum WebGLFramebufferBindingRequest {
 }
 
 pub type WebGLResult<T> = Result<T, WebGLError>;
-
-/// WebGL commands required to implement DOMToTexture feature.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum DOMToTextureCommand {
-    /// Attaches a HTMLIFrameElement to a WebGLTexture.
-    Attach(
-        WebGLContextId,
-        WebGLTextureId,
-        DocumentId,
-        PipelineId,
-        Size2D<i32>,
-    ),
-    /// Releases the HTMLIFrameElement to WebGLTexture attachment.
-    Detach(WebGLTextureId),
-    /// Lock message used for a correct synchronization with WebRender GL flow.
-    Lock(PipelineId, usize, WebGLSender<Option<(u32, Size2D<i32>)>>),
-}
 
 /// Information about a WebGL program linking operation.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -259,11 +259,6 @@ mod gen {
                     #[serde(default)]
                     enabled: bool,
                 },
-                webgl: {
-                    dom_to_texture: {
-                        enabled: bool,
-                    }
-                },
                 webgl2: {
                     enabled: bool,
                 },

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -680,16 +680,9 @@ interface mixin WebGLRenderingContextOverloads
     undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List value);
 };
 
-interface mixin WebGLRenderingContextExtensions {
-    [Throws, Pref="dom.webgl.dom_to_texture.enabled"]
-    undefined texImageDOM(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height,
-                     GLenum format, GLenum type, HTMLIFrameElement source); // May throw DOMException
-};
-
 [Exposed=(Window)]
 interface WebGLRenderingContext
 {
 };
 WebGLRenderingContext includes WebGLRenderingContextBase;
 WebGLRenderingContext includes WebGLRenderingContextOverloads;
-WebGLRenderingContext includes WebGLRenderingContextExtensions;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -440,10 +440,8 @@ where
             webgl_threads,
             webxr_layer_grand_manager,
             image_handler,
-            output_handler,
         } = WebGLComm::new(
             webrender_surfman.clone(),
-            webrender_gl.clone(),
             webrender_api.create_sender(),
             webrender_document,
             external_images.clone(),
@@ -452,11 +450,6 @@ where
 
         // Set webrender external image handler for WebGL textures
         external_image_handlers.set_handler(image_handler, WebrenderImageHandlerType::WebGL);
-
-        // Set DOM to texture handler, if enabled.
-        if let Some(output_handler) = output_handler {
-            webrender.set_output_image_handler(output_handler);
-        }
 
         // Create the WebXR main thread
         let mut webxr_main_thread =

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -30,7 +30,6 @@
   "dom.testable_crash.enabled": false,
   "dom.testbinding.enabled": false,
   "dom.testing.htmlinputelement.select_files.enabled": false,
-  "dom.webgl.dom_to_texture.enabled": false,
   "dom.webgl2.enabled": false,
   "dom.webgpu.enabled": false,
   "dom.webrtc.enabled": false,


### PR DESCRIPTION
This relies on WebRender's frame output API, `set_output_image_handler`,
which has been removed from the latest upstream [1]. It's sad to remove
this feature, which was probably a lot of work to implement, but it
seems difficult to patch WebRender to restore this functionality.

Fixes #29936.

1. https://hg.mozilla.org/mozilla-central/rev/361521e3c52324809553c555fb066d50f023d9bf

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29936.
- [x] These changes do not require tests because they remove functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
