### PR TITLE
Apply pixel rounding to border-width values

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -675,10 +675,10 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn build_border(&mut self, builder: &mut DisplayListBuilder) {
         let border = self.fragment.style.get_border();
         let widths = SideOffsets2D::new(
-            border.border_top_width.px(),
-            border.border_right_width.px(),
-            border.border_bottom_width.px(),
-            border.border_left_width.px(),
+            border.border_top_width.0.round_to_pixels().px(),
+            border.border_right_width.0.round_to_pixels().px(),
+            border.border_bottom_width.0.round_to_pixels().px(),
+            border.border_left_width.0.round_to_pixels().px(),
         );
         if widths == SideOffsets2D::zero() {
             return;

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -313,10 +313,10 @@ impl ComputedValuesExt for ComputedValues {
         let border = self.get_border();
         flow_relative::Sides::from_physical(
             &PhysicalSides::new(
-                border.border_top_width.0,
-                border.border_right_width.0,
-                border.border_bottom_width.0,
-                border.border_left_width.0,
+                border.border_top_width.0.round_to_pixels(),
+                border.border_right_width.0.round_to_pixels(),
+                border.border_bottom_width.0.round_to_pixels(),
+                border.border_left_width.0.round_to_pixels(),
             ),
             containing_block_writing_mode,
         )

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -304,6 +304,22 @@ impl CSSPixelLength {
             Some(max_size) => self.min(max_size),
         }
     }
+
+    #[inline]
+    /// Applies rounding to a length value, per https://drafts.csswg.org/css-values-4/#lengths
+    ///
+    /// If len is greater than zero, but less than 1 device pixel, round len up to 1 device pixel.
+    /// If len is greater than 1 device pixel, round it down to the nearest integer number of
+    /// device pixels.
+    pub fn round_to_pixels(self) -> Self {
+        if self.0 <= 0.0 {
+            CSSPixelLength::new(0.)
+        } else if self.0 < 1.0 {
+            CSSPixelLength::new(self.0.ceil())
+        } else {
+            CSSPixelLength::new(self.0.floor())
+        }
+    }
 }
 
 impl num_traits::Zero for CSSPixelLength {

--- a/tests/wpt/meta/css/css-borders/subpixel-border-width.tentative.html.ini
+++ b/tests/wpt/meta/css/css-borders/subpixel-border-width.tentative.html.ini
@@ -1,2 +1,0 @@
-[subpixel-border-width.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-borders/subpixel-borders-with-child-border-box-sizing.html.ini
+++ b/tests/wpt/meta/css/css-borders/subpixel-borders-with-child-border-box-sizing.html.ini
@@ -1,2 +1,0 @@
-[subpixel-borders-with-child-border-box-sizing.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-borders/subpixel-borders-with-child.html.ini
+++ b/tests/wpt/meta/css/css-borders/subpixel-borders-with-child.html.ini
@@ -1,2 +1,0 @@
-[subpixel-borders-with-child.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I was looking into some WPT test failures related to [css-borders](https://wpt.fyi/results/css/css-borders?run_id=5199197094019072) and found that CSS border values were not being rounded according to the rules defined in the spec for CSS lengths.

https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width

It seems necessary to make this adjustment both when drawing the borders, as well as calculating the dimensions of the box fragment.

This change is naive (so marked as draft) as I don't have a good understanding of the codebase, and it does not consider the device pixel ratio (https://github.com/servo/servo/issues/27457) but several WPT tests seem to pass with this adjustment.

Happy to rework this with direction from someone more familiar with the code, or close in favour of an alternative implementation. Cheers.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because: The implementation of this fix is likely to change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->