### PR TITLE
Don't skip the "Process Comment" step for non-PR try workflows

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   parse-comment:
     name: Process Comment
-    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
@@ -24,6 +23,11 @@ jobs:
                   repo: context.repo.repo,
                   body
                 })
+            }
+
+            // Don't run try for non-PR comments.
+            if (!context.payload.issue.pull_request) {
+              return { try: false };
             }
 
             let tokens = context.payload.comment.body.split(/\s+/);


### PR DESCRIPTION
For some reason skipping this step is causing internal GitHub errors,
causing jobs to falsely fail. I think we are hitting a bug in GitHub
Actions here.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix an issue with CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
