### PR TITLE
Check out the PR when triggering try from PR comments

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -25,7 +25,15 @@ jobs:
         chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment'
         with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 2
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,7 +55,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment'
         with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -41,7 +41,15 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment'
         with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
@@ -106,9 +114,17 @@ jobs:
   #     matrix:
   #       chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
   #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 2
+  #   - uses: actions/checkout@v3
+  #     if: github.event_name != 'issue_comment'
+  #     with:
+  #       fetch-depth: 2
+  #   # This is necessary to checkout the pull request if this run was triggered
+  #   # via an `issue_comment` action on a pull request.
+  #   - uses: actions/checkout@v3
+  #     if: github.event_name == 'issue_comment'
+  #     with:
+  #       ref: refs/pull/${{ github.event.issue.number }}/head
+  #       fetch-depth: 2
   #     - uses: actions/download-artifact@v3
   #       with:
   #         name: release-binary-macos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,15 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment'
         with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 2
       - name: wix311-binaries
         shell: powershell


### PR DESCRIPTION
When processing `issue_comment` GitHub actions `actions/checkout@v3` does not check out the PR if the comment was posted on a PR. We have to handle this manually.

Fixes #30067.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30067.
- [x] These changes do not require tests because it's difficult to test CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
