### PR TITLE
Minibrowser: Introduce minibrowser.enabled prefs

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -456,6 +456,9 @@ mod gen {
                     enabled: bool,
                 }
             },
+            minibrowser: {
+                enabled: bool,
+            },
             network: {
                 enforce_tls: {
                     enabled: bool,

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -104,6 +104,7 @@
   "layout.writing-mode.enabled": false,
   "media.glvideo.enabled": false,
   "media.testing.enabled": false,
+  "minibrowser.enabled": false,
   "network.enforce_tls.enabled": false,
   "network.enforce_tls.localhost": false,
   "network.enforce_tls.onion": false,


### PR DESCRIPTION
Introducing minibrowser.enabled prefs in preparation of #29976 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
