### PR TITLE
Handle BFC roots with auto width next to floats

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -364,6 +364,17 @@ impl PositioningContext {
                 .len(),
         }
     }
+
+    /// Truncate this [PositioningContext] to the given [PositioningContextLength].  This
+    /// is useful for "unhoisting" boxes in this context and returning it to the state at
+    /// the time that [`len()`] was called.
+    pub(crate) fn truncate(&mut self, length: &PositioningContextLength) {
+        if let Some(vec) = self.for_nearest_positioned_ancestor.as_mut() {
+            vec.truncate(length.for_nearest_positioned_ancestor);
+        }
+        self.for_nearest_containing_block_for_all_descendants
+            .truncate(length.for_nearest_containing_block_for_all_descendants);
+    }
 }
 
 /// A data structure which stores the size of a positioning context.

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-left-overflow.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-left-overflow.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-002-left-overflow.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/new-fc-relayout.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/new-fc-relayout.html.ini
@@ -1,2 +1,0 @@
-[new-fc-relayout.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/zero-width-floats.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/zero-width-floats.html.ini
@@ -1,0 +1,2 @@
+[zero-width-floats.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-004.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-direction-modify.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-direction-modify.html.ini
@@ -1,0 +1,2 @@
+[flex-direction-modify.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_complex_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_complex_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_complex_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_margin_inout_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_margin_inout_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_margin_inout_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_negative_margins_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_negative_margins_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_negative_margins_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_relative_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_relative_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_relative_a.html]
+  expected: FAIL


### PR DESCRIPTION
The specification says that independent formatting contexts and independent block formatting contexts should be placed next to floats. The code currently handles this situation, except for the case where an independent formatting context has auto width. This PR adds support for this. This case is a big trickier, because we must try to place the object and then see if the block size calculated from layout fits at the speculated position among the floats. If it doesn't, we must try a new position and lay out again until we find an appropriate spot.

Co-authored-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
