### PR TITLE
Remove calculate_clearance_and_adjoin_margin

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -981,22 +981,6 @@ impl SequentialLayoutState {
         Some(clear_position - position_with_zero_clearance)
     }
 
-    /// Helper function that computes the clearance and adds `block_start_margin` accordingly.
-    /// If there is no clearance, `block_start_margin` can just be adjoined to `current_margin`.
-    /// But clearance prevents them from collapsing, so `collapse_margins()` is called.
-    pub(crate) fn calculate_clearance_and_adjoin_margin(
-        &mut self,
-        style: &Arc<ComputedValues>,
-        block_start_margin: &CollapsedMargin,
-    ) -> Option<Length> {
-        let clearance = self.calculate_clearance(ClearSide::from_style(style), &block_start_margin);
-        if clearance.is_some() {
-            self.collapse_margins();
-        }
-        self.adjoin_assign(&block_start_margin);
-        clearance
-    }
-
     /// Adds a new adjoining margin.
     pub(crate) fn adjoin_assign(&mut self, margin: &CollapsedMargin) {
         self.current_margin.adjoin_assign(margin)

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -654,7 +654,11 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
 
             // Introduce clearance if necessary.
             clearance = sequential_layout_state
-                .calculate_clearance_and_adjoin_margin(style, &block_start_margin);
+                .calculate_clearance(ClearSide::from_style(style), &block_start_margin);
+            if clearance.is_some() {
+                sequential_layout_state.collapse_margins();
+            }
+            sequential_layout_state.adjoin_assign(&block_start_margin);
             if !start_margin_can_collapse_with_children {
                 sequential_layout_state.collapse_margins();
             }


### PR DESCRIPTION
It was useful when it had 3 callers, but #29977 removed 2 of them.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
