### PR TITLE
Fix failing unit test in winit prefs

### DIFF
--- a/ports/winit/prefs.rs
+++ b/ports/winit/prefs.rs
@@ -90,7 +90,7 @@ fn test_parse_pref_from_command_line() {
         prefs::pref_map().get("dom.bluetooth.enabled"),
         PrefValue::Bool(false)
     );
-    assert!(pref!(dom.bluetooth.enabled));
+    assert_eq!(pref!(dom.bluetooth.enabled), false);
 
     // Test with numbers
     test_parse_pref("layout.threads=42");


### PR DESCRIPTION
I think this was caused by #29758. This PR adds the correct expectation for the test

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
