### PR TITLE
Replace "-mmacosx-version-min" with MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -36,3 +36,6 @@ linker = "lld-link.exe"
 
 [target.aarch64-uwp-windows-msvc]
 linker = "lld-link.exe"
+
+[env]
+MACOSX_DEPLOYMENT_TARGET = "10.10"

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -79,15 +79,10 @@ class MachCommands(CommandBase):
         build_start = time()
 
         host = servo.platform.host_triple()
-        target_triple = self.cross_compile_target or servo.platform.host_triple()
-        if 'apple-darwin' in host and target_triple == host:
-            if 'CXXFLAGS' not in env:
-                env['CXXFLAGS'] = ''
-            env["CXXFLAGS"] += "-mmacosx-version-min=10.10"
-
         if 'windows' in host:
             vs_dirs = self.vs_dirs()
 
+        target_triple = self.cross_compile_target or servo.platform.host_triple()
         if host != target_triple and 'windows' in target_triple:
             if os.environ.get('VisualStudioVersion') or os.environ.get('VCINSTALLDIR'):
                 print("Can't cross-compile for Windows inside of a Visual Studio shell.\n"


### PR DESCRIPTION
It's unclear if the compiler flag was doing anything, but I've verified
(with otool) that the environment variable does affect the minimum
version of the MacOS set in the binary. We could examine later if this
is still necessary.

This was added in #23163 when switching CI from gcc to clang.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust build configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
