### PR TITLE
Run unit tests with both layout 2013 and layout 2020

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -287,7 +287,7 @@ impl FloatContext {
     }
 
     /// Places a new float and adds it to the list. Returns the start corner of its margin box.
-    pub(crate) fn add_float(&mut self, new_float: &PlacementInfo) -> Vec2<Length> {
+    pub fn add_float(&mut self, new_float: &PlacementInfo) -> Vec2<Length> {
         // Place the float.
         let new_float_origin = self.place_object(&new_float, self.ceiling);
         let new_float_extent = match new_float.side {
@@ -349,7 +349,7 @@ impl FloatContext {
 
 /// Information needed to place an object so that it doesn't collide with existing floats.
 #[derive(Clone, Debug)]
-pub(crate) struct PlacementInfo {
+pub struct PlacementInfo {
     /// The *margin* box size of the object.
     pub size: Vec2<Length>,
     /// Whether the object is (logically) aligned to the left or right.

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -8,9 +8,9 @@
 extern crate lazy_static;
 
 use euclid::num::Zero;
-use layout::flow::float::{ClearSide, FloatBand, FloatBandNode, FloatBandTree, FloatContext};
-use layout::flow::float::{ContainingBlockPositionInfo, FloatSide, PlacementInfo};
-use layout::geom::flow_relative::{Rect, Vec2};
+use layout_2020::flow::float::{ClearSide, FloatBand, FloatBandNode, FloatBandTree, FloatContext};
+use layout_2020::flow::float::{ContainingBlockPositionInfo, FloatSide, PlacementInfo};
+use layout_2020::geom::flow_relative::{Rect, Vec2};
 use quickcheck::{Arbitrary, Gen};
 use std::f32;
 use std::ops::Range;

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -927,7 +927,6 @@ class CommandBase(object):
         libsimpleservo=False,
         debug_mozjs=False, with_debug_assertions=False,
         with_frame_pointer=False, without_wgl=False,
-        with_layout_2020=False, with_layout_2013=False,
         **_kwargs
     ):
         env = env or self.build_env()

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -167,7 +167,7 @@ class MachCommands(CommandBase):
     @CommandArgument('--nocapture', default=False, action="store_true",
                      help="Run tests with nocapture ( show test stdout )")
     @CommandBase.build_like_command_arguments
-    def test_unit(self, test_name=None, package=None, bench=False, nocapture=False, with_layout_2020=False, **kwargs):
+    def test_unit(self, test_name=None, package=None, bench=False, nocapture=False, **kwargs):
         if test_name is None:
             test_name = []
 
@@ -200,6 +200,8 @@ class MachCommands(CommandBase):
         self_contained_tests = [
             "background_hang_monitor",
             "gfx",
+            "layout_2013",
+            "layout_2020",
             "msg",
             "net",
             "net_traits",
@@ -208,10 +210,6 @@ class MachCommands(CommandBase):
             "servo_config",
             "servo_remutex",
         ]
-        if with_layout_2020:
-            self_contained_tests.append("layout_2020")
-        else:
-            self_contained_tests.append("layout_2013")
         if not packages:
             packages = set(os.listdir(path.join(self.context.topdir, "tests", "unit"))) - set(['.DS_Store'])
             packages |= set(self_contained_tests)
@@ -255,7 +253,6 @@ class MachCommands(CommandBase):
             "bench" if bench else "test",
             args,
             env=env,
-            with_layout_2020=with_layout_2020,
             **kwargs)
 
     @Command('test-content',


### PR DESCRIPTION
Since #29950, unit tests were only running with the legacy layout, and there was no way to run them for layout 2020.

This patch makes './mach test-unit' run unit tests for both.

Also doing some changes so that the layout 2020 floats.rs tests compile.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is about running tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
