### PR TITLE
Fix package name for windows nightly

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Upload
         if: ${{ inputs.upload }}
         run: |
-          python mach upload-nightly win --secret-from-environment `
+          python mach upload-nightly windows-msvc --secret-from-environment `
             --github-release-id ${{ inputs.github-release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -53,13 +53,7 @@ PACKAGES = {
     'linux': [
         'release/servo-tech-demo.tar.gz',
     ],
-    'linux-layout2020': [
-        'release/servo-tech-demo.tar.gz',
-    ],
     'mac': [
-        'release/servo-tech-demo.dmg',
-    ],
-    'mac-layout2020': [
         'release/servo-tech-demo.dmg',
     ],
     'macbrew': [
@@ -70,10 +64,6 @@ PACKAGES = {
         'android/gradle/servoview/maven/org/mozilla/servoview/servoview-x86/',
     ],
     'windows-msvc': [
-        r'release\msi\Servo.exe',
-        r'release\msi\Servo.zip',
-    ],
-    'windows-msvc-layout2020': [
         r'release\msi\Servo.exe',
         r'release\msi\Servo.zip',
     ],


### PR DESCRIPTION
Also remove the 2020 specific packages.

The incorrect package name in windows.yml is causing nightly builds to fail.

---
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
