### PR TITLE
[NFC] winit: document event handling and improve naming

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -35,9 +35,9 @@ pub enum WebRenderDebugOption {
     RenderTargetDebug,
 }
 
-/// Events that the windowing system sends to Servo.
+/// Events that the embedder sends to Servo, including events from the windowing system.
 #[derive(Clone)]
-pub enum WindowEvent {
+pub enum EmbedderEvent {
     /// Sent when no message has arrived, but the event loop was kicked for some reason (perhaps
     /// by another Servo subsystem).
     ///
@@ -107,38 +107,38 @@ pub enum WindowEvent {
     IMEDismissed,
 }
 
-impl Debug for WindowEvent {
+impl Debug for EmbedderEvent {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            WindowEvent::Idle => write!(f, "Idle"),
-            WindowEvent::Refresh => write!(f, "Refresh"),
-            WindowEvent::Resize => write!(f, "Resize"),
-            WindowEvent::Keyboard(..) => write!(f, "Keyboard"),
-            WindowEvent::AllowNavigationResponse(..) => write!(f, "AllowNavigationResponse"),
-            WindowEvent::LoadUrl(..) => write!(f, "LoadUrl"),
-            WindowEvent::MouseWindowEventClass(..) => write!(f, "Mouse"),
-            WindowEvent::MouseWindowMoveEventClass(..) => write!(f, "MouseMove"),
-            WindowEvent::Touch(..) => write!(f, "Touch"),
-            WindowEvent::Wheel(..) => write!(f, "Wheel"),
-            WindowEvent::Scroll(..) => write!(f, "Scroll"),
-            WindowEvent::Zoom(..) => write!(f, "Zoom"),
-            WindowEvent::PinchZoom(..) => write!(f, "PinchZoom"),
-            WindowEvent::ResetZoom => write!(f, "ResetZoom"),
-            WindowEvent::Navigation(..) => write!(f, "Navigation"),
-            WindowEvent::Quit => write!(f, "Quit"),
-            WindowEvent::Reload(..) => write!(f, "Reload"),
-            WindowEvent::NewBrowser(..) => write!(f, "NewBrowser"),
-            WindowEvent::SendError(..) => write!(f, "SendError"),
-            WindowEvent::CloseBrowser(..) => write!(f, "CloseBrowser"),
-            WindowEvent::SelectBrowser(..) => write!(f, "SelectBrowser"),
-            WindowEvent::ToggleWebRenderDebug(..) => write!(f, "ToggleWebRenderDebug"),
-            WindowEvent::CaptureWebRender => write!(f, "CaptureWebRender"),
-            WindowEvent::ToggleSamplingProfiler(..) => write!(f, "ToggleSamplingProfiler"),
-            WindowEvent::ExitFullScreen(..) => write!(f, "ExitFullScreen"),
-            WindowEvent::MediaSessionAction(..) => write!(f, "MediaSessionAction"),
-            WindowEvent::ChangeBrowserVisibility(..) => write!(f, "ChangeBrowserVisibility"),
-            WindowEvent::IMEDismissed => write!(f, "IMEDismissed"),
-            WindowEvent::ClearCache => write!(f, "ClearCache"),
+            EmbedderEvent::Idle => write!(f, "Idle"),
+            EmbedderEvent::Refresh => write!(f, "Refresh"),
+            EmbedderEvent::Resize => write!(f, "Resize"),
+            EmbedderEvent::Keyboard(..) => write!(f, "Keyboard"),
+            EmbedderEvent::AllowNavigationResponse(..) => write!(f, "AllowNavigationResponse"),
+            EmbedderEvent::LoadUrl(..) => write!(f, "LoadUrl"),
+            EmbedderEvent::MouseWindowEventClass(..) => write!(f, "Mouse"),
+            EmbedderEvent::MouseWindowMoveEventClass(..) => write!(f, "MouseMove"),
+            EmbedderEvent::Touch(..) => write!(f, "Touch"),
+            EmbedderEvent::Wheel(..) => write!(f, "Wheel"),
+            EmbedderEvent::Scroll(..) => write!(f, "Scroll"),
+            EmbedderEvent::Zoom(..) => write!(f, "Zoom"),
+            EmbedderEvent::PinchZoom(..) => write!(f, "PinchZoom"),
+            EmbedderEvent::ResetZoom => write!(f, "ResetZoom"),
+            EmbedderEvent::Navigation(..) => write!(f, "Navigation"),
+            EmbedderEvent::Quit => write!(f, "Quit"),
+            EmbedderEvent::Reload(..) => write!(f, "Reload"),
+            EmbedderEvent::NewBrowser(..) => write!(f, "NewBrowser"),
+            EmbedderEvent::SendError(..) => write!(f, "SendError"),
+            EmbedderEvent::CloseBrowser(..) => write!(f, "CloseBrowser"),
+            EmbedderEvent::SelectBrowser(..) => write!(f, "SelectBrowser"),
+            EmbedderEvent::ToggleWebRenderDebug(..) => write!(f, "ToggleWebRenderDebug"),
+            EmbedderEvent::CaptureWebRender => write!(f, "CaptureWebRender"),
+            EmbedderEvent::ToggleSamplingProfiler(..) => write!(f, "ToggleSamplingProfiler"),
+            EmbedderEvent::ExitFullScreen(..) => write!(f, "ExitFullScreen"),
+            EmbedderEvent::MediaSessionAction(..) => write!(f, "MediaSessionAction"),
+            EmbedderEvent::ChangeBrowserVisibility(..) => write!(f, "ChangeBrowserVisibility"),
+            EmbedderEvent::IMEDismissed => write!(f, "IMEDismissed"),
+            EmbedderEvent::ClearCache => write!(f, "ClearCache"),
         }
     }
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -72,7 +72,7 @@ use compositing::compositor_thread::{
     CompositorProxy, CompositorReceiver, InitialCompositorState, Msg, WebrenderCanvasMsg,
     WebrenderFontMsg, WebrenderMsg,
 };
-use compositing::windowing::{EmbedderMethods, WindowEvent, WindowMethods};
+use compositing::windowing::{EmbedderEvent, EmbedderMethods, WindowMethods};
 use compositing::{CompositingReason, ConstellationMsg, IOCompositor, ShutdownState};
 #[cfg(all(
     not(target_os = "windows"),
@@ -522,19 +522,19 @@ where
         InitializedServo { servo, browser_id }
     }
 
-    fn handle_window_event(&mut self, event: WindowEvent) -> bool {
+    fn handle_window_event(&mut self, event: EmbedderEvent) -> bool {
         match event {
-            WindowEvent::Idle => {},
+            EmbedderEvent::Idle => {},
 
-            WindowEvent::Refresh => {
+            EmbedderEvent::Refresh => {
                 self.compositor.composite();
             },
 
-            WindowEvent::Resize => {
+            EmbedderEvent::Resize => {
                 return self.compositor.on_resize_window_event();
             },
 
-            WindowEvent::AllowNavigationResponse(pipeline_id, allowed) => {
+            EmbedderEvent::AllowNavigationResponse(pipeline_id, allowed) => {
                 let msg = ConstellationMsg::AllowNavigationResponse(pipeline_id, allowed);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -544,55 +544,55 @@ where
                 }
             },
 
-            WindowEvent::LoadUrl(top_level_browsing_context_id, url) => {
+            EmbedderEvent::LoadUrl(top_level_browsing_context_id, url) => {
                 let msg = ConstellationMsg::LoadUrl(top_level_browsing_context_id, url);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!("Sending load url to constellation failed ({:?}).", e);
                 }
             },
 
-            WindowEvent::ClearCache => {
+            EmbedderEvent::ClearCache => {
                 let msg = ConstellationMsg::ClearCache;
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!("Sending clear cache to constellation failed ({:?}).", e);
                 }
             },
 
-            WindowEvent::MouseWindowEventClass(mouse_window_event) => {
+            EmbedderEvent::MouseWindowEventClass(mouse_window_event) => {
                 self.compositor
                     .on_mouse_window_event_class(mouse_window_event);
             },
 
-            WindowEvent::MouseWindowMoveEventClass(cursor) => {
+            EmbedderEvent::MouseWindowMoveEventClass(cursor) => {
                 self.compositor.on_mouse_window_move_event_class(cursor);
             },
 
-            WindowEvent::Touch(event_type, identifier, location) => {
+            EmbedderEvent::Touch(event_type, identifier, location) => {
                 self.compositor
                     .on_touch_event(event_type, identifier, location);
             },
 
-            WindowEvent::Wheel(delta, location) => {
+            EmbedderEvent::Wheel(delta, location) => {
                 self.compositor.on_wheel_event(delta, location);
             },
 
-            WindowEvent::Scroll(delta, cursor, phase) => {
+            EmbedderEvent::Scroll(delta, cursor, phase) => {
                 self.compositor.on_scroll_event(delta, cursor, phase);
             },
 
-            WindowEvent::Zoom(magnification) => {
+            EmbedderEvent::Zoom(magnification) => {
                 self.compositor.on_zoom_window_event(magnification);
             },
 
-            WindowEvent::ResetZoom => {
+            EmbedderEvent::ResetZoom => {
                 self.compositor.on_zoom_reset_window_event();
             },
 
-            WindowEvent::PinchZoom(magnification) => {
+            EmbedderEvent::PinchZoom(magnification) => {
                 self.compositor.on_pinch_zoom_window_event(magnification);
             },
 
-            WindowEvent::Navigation(top_level_browsing_context_id, direction) => {
+            EmbedderEvent::Navigation(top_level_browsing_context_id, direction) => {
                 let msg =
                     ConstellationMsg::TraverseHistory(top_level_browsing_context_id, direction);
                 if let Err(e) = self.constellation_chan.send(msg) {
@@ -600,14 +600,14 @@ where
                 }
             },
 
-            WindowEvent::Keyboard(key_event) => {
+            EmbedderEvent::Keyboard(key_event) => {
                 let msg = ConstellationMsg::Keyboard(key_event);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!("Sending keyboard event to constellation failed ({:?}).", e);
                 }
             },
 
-            WindowEvent::IMEDismissed => {
+            EmbedderEvent::IMEDismissed => {
                 let msg = ConstellationMsg::IMEDismissed;
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -617,25 +617,25 @@ where
                 }
             },
 
-            WindowEvent::Quit => {
+            EmbedderEvent::Quit => {
                 self.compositor.maybe_start_shutting_down();
             },
 
-            WindowEvent::ExitFullScreen(top_level_browsing_context_id) => {
+            EmbedderEvent::ExitFullScreen(top_level_browsing_context_id) => {
                 let msg = ConstellationMsg::ExitFullScreen(top_level_browsing_context_id);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!("Sending exit fullscreen to constellation failed ({:?}).", e);
                 }
             },
 
-            WindowEvent::Reload(top_level_browsing_context_id) => {
+            EmbedderEvent::Reload(top_level_browsing_context_id) => {
                 let msg = ConstellationMsg::Reload(top_level_browsing_context_id);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!("Sending reload to constellation failed ({:?}).", e);
                 }
             },
 
-            WindowEvent::ToggleSamplingProfiler(rate, max_duration) => {
+            EmbedderEvent::ToggleSamplingProfiler(rate, max_duration) => {
                 self.profiler_enabled = !self.profiler_enabled;
                 let msg = if self.profiler_enabled {
                     ConstellationMsg::EnableProfiler(rate, max_duration)
@@ -647,15 +647,15 @@ where
                 }
             },
 
-            WindowEvent::ToggleWebRenderDebug(option) => {
+            EmbedderEvent::ToggleWebRenderDebug(option) => {
                 self.compositor.toggle_webrender_debug(option);
             },
 
-            WindowEvent::CaptureWebRender => {
+            EmbedderEvent::CaptureWebRender => {
                 self.compositor.capture_webrender();
             },
 
-            WindowEvent::NewBrowser(url, browser_id) => {
+            EmbedderEvent::NewBrowser(url, browser_id) => {
                 let msg = ConstellationMsg::NewBrowser(url, browser_id);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -665,7 +665,7 @@ where
                 }
             },
 
-            WindowEvent::SelectBrowser(ctx) => {
+            EmbedderEvent::SelectBrowser(ctx) => {
                 let msg = ConstellationMsg::SelectBrowser(ctx);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -675,7 +675,7 @@ where
                 }
             },
 
-            WindowEvent::CloseBrowser(ctx) => {
+            EmbedderEvent::CloseBrowser(ctx) => {
                 let msg = ConstellationMsg::CloseBrowser(ctx);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -685,7 +685,7 @@ where
                 }
             },
 
-            WindowEvent::SendError(ctx, e) => {
+            EmbedderEvent::SendError(ctx, e) => {
                 let msg = ConstellationMsg::SendError(ctx, e);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -695,7 +695,7 @@ where
                 }
             },
 
-            WindowEvent::MediaSessionAction(a) => {
+            EmbedderEvent::MediaSessionAction(a) => {
                 let msg = ConstellationMsg::MediaSessionAction(a);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
@@ -705,7 +705,7 @@ where
                 }
             },
 
-            WindowEvent::ChangeBrowserVisibility(top_level_browsing_context_id, visible) => {
+            EmbedderEvent::ChangeBrowserVisibility(top_level_browsing_context_id, visible) => {
                 let msg = ConstellationMsg::ChangeBrowserVisibility(
                     top_level_browsing_context_id,
                     visible,
@@ -750,7 +750,7 @@ where
         ::std::mem::replace(&mut self.embedder_events, Vec::new())
     }
 
-    pub fn handle_events(&mut self, events: Vec<WindowEvent>) -> bool {
+    pub fn handle_events(&mut self, events: Vec<EmbedderEvent>) -> bool {
         if self.compositor.receive_messages() {
             self.receive_messages();
         }

--- a/ports/gstplugin/servowebsrc.rs
+++ b/ports/gstplugin/servowebsrc.rs
@@ -69,8 +69,8 @@ use log::warn;
 
 use servo::compositing::windowing::AnimationState;
 use servo::compositing::windowing::EmbedderCoordinates;
+use servo::compositing::windowing::EmbedderEvent;
 use servo::compositing::windowing::EmbedderMethods;
-use servo::compositing::windowing::WindowEvent;
 use servo::compositing::windowing::WindowMethods;
 use servo::embedder_traits::EmbedderProxy;
 use servo::embedder_traits::EventLoopWaker;
@@ -221,14 +221,14 @@ impl ServoThread {
         let id = servo.top_level_browsing_context_id;
         let mut servo = servo.servo;
 
-        servo.handle_events(vec![WindowEvent::NewBrowser(url, id)]);
+        servo.handle_events(vec![EmbedderEvent::NewBrowser(url, id)]);
 
         let swap_chain = match webxr_mode {
             None => Some(webrender_swap_chain),
             Some(..) => {
                 set_pref!(dom.webxr.sessionavailable, true);
                 set_pref!(dom.webxr.unsafe_assume_user_intent, true);
-                servo.handle_events(vec![WindowEvent::ChangeBrowserVisibility(id, false)]);
+                servo.handle_events(vec![EmbedderEvent::ChangeBrowserVisibility(id, false)]);
                 None
             },
         };
@@ -256,7 +256,7 @@ impl ServoThread {
                 ServoWebSrcMsg::Stop => break,
             }
         }
-        self.servo.handle_events(vec![WindowEvent::Quit]);
+        self.servo.handle_events(vec![EmbedderEvent::Quit]);
     }
 
     fn send_swap_chain(&mut self, sender: Sender<SwapChain<Device>>) {
@@ -273,7 +273,7 @@ impl ServoThread {
             .window()
             .webrender_surfman
             .resize(size.to_untyped());
-        self.servo.handle_events(vec![WindowEvent::Resize]);
+        self.servo.handle_events(vec![EmbedderEvent::Resize]);
     }
 }
 

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -18,7 +18,7 @@ pub use servo::webrender_api::units::DeviceIntRect;
 use getopts::Options;
 use ipc_channel::ipc::IpcSender;
 use servo::compositing::windowing::{
-    AnimationState, EmbedderCoordinates, EmbedderMethods, MouseWindowEvent, WindowEvent,
+    AnimationState, EmbedderCoordinates, EmbedderEvent, EmbedderMethods, MouseWindowEvent,
     WindowMethods,
 };
 use servo::config::prefs::pref_map;
@@ -179,7 +179,7 @@ pub struct ServoGlue {
     // EmbedderMsg::CloseBrowser will pop from it,
     // and exit if it is empty afterwards.
     browsers: Vec<BrowserId>,
-    events: Vec<WindowEvent>,
+    events: Vec<EmbedderEvent>,
 
     context_menu_sender: Option<IpcSender<ContextMenuResult>>,
 }
@@ -316,7 +316,7 @@ pub fn init(
             events: vec![],
             context_menu_sender: None,
         };
-        let _ = servo_glue.process_event(WindowEvent::NewBrowser(url, servo.browser_id));
+        let _ = servo_glue.process_event(EmbedderEvent::NewBrowser(url, servo.browser_id));
         *s.borrow_mut() = Some(servo_glue);
     });
 
@@ -338,7 +338,7 @@ impl ServoGlue {
 
     /// Request shutdown. Will call on_shutdown_complete.
     pub fn request_shutdown(&mut self) -> Result<(), &'static str> {
-        self.process_event(WindowEvent::Quit)
+        self.process_event(EmbedderEvent::Quit)
     }
 
     /// Call after on_shutdown_complete
@@ -382,7 +382,7 @@ impl ServoGlue {
             .map_err(|_| "Can't parse URL")
             .and_then(|url| {
                 let browser_id = self.get_browser_id()?;
-                let event = WindowEvent::LoadUrl(browser_id, url);
+                let event = EmbedderEvent::LoadUrl(browser_id, url);
                 self.process_event(event)
             })
     }
@@ -390,7 +390,7 @@ impl ServoGlue {
     /// Reload the page.
     pub fn clear_cache(&mut self) -> Result<(), &'static str> {
         info!("clear_cache");
-        let event = WindowEvent::ClearCache;
+        let event = EmbedderEvent::ClearCache;
         self.process_event(event)
     }
 
@@ -398,14 +398,14 @@ impl ServoGlue {
     pub fn reload(&mut self) -> Result<(), &'static str> {
         info!("reload");
         let browser_id = self.get_browser_id()?;
-        let event = WindowEvent::Reload(browser_id);
+        let event = EmbedderEvent::Reload(browser_id);
         self.process_event(event)
     }
 
     /// Redraw the page.
     pub fn refresh(&mut self) -> Result<(), &'static str> {
         info!("refresh");
-        self.process_event(WindowEvent::Refresh)
+        self.process_event(EmbedderEvent::Refresh)
     }
 
     /// Stop loading the page.
@@ -418,7 +418,7 @@ impl ServoGlue {
     pub fn go_back(&mut self) -> Result<(), &'static str> {
         info!("go_back");
         let browser_id = self.get_browser_id()?;
-        let event = WindowEvent::Navigation(browser_id, TraversalDirection::Back(1));
+        let event = EmbedderEvent::Navigation(browser_id, TraversalDirection::Back(1));
         self.process_event(event)
     }
 
@@ -426,7 +426,7 @@ impl ServoGlue {
     pub fn go_forward(&mut self) -> Result<(), &'static str> {
         info!("go_forward");
         let browser_id = self.get_browser_id()?;
-        let event = WindowEvent::Navigation(browser_id, TraversalDirection::Forward(1));
+        let event = EmbedderEvent::Navigation(browser_id, TraversalDirection::Forward(1));
         self.process_event(event)
     }
 
@@ -434,7 +434,7 @@ impl ServoGlue {
     pub fn resize(&mut self, coordinates: Coordinates) -> Result<(), &'static str> {
         info!("resize");
         *self.callbacks.coordinates.borrow_mut() = coordinates;
-        self.process_event(WindowEvent::Resize)
+        self.process_event(EmbedderEvent::Resize)
     }
 
     /// Start scrolling.
@@ -443,7 +443,8 @@ impl ServoGlue {
     pub fn scroll_start(&mut self, dx: f32, dy: f32, x: i32, y: i32) -> Result<(), &'static str> {
         let delta = Vector2D::new(dx, dy);
         let scroll_location = ScrollLocation::Delta(delta);
-        let event = WindowEvent::Scroll(scroll_location, Point2D::new(x, y), TouchEventType::Down);
+        let event =
+            EmbedderEvent::Scroll(scroll_location, Point2D::new(x, y), TouchEventType::Down);
         self.process_event(event)
     }
 
@@ -453,7 +454,8 @@ impl ServoGlue {
     pub fn scroll(&mut self, dx: f32, dy: f32, x: i32, y: i32) -> Result<(), &'static str> {
         let delta = Vector2D::new(dx, dy);
         let scroll_location = ScrollLocation::Delta(delta);
-        let event = WindowEvent::Scroll(scroll_location, Point2D::new(x, y), TouchEventType::Move);
+        let event =
+            EmbedderEvent::Scroll(scroll_location, Point2D::new(x, y), TouchEventType::Move);
         self.process_event(event)
     }
 
@@ -463,13 +465,13 @@ impl ServoGlue {
     pub fn scroll_end(&mut self, dx: f32, dy: f32, x: i32, y: i32) -> Result<(), &'static str> {
         let delta = Vector2D::new(dx, dy);
         let scroll_location = ScrollLocation::Delta(delta);
-        let event = WindowEvent::Scroll(scroll_location, Point2D::new(x, y), TouchEventType::Up);
+        let event = EmbedderEvent::Scroll(scroll_location, Point2D::new(x, y), TouchEventType::Up);
         self.process_event(event)
     }
 
     /// Touch event: press down
     pub fn touch_down(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
-        let event = WindowEvent::Touch(
+        let event = EmbedderEvent::Touch(
             TouchEventType::Down,
             TouchId(pointer_id),
             Point2D::new(x as f32, y as f32),
@@ -479,7 +481,7 @@ impl ServoGlue {
 
     /// Touch event: move touching finger
     pub fn touch_move(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
-        let event = WindowEvent::Touch(
+        let event = EmbedderEvent::Touch(
             TouchEventType::Move,
             TouchId(pointer_id),
             Point2D::new(x as f32, y as f32),
@@ -489,7 +491,7 @@ impl ServoGlue {
 
     /// Touch event: Lift touching finger
     pub fn touch_up(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
-        let event = WindowEvent::Touch(
+        let event = EmbedderEvent::Touch(
             TouchEventType::Up,
             TouchId(pointer_id),
             Point2D::new(x as f32, y as f32),
@@ -499,7 +501,7 @@ impl ServoGlue {
 
     /// Cancel touch event
     pub fn touch_cancel(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
-        let event = WindowEvent::Touch(
+        let event = EmbedderEvent::Touch(
             TouchEventType::Cancel,
             TouchId(pointer_id),
             Point2D::new(x as f32, y as f32),
@@ -510,46 +512,47 @@ impl ServoGlue {
     /// Register a mouse movement.
     pub fn mouse_move(&mut self, x: f32, y: f32) -> Result<(), &'static str> {
         let point = Point2D::new(x, y);
-        let event = WindowEvent::MouseWindowMoveEventClass(point);
+        let event = EmbedderEvent::MouseWindowMoveEventClass(point);
         self.process_event(event)
     }
 
     /// Register a mouse button press.
     pub fn mouse_down(&mut self, x: f32, y: f32, button: MouseButton) -> Result<(), &'static str> {
         let point = Point2D::new(x, y);
-        let event = WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseDown(button, point));
+        let event =
+            EmbedderEvent::MouseWindowEventClass(MouseWindowEvent::MouseDown(button, point));
         self.process_event(event)
     }
 
     /// Register a mouse button release.
     pub fn mouse_up(&mut self, x: f32, y: f32, button: MouseButton) -> Result<(), &'static str> {
         let point = Point2D::new(x, y);
-        let event = WindowEvent::MouseWindowEventClass(MouseWindowEvent::MouseUp(button, point));
+        let event = EmbedderEvent::MouseWindowEventClass(MouseWindowEvent::MouseUp(button, point));
         self.process_event(event)
     }
 
     /// Start pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_start(&mut self, factor: f32, _x: u32, _y: u32) -> Result<(), &'static str> {
-        self.process_event(WindowEvent::PinchZoom(factor))
+        self.process_event(EmbedderEvent::PinchZoom(factor))
     }
 
     /// Pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom(&mut self, factor: f32, _x: u32, _y: u32) -> Result<(), &'static str> {
-        self.process_event(WindowEvent::PinchZoom(factor))
+        self.process_event(EmbedderEvent::PinchZoom(factor))
     }
 
     /// End pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_end(&mut self, factor: f32, _x: u32, _y: u32) -> Result<(), &'static str> {
-        self.process_event(WindowEvent::PinchZoom(factor))
+        self.process_event(EmbedderEvent::PinchZoom(factor))
     }
 
     /// Perform a click.
     pub fn click(&mut self, x: f32, y: f32) -> Result<(), &'static str> {
         let mouse_event = MouseWindowEvent::Click(MouseButton::Left, Point2D::new(x, y));
-        let event = WindowEvent::MouseWindowEventClass(mouse_event);
+        let event = EmbedderEvent::MouseWindowEventClass(mouse_event);
         self.process_event(event)
     }
 
@@ -559,7 +562,7 @@ impl ServoGlue {
             key,
             ..KeyboardEvent::default()
         };
-        self.process_event(WindowEvent::Keyboard(key_event))
+        self.process_event(EmbedderEvent::Keyboard(key_event))
     }
 
     pub fn key_up(&mut self, key: Key) -> Result<(), &'static str> {
@@ -568,7 +571,7 @@ impl ServoGlue {
             key,
             ..KeyboardEvent::default()
         };
-        self.process_event(WindowEvent::Keyboard(key_event))
+        self.process_event(EmbedderEvent::Keyboard(key_event))
     }
 
     pub fn media_session_action(
@@ -576,13 +579,13 @@ impl ServoGlue {
         action: MediaSessionActionType,
     ) -> Result<(), &'static str> {
         info!("Media session action {:?}", action);
-        self.process_event(WindowEvent::MediaSessionAction(action))
+        self.process_event(EmbedderEvent::MediaSessionAction(action))
     }
 
     pub fn change_visibility(&mut self, visible: bool) -> Result<(), &'static str> {
         info!("change_visibility");
         if let Ok(id) = self.get_browser_id() {
-            let event = WindowEvent::ChangeBrowserVisibility(id, visible);
+            let event = EmbedderEvent::ChangeBrowserVisibility(id, visible);
             self.process_event(event)
         } else {
             // Ignore visibility change if no browser has been created yet.
@@ -592,7 +595,7 @@ impl ServoGlue {
 
     pub fn ime_dismissed(&mut self) -> Result<(), &'static str> {
         info!("ime_dismissed");
-        self.process_event(WindowEvent::IMEDismissed)
+        self.process_event(EmbedderEvent::IMEDismissed)
     }
 
     pub fn on_context_menu_closed(
@@ -607,7 +610,7 @@ impl ServoGlue {
         Ok(())
     }
 
-    fn process_event(&mut self, event: WindowEvent) -> Result<(), &'static str> {
+    fn process_event(&mut self, event: EmbedderEvent) -> Result<(), &'static str> {
         self.events.push(event);
         if !self.batch_mode {
             self.perform_updates()
@@ -628,7 +631,8 @@ impl ServoGlue {
                             .callbacks
                             .host_callbacks
                             .on_allow_navigation(url.to_string());
-                        let window_event = WindowEvent::AllowNavigationResponse(pipeline_id, data);
+                        let window_event =
+                            EmbedderEvent::AllowNavigationResponse(pipeline_id, data);
                         self.events.push(window_event);
                         let _ = self.perform_updates();
                     }
@@ -687,7 +691,8 @@ impl ServoGlue {
                     };
                     if let Err(e) = res {
                         let reason = format!("Failed to send Prompt response: {}", e);
-                        self.events.push(WindowEvent::SendError(browser_id, reason));
+                        self.events
+                            .push(EmbedderEvent::SendError(browser_id, reason));
                     }
                 },
                 EmbedderMsg::AllowOpeningBrowser(response_chan) => {
@@ -703,7 +708,8 @@ impl ServoGlue {
                     if self.browser_id.is_none() {
                         self.browser_id = Some(new_browser_id);
                     }
-                    self.events.push(WindowEvent::SelectBrowser(new_browser_id));
+                    self.events
+                        .push(EmbedderEvent::SelectBrowser(new_browser_id));
                 },
                 EmbedderMsg::GetClipboardContents(sender) => {
                     let contents = self.callbacks.host_callbacks.get_clipboard_contents();
@@ -718,9 +724,9 @@ impl ServoGlue {
                     if let Some(prev_browser_id) = self.browsers.last() {
                         self.browser_id = Some(*prev_browser_id);
                         self.events
-                            .push(WindowEvent::SelectBrowser(*prev_browser_id));
+                            .push(EmbedderEvent::SelectBrowser(*prev_browser_id));
                     } else {
-                        self.events.push(WindowEvent::Quit);
+                        self.events.push(EmbedderEvent::Quit);
                     }
                 },
                 EmbedderMsg::Shutdown => {

--- a/ports/winit/app.rs
+++ b/ports/winit/app.rs
@@ -114,7 +114,7 @@ impl App {
             }
 
             // Handle the event
-            app.winit_event_to_embedder_event(e);
+            app.queue_embedder_events_for_winit_event(e);
 
             let animating = app.is_animating();
 
@@ -143,7 +143,7 @@ impl App {
 
     /// Processes the given winit Event, possibly converting it to an [EmbedderEvent] and
     /// routing that to the App or relevant Window event queues.
-    fn winit_event_to_embedder_event(&self, event: winit::event::Event<'_, WakerEvent>) {
+    fn queue_embedder_events_for_winit_event(&self, event: winit::event::Event<'_, WakerEvent>) {
         match event {
             // App level events
             winit::event::Event::Suspended => {
@@ -171,7 +171,7 @@ impl App {
                         warn!("Got an event from unknown window");
                     },
                     Some(window) => {
-                        window.winit_event_to_embedder_event(event);
+                        window.queue_embedder_events_for_winit_event(event);
                     },
                 }
             },

--- a/ports/winit/app.rs
+++ b/ports/winit/app.rs
@@ -141,7 +141,7 @@ impl App {
         std::mem::take(&mut *self.event_queue.borrow_mut())
     }
 
-    /// Processes the given winit Event, possibly converting it to an EmbedderEvent and
+    /// Processes the given winit Event, possibly converting it to an [EmbedderEvent] and
     /// routing that to the App or relevant Window event queues.
     fn winit_event_to_embedder_event(&self, event: winit::event::Event<'_, WakerEvent>) {
         match event {

--- a/ports/winit/app.rs
+++ b/ports/winit/app.rs
@@ -6,7 +6,7 @@
 
 use crate::browser::Browser;
 use crate::embedder::EmbedderCallbacks;
-use crate::events_loop::{EventsLoop, ServoEvent};
+use crate::events_loop::{EventsLoop, WakerEvent};
 use crate::window_trait::WindowPortsMethods;
 use crate::{headed_window, headless_window};
 use winit::window::WindowId;
@@ -76,8 +76,8 @@ impl App {
                     // it stops being valid.
                     let w = unsafe {
                         std::mem::transmute::<
-                            &EventLoopWindowTarget<ServoEvent>,
-                            &'static EventLoopWindowTarget<ServoEvent>
+                            &EventLoopWindowTarget<WakerEvent>,
+                            &'static EventLoopWindowTarget<WakerEvent>
                         >(w.unwrap())
                     };
                     let factory = Box::new(move || Ok(window.new_glwindow(w)));
@@ -143,7 +143,7 @@ impl App {
 
     /// Processes the given winit Event, possibly converting it to an EmbedderEvent and
     /// routing that to the App or relevant Window event queues.
-    fn winit_event_to_embedder_event(&self, event: winit::event::Event<'_, ServoEvent>) {
+    fn winit_event_to_embedder_event(&self, event: winit::event::Event<'_, WakerEvent>) {
         match event {
             // App level events
             winit::event::Event::Suspended => {

--- a/ports/winit/app.rs
+++ b/ports/winit/app.rs
@@ -114,7 +114,7 @@ impl App {
             }
 
             // Handle the event
-            app.winit_event_to_servo_event(e);
+            app.winit_event_to_embedder_event(e);
 
             let animating = app.is_animating();
 
@@ -141,8 +141,9 @@ impl App {
         std::mem::take(&mut *self.event_queue.borrow_mut())
     }
 
-    // This function decides whether the event should be handled during `run_forever`.
-    fn winit_event_to_servo_event(&self, event: winit::event::Event<'_, ServoEvent>) {
+    /// Processes the given winit Event, possibly converting it to an EmbedderEvent and
+    /// routing that to the App or relevant Window event queues.
+    fn winit_event_to_embedder_event(&self, event: winit::event::Event<'_, ServoEvent>) {
         match event {
             // App level events
             winit::event::Event::Suspended => {
@@ -170,7 +171,7 @@ impl App {
                         warn!("Got an event from unknown window");
                     },
                     Some(window) => {
-                        window.winit_event_to_servo_event(event);
+                        window.winit_event_to_embedder_event(event);
                     },
                 }
             },

--- a/ports/winit/browser.rs
+++ b/ports/winit/browser.rs
@@ -7,7 +7,7 @@ use crate::window_trait::{WindowPortsMethods, LINE_HEIGHT};
 use clipboard::{ClipboardContext, ClipboardProvider};
 use euclid::{Point2D, Vector2D};
 use keyboard_types::{Key, KeyboardEvent, Modifiers, ShortcutMatcher};
-use servo::compositing::windowing::{WebRenderDebugOption, WindowEvent};
+use servo::compositing::windowing::{WebRenderDebugOption, EmbedderEvent};
 use servo::embedder_traits::{
     ContextMenuResult, EmbedderMsg, FilterPattern, PermissionPrompt, PermissionRequest,
     PromptDefinition, PromptOrigin, PromptResult,
@@ -44,7 +44,7 @@ pub struct Browser<Window: WindowPortsMethods + ?Sized> {
     title: Option<String>,
 
     window: Rc<Window>,
-    event_queue: Vec<WindowEvent>,
+    event_queue: Vec<EmbedderEvent>,
     clipboard_ctx: Option<ClipboardContext>,
     shutdown_requested: bool,
 }
@@ -72,14 +72,14 @@ where
         }
     }
 
-    pub fn get_events(&mut self) -> Vec<WindowEvent> {
+    pub fn get_events(&mut self) -> Vec<EmbedderEvent> {
         std::mem::take(&mut self.event_queue)
     }
 
-    pub fn handle_window_events(&mut self, events: Vec<WindowEvent>) {
+    pub fn handle_window_events(&mut self, events: Vec<EmbedderEvent>) {
         for event in events {
             match event {
-                WindowEvent::Keyboard(key_event) => {
+                EmbedderEvent::Keyboard(key_event) => {
                     self.handle_key_from_window(key_event);
                 },
                 event => {
@@ -98,7 +98,7 @@ where
         ShortcutMatcher::from_event(key_event.clone())
             .shortcut(CMD_OR_CONTROL, 'R', || {
                 if let Some(id) = self.browser_id {
-                    self.event_queue.push(WindowEvent::Reload(id));
+                    self.event_queue.push(EmbedderEvent::Reload(id));
                 }
             })
             .shortcut(CMD_OR_CONTROL, 'L', || {
@@ -112,13 +112,13 @@ where
                 if let Some(input) = input {
                     if let Some(url) = sanitize_url(&input) {
                         if let Some(id) = self.browser_id {
-                            self.event_queue.push(WindowEvent::LoadUrl(id, url));
+                            self.event_queue.push(EmbedderEvent::LoadUrl(id, url));
                         }
                     }
                 }
             })
             .shortcut(CMD_OR_CONTROL, 'Q', || {
-                self.event_queue.push(WindowEvent::Quit);
+                self.event_queue.push(EmbedderEvent::Quit);
             })
             .shortcut(CMD_OR_CONTROL, 'P', || {
                 let rate = env::var("SAMPLING_RATE")
@@ -129,38 +129,38 @@ where
                     .ok()
                     .and_then(|s| s.parse().ok())
                     .unwrap_or(10);
-                self.event_queue.push(WindowEvent::ToggleSamplingProfiler(
+                self.event_queue.push(EmbedderEvent::ToggleSamplingProfiler(
                     Duration::from_millis(rate),
                     Duration::from_secs(duration),
                 ));
             })
             .shortcut(Modifiers::CONTROL, Key::F9, || {
-                self.event_queue.push(WindowEvent::CaptureWebRender)
+                self.event_queue.push(EmbedderEvent::CaptureWebRender)
             })
             .shortcut(Modifiers::CONTROL, Key::F10, || {
-                self.event_queue.push(WindowEvent::ToggleWebRenderDebug(
+                self.event_queue.push(EmbedderEvent::ToggleWebRenderDebug(
                     WebRenderDebugOption::RenderTargetDebug,
                 ));
             })
             .shortcut(Modifiers::CONTROL, Key::F11, || {
-                self.event_queue.push(WindowEvent::ToggleWebRenderDebug(
+                self.event_queue.push(EmbedderEvent::ToggleWebRenderDebug(
                     WebRenderDebugOption::TextureCacheDebug,
                 ));
             })
             .shortcut(Modifiers::CONTROL, Key::F12, || {
-                self.event_queue.push(WindowEvent::ToggleWebRenderDebug(
+                self.event_queue.push(EmbedderEvent::ToggleWebRenderDebug(
                     WebRenderDebugOption::Profiler,
                 ));
             })
             .shortcut(CMD_OR_ALT, Key::ArrowRight, || {
                 if let Some(id) = self.browser_id {
-                    let event = WindowEvent::Navigation(id, TraversalDirection::Forward(1));
+                    let event = EmbedderEvent::Navigation(id, TraversalDirection::Forward(1));
                     self.event_queue.push(event);
                 }
             })
             .shortcut(CMD_OR_ALT, Key::ArrowLeft, || {
                 if let Some(id) = self.browser_id {
-                    let event = WindowEvent::Navigation(id, TraversalDirection::Back(1));
+                    let event = EmbedderEvent::Navigation(id, TraversalDirection::Back(1));
                     self.event_queue.push(event);
                 }
             })
@@ -168,11 +168,11 @@ where
                 let state = self.window.get_fullscreen();
                 if state {
                     if let Some(id) = self.browser_id {
-                        let event = WindowEvent::ExitFullScreen(id);
+                        let event = EmbedderEvent::ExitFullScreen(id);
                         self.event_queue.push(event);
                     }
                 } else {
-                    self.event_queue.push(WindowEvent::Quit);
+                    self.event_queue.push(EmbedderEvent::Quit);
                 }
             })
             .otherwise(|| self.platform_handle_key(key_event));
@@ -183,12 +183,12 @@ where
         if let Some(id) = self.browser_id {
             if let Some(event) = ShortcutMatcher::from_event(key_event.clone())
                 .shortcut(CMD_OR_CONTROL, '[', || {
-                    WindowEvent::Navigation(id, TraversalDirection::Back(1))
+                    EmbedderEvent::Navigation(id, TraversalDirection::Back(1))
                 })
                 .shortcut(CMD_OR_CONTROL, ']', || {
-                    WindowEvent::Navigation(id, TraversalDirection::Forward(1))
+                    EmbedderEvent::Navigation(id, TraversalDirection::Forward(1))
                 })
-                .otherwise(|| WindowEvent::Keyboard(key_event))
+                .otherwise(|| EmbedderEvent::Keyboard(key_event))
             {
                 self.event_queue.push(event)
             }
@@ -202,16 +202,16 @@ where
     fn handle_key_from_servo(&mut self, _: Option<BrowserId>, event: KeyboardEvent) {
         ShortcutMatcher::from_event(event)
             .shortcut(CMD_OR_CONTROL, '=', || {
-                self.event_queue.push(WindowEvent::Zoom(1.1))
+                self.event_queue.push(EmbedderEvent::Zoom(1.1))
             })
             .shortcut(CMD_OR_CONTROL, '+', || {
-                self.event_queue.push(WindowEvent::Zoom(1.1))
+                self.event_queue.push(EmbedderEvent::Zoom(1.1))
             })
             .shortcut(CMD_OR_CONTROL, '-', || {
-                self.event_queue.push(WindowEvent::Zoom(1.0 / 1.1))
+                self.event_queue.push(EmbedderEvent::Zoom(1.0 / 1.1))
             })
             .shortcut(CMD_OR_CONTROL, '0', || {
-                self.event_queue.push(WindowEvent::ResetZoom)
+                self.event_queue.push(EmbedderEvent::ResetZoom)
             })
             .shortcut(Modifiers::empty(), Key::PageDown, || {
                 let scroll_location = ScrollLocation::Delta(Vector2D::new(
@@ -260,7 +260,7 @@ where
     }
 
     fn scroll_window_from_key(&mut self, scroll_location: ScrollLocation, phase: TouchEventType) {
-        let event = WindowEvent::Scroll(scroll_location, Point2D::zero(), phase);
+        let event = EmbedderEvent::Scroll(scroll_location, Point2D::zero(), phase);
         self.event_queue.push(event);
     }
 
@@ -366,7 +366,7 @@ where
                     if let Err(e) = res {
                         let reason = format!("Failed to send Prompt response: {}", e);
                         self.event_queue
-                            .push(WindowEvent::SendError(browser_id, reason));
+                            .push(EmbedderEvent::SendError(browser_id, reason));
                     }
                 },
                 EmbedderMsg::AllowUnload(sender) => {
@@ -374,13 +374,13 @@ where
                     if let Err(e) = sender.send(true) {
                         let reason = format!("Failed to send AllowUnload response: {}", e);
                         self.event_queue
-                            .push(WindowEvent::SendError(browser_id, reason));
+                            .push(EmbedderEvent::SendError(browser_id, reason));
                     }
                 },
                 EmbedderMsg::AllowNavigationRequest(pipeline_id, _url) => {
                     if let Some(_browser_id) = browser_id {
                         self.event_queue
-                            .push(WindowEvent::AllowNavigationResponse(pipeline_id, true));
+                            .push(EmbedderEvent::AllowNavigationResponse(pipeline_id, true));
                     }
                 },
                 EmbedderMsg::AllowOpeningBrowser(response_chan) => {
@@ -399,7 +399,7 @@ where
                         error!("Multiple top level browsing contexts not supported yet.");
                     }
                     self.event_queue
-                        .push(WindowEvent::SelectBrowser(new_browser_id));
+                        .push(EmbedderEvent::SelectBrowser(new_browser_id));
                 },
                 EmbedderMsg::Keyboard(key_event) => {
                     self.handle_key_from_servo(browser_id, key_event);
@@ -453,9 +453,9 @@ where
                     if let Some(prev_browser_id) = self.browsers.last() {
                         self.browser_id = Some(*prev_browser_id);
                         self.event_queue
-                            .push(WindowEvent::SelectBrowser(*prev_browser_id));
+                            .push(EmbedderEvent::SelectBrowser(*prev_browser_id));
                     } else {
-                        self.event_queue.push(WindowEvent::Quit);
+                        self.event_queue.push(EmbedderEvent::Quit);
                     }
                 },
                 EmbedderMsg::Shutdown => {
@@ -467,7 +467,7 @@ where
                     if let Err(e) = sender.send(selected) {
                         let reason =
                             format!("Failed to send GetSelectedBluetoothDevice response: {}", e);
-                        self.event_queue.push(WindowEvent::SendError(None, reason));
+                        self.event_queue.push(EmbedderEvent::SendError(None, reason));
                     };
                 },
                 EmbedderMsg::SelectFiles(patterns, multiple_files, sender) => {
@@ -480,7 +480,7 @@ where
                     };
                     if let Err(e) = res {
                         let reason = format!("Failed to send SelectFiles response: {}", e);
-                        self.event_queue.push(WindowEvent::SendError(None, reason));
+                        self.event_queue.push(EmbedderEvent::SendError(None, reason));
                     };
                 },
                 EmbedderMsg::PromptPermission(prompt, sender) => {

--- a/ports/winit/headed_window.rs
+++ b/ports/winit/headed_window.rs
@@ -4,7 +4,7 @@
 
 //! A winit window implementation.
 
-use crate::events_loop::{EventsLoop, ServoEvent};
+use crate::events_loop::{EventsLoop, WakerEvent};
 use crate::keyutils::keyboard_event_from_winit;
 use crate::window_trait::{WindowPortsMethods, LINE_HEIGHT};
 use euclid::{
@@ -484,7 +484,7 @@ impl WindowPortsMethods for Window {
 
     fn new_glwindow(
         &self,
-        event_loop: &winit::event_loop::EventLoopWindowTarget<ServoEvent>
+        event_loop: &winit::event_loop::EventLoopWindowTarget<WakerEvent>
     ) -> Box<dyn webxr::glwindow::GlWindow> {
         let size = self.winit_window.outer_size();
 

--- a/ports/winit/headed_window.rs
+++ b/ports/winit/headed_window.rs
@@ -393,7 +393,7 @@ impl WindowPortsMethods for Window {
         self.winit_window.id()
     }
 
-    fn winit_event_to_embedder_event(&self, event: winit::event::WindowEvent<'_>) {
+    fn queue_embedder_events_for_winit_event(&self, event: winit::event::WindowEvent<'_>) {
         match event {
             winit::event::WindowEvent::ReceivedCharacter(ch) => self.handle_received_character(ch),
             winit::event::WindowEvent::KeyboardInput { input, .. } => self.handle_keyboard_input(input),

--- a/ports/winit/headed_window.rs
+++ b/ports/winit/headed_window.rs
@@ -393,7 +393,7 @@ impl WindowPortsMethods for Window {
         self.winit_window.id()
     }
 
-    fn winit_event_to_servo_event(&self, event: winit::event::WindowEvent<'_>) {
+    fn winit_event_to_embedder_event(&self, event: winit::event::WindowEvent<'_>) {
         match event {
             winit::event::WindowEvent::ReceivedCharacter(ch) => self.handle_received_character(ch),
             winit::event::WindowEvent::KeyboardInput { input, .. } => self.handle_keyboard_input(input),

--- a/ports/winit/headless_window.rs
+++ b/ports/winit/headless_window.rs
@@ -4,7 +4,7 @@
 
 //! A headless window implementation.
 
-use crate::events_loop::ServoEvent;
+use crate::events_loop::WakerEvent;
 use crate::window_trait::WindowPortsMethods;
 use euclid::{Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
 use servo::compositing::windowing::{AnimationState, EmbedderEvent};
@@ -104,7 +104,7 @@ impl WindowPortsMethods for Window {
 
     fn new_glwindow(
         &self,
-        _events_loop: &winit::event_loop::EventLoopWindowTarget<ServoEvent>
+        _events_loop: &winit::event_loop::EventLoopWindowTarget<WakerEvent>
     ) -> Box<dyn webxr::glwindow::GlWindow> {
         unimplemented!()
     }

--- a/ports/winit/headless_window.rs
+++ b/ports/winit/headless_window.rs
@@ -7,7 +7,7 @@
 use crate::events_loop::ServoEvent;
 use crate::window_trait::WindowPortsMethods;
 use euclid::{Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
-use servo::compositing::windowing::{AnimationState, WindowEvent};
+use servo::compositing::windowing::{AnimationState, EmbedderEvent};
 use servo::compositing::windowing::{EmbedderCoordinates, WindowMethods};
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::style_traits::DevicePixel;
@@ -63,7 +63,7 @@ impl Window {
 }
 
 impl WindowPortsMethods for Window {
-    fn get_events(&self) -> Vec<WindowEvent> {
+    fn get_events(&self) -> Vec<EmbedderEvent> {
         vec![]
     }
 

--- a/ports/winit/headless_window.rs
+++ b/ports/winit/headless_window.rs
@@ -98,7 +98,7 @@ impl WindowPortsMethods for Window {
         self.animation_state.get() == AnimationState::Animating
     }
 
-    fn winit_event_to_servo_event(&self, _event: winit::event::WindowEvent<'_>) {
+    fn winit_event_to_embedder_event(&self, _event: winit::event::WindowEvent<'_>) {
         // Not expecting any winit events.
     }
 

--- a/ports/winit/headless_window.rs
+++ b/ports/winit/headless_window.rs
@@ -98,7 +98,7 @@ impl WindowPortsMethods for Window {
         self.animation_state.get() == AnimationState::Animating
     }
 
-    fn winit_event_to_embedder_event(&self, _event: winit::event::WindowEvent<'_>) {
+    fn queue_embedder_events_for_winit_event(&self, _event: winit::event::WindowEvent<'_>) {
         // Not expecting any winit events.
     }
 

--- a/ports/winit/window_trait.rs
+++ b/ports/winit/window_trait.rs
@@ -20,7 +20,7 @@ pub trait WindowPortsMethods: WindowMethods {
     fn has_events(&self) -> bool;
     fn page_height(&self) -> f32;
     fn get_fullscreen(&self) -> bool;
-    fn winit_event_to_embedder_event(&self, event: winit::event::WindowEvent<'_>);
+    fn queue_embedder_events_for_winit_event(&self, event: winit::event::WindowEvent<'_>);
     fn is_animating(&self) -> bool;
     fn set_title(&self, _title: &str) {}
     fn set_inner_size(&self, _size: DeviceIntSize) {}

--- a/ports/winit/window_trait.rs
+++ b/ports/winit/window_trait.rs
@@ -20,7 +20,7 @@ pub trait WindowPortsMethods: WindowMethods {
     fn has_events(&self) -> bool;
     fn page_height(&self) -> f32;
     fn get_fullscreen(&self) -> bool;
-    fn winit_event_to_servo_event(&self, event: winit::event::WindowEvent<'_>);
+    fn winit_event_to_embedder_event(&self, event: winit::event::WindowEvent<'_>);
     fn is_animating(&self) -> bool;
     fn set_title(&self, _title: &str) {}
     fn set_inner_size(&self, _size: DeviceIntSize) {}

--- a/ports/winit/window_trait.rs
+++ b/ports/winit/window_trait.rs
@@ -5,7 +5,7 @@
 //! Definition of Window.
 //! Implemented by headless and headed windows.
 
-use crate::events_loop::ServoEvent;
+use crate::events_loop::WakerEvent;
 use servo::compositing::windowing::{EmbedderEvent, WindowMethods};
 use servo::embedder_traits::Cursor;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
@@ -29,6 +29,6 @@ pub trait WindowPortsMethods: WindowMethods {
     fn set_cursor(&self, _cursor: Cursor) {}
     fn new_glwindow(
         &self,
-        events_loop: &winit::event_loop::EventLoopWindowTarget<ServoEvent>
+        events_loop: &winit::event_loop::EventLoopWindowTarget<WakerEvent>
     ) -> Box<dyn webxr::glwindow::GlWindow>;
 }

--- a/ports/winit/window_trait.rs
+++ b/ports/winit/window_trait.rs
@@ -6,7 +6,7 @@
 //! Implemented by headless and headed windows.
 
 use crate::events_loop::ServoEvent;
-use servo::compositing::windowing::{WindowEvent, WindowMethods};
+use servo::compositing::windowing::{EmbedderEvent, WindowMethods};
 use servo::embedder_traits::Cursor;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 
@@ -15,7 +15,7 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 pub const LINE_HEIGHT: f32 = 38.0;
 
 pub trait WindowPortsMethods: WindowMethods {
-    fn get_events(&self) -> Vec<WindowEvent>;
+    fn get_events(&self) -> Vec<EmbedderEvent>;
     fn id(&self) -> winit::window::WindowId;
     fn has_events(&self) -> bool;
     fn page_height(&self) -> f32;


### PR DESCRIPTION
This patch documents the flow of events between the winit port and Servo, and renames some types and other symbols to make them easier to understand:

* the compositing WindowEvent is now EmbedderEvent — this avoids confusion with winit­::event­::Event­::Window­Event and winit­::event­::Window­Event, and is more accurate than (say) “WindowingEvent” because some events are not from the windowing system (e.g. ClearCache)
* Servo.embedder_events is now messages_for_embedder — this avoids confusion with EmbedderEvent above, which flows in the opposite direction
* App:: and Window­::winit­_event­_to­_{servo → embedder}_event — this avoids confusion with the “servo events” in Browser­::handle­_servo­_events, which flow in the opposite direction
* the ServoEvent in app.rs is now WakerEvent — this avoids confusion with the “servo events” in Browser­::handle­_servo­_events, and there was only one variant Awakened anyway

As a result of this patch, “events” are named after the source (winit events, **embedder events**, window events, servo events), while “messages” are named after the destination unless they are “FromFooMsg” (**embedder messages**, **EmbedderMsg**, ConstellationMsg, Canvas2dMsg).

Reviewing the commits individually may be easier. The new documentation is in:

* [ports/winit/app.rs:144](https://github.com/servo/servo/commit/4b3cefbfe5ea11b9d14288597b8670148d036f99#diff-c33facf59c42b0aae74b6ce055d8184ffa68c84d116f48432c8fcb65a15070c4L144-R146)
* [a3ca86bd6a4890df41f5a967ee32d7af25aa2d02](https://github.com/servo/servo/commit/a3ca86bd6a4890df41f5a967ee32d7af25aa2d02)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes