### PR TITLE
Remove ClearSide enum

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -21,10 +21,9 @@ use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ops::Range;
 use std::{f32, mem};
-use style::computed_values::clear::T as ClearProperty;
 use style::computed_values::float::T as FloatProperty;
 use style::properties::ComputedValues;
-use style::values::computed::{CSSPixelLength, Length};
+use style::values::computed::{CSSPixelLength, Clear, Length};
 use style::values::specified::text::TextDecorationLine;
 
 /// A floating box.
@@ -243,10 +242,10 @@ impl FloatContext {
     /// don't collide with floats.
     pub(crate) fn place_object(&self, object: &PlacementInfo, ceiling: Length) -> Vec2<Length> {
         let ceiling = match object.clear {
-            ClearSide::None => ceiling,
-            ClearSide::Left => ceiling.max(self.clear_left_position),
-            ClearSide::Right => ceiling.max(self.clear_right_position),
-            ClearSide::Both => ceiling
+            Clear::None => ceiling,
+            Clear::Left => ceiling.max(self.clear_left_position),
+            Clear::Right => ceiling.max(self.clear_right_position),
+            Clear::Both => ceiling
                 .max(self.clear_left_position)
                 .max(self.clear_right_position),
         };
@@ -355,7 +354,7 @@ pub struct PlacementInfo {
     /// Whether the object is (logically) aligned to the left or right.
     pub side: FloatSide,
     /// Which side or sides to clear floats on.
-    pub clear: ClearSide,
+    pub clear: Clear,
 }
 
 /// Whether the float is left or right.
@@ -365,17 +364,6 @@ pub struct PlacementInfo {
 pub enum FloatSide {
     Left,
     Right,
-}
-
-/// Which side or sides to clear floats on.
-///
-/// See CSS 2.1 § 9.5.2: https://www.w3.org/TR/CSS2/visuren.html#flow-control
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ClearSide {
-    None = 0,
-    Left = 1,
-    Right = 2,
-    Both = 3,
 }
 
 /// Internal data structure that describes a nonoverlapping vertical region in which floats may be
@@ -402,17 +390,6 @@ impl FloatSide {
             FloatProperty::None => None,
             FloatProperty::Left => Some(FloatSide::Left),
             FloatProperty::Right => Some(FloatSide::Right),
-        }
-    }
-}
-
-impl ClearSide {
-    pub(crate) fn from_style(style: &ComputedValues) -> ClearSide {
-        match style.get_box().clear {
-            ClearProperty::None => ClearSide::None,
-            ClearProperty::Left => ClearSide::Left,
-            ClearProperty::Right => ClearSide::Right,
-            ClearProperty::Both => ClearSide::Both,
         }
     }
 }
@@ -938,10 +915,10 @@ impl SequentialLayoutState {
     /// https://www.w3.org/TR/2011/REC-CSS2-20110607/visuren.html#flow-control
     pub(crate) fn calculate_clearance(
         &self,
-        clear_side: ClearSide,
+        clear: Clear,
         block_start_margin: &CollapsedMargin,
     ) -> Option<Length> {
-        if clear_side == ClearSide::None {
+        if clear == Clear::None {
             return None;
         }
 
@@ -952,11 +929,11 @@ impl SequentialLayoutState {
 
         // Check if the hypothetical position is past the relevant floats,
         // in that case we don't need to add clearance.
-        let clear_position = match clear_side {
-            ClearSide::None => unreachable!(),
-            ClearSide::Left => self.floats.clear_left_position,
-            ClearSide::Right => self.floats.clear_right_position,
-            ClearSide::Both => self
+        let clear_position = match clear {
+            Clear::None => unreachable!(),
+            Clear::Left => self.floats.clear_left_position,
+            Clear::Right => self.floats.clear_right_position,
+            Clear::Both => self
                 .floats
                 .clear_left_position
                 .max(self.floats.clear_right_position),
@@ -1017,7 +994,7 @@ impl SequentialLayoutState {
         let margin_box_start_corner = self.floats.add_float(&PlacementInfo {
             size: &box_fragment.content_rect.size + &pbm_sums.sum(),
             side: FloatSide::from_style(&box_fragment.style).expect("Float box wasn't floated!"),
-            clear: ClearSide::from_style(&box_fragment.style),
+            clear: box_fragment.style.get_box().clear,
         });
 
         // This is the position of the float in the float-containing block formatting context. We add the

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -7,7 +7,7 @@
 use self::float::PlacementAmongFloats;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::flow::float::{ClearSide, ContainingBlockPositionInfo, FloatBox, SequentialLayoutState};
+use crate::flow::float::{ContainingBlockPositionInfo, FloatBox, SequentialLayoutState};
 use crate::flow::inline::InlineFormattingContext;
 use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentLayout, NonReplacedFormattingContext,
@@ -222,7 +222,7 @@ impl BlockFormattingContext {
         // (https://drafts.csswg.org/css2/#root-height), we implement this by imagining there is
         // an element with `clear: both` after the actual contents.
         let clearance = sequential_layout_state.and_then(|sequential_layout_state| {
-            sequential_layout_state.calculate_clearance(ClearSide::Both, &CollapsedMargin::zero())
+            sequential_layout_state.calculate_clearance(Clear::Both, &CollapsedMargin::zero())
         });
 
         IndependentLayout {
@@ -654,7 +654,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
 
             // Introduce clearance if necessary.
             clearance = sequential_layout_state
-                .calculate_clearance(ClearSide::from_style(style), &block_start_margin);
+                .calculate_clearance(style.get_box().clear, &block_start_margin);
             if clearance.is_some() {
                 sequential_layout_state.collapse_margins();
             }
@@ -877,7 +877,7 @@ impl NonReplacedFormattingContext {
 
         let block_start_margin = CollapsedMargin::new(margin.block_start);
         let clearance = sequential_layout_state
-            .calculate_clearance(ClearSide::from_style(&self.style), &block_start_margin);
+            .calculate_clearance(self.style.get_box().clear, &block_start_margin);
 
         let layout = self.layout(
             layout_context,
@@ -1037,8 +1037,8 @@ fn layout_in_flow_replaced_block_level<'a>(
     let mut adjustment_from_floats = Vec2::zero();
     if let Some(ref mut sequential_layout_state) = sequential_layout_state {
         let block_start_margin = CollapsedMargin::new(margin.block_start);
-        let clearance = sequential_layout_state
-            .calculate_clearance(ClearSide::from_style(style), &block_start_margin);
+        let clearance =
+            sequential_layout_state.calculate_clearance(style.get_box().clear, &block_start_margin);
 
         // We calculate a hypothetical value for `bfc_relative_block_position`,
         // assuming that there was no adjustment from floats. The real value will

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -8,8 +8,8 @@
 extern crate lazy_static;
 
 use euclid::num::Zero;
-use layout_2020::flow::float::{ClearSide, FloatBand, FloatBandNode, FloatBandTree, FloatContext};
 use layout_2020::flow::float::{ContainingBlockPositionInfo, FloatSide, PlacementInfo};
+use layout_2020::flow::float::{FloatBand, FloatBandNode, FloatBandTree, FloatContext};
 use layout_2020::geom::flow_relative::{Rect, Vec2};
 use quickcheck::{Arbitrary, Gen};
 use std::f32;
@@ -18,7 +18,7 @@ use std::panic::{self, PanicInfo};
 use std::sync::{Mutex, MutexGuard};
 use std::thread;
 use std::u32;
-use style::values::computed::Length;
+use style::values::computed::{Clear, Length};
 
 lazy_static! {
     static ref PANIC_HOOK_MUTEX: Mutex<()> = Mutex::new(());
@@ -362,7 +362,7 @@ impl Arbitrary for FloatInput {
                 } else {
                     FloatSide::Right
                 },
-                clear: new_clear_side(clear),
+                clear: new_clear(clear),
             },
             ceiling,
             containing_block_info: ContainingBlockPositionInfo::new_with_inline_offsets(
@@ -383,8 +383,8 @@ impl Arbitrary for FloatInput {
             this.info.size.block = Length::new(block_size);
             shrunk = true;
         }
-        if let Some(clear_side) = (self.info.clear as u8).shrink().next() {
-            this.info.clear = new_clear_side(clear_side);
+        if let Some(clear) = (self.info.clear as u8).shrink().next() {
+            this.info.clear = new_clear(clear);
             shrunk = true;
         }
         if let Some(left) = self.containing_block_info.inline_start.px().shrink().next() {
@@ -407,12 +407,12 @@ impl Arbitrary for FloatInput {
     }
 }
 
-fn new_clear_side(value: u8) -> ClearSide {
+fn new_clear(value: u8) -> Clear {
     match value & 3 {
-        0 => ClearSide::None,
-        1 => ClearSide::Left,
-        2 => ClearSide::Right,
-        _ => ClearSide::Both,
+        0 => Clear::None,
+        1 => Clear::Left,
+        2 => Clear::Right,
+        _ => Clear::Both,
     }
 }
 
@@ -707,7 +707,7 @@ fn check_floats_rule_10(placement: &FloatPlacement) {
     }
 
     for (this_float_index, this_float) in placement.placed_floats.iter().enumerate() {
-        if this_float.info.clear == ClearSide::None {
+        if this_float.info.clear == Clear::None {
             continue;
         }
 
@@ -731,10 +731,10 @@ fn check_floats_rule_10(placement: &FloatPlacement) {
             }
 
             match this_float.info.clear {
-                ClearSide::Left => assert_ne!(other_float.info.side, FloatSide::Left),
-                ClearSide::Right => assert_ne!(other_float.info.side, FloatSide::Right),
-                ClearSide::Both => assert!(false),
-                ClearSide::None => unreachable!(),
+                Clear::Left => assert_ne!(other_float.info.side, FloatSide::Left),
+                Clear::Right => assert_ne!(other_float.info.side, FloatSide::Right),
+                Clear::Both => assert!(false),
+                Clear::None => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
Just use Clear instead, they have the same values.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
