### PR TITLE
Embed git hash using vergen instead of mach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+
+[[package]]
 name = "app_units"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +964,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
- "time 0.3.21",
+ "time 0.3.23",
  "version_check",
 ]
 
@@ -4122,6 +4128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,6 +4974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5300,6 +5321,7 @@ dependencies = [
  "sig",
  "surfman",
  "tinyfiledialogs",
+ "vergen",
  "webxr",
  "winapi",
  "winit",
@@ -5697,6 +5719,7 @@ dependencies = [
  "serde_json",
  "servo-media",
  "surfman",
+ "vergen",
  "webxr",
  "webxr-api",
  "winapi",
@@ -6215,11 +6238,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa 1.0.1",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -6233,9 +6258,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -6643,6 +6668,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "vergen"
+version = "8.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time 0.3.23",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6885,7 +6921,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.21",
+ "time 0.3.23",
  "tokio",
  "tokio-stream",
  "unicode-segmentation",

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -31,6 +31,7 @@ libloading = "0.5"
 [build-dependencies]
 gl_generator = "0.14"
 serde_json = { workspace = true }
+vergen = { version = "8.0.0", features = [ "git", "gitcl" ]}
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]

--- a/ports/libsimpleservo/api/build.rs
+++ b/ports/libsimpleservo/api/build.rs
@@ -7,10 +7,23 @@ use serde_json::{self, Value};
 use std::env;
 use std::fs::File;
 use std::path::PathBuf;
+use vergen::EmitBuilder;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
+
+    if let Err(error) = EmitBuilder::builder()
+        .fail_on_error()
+        .git_sha(true /* short */)
+        .emit()
+    {
+        println!(
+            "cargo:warning=Could not generate git version information: {:?}",
+            error
+        );
+        println!("cargo:rustc-env=VERGEN_GIT_SHA=nogit");
+    }
 
     // Generate GL bindings
     // For now, we only support EGL, and only on Windows and Android.

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -185,12 +185,11 @@ pub struct ServoGlue {
 }
 
 pub fn servo_version() -> String {
-    let cargo_version = env!("CARGO_PKG_VERSION");
-    let git_info = option_env!("GIT_INFO");
-    match git_info {
-        Some(info) => format!("Servo {}{}", cargo_version, info),
-        None => format!("Servo {}", cargo_version),
-    }
+    format!(
+        "Servo {}-{}",
+        env!("CARGO_PKG_VERSION"),
+        env!("VERGEN_GIT_SHA")
+    )
 }
 
 /// Test if a url is valid.

--- a/ports/winit/Cargo.toml
+++ b/ports/winit/Cargo.toml
@@ -13,6 +13,9 @@ name = "servo"
 path = "main.rs"
 bench = false
 
+[build-dependencies]
+vergen = { version = "8.0.0", features = [ "git", "gitcl" ]}
+
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 

--- a/ports/winit/build.rs
+++ b/ports/winit/build.rs
@@ -8,6 +8,8 @@ extern crate cc;
 #[cfg(windows)]
 extern crate winres;
 
+use vergen::EmitBuilder;
+
 fn main() {
     #[cfg(windows)]
     {
@@ -21,5 +23,17 @@ fn main() {
         cc::Build::new()
             .file("platform/macos/count_threads.c")
             .compile("count_threads");
+    }
+
+    if let Err(error) = EmitBuilder::builder()
+        .fail_on_error()
+        .git_sha(true /* short */)
+        .emit()
+    {
+        println!(
+            "cargo:warning=Could not generate git version information: {:?}",
+            error
+        );
+        println!("cargo:rustc-env=VERGEN_GIT_SHA=nogit");
     }
 }

--- a/ports/winit/main2.rs
+++ b/ports/winit/main2.rs
@@ -164,10 +164,5 @@ pub fn main() {
 }
 
 pub fn servo_version() -> String {
-    let cargo_version = env!("CARGO_PKG_VERSION");
-    let git_info = option_env!("GIT_INFO");
-    match git_info {
-        Some(info) => format!("Servo {}{}", cargo_version, info),
-        None => format!("Servo {}", cargo_version),
-    }
+    format!("Servo {}-{}", env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"))
 }

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -32,7 +32,6 @@ from os import path
 from subprocess import PIPE
 from xml.etree.ElementTree import XML
 
-import six
 import toml
 
 from mach_bootstrap import _get_exec_path
@@ -577,41 +576,6 @@ class CommandBase(object):
 
         env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -W unused-extern-crates"
         env["CARGO_TARGET_DIR"] = servo.util.get_target_dir()
-
-        git_info = []
-        if os.path.isdir('.git') and is_build:
-            # Get the subject of the commit
-            git_commit_subject = subprocess.check_output([
-                'git', 'show', '-s', '--format=%s', 'HEAD'
-            ]).strip()
-
-            git_sha = None
-            # Check if it's a bundle commit
-            if git_commit_subject.startswith(b"Shallow version of commit "):
-                # This is a bundle commit
-                # Get the SHA-1 from the bundle subject: "Shallow version of commit {sha1}"
-                git_sha = git_commit_subject.split(b' ')[-1].strip()
-                # Shorten hash
-                # NOTE: Partially verifies the hash, but it will still pass if it's, e.g., a tree
-                git_sha = subprocess.check_output([
-                    'git', 'rev-parse', '--short', git_sha.decode('ascii')
-                ])
-            else:
-                # This is a regular commit
-                git_sha = subprocess.check_output([
-                    'git', 'rev-parse', '--short', 'HEAD'
-                ]).strip()
-
-            git_is_dirty = bool(subprocess.check_output([
-                'git', 'status', '--porcelain'
-            ]).strip())
-
-            git_info.append('')
-            git_info.append(six.ensure_str(git_sha))
-            if git_is_dirty:
-                git_info.append('dirty')
-
-        env['GIT_INFO'] = '-'.join(git_info)
 
         if self.config["build"]["thinlto"]:
             env['RUSTFLAGS'] += " -Z thinlto"


### PR DESCRIPTION
Embed the git hash into the servo binary using vergen instead of using
custom Python code in mach. The benefit here is ones less difference
between a normal cargo run and building via mach in addition to removing
a bunch of code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change the way that the version is generated.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
