### PR TITLE
Never skip workflows for explicitly triggered try jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           script: |
             // Never skip workflow runs for pull requests, merge groups, or manually triggered
             // workfows / try jobs, which might need to actually run / retry WPT tests.
-            if (!['pull_request', 'merge_group', 'workflow_run', 'workflow_call'].includes(context.eventName)) {
+            if (!['issue_comment', 'merge_group', 'pull_request', 'workflow_run', 'workflow_call'].includes(context.eventName)) {
               // Skip the run if an identical run already exists. This helps to avoid running
               // the workflow over and over again for the same commit hash.
               if ((await github.rest.actions.listWorkflowRuns({


### PR DESCRIPTION
Do not do the duplicate workflow checks for main workflow jobs triggered
by 'issue_comment' GitHub Actions. This prevents try jobs from being
skipped. This issue was not detected in my testing, because the main
workflow does not run in personal repositories and 'issue_comment'
actions cannot be tested from PRs.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix an issue with GitHub CI actions.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
