### PR TITLE
Properly position floats when subsequent boxes collapse margins with containing block

### DIFF
--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-float-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-float-003.xht.ini
@@ -1,2 +1,0 @@
-[clear-float-003.xht]
-  expected: FAIL


### PR DESCRIPTION
Margins should be able to collapse through floats when collapsing with
parent blocks (the containing block). To properly place floats in this
situation, we need to look at these subsequent floats to find out how
much of the margin will collapse with the parent.

This initial implementation is very basic and the second step would be
to cache this in order to avoid having to constantly recalculate it.

Fixes #29915.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29915.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
