### PR TITLE
Remove minibrowser from prefs

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -456,9 +456,6 @@ mod gen {
                     enabled: bool,
                 }
             },
-            minibrowser: {
-                enabled: bool,
-            },
             network: {
                 enforce_tls: {
                     enabled: bool,

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -104,7 +104,6 @@
   "layout.writing-mode.enabled": false,
   "media.glvideo.enabled": false,
   "media.testing.enabled": false,
-  "minibrowser.enabled": false,
   "network.enforce_tls.enabled": false,
   "network.enforce_tls.localhost": false,
   "network.enforce_tls.onion": false,


### PR DESCRIPTION
This is unused code as in #30042 we decided to allow enabling mini browser from command line

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
