### PR TITLE
Fix race condition and other issues related to Worker destruction.

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -378,7 +378,8 @@ impl DedicatedWorkerGlobalScope {
                     new_child_runtime(parent, Some(task_source))
                 };
 
-                let _ = context_sender.send(ContextForRequestInterrupt::new(runtime.cx()));
+                let context_for_interrupt = ContextForRequestInterrupt::new(runtime.cx());
+                let _ = context_sender.send(context_for_interrupt.clone());
 
                 let (devtools_mpsc_chan, devtools_mpsc_port) = unbounded();
                 ROUTER.route_ipc_receiver_to_crossbeam_sender(
@@ -476,7 +477,8 @@ impl DedicatedWorkerGlobalScope {
                         parent_sender,
                         CommonScriptMsg::CollectReports,
                     );
-                scope.clear_js_runtime();
+
+                scope.clear_js_runtime(context_for_interrupt);
             })
             .expect("Thread spawning failed")
     }

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -306,7 +306,8 @@ impl ServiceWorkerGlobalScope {
             .spawn(move || {
                 thread_state::initialize(ThreadState::SCRIPT | ThreadState::IN_WORKER);
                 let runtime = new_rt_and_cx(None);
-                let _ = context_sender.send(ContextForRequestInterrupt::new(runtime.cx()));
+                let context_for_interrupt = ContextForRequestInterrupt::new(runtime.cx());
+                let _ = context_sender.send(context_for_interrupt.clone());
 
                 let roots = RootCollection::new();
                 let _stack_roots = ThreadLocalStackRoots::new(&roots);
@@ -396,7 +397,8 @@ impl ServiceWorkerGlobalScope {
                         scope.script_chan(),
                         CommonScriptMsg::CollectReports,
                     );
-                scope.clear_js_runtime();
+
+                scope.clear_js_runtime(context_for_interrupt);
             })
             .expect("Thread spawning failed")
     }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -286,8 +286,14 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
             match result {
                 Ok(_) => (),
                 Err(_) => {
-                    println!("evaluate_script failed");
-                    return Err(Error::JSFailed);
+                    if self.is_closing() {
+                        // Don't return JSFailed as we might not have
+                        // any pending exceptions.
+                        println!("evaluate_script failed (terminated)");
+                    } else {
+                        println!("evaluate_script failed");
+                        return Err(Error::JSFailed);
+                    }
                 },
             }
         }


### PR DESCRIPTION
This PR has three fixes - the first commit contains fix for #30022 and #30052. The second commit fixes another issue in Worker.importScripts that was uncovered after #30052 was fixed.

### Fix for #30022 (Race condition in worker destruction leading to use-after-free of JSContext) -

During shutdown, the main script thread calls JS_RequestInterruptCallback(cx) for each worker thread it owns where cx is the JSContext* created for that worker. Although JS_RequestInterruptCallback is safe to call from threads other than the worker thread, it is possible the JSContext* has already been destroyed
    
For example, as noted in #30022, since the main thread sets the worker's `closing` flag to true to signal termination before it calls JS_RequestInterruptCallback, we can have a race condition where the worker exits its event loop when `closing` flags is set and then it (worker thread) destroys its own JSContext and JSRuntime. When the main thread resumes, it will call JS_RequestInterruptCallback for the worker's context, leading ta a use-after-free bug.
    
This patch solves this issue by improving the existing `ContextForRequestInterrupt` abstraction used for sharing the Worker's associated JSContext* with the parent script thread. Instead of simply wrapping a plain `*mut JSContext`, we now wrap the `*mut JSContext` in a nullable mutex i.e Mutex<Option<*mut JSContext>>
   
The mutex lock needs to be held by the parent thread when it calls JS_RequestInterruptCallback. Similary, before the worker destroys its JSContext, it locks and  sets the Option to None, signaling that the JSContext can no longer be used for interrupting the worker.

### Fix for #30052 - Woker.terminate doesn't force worker to exit.   
This patch also fixes the issue in #30052 by enforcing the use of ContextForRequestInterrupt abstraction which ensures the correct JSContext is used by the main thread when Worker.terminate is called.

Note: There maybe more optimizations possible here that we can explore in the future, like re-using the ContextForRequestInterrupt already stored in Worker's global scope as part of [list_auto_close_worker](https://github.com/servo/servo/blob/3fea90a231a94338d67712398fe3d2ba9d402211/components/script/dom/globalscope.rs#L267) instead of storing it again in Worker DOM struct.

### Fix for Worker.importScripts
After the fix for #30052,
the WPT test `/workers/Worker-terminate-forever-during-evaluation.html` started to crash, because when evaluation doesn't succeed, `importScripts` always returns `Error::JSFailed` code to the caller, which indicates that there is a Dom/JS exception to be thrown. However, this is not true when the script is terminated, which causes the generated binding layer for `importScript` to fail the assertion that there is a pending exception. This patch makes `importScripts` work similar to the [logic that evaluates the top-level script](https://github.com/servo/servo/blob/3fea90a231a94338d67712398fe3d2ba9d402211/components/script/dom/workerglobalscope.rs#L434) of the Worker - it simply prints 'evaluate_script failed - (terminated)' if the worker is terminating


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30022, #30052
- [x] These changes do not require tests because the fix for race condition is covered by the existing tests that surfaced the issue in CI. The fix for Worker.terminate does have an existing test `workers/Worker-terminate-forever.html` but this doesn't currently catch the issue as it doesn't recognize the case where the "worker is terminated because it was interrupted when terminate() is called" as distinct from the case where the "main script's shutting down forces worker to be interrupted and closed" eventually. I'm not sure what is the best way to express this case using the WPT test harness api.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
