### PR TITLE
Fix libsimpleservo build

### DIFF
--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -802,6 +802,7 @@ impl ServoGlue {
                 EmbedderMsg::NewFavicon(..) |
                 EmbedderMsg::HeadParsed |
                 EmbedderMsg::SetFullscreenState(..) |
+                EmbedderMsg::ReadyToPresent |
                 EmbedderMsg::ReportProfile(..) => {},
             }
         }


### PR DESCRIPTION
In #29976 we introduced a new member `ReadyToPresent` inside `EmbedderMsg` that resulted in libsimpleservo build to fail.

Fixed by adding missing field `EmbedderMsg::ReadyToPresent`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30107
