### PR TITLE
Pass `--layout-2013` flag in 'WPT import' job

### DIFF
--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -52,7 +52,7 @@ jobs:
           export CURRENT_DATE=$(date +"%d-%m-%Y")
           echo $CURRENT_DATE
           echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
-          ./mach update-wpt wpt-logs-linux-layout-2013/test-wpt.*.log
+          ./mach update-wpt --layout-2013 wpt-logs-linux-layout-2013/test-wpt.*.log
           ./mach update-wpt --layout-2020 wpt-logs-linux-layout-2020/test-wpt.*.log
           git add tests/wpt/meta tests/wpt/meta-legacy-layout
           git commit -a --amend --no-edit


### PR DESCRIPTION
PR #30048 switched `./mach update-wpt` to use 2020 layout engine by default.  Since the WPT import job was not passing any flags when updating 2013 expectations, it was not using the correct metadata files, leading to failures when landing the recent [wpt sync PR](https://github.com/servo/servo/pull/30075)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just fix bug in WPT import job