### PR TITLE
Name OS builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Linux Build
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Mac Build
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Windows Build
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Instead of this:
![unnamed builds](https://github.com/servo/servo/assets/16504129/610d7617-b5ed-49a4-aad4-e976f5afd879)
we get this:
![named builds](https://github.com/servo/servo/assets/16504129/f5c1c2ef-d799-4ba9-a376-910bd67ae8b3)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because it is trivial CI change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
