### PR TITLE
Return error when setting invalid <table> caption

### DIFF
--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -212,7 +212,8 @@ impl HTMLTableElementMethods for HTMLTableElement {
                     &document_from_node(self),
                     None,
                 );
-                self.SetCaption(Some(&caption)).expect("Generated caption is invalid");
+                self.SetCaption(Some(&caption))
+                    .expect("Generated caption is invalid");
                 caption
             },
         }

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -188,16 +188,17 @@ impl HTMLTableElementMethods for HTMLTableElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-caption
-    fn SetCaption(&self, new_caption: Option<&HTMLTableCaptionElement>) {
+    fn SetCaption(&self, new_caption: Option<&HTMLTableCaptionElement>) -> Fallible<()> {
         if let Some(ref caption) = self.GetCaption() {
             caption.upcast::<Node>().remove_self();
         }
 
         if let Some(caption) = new_caption {
             let node = self.upcast::<Node>();
-            node.InsertBefore(caption.upcast(), node.GetFirstChild().as_deref())
-                .expect("Insertion failed");
+            node.InsertBefore(caption.upcast(), node.GetFirstChild().as_deref())?;
         }
+
+        Ok(())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-table-createcaption
@@ -211,7 +212,7 @@ impl HTMLTableElementMethods for HTMLTableElement {
                     &document_from_node(self),
                     None,
                 );
-                self.SetCaption(Some(&caption));
+                self.SetCaption(Some(&caption)).expect("Generated caption is invalid");
                 caption
             },
         }

--- a/components/script/dom/webidls/HTMLTableElement.webidl
+++ b/components/script/dom/webidls/HTMLTableElement.webidl
@@ -7,7 +7,7 @@
 interface HTMLTableElement : HTMLElement {
   [HTMLConstructor] constructor();
 
-  [CEReactions]
+  [CEReactions, SetterThrows]
            attribute HTMLTableCaptionElement? caption;
   HTMLTableCaptionElement createCaption();
   [CEReactions]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Instead of causing a panic when we try and set the table caption to an invalid element, rasie an exception in the JS.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20220

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is simply exposing errors from a different function (`InsertBefore`) which is the function that needs (and I assume has) tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
