### PR TITLE
Resolve cyclic margin and padding percentages against zero

### DIFF
--- a/tests/wpt/meta/css/CSS2/normal-flow/intrinsic-size-with-negative-margins.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/intrinsic-size-with-negative-margins.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-size-with-negative-margins.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_align-items-stretch-3.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_align-items-stretch-3.html.ini
@@ -1,0 +1,2 @@
+[flexbox_align-items-stretch-3.html]
+  expected: FAIL


### PR DESCRIPTION
From https://drafts.csswg.org/css-sizing-3/#min-percentage-contribution

> For the min size properties, as well as for margins and paddings
> (and gutters), a cyclic percentage is resolved against zero
> for determining intrinsic size contributions.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #30084
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
