### PR TITLE
Remove gold config option and use lld on Linux

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -509,9 +509,11 @@ class CommandBase(object):
         if self.config["build"]["rustflags"]:
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " " + self.config["build"]["rustflags"]
 
-        if self.config["tools"]["rustc-with-gold"]:
-            if shutil.which('ld.gold'):
-                env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C link-args=-fuse-ld=gold"
+        # Turn on rust's version of lld if we are on x86 Linux.
+        # TODO(mrobinson): Gradually turn this on for more platforms, when support stabilizes.
+        # See https://github.com/rust-lang/rust/issues/39915
+        if not self.cross_compile_target and effective_target == "x86_64-unknown-linux-gnu":
+            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -Zgcc-ld=lld"
 
         if not (self.config["build"]["ccache"] == ""):
             env['CCACHE'] = self.config["build"]["ccache"]

--- a/servobuild.example
+++ b/servobuild.example
@@ -4,9 +4,6 @@
 
 # Tool options
 [tools]
-# If rustc-with-gold is true, will try to find and use gold linker with rustc.
-# Defaults to true
-rustc-with-gold = true
 
 # If uncommented, this command is used instead of the platform’s default
 # to notify at the end of a compilation that took a long time.


### PR DESCRIPTION
There are a few motivations for this change:

 1. lld is demonstrably faster than gold, but is really only stable on
    Linux at the moment. There's a good chance that it will be ready for
    all platforms soon though.
 2. Most people do not have gold installed on MacOS and Windows. You'd
    have to do this manually through homebrew. I think it's a safe
    assumption that this probably won't be slowing things down much on
    those platforms.
 3. We need to remove all configuration of the build that happens while
    running `./mach build` if we ever hope to make `cargo build`
    equivalent to the mach build. This unlocks static configuration of
    the rustflags. One of the big blockers for proper `cargo build`
    support.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
