### PR TITLE
Set the Windows subsystem using a rust directive

### DIFF
--- a/ports/winit/main.rs
+++ b/ports/winit/main.rs
@@ -14,6 +14,12 @@
 //!
 //! [winit]: https://github.com/rust-windowing/winit
 
+// Normally, rust uses the "Console" Windows subsystem, which pops up a console
+// when running an application. Switching to the "Windows" subsystem prevents
+// this, but also hides debugging output. Use the "Windows" console unless debug
+// mode is turned on.
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 #[cfg(not(target_os = "android"))]
 include!("main2.rs");
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -425,11 +425,6 @@ class MachCommands(CommandBase):
                 )
                 assert os.path.exists(servo_exe_dir)
 
-                # on msvc builds, use editbin to change the subsystem to windows, but only
-                # on release builds -- on debug builds, it hides log output
-                if not dev and not libsimpleservo:
-                    call(["editbin", "/nologo", "/subsystem:windows", path.join(servo_exe_dir, "servo.exe")],
-                         verbose=verbose)
                 # on msvc, we need to copy in some DLLs in to the servo.exe dir and the directory for unit tests.
                 for ssl_lib in ["libssl.dll", "libcrypto.dll"]:
                     ssl_path = path.join(env['OPENSSL_LIB_DIR'], "../bin", ssl_lib)


### PR DESCRIPTION
This is one less thing that mach has to do now.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
