### PR TITLE
Fix type attribute for module script not in case insensitive issue

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1186,7 +1186,9 @@ impl HTMLScriptElement {
             (Some(ref ty), _) => {
                 debug!("script type={}", &***ty);
 
-                if &***ty == String::from("module") {
+                if ty.to_ascii_lowercase().trim_matches(HTML_SPACE_CHARACTERS) ==
+                    String::from("module")
+                {
                     return Some(ScriptType::Module);
                 }
 

--- a/tests/wpt/meta-legacy-layout/html/semantics/scripting-1/the-script-element/module/type.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/scripting-1/the-script-element/module/type.html.ini
@@ -1,7 +1,0 @@
-[type.html]
-  [type="MODULE"]
-    expected: FAIL
-
-  [type="Module"]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/type.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/type.html.ini
@@ -1,7 +1,0 @@
-[type.html]
-  [type="MODULE"]
-    expected: FAIL
-
-  [type="Module"]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
* Use `to_ascii_lowercase()` and `trim_matches(HTML_SPACE_CHARACTERS)` to check type string

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30205  (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
