### PR TITLE
Use system lld on NixOS instead of rust-lld

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -17,6 +17,7 @@ clangStdenv.mkDerivation rec {
     gst_all_1.gst-plugins-bad
 
     rustup
+    llvmPackages.bintools # provides lld
 
     # Build utilities
     cmake dbus gcc git pkg-config which llvm autoconf213 perl yasm m4

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -498,7 +498,7 @@ class CommandBase(object):
         # TODO(mrobinson): Gradually turn this on for more platforms, when support stabilizes.
         # See https://github.com/rust-lang/rust/issues/39915
         if not self.cross_compile_target and effective_target == "x86_64-unknown-linux-gnu":
-            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -Zgcc-ld=lld"
+            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + servo.platform.get().linker_flag()
 
         if not (self.config["build"]["ccache"] == ""):
             env['CCACHE'] = self.config["build"]["ccache"]

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -67,7 +67,10 @@ class Base:
     def library_path_variable_name(self):
         raise NotImplementedError("Do not know how to set library path for platform.")
 
-    def executable_suffix(self):
+    def linker_flag(self) -> str:
+        return ""
+
+    def executable_suffix(self) -> str:
         return ""
 
     def _platform_bootstrap(self, _force: bool) -> bool:

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -127,6 +127,17 @@ class Linux(Base):
         installed_something |= self._platform_bootstrap_gstreamer(force)
         return installed_something
 
+    def linker_flag(self) -> str:
+        # the rust-lld binary downloaded by rustup
+        # doesn't respect NIX_LDFLAGS and also needs
+        # other patches to work correctly. Use system
+        # version of lld for now. See
+        # https://github.com/NixOS/nixpkgs/issues/220717
+        if self.distro.lower() == 'nixos':
+            return '-C link-arg=-fuse-ld=lld'
+        else:
+            return '-Zgcc-ld=lld'
+
     def install_non_gstreamer_dependencies(self, force: bool) -> bool:
         install = False
         pkgs = []


### PR DESCRIPTION
The -Zgcc-ld=lld flag makes rust use the rust-lld
linker that is distributed as part of rust toolchain. 
However, this flag doesn't work on nixos correctly as
  1) rust-lld needs to be patched to have the correct rpath
     to find libz.so
  2) the bin/gcc-ld/ld.lld wrapper which calls rust-lld also
     needs to be patched to use the correct dynamic loader
  3) rust-lld doesn't respect NIX_LDFLAGS which contains
     the additional search path derived from buildInputs.
     The system linkers on nixos are wrapped so that
     NIX_LDFLAGS is added as the rpath to the final binary.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix compilation issues.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
