### PR TITLE
Fix viewport origin of webrender frame

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -918,7 +918,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
         self.webrender_api.set_document_view(
             self.webrender_document,
-            self.embedder_coordinates.get_flipped_viewport(),
+            self.embedder_coordinates.get_viewport(),
             self.embedder_coordinates.hidpi_factor.get(),
         );
 

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -200,13 +200,13 @@ pub struct EmbedderCoordinates {
 }
 
 impl EmbedderCoordinates {
-    // Get the viewport for webrender usage.
+    /// Get the unflipped viewport rectangle for use with the WebRender API.
     pub fn get_viewport(&self) -> DeviceIntRect {
         DeviceIntRect::from_untyped(&self.viewport.to_untyped())
     }
 
-    // Get the flipped viewport. This is used when we need to draw directly
-    // since origin of webrender is usually bottom left.
+    /// Get the flipped viewport rectangle. This should be used when drawing directly
+    /// to the framebuffer with OpenGL commands.
     pub fn get_flipped_viewport(&self) -> DeviceIntRect {
         let fb_height = self.framebuffer.height;
         let mut view = self.viewport.clone();

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -200,6 +200,13 @@ pub struct EmbedderCoordinates {
 }
 
 impl EmbedderCoordinates {
+    // Get the viewport for webrender usage.
+    pub fn get_viewport(&self) -> DeviceIntRect {
+        DeviceIntRect::from_untyped(&self.viewport.to_untyped())
+    }
+
+    // Get the flipped viewport. This is used when we need to draw directly
+    // since origin of webrender is usually bottom left.
     pub fn get_flipped_viewport(&self) -> DeviceIntRect {
         let fb_height = self.framebuffer.height;
         let mut view = self.viewport.clone();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -381,6 +381,11 @@ where
         let wr_document_layer = 0; //TODO
         let webrender_document =
             webrender_api.add_document(coordinates.framebuffer, wr_document_layer);
+        webrender_api.set_document_view(
+            webrender_document,
+            coordinates.get_viewport(),
+            coordinates.hidpi_factor.get(),
+        );
 
         // Important that this call is done in a single-threaded fashion, we
         // can't defer it after `create_constellation` has started.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
If we try to provide [viewport origin](https://github.com/servo/servo/blob/master/ports/winit/headed_window.rs#L529) other that (0, 0), the origin of the document viewport will still be fixed to (0, 0) initially and it's still a bit off if we resize the window. This PR tries to fix the origin by `set_document_view` when initializing webrender document and passing correct viewport origin.

The flipped viewport is only useful when drawing directly like [clearing background](https://github.com/servo/servo/blob/master/components/compositing/compositor.rs#L1742) through gl api directly.
Webredner itself will detect this and proving correct origin when drawing frames.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
