### PR TITLE
More tweaks for the try GitHub Action

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -1,5 +1,8 @@
-on: issue_comment
 name: Try
+
+on:
+  issue_comment:
+    types: [created]
 
 jobs:
   parse-comment:
@@ -87,7 +90,7 @@ jobs:
     if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).try}}
     steps:
       - name: Success
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') }}
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
- Don't trigger try jobs when comments are deleted or edited.
- Don't report success for cancelled jobs.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they change CI behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
