### PR TITLE
Pin GNU Make to 4.3 on NixOS

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -2,7 +2,12 @@
 # NOTE: This does not work offline or for nix-build
 
 with import <nixpkgs> {};
-
+let
+    pinnedSha = "6adf48f53d819a7b6e15672817fa1e78e5f4e84f";
+    pinnedNixpkgs = import (builtins.fetchTarball {
+        url = "https://github.com/NixOS/nixpkgs/archive/${pinnedSha}.tar.gz";
+    }) {};
+in
 clangStdenv.mkDerivation rec {
   name = "servo-env";
 
@@ -22,6 +27,11 @@ clangStdenv.mkDerivation rec {
     # Build utilities
     cmake dbus gcc git pkg-config which llvm autoconf213 perl yasm m4
     (python3.withPackages (ps: with ps; [virtualenv pip dbus]))
+    # This pins gnumake to 4.3 since 4.4 breaks jobserver
+    # functionality in mozjs and causes builds to be extremely
+    # slow as it behaves as if -j1 was passed.
+    # See https://github.com/servo/mozjs/issues/375
+    pinnedNixpkgs.gnumake
   ] ++ (lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.AppKit
   ]);


### PR DESCRIPTION
This pins gnumake to 4.3 since 4.4 breaks jobserver functionality in mozjs and causes builds to be extremely
slow as it behaves as if -j1 was passed. See https://github.com/servo/mozjs/issues/375 for more information.

We should be able to revert this once we update the rust toolchain in #29993. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because only the NixOS environment is modified.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
