### PR TITLE
Switch default layout option to `--layout-2020` in some mach commands

### DIFF
--- a/python/wpt/__init__.py
+++ b/python/wpt/__init__.py
@@ -33,9 +33,9 @@ def create_parser():
                         help="Run under chaos mode in rr until a failure is captured")
     parser.add_argument('--pref', default=[], action="append", dest="prefs",
                         help="Pass preferences to servo")
-    parser.add_argument('--layout-2020', '--with-layout-2020', default=False,
+    parser.add_argument('--layout-2020', '--with-layout-2020', default=True,
                         action="store_true", help="Use expected results for the 2020 layout engine")
-    parser.add_argument('--layout-2013', '--with-layout-2013', default=True,
+    parser.add_argument('--layout-2013', '--with-layout-2013', default=False,
                         action="store_true", help="Use expected results for the 2013 layout engine")
     parser.add_argument('--log-servojson', action="append", type=mozlog.commandline.log_file,
                         help="Servo's JSON logger of unexpected results")
@@ -53,17 +53,16 @@ def create_parser():
 
 
 def update_args_for_legacy_layout(kwargs: dict):
-    if kwargs.pop("layout_2020"):
-        return
-    kwargs["test_paths"]["/"]["metadata_path"] = os.path.join(
-        WPT_PATH, "meta-legacy-layout"
-    )
-    kwargs["test_paths"]["/_mozilla/"]["metadata_path"] = os.path.join(
-        WPT_PATH, "mozilla", "meta-legacy-layout"
-    )
-    kwargs["include_manifest"] = os.path.join(
-        WPT_PATH, "include-legacy-layout.ini"
-    )
+    if kwargs.pop("layout_2013"):
+        kwargs["test_paths"]["/"]["metadata_path"] = os.path.join(
+            WPT_PATH, "meta-legacy-layout"
+        )
+        kwargs["test_paths"]["/_mozilla/"]["metadata_path"] = os.path.join(
+            WPT_PATH, "mozilla", "meta-legacy-layout"
+        )
+        kwargs["include_manifest"] = os.path.join(
+            WPT_PATH, "include-legacy-layout.ini"
+        )
 
 
 def run_tests():

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -103,7 +103,7 @@ def run_tests(**kwargs):
     kwargs.setdefault("binary_args", [])
     if prefs:
         kwargs["binary_args"] += ["--pref=" + pref for pref in prefs]
-    if not kwargs.get("layout_2020", False):
+    if kwargs.get("layout_2013"):
         kwargs["binary_args"] += ["--legacy-layout"]
 
     if not kwargs.get("no_default_test_types"):

--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -126,8 +126,8 @@ def run_update(**kwargs) -> bool:
 
 def create_parser(**_kwargs):
     parser = wptcommandline.create_parser_update()
-    parser.add_argument("--layout-2020", "--with-layout-2020", default=False, action="store_true",
+    parser.add_argument("--layout-2020", "--with-layout-2020", default=True, action="store_true",
                         help="Use expected results for the 2020 layout engine")
-    parser.add_argument("--layout-2013", "--with-layout-2013", default=True, action="store_true",
+    parser.add_argument("--layout-2013", "--with-layout-2013", default=False, action="store_true",
                         help="Use expected results for the 2013 layout engine")
     return parser


### PR DESCRIPTION
Currently, `./mach test-wpt` family of commands (`test-wpt`, `test-wpt-android`, and `test-wpt-failure`) and `./mach update-wpt` default to using the legacy-layout option `--layout-2013` unless `--layout-2020` is specified.

Given that we are now using layout-2020 by default, this change updates these commands to default to using the `--layout-2020` option instead of `--layout-2013`.

---

<!-- Please describe your changes on the following line: -->

This fixes https://github.com/servo/servo/issues/30036.
(I was considering addressing [this comment on the issue](https://github.com/servo/servo/issues/30036#issuecomment-1656087431) in this pull request as well. But to keep the focus of the PR clear, I have decided to handle that in a separate pull request.)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30036

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
