### PR TITLE
Cache .deb for libffi instead of always downloading

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -39,6 +39,16 @@ jobs:
         with:
           name: release-binary
           path: release-binary
+      - name: Cache libffi
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ./libffi6_3.2.1-8_amd64.deb
+          key: cache-libffi
+      - name: Download libffi
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
       - name: unPackage binary
         run: tar -xzf release-binary/target.tar.gz
       - name: Prep test environment
@@ -46,7 +56,6 @@ jobs:
           python3 -m pip install --upgrade pip virtualenv
           sudo apt update
           sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
-          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
           python3 ./mach bootstrap-gstreamer
       - name: Sync from upstream WPT


### PR DESCRIPTION
Connections to mirrors.kernel.org have recently been timing out frequently ([latest](https://github.com/servo/servo/actions/runs/5910609625/job/16032728310) failure). I've done the same in our [internal WPT dashboard ](https://github.com/servo/internal-wpt-dashboard/commit/9ef9aa7f53e757e96b1e15121ba7bac611b784c1) previously and it seems to work well so far. Maybe we can also host this in servo-build-deps as well, in addition to caching.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they modify CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
