### PR TITLE
Set the MacOS rpath in the build script

### DIFF
--- a/ports/libsimpleservo/api/build.rs
+++ b/ports/libsimpleservo/api/build.rs
@@ -25,6 +25,12 @@ fn main() {
         println!("cargo:rustc-env=VERGEN_GIT_SHA=nogit");
     }
 
+    // On MacOS, all dylib dependencies are shipped along with the binary
+    // in the "/lib" directory. Setting the rpath here, allows the dynamic
+    // linker to locate them. See `man dyld` for more info.
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/lib/");
+
     // Generate GL bindings
     // For now, we only support EGL, and only on Windows and Android.
     if target.contains("android") || target.contains("windows") {

--- a/ports/winit/build.rs
+++ b/ports/winit/build.rs
@@ -36,4 +36,10 @@ fn main() {
         );
         println!("cargo:rustc-env=VERGEN_GIT_SHA=nogit");
     }
+
+    // On MacOS, all dylib dependencies are shipped along with the binary
+    // in the "/lib" directory. Setting the rpath here, allows the dynamic
+    // linker to locate them. See `man dyld` for more info.
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/lib/");
 }

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -238,12 +238,6 @@ class MachCommands(CommandBase):
                     if not package_gstreamer_dylibs(self.cross_compile_target, servo_path):
                         return 1
 
-                    # On Mac we use the relocatable dylibs from offical gstreamer
-                    # .pkg distribution. We need to add an LC_RPATH to the servo binary
-                    # to allow the dynamic linker to be able to locate these dylibs
-                    # See `man dyld` for more info
-                    add_rpath_to_binary(servo_path, "@executable_path/lib/")
-
                 # On the Mac, set a lovely icon. This makes it easier to pick out the Servo binary in tools
                 # like Instruments.app.
                 try:
@@ -402,14 +396,6 @@ def install_name_tool(binary, *args):
 
 def change_link_name(binary, old, new):
     install_name_tool(binary, '-change', old, f"@executable_path/{new}")
-
-
-def add_rpath_to_binary(binary, relative_path):
-    install_name_tool(binary, "-add_rpath", relative_path)
-
-
-def change_rpath_in_binary(binary, old, new):
-    install_name_tool(binary, "-rpath", old, new)
 
 
 def is_system_library(lib):


### PR DESCRIPTION
Use the build script to set the rpath in MacOS instead of mach. This is
another step toward allowing building servo without mach.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
