### PR TITLE
Remove old code for out-of-date CA stores

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,11 +25,6 @@ colorama == 0.3.7
 boto3 == 1.26.127
 PyGithub == 1.58.1
 
-# Default root CAs on Windows CI do not trust CloudFront certificates,
-# connecting to https://static.rust-lang.org would fail:
-# https://github.com/servo/servo/pull/18942
-certifi
-
 # For Python3 compatibility
 six == 1.15
 

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -23,7 +23,6 @@ from mach.decorators import (
 )
 
 from servo.command_base import CommandBase, cd, call
-from servo.util import get_static_rust_lang_org_dist, get_urlopen_kwargs
 
 
 @CommandProvider
@@ -172,8 +171,8 @@ class MachCommands(CommandBase):
              description='Update the Rust version to latest Nightly',
              category='devenv')
     def rustup(self):
-        url = get_static_rust_lang_org_dist() + "/channel-rust-nightly-date.txt"
-        nightly_date = urllib.request.urlopen(url, **get_urlopen_kwargs()).read()
+        nightly_date = urllib.request.urlopen(
+            "https://static.rust-lang.org/dist/channel-rust-nightly-date.txt").read()
         toolchain = b"nightly-" + nightly_date
         filename = path.join(self.context.topdir, "rust-toolchain")
         with open(filename, "wb") as f:

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -25,29 +25,8 @@ import six
 from io import BufferedIOBase, BytesIO
 from socket import error as socket_error
 
-try:
-    from ssl import HAS_SNI
-except ImportError:
-    HAS_SNI = False
-
 SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 SERVO_ROOT = os.path.abspath(os.path.join(SCRIPT_PATH, "..", ".."))
-HAS_SNI_AND_RECENT_PYTHON = HAS_SNI and sys.version_info >= (2, 7, 9)
-
-
-def get_static_rust_lang_org_dist():
-    if HAS_SNI_AND_RECENT_PYTHON:
-        return "https://static.rust-lang.org/dist"
-
-    return "https://static-rust-lang-org.s3.amazonaws.com/dist"
-
-
-def get_urlopen_kwargs():
-    # The cafile parameter was added in 2.7.9
-    if HAS_SNI_AND_RECENT_PYTHON:
-        import certifi
-        return {"cafile": certifi.where()}
-    return {}
 
 
 def remove_readonly(func, path, _):
@@ -74,7 +53,7 @@ def download(description: str, url: str, writer: BufferedIOBase, start_byte: int
         req = urllib.request.Request(url)
         if start_byte:
             req = urllib.request.Request(url, headers={'Range': 'bytes={}-'.format(start_byte)})
-        resp = urllib.request.urlopen(req, **get_urlopen_kwargs())
+        resp = urllib.request.urlopen(req)
 
         fsize = None
         if resp.info().get('Content-Length'):


### PR DESCRIPTION
This code was written to handle both Python 2 (which we no longer
support) and old Windows CI machines that did not have up-to-date CA
stores. I think we can remove this now.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not really change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
