### PR TITLE
Use the WebRender clip chain API

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -2616,6 +2616,8 @@ impl BlockFlow {
             clip: ClippingRegion::from_rect(border_box.to_layout()),
             content_rect: LayoutRect::zero(),
             node_type: ClipScrollNodeType::StickyFrame(sticky_frame_data),
+            scroll_node_id: None,
+            clip_chain_id: None,
         });
 
         let new_clipping_and_scrolling = ClippingAndScrolling::simple(new_clip_scroll_index);
@@ -2683,6 +2685,8 @@ impl BlockFlow {
             clip: clip,
             content_rect: Rect::new(content_box.origin, content_size).to_layout(),
             node_type: ClipScrollNodeType::ScrollFrame(sensitivity, external_id),
+            scroll_node_id: None,
+            clip_chain_id: None,
         });
 
         let new_clipping_and_scrolling = ClippingAndScrolling::simple(new_clip_scroll_index);
@@ -2719,6 +2723,8 @@ impl BlockFlow {
             clip: ClippingRegion::from_rect(clip_rect.to_layout()),
             content_rect: LayoutRect::zero(), // content_rect isn't important for clips.
             node_type: ClipScrollNodeType::Clip(ClipType::Rect),
+            scroll_node_id: None,
+            clip_chain_id: None,
         });
 
         let new_indices = ClippingAndScrolling::new(new_index, new_index);

--- a/components/layout/display_list/items.rs
+++ b/components/layout/display_list/items.rs
@@ -18,6 +18,7 @@ use gfx_traits::print_tree::PrintTree;
 use gfx_traits::{self, StackingContextId};
 use msg::constellation_msg::PipelineId;
 use net_traits::image::base::Image;
+use script_traits::compositor::ScrollTreeNodeId;
 use servo_geometry::MaxRect;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -31,6 +32,7 @@ use webrender_api::{
     FilterOp, GlyphInstance, GradientStop, ImageKey, MixBlendMode, PrimitiveFlags,
     ScrollSensitivity, Shadow, SpatialId, StickyOffsetBounds, TransformStyle,
 };
+use wr::ClipChainId;
 
 pub use style::dom::OpaqueNode;
 
@@ -369,6 +371,12 @@ pub struct ClipScrollNode {
 
     /// The type of this ClipScrollNode.
     pub node_type: ClipScrollNodeType,
+
+    /// The WebRender spatial id of this node assigned during WebRender conversion.
+    pub scroll_node_id: Option<ScrollTreeNodeId>,
+
+    /// The WebRender clip id of this node assigned during WebRender conversion.
+    pub clip_chain_id: Option<ClipChainId>,
 }
 
 impl ClipScrollNode {
@@ -378,6 +386,8 @@ impl ClipScrollNode {
             clip: ClippingRegion::from_rect(LayoutRect::zero()),
             content_rect: LayoutRect::zero(),
             node_type: ClipScrollNodeType::Placeholder,
+            scroll_node_id: None,
+            clip_chain_id: None,
         }
     }
 
@@ -400,6 +410,8 @@ impl ClipScrollNode {
             clip: ClippingRegion::from_rect(clip_rect),
             content_rect: LayoutRect::zero(), // content_rect isn't important for clips.
             node_type: ClipScrollNodeType::Clip(ClipType::Rounded(complex_region)),
+            scroll_node_id: None,
+            clip_chain_id: None,
         }
     }
 }


### PR DESCRIPTION
The old clipping API has been [removed from WebRender][removed], so this switches
both legacy and new layout over to use the clip chain API in preparation
for the WebRender upgrade.

[removed]: https://hg.mozilla.org/mozilla-central/rev/dc8ed2eca5091a75725ddccb3ea7d3359b9cf6ef

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
