### PR TITLE
Fix the docs build

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -141,7 +141,7 @@ def call(*args, **kwargs):
     return subprocess.call(*args, shell=sys.platform == 'win32', **kwargs)
 
 
-def check_output(*args, **kwargs):
+def check_output(*args, **kwargs) -> bytes:
     """Wrap `subprocess.call`, printing the command if verbose=True."""
     verbose = kwargs.pop('verbose', False)
     if verbose:
@@ -980,10 +980,10 @@ class CommandBase(object):
 
         servo.platform.get().passive_bootstrap()
 
-        needs_toolchain_install = self.cross_compile_target \
-            and self.cross_compile_target not in check_output(
-                ["rustup", "target", "list", "--installed"], cwd=self.context.topdir
-            )
+        needs_toolchain_install = self.cross_compile_target and \
+            self.cross_compile_target not in \
+            check_output(["rustup", "target", "list", "--installed"],
+                         cwd=self.context.topdir).decode()
         if needs_toolchain_install:
             check_call(["rustup", "target", "add", self.cross_compile_target],
                        cwd=self.context.topdir)

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -245,7 +245,9 @@ class PostBuildCommands(CommandBase):
     @CommandBase.build_like_command_arguments
     def doc(self, params: List[str], **kwargs):
         self.ensure_bootstrapped()
-        rustc_path = check_output(["rustup" + BIN_SUFFIX, "which", "rustc"], cwd=self.context.topdir)
+        rustc_path = check_output(
+            ["rustup" + BIN_SUFFIX, "which", "rustc"],
+            cwd=self.context.topdir).decode("utf-8")
         assert path.basename(path.dirname(rustc_path)) == "bin"
         toolchain_path = path.dirname(path.dirname(rustc_path))
         rust_docs = path.join(toolchain_path, "share", "doc", "rust", "html")


### PR DESCRIPTION
Type inference was incorrectly inferring that our `check_output()`
helper was returning `str` when in reality, it returns `bytes`. This
fixes the callers that were no longer decoding those bytes and fixes the
type annotation on the function.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix build scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
