### PR TITLE
Use @servo-bot token for approving dependabot PR

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -2,8 +2,7 @@ name: Approve & merge successful dependabot patch upgrade PRs
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   dependabot:
@@ -13,8 +12,6 @@ jobs:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve the PR & enable auto-merge
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: |
@@ -22,4 +19,4 @@ jobs:
           gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.SERVO_DEPENDABOT_TOKEN}}


### PR DESCRIPTION
The default GITHUB_TOKEN is created for  the 'github-bot' user
and has limitations. Specifically, events generated by  github-bot
cannot trigger additional workflows.

This PR uses fine-grained PAT generated for @servo-bot account
with the permissions scoped to servo/servo repo and grants the
'contents: write' and 'pull_request: write' permissions.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only modify CI authentcation tokens

