### PR TITLE
Layout 2020: Properly calculate clearance

### DIFF
--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-on-child-with-margins.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-on-child-with-margins.html.ini
@@ -1,2 +1,0 @@
-[clear-on-child-with-margins.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-on-parent-with-margins.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-on-parent-with-margins.html.ini
@@ -1,2 +1,0 @@
-[clear-on-parent-with-margins.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/negative-clearance-after-bottom-margin.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/negative-clearance-after-bottom-margin.html.ini
@@ -1,2 +1,0 @@
-[negative-clearance-after-bottom-margin.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/nested-clearance-new-formatting-context.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/nested-clearance-new-formatting-context.html.ini
@@ -1,2 +1,0 @@
-[nested-clearance-new-formatting-context.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
calculate_clearance() was not taking into account that adding clearance prevents top margin from collapsing with earlier margins.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29885 and #29919
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
