### PR TITLE
Fix typo in build.rs link directive for EGL

### DIFF
--- a/ports/libsimpleservo/api/build.rs
+++ b/ports/libsimpleservo/api/build.rs
@@ -39,14 +39,14 @@ fn main() {
             .write_bindings(gl_generator::StaticStructGenerator, &mut file)
             .unwrap();
 
-        // Historically, Android builds have succeeded with rust-link-lib=EGL.
+        // Historically, Android builds have succeeded with rustc-link-lib=EGL.
         // On Windows when relying on %LIBS% to contain libEGL.lib, however,
         // we must explicitly use rustc-link-lib=libEGL or rustc will attempt
         // to link EGL.lib instead.
         if target.contains("windows") {
             println!("cargo:rustc-link-lib=libEGL");
         } else {
-            println!("cargo:rust-link-lib=EGL");
+            println!("cargo:rustc-link-lib=EGL");
         }
     }
 


### PR DESCRIPTION
Due to this incorrect link directive, libsimpleservo.so ends up with
undefined references that cause the JNI `System.loadLibrary` to fail.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix broken Android build
