### PR TITLE
Layout floats as children of their inline ancestors

### DIFF
--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -131,19 +131,6 @@ pub(crate) struct IFrameFragment {
 }
 
 impl Fragment {
-    pub fn offset_inline(&mut self, offset: &Length) {
-        let position = match self {
-            Fragment::Box(f) => &mut f.content_rect.start_corner,
-            Fragment::Float(_) | Fragment::AbsoluteOrFixedPositioned(_) => return,
-            Fragment::Anonymous(f) => &mut f.rect.start_corner,
-            Fragment::Text(f) => &mut f.rect.start_corner,
-            Fragment::Image(f) => &mut f.rect.start_corner,
-            Fragment::IFrame(f) => &mut f.rect.start_corner,
-        };
-
-        position.inline += *offset;
-    }
-
     pub fn base(&self) -> Option<&BaseFragment> {
         Some(match self {
             Fragment::Box(fragment) => &fragment.base,

--- a/tests/wpt/meta-legacy-layout/css/css-text/text-indent/text-indent-overflow.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/text-indent/text-indent-overflow.html.ini
@@ -1,0 +1,2 @@
+[text-indent-overflow.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-color/inline-opacity-float-child.html.ini
+++ b/tests/wpt/meta/css/css-color/inline-opacity-float-child.html.ini
@@ -1,2 +1,0 @@
-[inline-opacity-float-child.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/filtered-inline-applies-to-float.html.ini
+++ b/tests/wpt/meta/css/filter-effects/filtered-inline-applies-to-float.html.ini
@@ -1,2 +1,0 @@
-[filtered-inline-applies-to-float.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-text/text-indent/reference/text-indent-overflow-ref.html
+++ b/tests/wpt/tests/css/css-text/text-indent/reference/text-indent-overflow-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: text-indent causing text to overflow container</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<style>
+.container {
+  border: solid;
+  width: 200px;
+}
+
+.content {
+  display: inline-block;
+  width: 50px;
+  height: 20px;
+  background: green;
+}
+</style>
+
+<p>Test passes if the green square is positioned just past the content edge of the box.</p>
+
+<div class="container">
+  <span style="margin-left: 200px;"><div class="content"></div></span>
+</div>

--- a/tests/wpt/tests/css/css-text/text-indent/reference/text-indent-text-align-end-ref.html
+++ b/tests/wpt/tests/css/css-text/text-indent/reference/text-indent-text-align-end-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: text-indent with text-align: end</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<meta name="assert" content="Percentages in text-indent refer to width of the element's content box">
+<style>
+.container {
+  border: solid;
+  width: 200px;
+  text-align: end;
+}
+
+.content {
+  display: inline-block;
+  width: 50px;
+  height: 20px;
+  background: green;
+}
+</style>
+
+<p>Test passes if the green square is positioned against the right edge of the box.</p>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/tests/wpt/tests/css/css-text/text-indent/text-indent-overflow.html
+++ b/tests/wpt/tests/css/css-text/text-indent/text-indent-overflow.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: text-indent causing text to overflow container</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<link rel="match" href="reference/text-indent-overflow-ref.html">
+<meta name="assert" content="Percentages in text-indent refer to width of the element's content box">
+<style>
+.container {
+  border: solid;
+  width: 200px;
+  text-indent: 200px;
+  text-align: right;
+}
+
+.content {
+  display: inline-block;
+  width: 50px;
+  height: 20px;
+  background: green;
+}
+</style>
+
+<p>Test passes if the green square is positioned just past the content edge of the box.</p>
+
+<!--
+  In this case the `text-indent` is as wide as the container, but should be
+  handled like the linebox had a large left margin, causing the content to
+  overflow the container.
+-->
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/tests/wpt/tests/css/css-text/text-indent/text-indent-text-align-end.html
+++ b/tests/wpt/tests/css/css-text/text-indent/text-indent-text-align-end.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: text-indent with text-align: end</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<link rel="match" href="reference/text-indent-text-align-end-ref.html">
+<meta name="assert" content="Percentages in text-indent refer to width of the element's content box">
+<style>
+.container {
+  border: solid;
+  width: 200px;
+  text-indent: 50px;
+  text-align: end;
+}
+
+.content {
+  display: inline-block;
+  width: 50px;
+  height: 20px;
+  background: green;
+}
+</style>
+
+<p>Test passes if the green square is positioned against the right edge of the box.</p>
+
+<!--
+  In this case the `text-indent` doesn't affect the positioning of the content
+  when text-align positions it further than the indent does.
+-->
+<div class="container">
+  <div class="content"></div>
+</div>


### PR DESCRIPTION
When layout was split into two phases, floats were laid out as direct
children of the inline formatting context. This meant that they were
positioned properly, but not properly made children of their inline
ancestors' stacking contexts. This change maintains the proper
positioning of floats, but positions them relatively to their inline
ancestors.

The big change here is that `text-align` needs to be taken into account
before actually laying out LineItems. This has the added benefit of
setting inline layout for the implementation of `text-align: full`. Now
all line items are laid out at the real final position and we can adjust
the `start_corner` property of float `BoxFragments` when their ancestors
are laid out.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
