### PR TITLE
 Update mozangle, cc, and cmake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -3722,9 +3722,9 @@ checksum = "eeb5a94c61e12e2cfc16ee3e2b6eca8f126a43c888586626337544a7e824a1af"
 
 [[package]]
 name = "mozangle"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef98797da14500fb5eaabc90dc91cf7c42710c11330351521d72f4aa268d689c"
+checksum = "abe944fd6e85e054436f598b5fb12f492da8cf9554981bd4a23a91982f72657c"
 dependencies = [
  "cc",
  "gl_generator 0.13.1",

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -118,7 +118,6 @@ class MachCommands(CommandBase):
         self.ensure_clobbered()
 
         build_start = time()
-        env["CARGO_TARGET_DIR"] = target_path
 
         host = servo.platform.host_triple()
         target_triple = self.cross_compile_target or servo.platform.host_triple()
@@ -400,10 +399,6 @@ class MachCommands(CommandBase):
             print(["Calling", "cargo", "build"] + opts)
             for key in env:
                 print((key, env[key]))
-
-        if sys.platform != "win32":
-            env.setdefault("CC", "clang")
-            env.setdefault("CXX", "clang++")
 
         status = self.run_cargo_build_like_command(
             "build", opts, env=env, verbose=verbose,

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -31,6 +31,8 @@ from mach.decorators import (
     CommandProvider,
     Command,
 )
+
+import servo.util
 import tidy
 
 from servo.command_base import (
@@ -260,10 +262,20 @@ class MachCommands(CommandBase):
         if nocapture:
             args += ["--", "--nocapture"]
 
+        # We are setting is_build here to true, because running `cargo test` can trigger builds.
+        env = self.build_env(is_build=True)
+
+        # on MSVC, we need some DLLs in the path. They were copied
+        # in to the servo.exe build dir, so just point PATH to that.
+        # TODO(mrobinson): This should be removed entirely.
+        if "msvc" in servo.platform.host_triple():
+            servo.util.prepend_paths_to_env(
+                env, "PATH", path.dirname(self.get_binary_path(False, False)))
+
         return self.run_cargo_build_like_command(
             "bench" if bench else "test",
             args,
-            env=self.build_env(test_unit=True),
+            env=env,
             with_layout_2020=with_layout_2020,
             **kwargs)
 


### PR DESCRIPTION
This also moves some environment variable configuration to the shared
`build_env()` method, because previously clang was only being chosen for
running `./mach build` and not `./mach test-unit` which was leading to
rebuilds and thus build failures when running `test-unit`. I guess the
cmake crate does not expect the compiler to change between subsequent
runs.

Fixes #29674

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
