### PR TITLE
Make the `--release`/`--dev` more consistent and less surprising

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Release build
         run: python3 ./mach build --release
       - name: Smoketest
-        run: xvfb-run python3 ./mach smoketest
+        run: xvfb-run python3 ./mach smoketest --release
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -42,7 +42,7 @@ jobs:
           python3 -m pip install --upgrade pip virtualenv
           python3 ./mach bootstrap
       - name: Smoketest
-        run: python3 ./mach smoketest
+        run: python3 ./mach smoketest --release
       - name: Run tests
         run: |
           python3 ./mach test-wpt --with-${{ inputs.layout }} \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           python3 ./mach build --release
       - name: Smoketest
-        run: python3 ./mach smoketest
+        run: python3 ./mach smoketest --release
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Release build
         run: python3 ./mach build --release
       - name: Smoketest
-        run: xvfb-run python3 ./mach smoketest
+        run: xvfb-run python3 ./mach smoketest --release
       - name: Unit tests
         run: python3 ./mach test-unit --release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Copy resources
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
-        run: python mach smoketest --angle
+        run: python mach smoketest --angle --release
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
         run: python mach test-unit --release

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -44,7 +44,7 @@ class MachCommands(CommandBase):
     @CommandArgument(
         'params', default=None, nargs='...',
         help="Command-line arguments to be passed through to cargo check")
-    @CommandBase.build_like_command_arguments
+    @CommandBase.common_command_arguments(build_configuration=True, build_type=False)
     def check(self, params, **kwargs):
         if not params:
             params = []
@@ -129,7 +129,7 @@ class MachCommands(CommandBase):
     @CommandArgument(
         'params', default=None, nargs='...',
         help="Command-line arguments to be passed through to cargo-fix")
-    @CommandBase.build_like_command_arguments
+    @CommandBase.common_command_arguments(build_configuration=True, build_type=False)
     def cargo_fix(self, params, **kwargs):
         if not params:
             params = []
@@ -144,7 +144,7 @@ class MachCommands(CommandBase):
     @CommandArgument(
         'params', default=None, nargs='...',
         help="Command-line arguments to be passed through to cargo-clippy")
-    @CommandBase.build_like_command_arguments
+    @CommandBase.common_command_arguments(build_configuration=True, build_type=False)
     def cargo_clippy(self, params, **kwargs):
         if not params:
             params = []

--- a/python/wpt/__init__.py
+++ b/python/wpt/__init__.py
@@ -27,8 +27,6 @@ import wptrunner.wptcommandline  # noqa: E402
 
 def create_parser():
     parser = wptrunner.wptcommandline.create_parser()
-    parser.add_argument('--release', default=False, action="store_true",
-                        help="Run with a release build of servo")
     parser.add_argument('--rr-chaos', default=False, action="store_true",
                         help="Run under chaos mode in rr until a failure is captured")
     parser.add_argument('--pref', default=[], action="append", dest="prefs",

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -33,24 +33,13 @@ TRACKER_API_ENV_VAR = "INTERMITTENT_TRACKER_API"
 TRACKER_DASHBOARD_SECRET_ENV_VAR = "INTERMITTENT_TRACKER_DASHBOARD_SECRET"
 
 
-def determine_build_type(kwargs: dict, target_dir: str):
-    if kwargs["release"]:
-        return "release"
-    elif kwargs["debug"]:
-        return "debug"
-    elif os.path.exists(os.path.join(target_dir, "debug")):
-        return "debug"
-    elif os.path.exists(os.path.join(target_dir, "release")):
-        return "release"
-    return "debug"
-
-
 def set_if_none(args: dict, key: str, value):
     if key not in args or args[key] is None:
         args[key] = value
 
 
-def run_tests(**kwargs):
+def run_tests(default_binary_path: str, **kwargs):
+    print(default_binary_path)
     # By default, Rayon selects the number of worker threads based on the
     # available CPU count. This doesn't work very well when running tests on CI,
     # since we run so many Servo processes in parallel. The result is a lot of
@@ -78,17 +67,6 @@ def run_tests(**kwargs):
     set_if_none(kwargs, "chunk_type", "id_hash")
 
     kwargs["user_stylesheets"].append(os.path.join(SERVO_ROOT, "resources", "ahem.css"))
-
-    if "CARGO_TARGET_DIR" in os.environ:
-        target_dir = os.path.join(os.environ["CARGO_TARGET_DIR"])
-    else:
-        target_dir = os.path.join(SERVO_ROOT, "target")
-
-    binary_name = ("servo.exe" if sys.platform == "win32" else "servo")
-
-    default_binary_path = os.path.join(
-        target_dir, determine_build_type(kwargs, target_dir), binary_name
-    )
 
     set_if_none(kwargs, "binary", default_binary_path)
     set_if_none(kwargs, "webdriver_binary", default_binary_path)


### PR DESCRIPTION
There were some issues with the way that the `--release` and `--dev` arguments were handled in mach commands.

 - Not all commands accepted them in the same way. For instance `./mach test-wpt` didn't really accept them at all.
 - If you did not pass either of them, mach would try to guess which build you meant. This guess was often quite surprising as it wasn't printed and it depended on the state of the your target directory, which is difficult to remember.
 - The `dev` profile is colloquially called a "debug" profile and some commands accepted `-d` or `--debug...` like arguments, but `--debug` with `./mach run` meant run in a debugger. It was easy to mix this up.

This change:

 - Centralizes where build type argument processing happens. Now it the same shared decorator in CommandBase.
 - Uses a `BuildType` enum instead of passing around two different booleans. This reduces the error checking for situations where both are true.
 - Be much less clever about guessing what build to use. Now if you don't specify a build type, `--dev` is chosen. I think this behavior matches cargo.
 - Makes it so that `./mach test-wpt` accepts the exact same arguments and has the same behavior as other commands. In addition, the suite correct for `test-wpt` is removed. There are only two suites now and it's quite unlikely that people will confuse WPT tests for rust unit tests.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they change build scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
