### PR TITLE
When using "try-<platform>" trigger unit tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
-        if: ${{ inputs.unit-tests }}
+        if: ${{ inputs.unit-tests || github.ref_name == 'try-linux' }}
         run: python3 ./mach test-unit --release --with-${{ env.LAYOUT }}
       - name: Rename build timing
         run: cp -r target/cargo-timings target/cargo-timings-linux-${{ env.LAYOUT }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
-        if: ${{ inputs.unit-tests }}
+        if: ${{ inputs.unit-tests || github.ref_name == 'try-mac' }}
         run: python3 ./mach test-unit --release --with-${{ env.LAYOUT }}
       - name: Package
         run: python3 ./mach package --release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Smoketest
         run: python mach smoketest --angle
       - name: Unit tests
-        if: ${{ inputs.unit-tests }}
+        if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
         run: python mach test-unit --release --with-${{ env.LAYOUT }}
       - name: Rename build timing
         run: cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows-${{ env.LAYOUT }} -Recurse


### PR DESCRIPTION
There is currently no way to trigger unit tests using the bors-servo try
infrastructure. This change makes it so that using try-<platform>
triggers unit tests for that platform. This will be especially useful
when testing changes for Windows before trying to land them.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are just GitHub Actions changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
