### PR TITLE
Enable grouping of patch updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    patch-updates:
+      update-types:
+       - patch
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
This feature was released recently. This could potentially cut down on the CI hours spent on merging dependabot PRs.

More info here:
https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-version-updates-with-comment-commands

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only modify dependabot config