### PR TITLE
Check computed (min-)block-size when determining margin collapse

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -644,13 +644,14 @@ fn layout_in_flow_non_replaced_block_level(
         NonReplacedContents::EstablishesAnIndependentFormattingContext(_) => false,
     };
 
+    let computed_block_size = style.content_block_size();
     let start_margin_can_collapse_with_children = block_is_same_formatting_context &&
         pbm.padding.block_start == Length::zero() &&
         pbm.border.block_start == Length::zero();
     let end_margin_can_collapse_with_children = block_is_same_formatting_context &&
         pbm.padding.block_end == Length::zero() &&
         pbm.border.block_end == Length::zero() &&
-        block_size == LengthOrAuto::Auto;
+        computed_block_size.is_auto();
 
     let mut clearance = None;
     let parent_containing_block_position_info;
@@ -751,12 +752,13 @@ fn layout_in_flow_non_replaced_block_level(
             } else {
                 content_block_size += collapsible_margins_in_children.end.solve();
             }
+            let computed_min_block_size = style.min_block_size();
             block_margins_collapsed_with_children.collapsed_through =
                 collapsible_margins_in_children.collapsed_through &&
-                    block_is_same_formatting_context &&
                     pbm.padding_border_sums.block == Length::zero() &&
-                    block_size.auto_is(|| Length::zero()) == Length::zero() &&
-                    min_box_size.block == Length::zero();
+                    (computed_block_size.is_definitely_zero() || computed_block_size.is_auto()) &&
+                    (computed_min_block_size.is_definitely_zero() ||
+                        computed_min_block_size.is_auto());
         },
         NonReplacedContents::EstablishesAnIndependentFormattingContext(non_replaced) => {
             let independent_layout = non_replaced.layout(

--- a/tests/wpt/meta/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html.ini
@@ -1,0 +1,2 @@
+[margin-collapse-through-percentage-height-block.html]
+  expected: FAIL


### PR DESCRIPTION
To collapse margins through, CSS2 requires "zero or auto computed height" and "zero computed min-height" (the latter should also also include auto, which was introduced in CSS3 as the new initial value).

Similarly, "auto computed height" is required to collapse the bottom margin with the bottom margin of the contents.

Therefore this patch stops collapsing when the used height is clamped to zero by max-height, but the computed value is not zero. Same for non-zero percentages that are indefinite or that resolve to 0px.

Note that 0% and calc(0% + 0px) are still considered to be zero (so they allow margin collapse), this may a bit inconsistent but matches Firefox (for the collapsing through case).

This also matches the heuristics in find_block_margin_collapsing_with_parent(). We could change the heuristics instead, but then they would have to track block sizes in order to be able to resolve percentages.

The change makes margin-collapse-through-percentage-height-block.html fail, that test is only passing on Blink, which did a different interpretation of the spec. To be fair, various places of CSS2 loosely consider that indefinite percentages compute to auto, and even Firefox does so when determining whether to collapse the top margin with the contents.

Since the spec isn't particularly clear and interoperability is lacking, I filed https://github.com/w3c/csswg-drafts/issues/8919.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29907
- [X] There are tests for these changes (1 test fails, see above)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
