### PR TITLE
Get LLVM from chocolatey

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,8 @@ jobs:
           Start-BitsTransfer -Source https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip -Destination C:\\wix311-binaries.zip
           Expand-Archive C:\\wix311-binaries.zip -DestinationPath C:\\wix
           echo "C:\\wix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Remove msys from PATH # see https://github.com/actions/runner-images/issues/2208
+        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
       - name: Bootstrap

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -468,12 +468,9 @@ class CommandBase(object):
 
         effective_target = self.cross_compile_target or servo.platform.host_triple()
         if "msvc" in effective_target:
-            util.append_paths_to_env(env, "PATH", path.join(self.msvc_package_dir("llvm"), "bin"))
-
-            # These two environment variables are necessary for building mozjs. It would
-            # be nice to be able to set them in the cargo configuration somehow, but they
-            # are platform-dependent.
-            env["LIBCLANG_PATH"] = path.join(self.msvc_package_dir("llvm"), "lib")
+            # This environment variable is necessary for building mozjs. It would
+            # be nice to be able to set it in the cargo configuration somehow, but it
+            # is platform-dependent.
             env["MOZILLA_BUILD"] = path.join(self.msvc_package_dir("moztools"))
 
             # Always build harfbuzz from source

--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -19,7 +19,6 @@ from .base import Base
 
 DEPS_URL = "https://github.com/servo/servo-build-deps/releases/download/msvc-deps/"
 DEPENDENCIES = {
-    "llvm": "15.0.5",
     "moztools": "3.2",
 }
 

--- a/support/windows/chocolatey.config
+++ b/support/windows/chocolatey.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="cmake" version="3.26.4" installArguments="ADD_CMAKE_TO_PATH=System"/>
   <package id="git"/>
+  <package id="llvm"/>
   <package id="ninja"/>
   <package id="python"/>
   <package id="python3-virtualenv"/>


### PR DESCRIPTION
LLVM is the largest package that we get from servo-build-deps, so installing it via chocolatey should reduce the amount of data that we transfer from that source. In addition, it's one less dependency that we have to manage.

It also seems that installing LLVM to the default location with choco means that we no longer have to set the LIBCLANG_PATH environment variable for bindgen.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are just a build dependency change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
