### PR TITLE
Split line layout into two phases

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -372,6 +372,7 @@ impl BlockContainer {
                 positioning_context,
                 containing_block,
                 sequential_layout_state,
+                collapsible_with_parent_start_margin,
             ),
         }
     }

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -155,6 +155,7 @@ impl BoxFragment {
                 \ncontent={:?}\
                 \npadding rect={:?}\
                 \nborder rect={:?}\
+                \nmargin={:?}\
                 \nclearance={:?}\
                 \nscrollable_overflow={:?}\
                 \noverflow={:?} / {:?}",
@@ -162,6 +163,7 @@ impl BoxFragment {
             self.content_rect,
             self.padding_rect(),
             self.border_rect(),
+            self.margin,
             self.clearance,
             self.scrollable_overflow(&PhysicalRect::zero()),
             self.style.get_box().overflow_x,

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -299,11 +299,12 @@ impl AnonymousFragment {
 impl TextFragment {
     pub fn print(&self, tree: &mut PrintTree) {
         tree.add_item(format!(
-            "Text num_glyphs={}",
+            "Text num_glyphs={} box={:?}",
             self.glyphs
                 .iter()
                 .map(|glyph_store| glyph_store.len().0)
-                .sum::<isize>()
+                .sum::<isize>(),
+            self.rect,
         ));
     }
 }

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -32,7 +32,7 @@ pub mod flow_relative {
         pub size: Vec2<T>,
     }
 
-    #[derive(Clone, Serialize)]
+    #[derive(Clone, Debug, Serialize)]
     pub struct Sides<T> {
         pub inline_start: T,
         pub inline_end: T,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -55,6 +55,7 @@ pub(crate) enum DisplayInside {
 }
 
 /// Percentages resolved but not `auto` margins
+#[derive(Clone)]
 pub(crate) struct PaddingBorderMargin {
     pub padding: flow_relative::Sides<Length>,
     pub border: flow_relative::Sides<Length>,

--- a/tests/wpt/meta/css/CSS2/abspos/remove-block-between-inline-and-abspos.html.ini
+++ b/tests/wpt/meta/css/CSS2/abspos/remove-block-between-inline-and-abspos.html.ini
@@ -1,2 +1,0 @@
-[remove-block-between-inline-and-abspos.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/block-in-inline-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/block-in-inline-007.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-141.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-141.xht.ini
@@ -1,0 +1,2 @@
+[floats-141.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/float-no-content-beside-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/float-no-content-beside-001.html.ini
@@ -1,0 +1,2 @@
+[float-no-content-beside-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/float-nowrap-4.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/float-nowrap-4.html.ini
@@ -1,2 +1,0 @@
-[float-nowrap-4.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001b.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-001b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001c.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-001c.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-001c.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-non-replaced-width-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-non-replaced-width-007.xht.ini
@@ -1,2 +1,0 @@
-[block-non-replaced-width-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-on-blank-line-rtl-left-align.html.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-on-blank-line-rtl-left-align.html.ini
@@ -1,2 +1,0 @@
-[text-indent-on-blank-line-rtl-left-align.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-008.xht.ini
@@ -1,2 +1,0 @@
-[white-space-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-normal-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-normal-007.xht.ini
@@ -1,2 +1,0 @@
-[white-space-normal-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/zindex/stack-floats-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/zindex/stack-floats-003.xht.ini
@@ -1,2 +1,0 @@
-[stack-floats-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-color/inline-opacity-float-child.html.ini
+++ b/tests/wpt/meta/css/css-color/inline-opacity-float-child.html.ini
@@ -1,0 +1,2 @@
+[inline-opacity-float-child.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/pseudo-element-inline-box.html.ini
+++ b/tests/wpt/meta/css/css-content/pseudo-element-inline-box.html.ini
@@ -1,0 +1,2 @@
+[pseudo-element-inline-box.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_flex-none-wrappable-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_flex-none-wrappable-content.html.ini
@@ -1,0 +1,2 @@
+[flexbox_flex-none-wrappable-content.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-relative-003.html.ini
+++ b/tests/wpt/meta/css/css-position/position-relative-003.html.ini
@@ -1,2 +1,0 @@
-[position-relative-003.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-position/position-relative-004.html.ini
+++ b/tests/wpt/meta/css/css-position/position-relative-004.html.ini
@@ -1,2 +1,0 @@
-[position-relative-004.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/filter-effects/filtered-inline-applies-to-float.html.ini
+++ b/tests/wpt/meta/css/filter-effects/filtered-inline-applies-to-float.html.ini
@@ -1,0 +1,2 @@
+[filtered-inline-applies-to-float.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/input_whitespace.html.ini
+++ b/tests/wpt/mozilla/meta/css/input_whitespace.html.ini
@@ -1,2 +1,0 @@
-[input_whitespace.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/list_style_position_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/list_style_position_a.html.ini
@@ -1,0 +1,2 @@
+[list_style_position_a.html]
+  expected: FAIL


### PR DESCRIPTION
In the first phase, we gather LineItems and then when we have enough to
form a line we turn them into Fragments. This will make it possible to
more simply implement `vertical-align` and `text-align: justify` because
we need to measure the different aspects of the candidate line and then
produce a Fragments.

This is a general refactor of the way that inline layout works, so comes
with some progressions. In addition there are some new failures.

New failures:

Some tests are now failing because only the test or reference is getting
proper line height when it wasn't before. These should be fixed in a
followup change that properly calculate line-height in more cases:

 - /_mozilla/css/list_style_position_a.html
 - /css/CSS2/floats/float-no-content-beside-001.html
 - /css/css-content/pseudo-element-inline-box.html
 - /css/css-flexbox/flexbox_flex-none-wrappable-content.html

Some tests are now failing because floats are now placed properly, but
are no longer in their inline box stacking contexts. These will be fixed
by a followup change which properly parents them:

- /css/filter-effects/filtered-inline-applies-to-float.html.ini
- /css/css-color/inline-opacity-float-child.html.ini

One test is failing due to floating point precision errors:

- /css/CSS2/floats-clear/floats-141.xht.ini

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
