### PR TITLE
Fix /custom-elements/when-defined-reentry-crash.html

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -397,7 +397,8 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         }
 
         // Step 16, 16.3
-        if let Some(promise) = self.when_defined.borrow_mut().remove(&name) {
+        let promise = self.when_defined.borrow_mut().remove(&name);
+        if let Some(promise) = promise {
             unsafe {
                 rooted!(in(*cx) let mut constructor = UndefinedValue());
                 definition


### PR DESCRIPTION
The problem is a double-borrow of the `when_defined` member. The fix is
to let go of the borrow before resolving the promise which will
eventually try to borrow `when_defined` again.

Fixes #30120.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30120.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
