### PR TITLE
mach: fix exit status on NixOS

### DIFF
--- a/mach
+++ b/mach
@@ -40,7 +40,8 @@ if __name__ == '__main__':
         print('NOTE: Entering nix-shell etc/shell.nix')
         try:
             # sys argv already contains the ./mach part, so we just need to pass it as-is
-            subprocess.Popen(['nix-shell', mach_dir + '/etc/shell.nix', '--run', ' '.join(map(quote, sys.argv))]).wait()
+            result = subprocess.run(['nix-shell', mach_dir + '/etc/shell.nix', '--run', ' '.join(map(quote, sys.argv))])
+            sys.exit(result.returncode)
         except KeyboardInterrupt:
             sys.exit(0)
     else:


### PR DESCRIPTION
mach always exits with status code 0 on NixOS, which makes it impossible to check if the build failed programmatically. This patch fixes that.


---

- [ ] ~~`./mach build -d` does not report any errors~~
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect the interactive tooling only