### PR TITLE
normalize more webrender use statements

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -27,7 +27,8 @@ use std::sync::{Arc, Mutex};
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font;
 use style_traits::values::ToCss;
-use webrender_api::units::RectExt as RectExt_;
+use webrender_api::units::{DeviceIntSize, RectExt as RectExt_};
+use webrender_api::{ImageData, ImageDescriptor, ImageDescriptorFlags, ImageFormat, ImageKey};
 
 /// The canvas data stores a state machine for the current status of
 /// the path data and any relevant transformations that are
@@ -405,11 +406,11 @@ pub struct CanvasData<'a> {
     state: CanvasPaintState<'a>,
     saved_states: Vec<CanvasPaintState<'a>>,
     webrender_api: Box<dyn WebrenderApi>,
-    image_key: Option<webrender_api::ImageKey>,
+    image_key: Option<ImageKey>,
     /// An old webrender image key that can be deleted when the next epoch ends.
-    old_image_key: Option<webrender_api::ImageKey>,
+    old_image_key: Option<ImageKey>,
     /// An old webrender image key that can be deleted when the current epoch ends.
-    very_old_image_key: Option<webrender_api::ImageKey>,
+    very_old_image_key: Option<ImageKey>,
     font_cache_thread: Mutex<FontCacheThread>,
 }
 
@@ -1107,15 +1108,15 @@ impl<'a> CanvasData<'a> {
     pub fn send_data(&mut self, chan: IpcSender<CanvasImageData>) {
         let size = self.drawtarget.get_size();
 
-        let descriptor = webrender_api::ImageDescriptor {
-            size: webrender_api::units::DeviceIntSize::new(size.width, size.height),
+        let descriptor = ImageDescriptor {
+            size: DeviceIntSize::new(size.width, size.height),
             stride: None,
-            format: webrender_api::ImageFormat::BGRA8,
+            format: ImageFormat::BGRA8,
             offset: 0,
-            flags: webrender_api::ImageDescriptorFlags::empty(),
+            flags: ImageDescriptorFlags::empty(),
         };
         let data = self.drawtarget.snapshot_data_owned();
-        let data = webrender_api::ImageData::Raw(Arc::new(data));
+        let data = ImageData::Raw(Arc::new(data));
 
         let mut updates = vec![];
 

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -27,7 +27,7 @@ pub enum ImageUpdate {
 }
 
 pub trait WebrenderApi {
-    fn generate_key(&self) -> Result<webrender_api::ImageKey, ()>;
+    fn generate_key(&self) -> Result<ImageKey, ()>;
     fn update_images(&self, updates: Vec<ImageUpdate>);
     fn clone(&self) -> Box<dyn WebrenderApi>;
 }

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -16,6 +16,7 @@ use surfman::SurfaceTexture;
 use surfman_chains::SwapChains;
 use surfman_chains_api::SwapChainAPI;
 use surfman_chains_api::SwapChainsAPI;
+use webrender_api::{DocumentId, RenderApiSender};
 use webrender_surfman::WebrenderSurfman;
 use webrender_traits::{
     WebrenderExternalImageApi, WebrenderExternalImageRegistry, WebrenderImageSource,
@@ -33,8 +34,8 @@ impl WebGLComm {
     /// Creates a new `WebGLComm` object.
     pub fn new(
         surfman: WebrenderSurfman,
-        webrender_api_sender: webrender_api::RenderApiSender,
-        webrender_doc: webrender_api::DocumentId,
+        webrender_api_sender: RenderApiSender,
+        webrender_doc: DocumentId,
         external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
         api_type: GlType,
     ) -> WebGLComm {

--- a/components/canvas_traits/canvas.rs
+++ b/components/canvas_traits/canvas.rs
@@ -9,6 +9,7 @@ use serde_bytes::ByteBuf;
 use std::default::Default;
 use std::str::FromStr;
 use style::properties::style_structs::Font as FontStyleStruct;
+use webrender_api::ImageKey;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum FillRule {
@@ -30,7 +31,7 @@ pub enum CanvasMsg {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CanvasImageData {
-    pub image_key: webrender_api::ImageKey,
+    pub image_key: ImageKey,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -20,8 +20,8 @@ use script_traits::{AnimationState, EventResult, MouseButton, MouseEventType};
 use std::fmt::{Debug, Error, Formatter};
 use std::rc::Rc;
 use style_traits::CSSPixel;
-use webrender_api;
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize};
+use webrender_api::{self, DocumentId, FontInstanceKey, FontKey, ImageKey, RenderApi};
 use webrender_surfman::WebrenderSurfman;
 
 /// Sends messages to the compositor.
@@ -124,16 +124,12 @@ pub enum Msg {
 }
 
 pub enum WebrenderFontMsg {
-    AddFontInstance(
-        webrender_api::FontKey,
-        f32,
-        Sender<webrender_api::FontInstanceKey>,
-    ),
-    AddFont(gfx_traits::FontData, Sender<webrender_api::FontKey>),
+    AddFontInstance(FontKey, f32, Sender<FontInstanceKey>),
+    AddFont(gfx_traits::FontData, Sender<FontKey>),
 }
 
 pub enum WebrenderCanvasMsg {
-    GenerateKey(Sender<webrender_api::ImageKey>),
+    GenerateKey(Sender<ImageKey>),
     UpdateImages(Vec<ImageUpdate>),
 }
 
@@ -186,8 +182,8 @@ pub struct InitialCompositorState {
     pub mem_profiler_chan: mem::ProfilerChan,
     /// Instance of webrender API
     pub webrender: webrender::Renderer,
-    pub webrender_document: webrender_api::DocumentId,
-    pub webrender_api: webrender_api::RenderApi,
+    pub webrender_document: DocumentId,
+    pub webrender_api: RenderApi,
     pub webrender_surfman: WebrenderSurfman,
     pub webrender_gl: Rc<dyn gleam::gl::Gl>,
     pub webxr_main_thread: webxr::MainThreadRegistry,

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -16,8 +16,7 @@ use std::fmt::{Debug, Error, Formatter};
 use std::time::Duration;
 use style_traits::DevicePixel;
 
-use webrender_api::units::DevicePoint;
-use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
+use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePoint};
 use webrender_api::ScrollLocation;
 use webrender_surfman::WebrenderSurfman;
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -178,6 +178,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use style_traits::CSSPixel;
 use webgpu::{self, WebGPU, WebGPURequest};
+use webrender_api::{DocumentId, RenderApi, RenderApiSender};
 use webrender_traits::WebrenderExternalImageRegistry;
 
 type PendingApprovalNavigations = HashMap<PipelineId, (LoadData, HistoryEntryReplacement)>;
@@ -221,7 +222,7 @@ struct MessagePortInfo {
 /// Webrender related objects required by WebGPU threads
 struct WebrenderWGPU {
     /// Webrender API.
-    webrender_api: webrender_api::RenderApi,
+    webrender_api: RenderApi,
 
     /// List of Webrender external images
     webrender_external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
@@ -394,7 +395,7 @@ pub struct Constellation<Message, LTF, STF, SWF> {
     timer_scheduler: TimerScheduler,
 
     /// A single WebRender document the constellation operates on.
-    webrender_document: webrender_api::DocumentId,
+    webrender_document: DocumentId,
 
     /// Webrender related objects required by WebGPU threads
     webrender_wgpu: WebrenderWGPU,
@@ -543,10 +544,10 @@ pub struct InitialConstellationState {
     pub mem_profiler_chan: mem::ProfilerChan,
 
     /// Webrender document ID.
-    pub webrender_document: webrender_api::DocumentId,
+    pub webrender_document: DocumentId,
 
     /// Webrender API.
-    pub webrender_api_sender: webrender_api::RenderApiSender,
+    pub webrender_api_sender: RenderApiSender,
 
     /// Webrender external images
     pub webrender_external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -48,6 +48,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use webrender_api::DocumentId;
 
 /// A `Pipeline` is the constellation's view of a `Document`. Each pipeline has an
 /// event loop (executed by a script thread) and a layout thread. A script thread
@@ -190,7 +191,7 @@ pub struct InitialPipelineState {
     pub webrender_api_sender: script_traits::WebrenderIpcSender,
 
     /// The ID of the document processed by this script thread.
-    pub webrender_document: webrender_api::DocumentId,
+    pub webrender_document: DocumentId,
 
     /// A channel to the WebGL thread.
     pub webgl_chan: Option<WebGLPipeline>,
@@ -514,7 +515,7 @@ pub struct UnprivilegedPipelineContent {
     pipeline_namespace_id: PipelineNamespaceId,
     webrender_api_sender: script_traits::WebrenderIpcSender,
     webrender_image_api_sender: net_traits::WebrenderIpcSender,
-    webrender_document: webrender_api::DocumentId,
+    webrender_document: DocumentId,
     webgl_chan: Option<WebGLPipeline>,
     webxr_registry: webxr_api::Registry,
     player_context: WindowGLContext,

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -27,6 +27,7 @@ use style::computed_values::{font_stretch, font_style, font_variant_caps, font_w
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font::{GenericFontFamily, SingleFontFamily};
 use unicode_script::Script;
+use webrender_api::FontInstanceKey;
 
 macro_rules! ot_tag {
     ($t1:expr, $t2:expr, $t3:expr, $t4:expr) => {
@@ -145,7 +146,7 @@ pub struct Font {
     shaper: Option<Shaper>,
     shape_cache: RefCell<HashMap<ShapeCacheEntry, Arc<GlyphStore>>>,
     glyph_advance_cache: RefCell<HashMap<u32, FractionalPixel>>,
-    pub font_key: webrender_api::FontInstanceKey,
+    pub font_key: FontInstanceKey,
 }
 
 impl Font {
@@ -153,7 +154,7 @@ impl Font {
         handle: FontHandle,
         descriptor: FontDescriptor,
         actual_pt_size: Au,
-        font_key: webrender_api::FontInstanceKey,
+        font_key: FontInstanceKey,
     ) -> Font {
         let metrics = handle.metrics();
 

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -21,6 +21,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
 use style::properties::style_structs::Font as FontStyleStruct;
+use webrender_api::{FontInstanceKey, FontKey};
 
 static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 
@@ -29,11 +30,7 @@ static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 static FONT_CACHE_EPOCH: AtomicUsize = AtomicUsize::new(0);
 
 pub trait FontSource {
-    fn get_font_instance(
-        &mut self,
-        key: webrender_api::FontKey,
-        size: Au,
-    ) -> webrender_api::FontInstanceKey;
+    fn get_font_instance(&mut self, key: FontKey, size: Au) -> FontInstanceKey;
 
     fn font_template(
         &mut self,

--- a/components/gfx/tests/font_context.rs
+++ b/components/gfx/tests/font_context.rs
@@ -24,6 +24,7 @@ use style::values::computed::font::{
 };
 use style::values::computed::font::{FontStretch, FontWeight, SingleFontFamily};
 use style::values::generics::font::FontStyle;
+use webrender_api::{FontInstanceKey, FontKey, IdNamespace};
 
 struct TestFontSource {
     handle: FontContextHandle,
@@ -68,12 +69,8 @@ impl TestFontSource {
 }
 
 impl FontSource for TestFontSource {
-    fn get_font_instance(
-        &mut self,
-        _key: webrender_api::FontKey,
-        _size: Au,
-    ) -> webrender_api::FontInstanceKey {
-        webrender_api::FontInstanceKey(webrender_api::IdNamespace(0), 0)
+    fn get_font_instance(&mut self, _key: FontKey, _size: Au) -> FontInstanceKey {
+        FontInstanceKey(IdNamespace(0), 0)
     }
 
     fn font_template(
@@ -89,7 +86,7 @@ impl FontSource for TestFontSource {
             .and_then(|family| family.find_font_for_style(&template_descriptor, handle))
             .map(|template| FontTemplateInfo {
                 font_template: template,
-                font_key: webrender_api::FontKey(webrender_api::IdNamespace(0), 0),
+                font_key: FontKey(IdNamespace(0), 0),
             })
     }
 }

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -14,6 +14,7 @@ use std::slice::Iter;
 use std::sync::Arc;
 use style::str::char_is_whitespace;
 use unicode_bidi as bidi;
+use webrender_api::FontInstanceKey;
 use xi_unicode::LineBreakLeafIter;
 
 thread_local! {
@@ -29,7 +30,7 @@ pub struct TextRun {
     pub font_template: Arc<FontTemplateData>,
     pub actual_pt_size: Au,
     pub font_metrics: FontMetrics,
-    pub font_key: webrender_api::FontInstanceKey,
+    pub font_key: FontInstanceKey,
     /// The glyph runs that make up this text run.
     pub glyphs: Arc<Vec<GlyphRun>>,
     pub bidi_level: bidi::Level,

--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -17,6 +17,7 @@ pub mod print_tree;
 
 use range::RangeIndex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use webrender_api::{Epoch as WebRenderEpoch, FontInstanceKey, FontKey, NativeFontHandle};
 
 /// A newtype struct for denoting the age of messages; prevents race conditions.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -28,9 +29,9 @@ impl Epoch {
     }
 }
 
-impl Into<webrender_api::Epoch> for Epoch {
-    fn into(self) -> webrender_api::Epoch {
-        webrender_api::Epoch(self.0)
+impl Into<WebRenderEpoch> for Epoch {
+    fn into(self) -> WebRenderEpoch {
+        WebRenderEpoch(self.0)
     }
 }
 
@@ -112,14 +113,10 @@ pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
 
 pub enum FontData {
     Raw(Vec<u8>),
-    Native(webrender_api::NativeFontHandle),
+    Native(NativeFontHandle),
 }
 
 pub trait WebrenderApi {
-    fn add_font_instance(
-        &self,
-        font_key: webrender_api::FontKey,
-        size: f32,
-    ) -> webrender_api::FontInstanceKey;
-    fn add_font(&self, data: FontData) -> webrender_api::FontKey;
+    fn add_font_instance(&self, font_key: FontKey, size: f32) -> FontInstanceKey;
+    fn add_font(&self, data: FontData) -> FontKey;
 }

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -258,7 +258,7 @@ impl DisplayItem {
                 let stacking_context = &item.stacking_context;
                 debug_assert_eq!(stacking_context.context_type, StackingContextType::Real);
 
-                //let mut info = webrender_api::LayoutPrimitiveInfo::new(stacking_context.bounds);
+                //let mut info = LayoutPrimitiveInfo::new(stacking_context.bounds);
                 let mut bounds = stacking_context.bounds;
                 let spatial_id =
                     if let Some(frame_index) = stacking_context.established_reference_frame {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -64,8 +64,8 @@ use style::values::computed::counters::ContentItem;
 use style::values::computed::{Length, Size, VerticalAlign};
 use style::values::generics::box_::{Perspective, VerticalAlignKeyword};
 use style::values::generics::transform;
-use webrender_api;
 use webrender_api::units::LayoutTransform;
+use webrender_api::{self, ImageKey};
 
 // From gfxFontConstants.h in Firefox.
 static FONT_SUBSCRIPT_OFFSET_RATIO: f32 = 0.20;
@@ -336,9 +336,9 @@ impl InlineAbsoluteFragmentInfo {
 
 #[derive(Clone)]
 pub enum CanvasFragmentSource {
-    WebGL(webrender_api::ImageKey),
+    WebGL(ImageKey),
     Image(Option<Arc<Mutex<IpcSender<CanvasMsg>>>>),
-    WebGPU(webrender_api::ImageKey),
+    WebGPU(ImageKey),
 }
 
 #[derive(Clone)]

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -20,7 +20,7 @@ use euclid::default::{Point2D, Rect, Size2D, Vector2D};
 use servo_config::opts;
 use style::servo::restyle_damage::ServoRestyleDamage;
 use webrender_api::units::LayoutPoint;
-use webrender_api::PropertyBinding;
+use webrender_api::{ColorF, PropertyBinding, RectangleDisplayItem};
 
 pub fn resolve_generated_content(root: &mut dyn Flow, layout_context: &LayoutContext) {
     ResolveGeneratedContent::new(&layout_context).traverse(root, 0);
@@ -75,7 +75,7 @@ pub fn reflow(root: &mut dyn Flow, layout_context: &LayoutContext, relayout_mode
 pub fn build_display_list_for_subtree<'a>(
     flow_root: &mut dyn Flow,
     layout_context: &'a LayoutContext,
-    background_color: webrender_api::ColorF,
+    background_color: ColorF,
     client_size: Size2D<Au>,
 ) -> DisplayListBuildState<'a> {
     let mut state = StackingContextCollectionState::new(layout_context.id);
@@ -94,7 +94,7 @@ pub fn build_display_list_for_subtree<'a>(
     );
     state.add_display_item(DisplayItem::Rectangle(CommonDisplayItem::new(
         base,
-        webrender_api::RectangleDisplayItem {
+        RectangleDisplayItem {
             color: PropertyBinding::Value(background_color),
             common: items::empty_common_item_properties(),
             bounds: bounds.to_layout(),

--- a/components/layout_2020/display_list/conversions.rs
+++ b/components/layout_2020/display_list/conversions.rs
@@ -8,7 +8,7 @@ use style::computed_values::text_decoration_style::T as ComputedTextDecorationSt
 use style::computed_values::transform_style::T as ComputedTransformStyle;
 use style::values::computed::Filter as ComputedFilter;
 use style::values::computed::Length;
-use webrender_api as wr;
+use webrender_api::{units, FilterOp, LineStyle, MixBlendMode, TransformStyle};
 
 pub trait ToWebRender {
     type Type;
@@ -16,18 +16,18 @@ pub trait ToWebRender {
 }
 
 impl ToWebRender for ComputedFilter {
-    type Type = wr::FilterOp;
+    type Type = FilterOp;
     fn to_webrender(&self) -> Self::Type {
         match *self {
-            ComputedFilter::Blur(radius) => wr::FilterOp::Blur(radius.px()),
-            ComputedFilter::Brightness(amount) => wr::FilterOp::Brightness(amount.0),
-            ComputedFilter::Contrast(amount) => wr::FilterOp::Contrast(amount.0),
-            ComputedFilter::Grayscale(amount) => wr::FilterOp::Grayscale(amount.0),
-            ComputedFilter::HueRotate(angle) => wr::FilterOp::HueRotate(angle.radians()),
-            ComputedFilter::Invert(amount) => wr::FilterOp::Invert(amount.0),
-            ComputedFilter::Opacity(amount) => wr::FilterOp::Opacity(amount.0.into(), amount.0),
-            ComputedFilter::Saturate(amount) => wr::FilterOp::Saturate(amount.0),
-            ComputedFilter::Sepia(amount) => wr::FilterOp::Sepia(amount.0),
+            ComputedFilter::Blur(radius) => FilterOp::Blur(radius.px()),
+            ComputedFilter::Brightness(amount) => FilterOp::Brightness(amount.0),
+            ComputedFilter::Contrast(amount) => FilterOp::Contrast(amount.0),
+            ComputedFilter::Grayscale(amount) => FilterOp::Grayscale(amount.0),
+            ComputedFilter::HueRotate(angle) => FilterOp::HueRotate(angle.radians()),
+            ComputedFilter::Invert(amount) => FilterOp::Invert(amount.0),
+            ComputedFilter::Opacity(amount) => FilterOp::Opacity(amount.0.into(), amount.0),
+            ComputedFilter::Saturate(amount) => FilterOp::Saturate(amount.0),
+            ComputedFilter::Sepia(amount) => FilterOp::Sepia(amount.0),
             // Statically check that DropShadow is impossible.
             ComputedFilter::DropShadow(ref shadow) => match *shadow {},
             // Statically check that Url is impossible.
@@ -36,64 +36,64 @@ impl ToWebRender for ComputedFilter {
     }
 }
 impl ToWebRender for ComputedMixBlendMode {
-    type Type = wr::MixBlendMode;
+    type Type = MixBlendMode;
     fn to_webrender(&self) -> Self::Type {
         match *self {
-            ComputedMixBlendMode::Normal => wr::MixBlendMode::Normal,
-            ComputedMixBlendMode::Multiply => wr::MixBlendMode::Multiply,
-            ComputedMixBlendMode::Screen => wr::MixBlendMode::Screen,
-            ComputedMixBlendMode::Overlay => wr::MixBlendMode::Overlay,
-            ComputedMixBlendMode::Darken => wr::MixBlendMode::Darken,
-            ComputedMixBlendMode::Lighten => wr::MixBlendMode::Lighten,
-            ComputedMixBlendMode::ColorDodge => wr::MixBlendMode::ColorDodge,
-            ComputedMixBlendMode::ColorBurn => wr::MixBlendMode::ColorBurn,
-            ComputedMixBlendMode::HardLight => wr::MixBlendMode::HardLight,
-            ComputedMixBlendMode::SoftLight => wr::MixBlendMode::SoftLight,
-            ComputedMixBlendMode::Difference => wr::MixBlendMode::Difference,
-            ComputedMixBlendMode::Exclusion => wr::MixBlendMode::Exclusion,
-            ComputedMixBlendMode::Hue => wr::MixBlendMode::Hue,
-            ComputedMixBlendMode::Saturation => wr::MixBlendMode::Saturation,
-            ComputedMixBlendMode::Color => wr::MixBlendMode::Color,
-            ComputedMixBlendMode::Luminosity => wr::MixBlendMode::Luminosity,
+            ComputedMixBlendMode::Normal => MixBlendMode::Normal,
+            ComputedMixBlendMode::Multiply => MixBlendMode::Multiply,
+            ComputedMixBlendMode::Screen => MixBlendMode::Screen,
+            ComputedMixBlendMode::Overlay => MixBlendMode::Overlay,
+            ComputedMixBlendMode::Darken => MixBlendMode::Darken,
+            ComputedMixBlendMode::Lighten => MixBlendMode::Lighten,
+            ComputedMixBlendMode::ColorDodge => MixBlendMode::ColorDodge,
+            ComputedMixBlendMode::ColorBurn => MixBlendMode::ColorBurn,
+            ComputedMixBlendMode::HardLight => MixBlendMode::HardLight,
+            ComputedMixBlendMode::SoftLight => MixBlendMode::SoftLight,
+            ComputedMixBlendMode::Difference => MixBlendMode::Difference,
+            ComputedMixBlendMode::Exclusion => MixBlendMode::Exclusion,
+            ComputedMixBlendMode::Hue => MixBlendMode::Hue,
+            ComputedMixBlendMode::Saturation => MixBlendMode::Saturation,
+            ComputedMixBlendMode::Color => MixBlendMode::Color,
+            ComputedMixBlendMode::Luminosity => MixBlendMode::Luminosity,
         }
     }
 }
 
 impl ToWebRender for ComputedTransformStyle {
-    type Type = wr::TransformStyle;
+    type Type = TransformStyle;
     fn to_webrender(&self) -> Self::Type {
         match *self {
-            ComputedTransformStyle::Flat => wr::TransformStyle::Flat,
-            ComputedTransformStyle::Preserve3d => wr::TransformStyle::Preserve3D,
+            ComputedTransformStyle::Flat => TransformStyle::Flat,
+            ComputedTransformStyle::Preserve3d => TransformStyle::Preserve3D,
         }
     }
 }
 
 impl ToWebRender for PhysicalPoint<Length> {
-    type Type = webrender_api::units::LayoutPoint;
+    type Type = units::LayoutPoint;
     fn to_webrender(&self) -> Self::Type {
-        webrender_api::units::LayoutPoint::new(self.x.px(), self.y.px())
+        units::LayoutPoint::new(self.x.px(), self.y.px())
     }
 }
 
 impl ToWebRender for PhysicalSize<Length> {
-    type Type = webrender_api::units::LayoutSize;
+    type Type = units::LayoutSize;
     fn to_webrender(&self) -> Self::Type {
-        webrender_api::units::LayoutSize::new(self.width.px(), self.height.px())
+        units::LayoutSize::new(self.width.px(), self.height.px())
     }
 }
 
 impl ToWebRender for PhysicalRect<Length> {
-    type Type = webrender_api::units::LayoutRect;
+    type Type = units::LayoutRect;
     fn to_webrender(&self) -> Self::Type {
-        webrender_api::units::LayoutRect::new(self.origin.to_webrender(), self.size.to_webrender())
+        units::LayoutRect::new(self.origin.to_webrender(), self.size.to_webrender())
     }
 }
 
 impl ToWebRender for PhysicalSides<Length> {
-    type Type = webrender_api::units::LayoutSideOffsets;
+    type Type = units::LayoutSideOffsets;
     fn to_webrender(&self) -> Self::Type {
-        webrender_api::units::LayoutSideOffsets::new(
+        units::LayoutSideOffsets::new(
             self.top.px(),
             self.right.px(),
             self.bottom.px(),
@@ -103,14 +103,14 @@ impl ToWebRender for PhysicalSides<Length> {
 }
 
 impl ToWebRender for ComputedTextDecorationStyle {
-    type Type = webrender_api::LineStyle;
+    type Type = LineStyle;
     fn to_webrender(&self) -> Self::Type {
         match *self {
-            ComputedTextDecorationStyle::Solid => wr::LineStyle::Solid,
-            ComputedTextDecorationStyle::Dotted => wr::LineStyle::Dotted,
-            ComputedTextDecorationStyle::Dashed => wr::LineStyle::Dashed,
-            ComputedTextDecorationStyle::Wavy => wr::LineStyle::Wavy,
-            _ => wr::LineStyle::Solid,
+            ComputedTextDecorationStyle::Solid => LineStyle::Solid,
+            ComputedTextDecorationStyle::Dotted => LineStyle::Dotted,
+            ComputedTextDecorationStyle::Dashed => LineStyle::Dashed,
+            ComputedTextDecorationStyle::Wavy => LineStyle::Wavy,
+            _ => LineStyle::Solid,
         }
     }
 }

--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -66,7 +66,7 @@ pub(super) fn build_linear(
 ) {
     use style::values::specified::position::HorizontalPositionKeyword::*;
     use style::values::specified::position::VerticalPositionKeyword::*;
-    use webrender_api::units::LayoutVector2D as Vec2;
+    use units::LayoutVector2D as Vec2;
     let gradient_box = layer.tile_size;
 
     // A vector of length 1.0 in the direction of the gradient line

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -42,7 +42,7 @@ pub struct WebRenderImageInfo {
     pub key: Option<wr::ImageKey>,
 }
 
-// `webrender_api::display_item::ItemTag` is private
+// webrender's `ItemTag` is private.
 type ItemTag = (u64, u16);
 type HitInfo = Option<ItemTag>;
 

--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -14,6 +14,7 @@ use gfx_traits::print_tree::PrintTree;
 use style::animation::AnimationSetKey;
 use style::dom::OpaqueNode;
 use style::values::computed::Length;
+use webrender_api::units;
 
 #[derive(Serialize)]
 pub struct FragmentTree {
@@ -61,8 +62,8 @@ impl FragmentTree {
         }
     }
 
-    pub fn scrollable_overflow(&self) -> webrender_api::units::LayoutSize {
-        webrender_api::units::LayoutSize::from_untyped(Size2D::new(
+    pub fn scrollable_overflow(&self) -> units::LayoutSize {
+        units::LayoutSize::from_untyped(Size2D::new(
             self.scrollable_overflow.size.width.px(),
             self.scrollable_overflow.size.height.px(),
         ))

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -34,14 +34,14 @@ use style::values::generics::text::LineHeight;
 use style_traits::CSSPixel;
 use style_traits::ToCss;
 use webrender_api::units::LayoutPixel;
-use webrender_api::ExternalScrollId;
+use webrender_api::{DisplayListBuilder, ExternalScrollId};
 
 /// Mutable data belonging to the LayoutThread.
 ///
 /// This needs to be protected by a mutex so we can do fast RPCs.
 pub struct LayoutThreadData {
     /// The root stacking context.
-    pub display_list: Option<webrender_api::DisplayListBuilder>,
+    pub display_list: Option<DisplayListBuilder>,
 
     /// A queued response for the union of the content boxes of a node.
     pub content_box_response: Option<Rect<Au>>,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -100,6 +100,7 @@ use style::traversal_flags::TraversalFlags;
 use style_traits::CSSPixel;
 use style_traits::DevicePixel;
 use style_traits::SpeculativePainter;
+use webrender_api::{units, HitTestFlags, ScrollClamping};
 
 /// Information needed by the layout thread.
 pub struct LayoutThread {
@@ -1136,15 +1137,15 @@ impl LayoutThread {
                 &QueryMsg::StyleQuery => {},
                 &QueryMsg::NodesFromPointQuery(client_point, ref reflow_goal) => {
                     let mut flags = match reflow_goal {
-                        &NodesFromPointQueryType::Topmost => webrender_api::HitTestFlags::empty(),
-                        &NodesFromPointQueryType::All => webrender_api::HitTestFlags::FIND_ALL,
+                        &NodesFromPointQueryType::Topmost => HitTestFlags::empty(),
+                        &NodesFromPointQueryType::All => HitTestFlags::FIND_ALL,
                     };
 
                     // The point we get is not relative to the entire WebRender scene, but to this
                     // particular pipeline, so we need to tell WebRender about that.
-                    flags.insert(webrender_api::HitTestFlags::POINT_RELATIVE_TO_PIPELINE_VIEWPORT);
+                    flags.insert(HitTestFlags::POINT_RELATIVE_TO_PIPELINE_VIEWPORT);
 
-                    let client_point = webrender_api::units::WorldPoint::from_untyped(client_point);
+                    let client_point = units::WorldPoint::from_untyped(client_point);
                     let results = self.webrender_api.hit_test(
                         Some(self.id.to_webrender()),
                         client_point,
@@ -1178,9 +1179,9 @@ impl LayoutThread {
 
         let point = Point2D::new(-state.scroll_offset.x, -state.scroll_offset.y);
         self.webrender_api.send_scroll_node(
-            webrender_api::units::LayoutPoint::from_untyped(point),
+            units::LayoutPoint::from_untyped(point),
             state.scroll_id,
-            webrender_api::ScrollClamping::ToContentBounds,
+            ScrollClamping::ToContentBounds,
         );
     }
 
@@ -1248,7 +1249,7 @@ impl LayoutThread {
         epoch.next();
         self.epoch.set(epoch);
 
-        let viewport_size = webrender_api::units::LayoutSize::from_untyped(Size2D::new(
+        let viewport_size = units::LayoutSize::from_untyped(Size2D::new(
             self.viewport_size.width.to_f32_px(),
             self.viewport_size.height.to_f32_px(),
         ));

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -58,6 +58,12 @@ use std::os::raw::c_void;
 #[cfg(feature = "servo")]
 use uuid::Uuid;
 use void::Void;
+use webrender_api::{
+    BorderRadius, BorderStyle, BoxShadowClipMode, ColorF, ComplexClipRegion, ExtendMode,
+    ExternalScrollId, FilterOp, FontInstanceKey, GlyphInstance, GradientStop, ImageKey,
+    ImageRendering, LineStyle, MixBlendMode, NinePatchBorder, NormalBorder, RepeatMode,
+    ScrollSensitivity, StickyOffsetBounds, TransformStyle,
+};
 
 /// A C function that takes a pointer to a heap allocation and returns its size.
 type VoidPtrToSizeFn = unsafe extern "C" fn(ptr: *const c_void) -> usize;
@@ -800,47 +806,47 @@ impl MallocSizeOf for url::Host {
     }
 }
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::BorderRadius);
+malloc_size_of_is_0!(BorderRadius);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::BorderStyle);
+malloc_size_of_is_0!(BorderStyle);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::BoxShadowClipMode);
+malloc_size_of_is_0!(BoxShadowClipMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ColorF);
+malloc_size_of_is_0!(ColorF);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ComplexClipRegion);
+malloc_size_of_is_0!(ComplexClipRegion);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ExtendMode);
+malloc_size_of_is_0!(ExtendMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::FilterOp);
+malloc_size_of_is_0!(FilterOp);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ExternalScrollId);
+malloc_size_of_is_0!(ExternalScrollId);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::FontInstanceKey);
+malloc_size_of_is_0!(FontInstanceKey);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::GradientStop);
+malloc_size_of_is_0!(GradientStop);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::GlyphInstance);
+malloc_size_of_is_0!(GlyphInstance);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::NinePatchBorder);
+malloc_size_of_is_0!(NinePatchBorder);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ImageKey);
+malloc_size_of_is_0!(ImageKey);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ImageRendering);
+malloc_size_of_is_0!(ImageRendering);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::LineStyle);
+malloc_size_of_is_0!(LineStyle);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::MixBlendMode);
+malloc_size_of_is_0!(MixBlendMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::NormalBorder);
+malloc_size_of_is_0!(NormalBorder);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::RepeatMode);
+malloc_size_of_is_0!(RepeatMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ScrollSensitivity);
+malloc_size_of_is_0!(ScrollSensitivity);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::StickyOffsetBounds);
+malloc_size_of_is_0!(StickyOffsetBounds);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::TransformStyle);
+malloc_size_of_is_0!(TransformStyle);
 
 #[cfg(feature = "servo")]
 impl MallocSizeOf for keyboard_types::Key {

--- a/components/media/media_thread.rs
+++ b/components/media/media_thread.rs
@@ -9,6 +9,7 @@ use crate::{GLPlayerMsg, GLPlayerMsgForward};
 use fnv::FnvHashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use webrender_api::ExternalImageId;
 use webrender_traits::{WebrenderExternalImageRegistry, WebrenderImageHandlerType};
 
 /// A GLPlayerThread manages the life cycle and message demultiplexing of
@@ -69,7 +70,7 @@ impl GLPlayerThread {
                 self.external_images
                     .lock()
                     .unwrap()
-                    .remove(&webrender_api::ExternalImageId(id));
+                    .remove(&ExternalImageId(id));
                 if self.players.remove(&id).is_none() {
                     warn!("Tried to remove an unknown player");
                 }

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -13,6 +13,8 @@ use std::mem;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
+use webrender_api::ExternalScrollId;
+use webrender_api::PipelineId as WebRenderPipelineId;
 
 macro_rules! namespace_id_method {
     ($func_name:ident, $func_return_data_type:ident, $self:ident, $index_name:ident) => {
@@ -206,15 +208,15 @@ impl PipelineId {
         })
     }
 
-    pub fn to_webrender(&self) -> webrender_api::PipelineId {
+    pub fn to_webrender(&self) -> WebRenderPipelineId {
         let PipelineNamespaceId(namespace_id) = self.namespace_id;
         let PipelineIndex(index) = self.index;
-        webrender_api::PipelineId(namespace_id, index.get())
+        WebRenderPipelineId(namespace_id, index.get())
     }
 
     #[allow(unsafe_code)]
-    pub fn from_webrender(pipeline: webrender_api::PipelineId) -> PipelineId {
-        let webrender_api::PipelineId(namespace_id, index) = pipeline;
+    pub fn from_webrender(pipeline: WebRenderPipelineId) -> PipelineId {
+        let WebRenderPipelineId(namespace_id, index) = pipeline;
         unsafe {
             PipelineId {
                 namespace_id: PipelineNamespaceId(namespace_id),
@@ -224,7 +226,7 @@ impl PipelineId {
     }
 
     pub fn root_scroll_id(&self) -> webrender_api::ExternalScrollId {
-        webrender_api::ExternalScrollId(0, self.to_webrender())
+        ExternalScrollId(0, self.to_webrender())
     }
 }
 

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -22,8 +22,9 @@ use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use webrender_api::units::DeviceIntSize;
-use webrender_api::ImageDescriptorFlags;
+use webrender_api::{
+    units::DeviceIntSize, ImageData, ImageDescriptor, ImageDescriptorFlags, ImageFormat,
+};
 
 ///
 /// TODO(gw): Remaining work on image cache:
@@ -77,14 +78,14 @@ fn set_webrender_image_key(webrender_api: &WebrenderIpcSender, image: &mut Image
     };
     let mut flags = ImageDescriptorFlags::ALLOW_MIPMAPS;
     flags.set(ImageDescriptorFlags::IS_OPAQUE, is_opaque);
-    let descriptor = webrender_api::ImageDescriptor {
+    let descriptor = ImageDescriptor {
         size: DeviceIntSize::new(image.width as i32, image.height as i32),
         stride: None,
-        format: webrender_api::ImageFormat::BGRA8,
+        format: ImageFormat::BGRA8,
         offset: 0,
         flags,
     };
-    let data = webrender_api::ImageData::new(bytes);
+    let data = ImageData::new(bytes);
     let image_key = webrender_api.generate_image_key();
     webrender_api.add_image(image_key, descriptor, data);
     image.id = Some(image_key);

--- a/components/net_traits/image/base.rs
+++ b/components/net_traits/image/base.rs
@@ -7,6 +7,7 @@ use image::ImageFormat;
 use ipc_channel::ipc::IpcSharedMemory;
 use pixels::PixelFormat;
 use std::fmt;
+use webrender_api::ImageKey;
 
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
 pub struct Image {
@@ -16,7 +17,7 @@ pub struct Image {
     #[ignore_malloc_size_of = "Defined in ipc-channel"]
     pub bytes: IpcSharedMemory,
     #[ignore_malloc_size_of = "Defined in webrender_api"]
-    pub id: Option<webrender_api::ImageKey>,
+    pub id: Option<ImageKey>,
     pub cors_status: CorsStatus,
 }
 

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -25,6 +25,10 @@ use ipc_channel::ipc;
 use script_layout_interface::HTMLCanvasDataSource;
 use std::cell::Cell;
 use webgpu::{wgpu::id, wgt, WebGPU, WebGPURequest, PRESENTATION_BUFFER_COUNT};
+use webrender_api::{
+    units, ExternalImageData, ExternalImageId, ExternalImageType, ImageData, ImageDescriptor,
+    ImageDescriptorFlags, ImageFormat, ImageKey,
+};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd)]
 pub struct WebGPUContextId(pub u64);
@@ -78,7 +82,7 @@ impl GPUCanvasContext {
         let image_key = if self.webrender_image.get().is_some() {
             self.webrender_image.get().unwrap()
         } else {
-            webrender_api::ImageKey::DUMMY
+            ImageKey::DUMMY
         };
         HTMLCanvasDataSource::WebGPU(image_key)
     }
@@ -145,13 +149,13 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
             );
         }
 
-        let image_desc = webrender_api::ImageDescriptor {
+        let image_desc = ImageDescriptor {
             format: match descriptor.format {
-                GPUTextureFormat::Rgba8unorm => webrender_api::ImageFormat::RGBA8,
-                GPUTextureFormat::Bgra8unorm => webrender_api::ImageFormat::BGRA8,
+                GPUTextureFormat::Rgba8unorm => ImageFormat::RGBA8,
+                GPUTextureFormat::Bgra8unorm => ImageFormat::BGRA8,
                 _ => panic!("SwapChain format({:?}) not supported", descriptor.format),
             },
-            size: webrender_api::units::DeviceIntSize::new(
+            size: units::DeviceIntSize::new(
                 self.size.get().width as i32,
                 self.size.get().height as i32,
             ),
@@ -160,13 +164,13 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
                     as i32,
             ),
             offset: 0,
-            flags: webrender_api::ImageDescriptorFlags::from_bits(1).unwrap(),
+            flags: ImageDescriptorFlags::from_bits(1).unwrap(),
         };
 
-        let image_data = webrender_api::ImageData::External(webrender_api::ExternalImageData {
-            id: webrender_api::ExternalImageId(self.context_id.0),
+        let image_data = ImageData::External(ExternalImageData {
+            id: ExternalImageId(self.context_id.0),
             channel_index: 0,
-            image_type: webrender_api::ExternalImageType::Buffer,
+            image_type: ExternalImageType::Buffer,
         });
 
         let (sender, receiver) = ipc::channel().unwrap();

--- a/components/script/dom/gpuswapchain.rs
+++ b/components/script/dom/gpuswapchain.rs
@@ -12,6 +12,7 @@ use crate::dom::gpucanvascontext::GPUCanvasContext;
 use crate::dom::gputexture::GPUTexture;
 use dom_struct::dom_struct;
 use webgpu::{WebGPU, WebGPURequest, WebGPUTexture};
+use webrender_api::ImageKey;
 
 #[dom_struct]
 pub struct GPUSwapChain {
@@ -56,7 +57,7 @@ impl GPUSwapChain {
 }
 
 impl GPUSwapChain {
-    pub fn destroy(&self, external_id: u64, image_key: webrender_api::ImageKey) {
+    pub fn destroy(&self, external_id: u64, image_key: ImageKey) {
         if let Err(e) = self.channel.0.send((
             None,
             WebGPURequest::DestroySwapChain {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -83,6 +83,7 @@ use std::cell::Cell;
 use std::cmp;
 use std::ptr::{self, NonNull};
 use std::rc::Rc;
+use webrender_api::ImageKey;
 
 // From the GLES 2.0.25 spec, page 85:
 //
@@ -165,7 +166,7 @@ pub struct WebGLRenderingContext {
     #[ignore_malloc_size_of = "Channels are hard"]
     webgl_sender: WebGLMessageSender,
     #[ignore_malloc_size_of = "Defined in webrender"]
-    webrender_image: webrender_api::ImageKey,
+    webrender_image: ImageKey,
     webgl_version: WebGLVersion,
     glsl_version: WebGLSLVersion,
     #[ignore_malloc_size_of = "Defined in surfman"]

--- a/components/script_layout_interface/lib.rs
+++ b/components/script_layout_interface/lib.rs
@@ -27,6 +27,7 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 use std::any::Any;
 use std::sync::atomic::AtomicIsize;
 use style::data::ElementData;
+use webrender_api::ImageKey;
 
 #[derive(MallocSizeOf)]
 pub struct StyleData {
@@ -121,9 +122,9 @@ pub enum LayoutElementType {
 }
 
 pub enum HTMLCanvasDataSource {
-    WebGL(webrender_api::ImageKey),
+    WebGL(ImageKey),
     Image(Option<IpcSender<CanvasMsg>>),
-    WebGPU(webrender_api::ImageKey),
+    WebGPU(ImageKey),
 }
 
 pub struct HTMLCanvasData {
@@ -162,5 +163,5 @@ pub struct PendingImage {
 }
 
 pub struct HTMLMediaData {
-    pub current_frame: Option<(webrender_api::ImageKey, i32, i32)>,
+    pub current_frame: Option<(ImageKey, i32, i32)>,
 }


### PR DESCRIPTION
- Use the WebRender clip chain API
- Use explicit WebRender hit test items in legacy layout
- Try to `use` WebRender types more

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
