### PR TITLE
Remove rayon_croissant and clean up `contains_floats`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,6 @@ dependencies = [
  "quickcheck",
  "range",
  "rayon",
- "rayon_croissant",
  "script_layout_interface",
  "script_traits",
  "serde",
@@ -3687,12 +3686,6 @@ name = "mitochondria"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
-
-[[package]]
-name = "moite_moite"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb5a94c61e12e2cfc16ee3e2b6eca8f126a43c888586626337544a7e824a1af"
 
 [[package]]
 name = "mozangle"
@@ -4812,16 +4805,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rayon_croissant"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4aafda434bd10fec689858e2b1d713d0b784b1e60df3761ac8fa727d7e8e27"
-dependencies = [
- "moite_moite",
- "rayon",
 ]
 
 [[package]]

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -34,7 +34,6 @@ net_traits = { path = "../net_traits" }
 parking_lot = { workspace = true }
 range = { path = "../range" }
 rayon = { workspace = true }
-rayon_croissant = "0.2.0"
 script_layout_interface = { path = "../script_layout_interface" }
 script_traits = { path = "../script_traits" }
 serde = { workspace = true }

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -39,6 +39,7 @@ pub(crate) struct InlineFormattingContext {
     // Whether this IFC contains the 1st formatted line of an element
     // https://www.w3.org/TR/css-pseudo-4/#first-formatted-line
     pub(super) has_first_formatted_line: bool,
+    pub(super) contains_floats: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -172,6 +173,7 @@ impl InlineFormattingContext {
             inline_level_boxes: Default::default(),
             text_decoration_line,
             has_first_formatted_line,
+            contains_floats: false,
         }
     }
 

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -7,7 +7,6 @@ use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::{iter_child_nodes, Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexLevelBox;
-use crate::flow::construct::ContainsFloats;
 use crate::flow::float::FloatBox;
 use crate::flow::inline::InlineLevelBox;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
@@ -45,15 +44,17 @@ impl BoxTree {
     where
         Node: 'dom + Copy + LayoutNode<'dom> + Send + Sync,
     {
-        let (contains_floats, boxes) = construct_for_root_element(&context, root_element);
+        let boxes = construct_for_root_element(&context, root_element);
 
         // Zero box for `:root { display: none }`, one for the root element otherwise.
         assert!(boxes.len() <= 1);
 
+        let contents = BlockContainer::BlockLevelBoxes(boxes);
+        let contains_floats = contents.contains_floats();
         Self {
             root: BlockFormattingContext {
-                contains_floats: contains_floats == ContainsFloats::Yes,
-                contents: BlockContainer::BlockLevelBoxes(boxes),
+                contents,
+                contains_floats,
             },
             canvas_background: CanvasBackground::for_root_element(context, root_element),
         }
@@ -209,14 +210,14 @@ impl BoxTree {
 fn construct_for_root_element<'dom>(
     context: &LayoutContext,
     root_element: impl NodeExt<'dom>,
-) -> (ContainsFloats, Vec<ArcRefCell<BlockLevelBox>>) {
+) -> Vec<ArcRefCell<BlockLevelBox>> {
     let info = NodeAndStyleInfo::new(root_element, root_element.style(context));
     let box_style = info.style.get_box();
 
     let display_inside = match Display::from(box_style.display) {
         Display::None => {
             root_element.unset_all_boxes();
-            return (ContainsFloats::No, Vec::new());
+            return Vec::new();
         },
         Display::Contents => {
             // Unreachable because the style crate adjusts the computed values:
@@ -230,41 +231,32 @@ fn construct_for_root_element<'dom>(
 
     let contents =
         ReplacedContent::for_element(root_element).map_or(Contents::OfElement, Contents::Replaced);
-    let (contains_floats, root_box) = if box_style.position.is_absolutely_positioned() {
-        (
-            ContainsFloats::No,
-            BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
-                AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),
-            )),
-        )
+    let root_box = if box_style.position.is_absolutely_positioned() {
+        BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
+            AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),
+        ))
     } else if box_style.float.is_floating() {
-        (
-            ContainsFloats::Yes,
-            BlockLevelBox::OutOfFlowFloatBox(FloatBox::construct(
-                context,
-                &info,
-                display_inside,
-                contents,
-            )),
-        )
+        BlockLevelBox::OutOfFlowFloatBox(FloatBox::construct(
+            context,
+            &info,
+            display_inside,
+            contents,
+        ))
     } else {
         let propagated_text_decoration_line = info.style.clone_text_decoration_line();
-        (
-            ContainsFloats::No,
-            BlockLevelBox::Independent(IndependentFormattingContext::construct(
-                context,
-                &info,
-                display_inside,
-                contents,
-                propagated_text_decoration_line,
-            )),
-        )
+        BlockLevelBox::Independent(IndependentFormattingContext::construct(
+            context,
+            &info,
+            display_inside,
+            contents,
+            propagated_text_decoration_line,
+        ))
     };
     let root_box = ArcRefCell::new(root_box);
     root_element
         .element_box_slot()
         .set(LayoutBox::BlockLevel(root_box.clone()));
-    (contains_floats, vec![root_box])
+    vec![root_box]
 }
 
 impl BoxTree {


### PR DESCRIPTION
Remove rayon_croissant and refactor the way that information about
floats in flows bubbles up. This simplifies the code a good deal and
lets us take advantage of some more optimized functions provided by
rayon. This removes 2 crates from the dependency tree.

In addition, this allows avoiding passing `contains_floats` up from
every box tree construction function. This makes things simpler, but
also opens up the possibility of passing more of these flags up in the
future (such as `contains_counters`).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
