### PR TITLE
Layout 2020: implement clearance as Option<Length>

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -855,7 +855,7 @@ impl FlexLine<'_> {
                         flex_context.sides_to_flow_relative(item.padding),
                         flex_context.sides_to_flow_relative(item.border),
                         margin,
-                        Length::zero(),
+                        None,
                         collapsed_margin,
                     ),
                     item_result.positioning_context,

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -744,7 +744,7 @@ impl FloatBox {
                     margin,
                     // Clearance is handled internally by the float placement logic, so there's no need
                     // to store it explicitly in the fragment.
-                    Length::zero(), // clearance
+                    None, // clearance
                     CollapsedBlockMargins::zero(),
                 )
             },
@@ -826,9 +826,9 @@ impl SequentialLayoutState {
     /// needs to have.
     ///
     /// https://www.w3.org/TR/2011/REC-CSS2-20110607/visuren.html#flow-control
-    pub(crate) fn calculate_clearance(&self, clear_side: ClearSide) -> Length {
+    pub(crate) fn calculate_clearance(&self, clear_side: ClearSide) -> Option<Length> {
         if clear_side == ClearSide::None {
-            return Length::zero();
+            return None;
         }
 
         let hypothetical_block_position = self.current_block_position_including_margins();
@@ -848,7 +848,10 @@ impl SequentialLayoutState {
                 .max(self.floats.clear_right_position)
                 .max(hypothetical_block_position),
         };
-        clear_position - hypothetical_block_position
+        if hypothetical_block_position >= clear_position {
+            return None;
+        }
+        Some(clear_position - hypothetical_block_position)
     }
 
     /// Adds a new adjoining margin.

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -554,7 +554,7 @@ impl<'box_tree> PartialInlineBoxFragment<'box_tree> {
             self.padding.clone(),
             self.border.clone(),
             self.margin.clone(),
-            Length::zero(),
+            None,
             CollapsedBlockMargins::zero(),
         );
         let last_fragment = self.last_box_tree_fragment && !at_line_break;
@@ -619,7 +619,7 @@ fn layout_atomic(
                 pbm.padding,
                 pbm.border,
                 margin,
-                Length::zero(),
+                None,
                 CollapsedBlockMargins::zero(),
             )
         },
@@ -701,7 +701,7 @@ fn layout_atomic(
                 pbm.padding,
                 pbm.border,
                 margin,
-                Length::zero(),
+                None,
                 CollapsedBlockMargins::zero(),
             )
         },

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -31,7 +31,13 @@ pub(crate) struct BoxFragment {
     pub border: Sides<Length>,
     pub margin: Sides<Length>,
 
-    pub clearance: Length,
+    /// When the `clear` property is not set to `none`, it may introduce clearance.
+    /// Clearance is some extra spacing that is added above the top margin,
+    /// so that the element doesn't overlap earlier floats in the same BFC.
+    /// The presence of clearance prevents the top margin from collapsing with
+    /// earlier margins or with the bottom margin of the parent block.
+    /// https://drafts.csswg.org/css2/#clearance
+    pub clearance: Option<Length>,
 
     pub block_margins_collapsed_with_children: CollapsedBlockMargins,
 
@@ -51,7 +57,7 @@ impl BoxFragment {
         padding: Sides<Length>,
         border: Sides<Length>,
         margin: Sides<Length>,
-        clearance: Length,
+        clearance: Option<Length>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
     ) -> BoxFragment {
         let position = style.get_box().position;
@@ -85,7 +91,7 @@ impl BoxFragment {
         padding: Sides<Length>,
         border: Sides<Length>,
         margin: Sides<Length>,
-        clearance: Length,
+        clearance: Option<Length>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
         overconstrained: PhysicalSize<bool>,
     ) -> BoxFragment {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -620,7 +620,7 @@ impl HoistedAbsolutelyPositionedBox {
                 pbm.padding,
                 pbm.border,
                 margin,
-                Length::zero(),
+                None,
                 CollapsedBlockMargins::zero(),
                 physical_overconstrained,
             )


### PR DESCRIPTION
Clearance was implemented as a Length, where zero meant no clearance. However, having a clearance of 0px should be different than having no clearance, since the former can still prevent margin collapse.

This patch keeps the existing behavior, so it won't be possible to get a clearance of Some(Length::zero()), but it prepares the terrain for a follow-up to fix calculate_clearance to return the proper thing.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there should be no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
