### PR TITLE
Cmd or Ctrl+L should focus on location bar in minibrowser mode

### DIFF
--- a/ports/winit/browser.rs
+++ b/ports/winit/browser.rs
@@ -113,17 +113,19 @@ where
                 }
             })
             .shortcut(CMD_OR_CONTROL, 'L', || {
-                let url: String = if let Some(ref current_url) = self.current_url {
-                    current_url.to_string()
-                } else {
-                    String::from("")
-                };
-                let title = "URL or search query";
-                let input = tinyfiledialogs::input_box(title, title, &tiny_dialog_escape(&url));
-                if let Some(input) = input {
-                    if let Some(url) = sanitize_url(&input) {
-                        if let Some(id) = self.browser_id {
-                            self.event_queue.push(EmbedderEvent::LoadUrl(id, url));
+                if !opts::get().minibrowser {
+                    let url: String = if let Some(ref current_url) = self.current_url {
+                        current_url.to_string()
+                    } else {
+                        String::from("")
+                    };
+                    let title = "URL or search query";
+                    let input = tinyfiledialogs::input_box(title, title, &tiny_dialog_escape(&url));
+                    if let Some(input) = input {
+                        if let Some(url) = sanitize_url(&input) {
+                            if let Some(id) = self.browser_id {
+                                self.event_queue.push(EmbedderEvent::LoadUrl(id, url));
+                            }
                         }
                     }
                 }

--- a/ports/winit/minibrowser.rs
+++ b/ports/winit/minibrowser.rs
@@ -4,7 +4,7 @@
 
  use std::{cell::{RefCell, Cell}, sync::Arc};
 
-use egui::TopBottomPanel;
+use egui::{TopBottomPanel, Modifiers, Key};
 use servo::{servo_url::ServoUrl, compositing::windowing::EmbedderEvent};
 use servo::webrender_surfman::WebrenderSurfman;
 
@@ -51,15 +51,20 @@ impl Minibrowser {
                     ui.available_size(),
                     egui::Layout::right_to_left(egui::Align::Center),
                     |ui| {
+                        let response = ui.add_sized(
+                            ui.available_size(),
+                            egui::TextEdit::singleline(&mut *location.borrow_mut()),
+                        );
+
                         if ui.button("go").clicked() {
                             event_queue.borrow_mut().push(MinibrowserEvent::Go);
                             location_dirty.set(false);
                         }
-                        if ui.add_sized(
-                            ui.available_size(),
-                            egui::TextEdit::singleline(&mut *location.borrow_mut()),
-                        ).changed() {
+                        if response.changed() {
                             location_dirty.set(true);
+                        }
+                        if ui.input(|i| i.clone().consume_key(Modifiers::COMMAND, Key::L)) {
+                            response.request_focus();
                         }
                     },
                 );

--- a/ports/winit/minibrowser.rs
+++ b/ports/winit/minibrowser.rs
@@ -51,20 +51,20 @@ impl Minibrowser {
                     ui.available_size(),
                     egui::Layout::right_to_left(egui::Align::Center),
                     |ui| {
-                        let response = ui.add_sized(
-                            ui.available_size(),
-                            egui::TextEdit::singleline(&mut *location.borrow_mut()),
-                        );
-
                         if ui.button("go").clicked() {
                             event_queue.borrow_mut().push(MinibrowserEvent::Go);
                             location_dirty.set(false);
                         }
-                        if response.changed() {
+
+                        let location_field = ui.add_sized(
+                            ui.available_size(),
+                            egui::TextEdit::singleline(&mut *location.borrow_mut()),
+                        );
+                        if location_field.changed() {
                             location_dirty.set(true);
                         }
                         if ui.input(|i| i.clone().consume_key(Modifiers::COMMAND, Key::L)) {
-                            response.request_focus();
+                            location_field.request_focus();
                         }
                     },
                 );


### PR DESCRIPTION
Adding keyboard shortcut cmd+L & ctrl+L that focus the location bar when in minibrowser mode

- `Modifiers::COMMAND` of egui is : Cmd key on Mac, elsewhere: Ctrl key.
- Added a condition around servo's `CMD_OR_CTRL+L` shortcut, as we still want that to work when not in minibrowser mode.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30049 