### PR TITLE
Fix an overflow issue in the layout_2020 unit tests

### DIFF
--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -314,7 +314,7 @@ fn test_tree_range_setting() {
 
         for range in ranges {
             let start = range.start_index.min(tops.len() as u32 - 1);
-            let end = (range.start_index + range.length).min(tops.len() as u32 - 1);
+            let end = (range.start_index as u64 + range.length as u64).min(tops.len() as u64 - 1);
             let block_range = tops[start as usize]..tops[end as usize];
             let length = Length::new(range.length as f32);
             let new_tree = tree.set_range(&block_range, range.side, length);


### PR DESCRIPTION
Fix failing unit test due to overflow.

<details>
<summary>failing test log</summary>

```
$ ./mach test-unit test_tree_range_setting
      Timing report saved to /path/to/servo/target/cargo-timings/cargo-timing-20230805T090747Z.html
    Finished test [unoptimized + debuginfo] target(s) in 1.44s
     Running unittests lib.rs (target/debug/deps/background_hang_monitor-991cde6a4bf697da)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/hang_monitor_tests.rs (target/debug/deps/hang_monitor_tests-17afc9a90835517e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s

     Running unittests lib.rs (target/debug/deps/deny_public_fields_tests-b51bf4d3d71f1a6e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests lib.rs (target/debug/deps/gfx-b6fdddc62e398b7a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/font_context.rs (target/debug/deps/font_context-06c616d3ef15ae5e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s

     Running tests/font_template.rs (target/debug/deps/font_template-0da502ba1710f24f)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s

     Running tests/text_util.rs (target/debug/deps/text_util-6a692eb5174b3c2a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s

     Running unittests lib.rs (target/debug/deps/layout_2013-ac2da0712ac98b6d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/size_of.rs (target/debug/deps/size_of-c1dd212ed2b13bce)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s

     Running unittests lib.rs (target/debug/deps/layout_2020-b5d6abbe15bdcf6d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s

     Running tests/floats.rs (target/debug/deps/floats-7fafad8026494fc8)

running 1 test
test test_tree_range_setting ... FAILED

failures:

---- test_tree_range_setting stdout ----
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at 'attempt to add with overflow', components/layout_2020/tests/floats.rs:317:23
thread 'test_tree_range_setting' panicked at '[quickcheck] TEST FAILED (runtime error). Arguments: ([], [FloatRangeInput { start_index: 2186238731, side: Left, length: 3516551292 }])
Error: "attempt to add with overflow"', /home/ohno/.cargo/registry/src/github.com-1ecc6299db9ec823/quickcheck-1.0.3/src/tester.rs:165:28


failures:
    test_tree_range_setting

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p layout_2020 --test floats`
```

</details>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
