### PR TITLE
Remove unnecessary `join()`s from GitHub Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -144,8 +144,8 @@ jobs:
     steps:
       - name: Mark the job as successful
         run: exit 0
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
       - name: Mark the job as unsuccessful
         run: exit 1
-        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -154,7 +154,7 @@ jobs:
     steps:
       - name: Mark the job as successful
         run: exit 0
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
       - name: Mark the job as unsuccessful
         run: exit 1
-        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,8 +128,8 @@ jobs:
         if: ${{ fromJson(needs.decision.outputs.configuration).platform == 'none' }}
         run: exit 0
       - name: Mark the job as successful
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0
       - name: Mark the job as unsuccessful
-        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -90,7 +90,7 @@ jobs:
     if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).try}}
     steps:
       - name: Success
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: actions/github-script@v6
         with:
           script: |
@@ -106,7 +106,7 @@ jobs:
                 body: "✨ Try run (" + formattedURL + ") " + "succeeded.",
               });
       - name: Failure
-        if: ${{ contains(join(needs.*.result, ','), 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -103,8 +103,8 @@ jobs:
     steps:
       - name: Mark the job as successful
         run: exit 0
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
       - name: Mark the job as unsuccessful
         run: exit 1
-        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
 


### PR DESCRIPTION
`contains()` works on arrays as well as strings, so the `join` is
unnecessary when trying to detect job statuses.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
