### PR TITLE
docs: Fix sample command in COMMAND_LINE_ARGS doc

### DIFF
--- a/docs/COMMAND_LINE_ARGS.md
+++ b/docs/COMMAND_LINE_ARGS.md
@@ -26,7 +26,7 @@ Use `--devtools 6000` to start the devtools server on port 6000.
 
 e.g.
 ```
-./mach run -d --devtools 6000 https://servo.org
+./mach run -d --devtools=6000 https://servo.org
 ```
 
 To connect to the server, follow [this guide](https://developer.mozilla.org/en-US/docs/Tools/Remote_Debugging/Debugging_Firefox_Desktop#Connect).


### PR DESCRIPTION
This is a minor fix for a sample command in docs/COMMAND_LINE_ARGS. `--devtool 6000` doesn't work as intended, as stated [here](https://github.com/servo/servo/wiki/Devtools).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this is a simple documentation fix.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
