### PR TITLE
Remove the YAML tidy code

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -36,10 +36,6 @@ six == 1.15
 # For sending build notifications.
 notify-py == 0.3.42
 
-# A few more requirements for tidy.
-voluptuous == 0.12.1
-PyYAML == 5.4
-
 # For wpt scripts and their tests.
 flask
 requests

--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -180,21 +180,6 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('Unordered key (found b before a)', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
-    def test_yaml_with_duplicate_key(self):
-        errors = tidy.collect_errors_for_files(iterFile('duplicate_keys_buildbot_steps.yml'), [tidy.check_yaml], [], print_text=False)
-        self.assertEqual('Duplicated Key (duplicate_yaml_key)', next(errors)[2])
-        self.assertNoMoreErrors(errors)
-
-    def test_non_list_mapped_buildbot_steps(self):
-        errors = tidy.collect_errors_for_files(iterFile('non_list_mapping_buildbot_steps.yml'), [tidy.check_yaml], [], print_text=False)
-        self.assertEqual("expected a list for dictionary value @ data['non-list-key']", next(errors)[2])
-        self.assertNoMoreErrors(errors)
-
-    def test_non_string_list_mapping_buildbot_steps(self):
-        errors = tidy.collect_errors_for_files(iterFile('non_string_list_buildbot_steps.yml'), [tidy.check_yaml], [], print_text=False)
-        self.assertEqual("expected str @ data['mapping_key'][0]", next(errors)[2])
-        self.assertNoMoreErrors(errors)
-
     def test_lock(self):
         errors = tidy.collect_errors_for_files(iterFile('duplicated_package.lock'), [tidy.check_lock], [], print_text=False)
         msg = """duplicate versions for package `test`

--- a/python/tidy/tests/duplicate_keys_buildbot_steps.yml
+++ b/python/tidy/tests/duplicate_keys_buildbot_steps.yml
@@ -1,7 +1,0 @@
----
-duplicate_yaml_key:
-    - value1
-other_key:
-    - value2
-duplicate_yaml_key:
-    - value3

--- a/python/tidy/tests/non_list_mapping_buildbot_steps.yml
+++ b/python/tidy/tests/non_list_mapping_buildbot_steps.yml
@@ -1,2 +1,0 @@
----
-non-list-key: "string string"

--- a/python/tidy/tests/non_string_list_buildbot_steps.yml
+++ b/python/tidy/tests/non_string_list_buildbot_steps.yml
@@ -1,7 +1,0 @@
----
-# This is a buildbot_steps.yml file that should break linting becasue it is not a
-# mapping to a list of strings
-mapping_key:
-    - - list_of_list
-      - sublist_item1
-      - sublist_item2


### PR DESCRIPTION
This code was used to test buildbox_steps.yml, but Servo no longer uses
buildbot, so this code is essentially unused. In addition, YAML +
Cython 3 is causing issues on the CI.

Fixes #30003

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they remove a tidy feature.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
