### PR TITLE
Use explicit WebRender hit test items in legacy layout

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -281,8 +281,12 @@ impl Fragment {
             return;
         }
 
-        let mut common = builder.common_properties(rect.to_webrender(), &fragment.parent_style);
-        common.hit_info = builder.hit_info(&fragment.parent_style, fragment.base.tag, Cursor::Text);
+        let common = builder.common_properties(rect.to_webrender(), &fragment.parent_style);
+
+        let hit_info = builder.hit_info(&fragment.parent_style, fragment.base.tag, Cursor::Text);
+        let mut hit_test_common = common.clone();
+        hit_test_common.hit_info = hit_info;
+        builder.wr().push_hit_test(&hit_test_common);
 
         let color = fragment.parent_style.clone_color();
         let font_metrics = &fragment.font_metrics;


### PR DESCRIPTION
Including hit tests in non-hit test display list items is no longer
supported in upstream WebRender [^1], so this change switches legacy layout
to always use explicit hit test display list items.

[^1]: https://hg.mozilla.org/mozilla-central/rev/b803fd88181eaf33ed1932e959cbf538f7d95e58

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
