### PR TITLE
Mark skipped CI workflows as successful

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,39 +17,61 @@ jobs:
   decision:
     name: Decision
     runs-on: ubuntu-20.04
+    outputs:
+      skipped: ${{ steps.skipDecision.outputs.result }}
+      platforms: ${{ steps.platformDecision.outputs.result }}
     steps:
-      # If an identical build exists that suceeded, skip this workflow run. We don't do
-      # this check for pull_request and merge_group events, out of caution.
-      - name: Skip previous identical builds
-        if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+      - name: Skip Decision
+        id: skipDecision
         uses: actions/github-script@v6
         with:
+          result-encoding: string
           script: |
+            // Never skip workflow runs for pull requests or merge groups, which might
+            // need to actually run / retry WPT tests.
+            if (context.eventName == "pull_request" || context.eventName == "merge_group") {
+              return "run";
+            }
+            // Skip the run if an identical run already exists. This helps to avoid running
+            // the workflow over and over again for the same commit hash.
             if ((await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: "main.yml",
               head_sha: context.sha,
               status: "success",
-            })).data.workflow_runs.length > 0)
-              await github.rest.actions.cancelWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: context.runId,
-              });
+            })).data.workflow_runs.length > 0) {
+              return "skip"
+            } else {
+              return "run"
+            }
+      - name: Platform Decision
+        id: platformDecision
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            if ("${{ steps.skipDecision.outputs.result }}" == "skip") {
+              return "none";
+            }
+            if (context.eventName == "push" || context.eventName == "merge_group") {
+              return "all";
+            }
+            return "linux"
+
 
   build-win:
     name: Windows
-    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
     needs: ["decision"]
+    if: ${{ needs.decision.outputs.platforms == 'all' }}
     uses: ./.github/workflows/windows.yml
     with:
       unit-tests: true
 
   build-mac:
     name: Mac
-    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
     needs: ["decision"]
+    if: ${{ needs.decision.outputs.platforms == 'all' }}
     uses: ./.github/workflows/mac.yml
     with:
       unit-tests: true
@@ -57,13 +79,14 @@ jobs:
   build-linux:
     name: Linux
     needs: ["decision"]
+    if: ${{ needs.decision.outputs.platforms == 'all' || needs.decision.outputs.platforms == 'linux' }}
     uses: ./.github/workflows/linux.yml
     with:
       wpt: 'test'
       layout: ${{ (github.event_name == 'push' || github.event_name == 'merge_group') && 'all' || 'none' }}
       unit-tests: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
 
-  build_result:
+  build-result:
     name: Result
     runs-on: ubuntu-latest
     if: always()
@@ -75,9 +98,12 @@ jobs:
       - "build-linux"
 
     steps:
-      - name: Mark the job as successful
+      - name: Mark skipped jobs as successful
+        if: ${{ needs.decision.outputs.skipped == 'skip' }}
         run: exit 0
+      - name: Mark the job as successful
         if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        run: exit 0
       - name: Mark the job as unsuccessful
-        run: exit 1
         if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')
+        run: exit 1


### PR DESCRIPTION
When the decision job decides that a workflow should be skipped because
an identical one has already run, that workflow should be marked as
successful and not unsuccessful.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix CI behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
