### PR TITLE
Properly position floats when subsequent boxes collapse margins with containing block (2)

### DIFF
--- a/tests/wpt/meta/css/CSS2/floats-clear/adjoining-float-nested-forced-clearance-002.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/adjoining-float-nested-forced-clearance-002.html.ini
@@ -1,0 +1,2 @@
+[adjoining-float-nested-forced-clearance-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-on-parent-with-margins-no-clearance.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-on-parent-with-margins-no-clearance.html.ini
@@ -1,2 +1,0 @@
-[clear-on-parent-with-margins-no-clearance.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-157.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-157.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-157.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-015.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-039.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-039.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-039.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-041.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-collapse-041.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-041.xht]
-  expected: FAIL


### PR DESCRIPTION
PR #29939 tried to address this but missed various cases.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29944
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
