### PR TITLE
Never resolve margin-left:auto to a negative amount

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1155,12 +1155,15 @@ fn solve_inline_margins_for_in_flow_block_level(
     pbm: &PaddingBorderMargin,
     inline_size: Length,
 ) -> (Length, Length) {
-    let available = containing_block.inline_size - pbm.padding_border_sums.inline - inline_size;
-    match (pbm.margin.inline_start, pbm.margin.inline_end) {
-        (LengthOrAuto::Auto, LengthOrAuto::Auto) => (available / 2., available / 2.),
-        (LengthOrAuto::Auto, LengthOrAuto::LengthPercentage(end)) => (available - end, end),
-        (LengthOrAuto::LengthPercentage(start), _) => (start, available - start),
-    }
+    let free_space = containing_block.inline_size - pbm.padding_border_sums.inline - inline_size;
+    let margin_inline_start = match (pbm.margin.inline_start, pbm.margin.inline_end) {
+        (LengthOrAuto::Auto, LengthOrAuto::Auto) => Length::zero().max(free_space / 2.),
+        (LengthOrAuto::Auto, LengthOrAuto::LengthPercentage(end)) => {
+            Length::zero().max(free_space - end)
+        },
+        (LengthOrAuto::LengthPercentage(start), _) => start,
+    };
+    (margin_inline_start, free_space - margin_inline_start)
 }
 
 /// State that we maintain when placing blocks.

--- a/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-auto-on-block-box-ref.html
+++ b/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-auto-on-block-box-ref.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<pre style="font: 5px/1 Ahem">
+                                                       XXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                         XXXXXXXXXX
+                              XXXXXXXXXX
+                                   XXXXXXXXXX
+                                        XXXXXXXXXX
+                                             XXXXXXXXXX
+                                                  XXXXXXXXXX
+                                                       XXXXXXXXXX
+                                                            XXXXXXXXXX
+                                                                 XXXXXXXXXX
+                                                                      XXXXXXXXXX
+                                                                           XXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+          XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                              XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                        XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                            XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                                      XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                                                XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                                                          XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                                                                    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                                                     XXXXXXXXXX
+                                                                                XXXXXXXXXX
+                                                                           XXXXXXXXXX
+                                                                      XXXXXXXXXX
+                                                                 XXXXXXXXXX
+                                                            XXXXXXXXXX
+                                                       XXXXXXXXXX
+                                                  XXXXXXXXXX
+                                                  XXXXXXXXXX
+                                                  XXXXXXXXXX
+                                                  XXXXXXXXXX
+                                                                                XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                                      XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                            XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                                                  XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+</pre>

--- a/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-auto-on-block-box.html
+++ b/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-auto-on-block-box.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: Resolution of margin-left or margin-right set to auto on a non-replaced block box</title>
+<link rel="match" href="margin-auto-on-block-box-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css2/#blockwidth">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<meta name="assert" content="
+    margin-left:auto shouldn't resolve to a negative amount (assuming direction:ltr).
+    margin-right:auto may resolve to a negative amount when there is over-constraintment.">
+
+<style>
+.wrapper {
+  width: 100px;
+  margin-left: 250px;
+}
+.test {
+  width: 50px;
+  height: 5px;
+  background: black;
+  margin: auto;
+}
+.test.big {
+  width: 200px;
+}
+</style>
+
+<div class="wrapper">
+  <div class="test"></div>
+  <div class="test big"></div>
+
+  <div class="test" style="margin-left: -125px"></div>
+  <div class="test" style="margin-left: -100px"></div>
+  <div class="test" style="margin-left: -75px"></div>
+  <div class="test" style="margin-left: -50px"></div>
+  <div class="test" style="margin-left: -25px"></div>
+  <div class="test" style="margin-left: 0"></div>
+  <div class="test" style="margin-left: 25px"></div>
+  <div class="test" style="margin-left: 50px"></div>
+  <div class="test" style="margin-left: 75px"></div>
+  <div class="test" style="margin-left: 100px"></div>
+  <div class="test" style="margin-left: 125px"></div>
+
+  <div class="test big" style="margin-left: -250px"></div>
+  <div class="test big" style="margin-left: -200px"></div>
+  <div class="test big" style="margin-left: -150px"></div>
+  <div class="test big" style="margin-left: -100px"></div>
+  <div class="test big" style="margin-left: -50px"></div>
+  <div class="test big" style="margin-left: 0"></div>
+  <div class="test big" style="margin-left: 50px"></div>
+  <div class="test big" style="margin-left: 100px"></div>
+  <div class="test big" style="margin-left: 150px"></div>
+  <div class="test big" style="margin-left: 200px"></div>
+  <div class="test big" style="margin-left: 250px"></div>
+
+  <div class="test" style="margin-right: -125px"></div>
+  <div class="test" style="margin-right: -100px"></div>
+  <div class="test" style="margin-right: -75px"></div>
+  <div class="test" style="margin-right: -50px"></div>
+  <div class="test" style="margin-right: -25px"></div>
+  <div class="test" style="margin-right: 0"></div>
+  <div class="test" style="margin-right: 25px"></div>
+  <div class="test" style="margin-right: 50px"></div>
+  <div class="test" style="margin-right: 75px"></div>
+  <div class="test" style="margin-right: 100px"></div>
+  <div class="test" style="margin-right: 125px"></div>
+
+  <div class="test big" style="margin-right: -250px"></div>
+  <div class="test big" style="margin-right: -200px"></div>
+  <div class="test big" style="margin-right: -150px"></div>
+  <div class="test big" style="margin-right: -100px"></div>
+  <div class="test big" style="margin-right: -50px"></div>
+  <div class="test big" style="margin-right: 0"></div>
+  <div class="test big" style="margin-right: 50px"></div>
+  <div class="test big" style="margin-right: 100px"></div>
+  <div class="test big" style="margin-right: 150px"></div>
+  <div class="test big" style="margin-right: 200px"></div>
+  <div class="test big" style="margin-right: 250px"></div>
+</div>


### PR DESCRIPTION
With direction:ltr (and we don't support direction:rtl yet), the rules from https://drafts.csswg.org/css2/#blockwidth imply that margin-left shouldn't resolve auto to a negative amount.

This aligns Servo with Gecko and Blink. WebKit may resolve to a negative amount in some cases.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #30059
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
