### PR TITLE
Let WPT commands take the --legacy-layout argument

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -12,6 +12,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  WPT_COMMAND_LINE_ARG: "${{ inputs.layout == 'layout-2013' && '--legacy-layout' || '' }}"
 
 jobs:
   linux-wpt:
@@ -65,7 +66,7 @@ jobs:
       - name: Run tests
         if: ${{ inputs.wpt != 'sync' }}
         run: |
-          python3 ./mach test-wpt --with-${{ inputs.layout }} \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --release --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
@@ -77,7 +78,7 @@ jobs:
       - name: Run tests (sync)
         if: ${{ inputs.wpt == 'sync' }}
         run: |
-          python3 ./mach test-wpt --with-${{ inputs.layout }} \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --release --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -10,6 +10,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  WPT_COMMAND_LINE_ARG: "${{ inputs.layout == 'layout-2013' && '--legacy-layout' || '' }}"
 
 jobs:
   mac-wpt:
@@ -45,7 +46,7 @@ jobs:
         run: python3 ./mach smoketest --release
       - name: Run tests
         run: |
-          python3 ./mach test-wpt --with-${{ inputs.layout }} \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --release --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -52,8 +52,8 @@ jobs:
           export CURRENT_DATE=$(date +"%d-%m-%Y")
           echo $CURRENT_DATE
           echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
-          ./mach update-wpt --layout-2013 wpt-logs-linux-layout-2013/test-wpt.*.log
-          ./mach update-wpt --layout-2020 wpt-logs-linux-layout-2020/test-wpt.*.log
+          ./mach update-wpt --legacy-layout wpt-logs-linux-layout-2013/test-wpt.*.log
+          ./mach update-wpt wpt-logs-linux-layout-2020/test-wpt.*.log
           git add tests/wpt/meta tests/wpt/meta-legacy-layout
           git commit -a --amend --no-edit
       - name: Push changes

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -257,7 +257,6 @@ class CommandBase(object):
         self.config["build"].setdefault("mode", "")
         self.config["build"].setdefault("debug-assertions", False)
         self.config["build"].setdefault("debug-mozjs", False)
-        self.config["build"].setdefault("layout-2020", True)
         self.config["build"].setdefault("media-stack", "auto")
         self.config["build"].setdefault("ccache", "")
         self.config["build"].setdefault("rustflags", "")

--- a/python/wpt/__init__.py
+++ b/python/wpt/__init__.py
@@ -31,10 +31,8 @@ def create_parser():
                         help="Run under chaos mode in rr until a failure is captured")
     parser.add_argument('--pref', default=[], action="append", dest="prefs",
                         help="Pass preferences to servo")
-    parser.add_argument('--layout-2020', '--with-layout-2020', default=True,
-                        action="store_true", help="Use expected results for the 2020 layout engine")
-    parser.add_argument('--layout-2013', '--with-layout-2013', default=False,
-                        action="store_true", help="Use expected results for the 2013 layout engine")
+    parser.add_argument('--legacy-layout', '--layout-2013', '--with-layout-2013', default=False,
+                        action="store_true", help="Use expected results for the legacy layout engine")
     parser.add_argument('--log-servojson', action="append", type=mozlog.commandline.log_file,
                         help="Servo's JSON logger of unexpected results")
     parser.add_argument('--always-succeed', default=False, action="store_true",
@@ -51,16 +49,15 @@ def create_parser():
 
 
 def update_args_for_legacy_layout(kwargs: dict):
-    if kwargs.pop("layout_2013"):
-        kwargs["test_paths"]["/"]["metadata_path"] = os.path.join(
-            WPT_PATH, "meta-legacy-layout"
-        )
-        kwargs["test_paths"]["/_mozilla/"]["metadata_path"] = os.path.join(
-            WPT_PATH, "mozilla", "meta-legacy-layout"
-        )
-        kwargs["test_paths"]["/_webgl/"]["metadata_path"] = os.path.join(
-            WPT_PATH, "webgl", "meta-legacy-layout"
-        )
+    kwargs["test_paths"]["/"]["metadata_path"] = os.path.join(
+        WPT_PATH, "meta-legacy-layout"
+    )
+    kwargs["test_paths"]["/_mozilla/"]["metadata_path"] = os.path.join(
+        WPT_PATH, "mozilla", "meta-legacy-layout"
+    )
+    kwargs["test_paths"]["/_webgl/"]["metadata_path"] = os.path.join(
+        WPT_PATH, "webgl", "meta-legacy-layout"
+    )
 
 
 def run_tests():

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -39,7 +39,12 @@ def set_if_none(args: dict, key: str, value):
 
 
 def run_tests(default_binary_path: str, **kwargs):
-    print(default_binary_path)
+    legacy_layout = kwargs.pop("legacy_layout")
+    message = f"Running WPT tests with {default_binary_path}"
+    if legacy_layout:
+        message += " (legacy layout)"
+    print(message)
+
     # By default, Rayon selects the number of worker threads based on the
     # available CPU count. This doesn't work very well when running tests on CI,
     # since we run so many Servo processes in parallel. The result is a lot of
@@ -81,8 +86,8 @@ def run_tests(default_binary_path: str, **kwargs):
     kwargs.setdefault("binary_args", [])
     if prefs:
         kwargs["binary_args"] += ["--pref=" + pref for pref in prefs]
-    if kwargs.get("layout_2013"):
-        kwargs["binary_args"] += ["--legacy-layout"]
+    if legacy_layout:
+        kwargs["binary_args"].append("--legacy-layout")
 
     if not kwargs.get("no_default_test_types"):
         test_types = {
@@ -98,7 +103,8 @@ def run_tests(default_binary_path: str, **kwargs):
 
     wptcommandline.check_args(kwargs)
 
-    update_args_for_legacy_layout(kwargs)
+    if legacy_layout:
+        update_args_for_legacy_layout(kwargs)
 
     mozlog.commandline.log_formatters["servo"] = (
         ServoFormatter,

--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -110,7 +110,9 @@ def update_tests(**kwargs) -> int:
     wptcommandline.set_from_config(kwargs)
     if hasattr(wptcommandline, 'check_paths'):
         wptcommandline.check_paths(kwargs)
-    update_args_for_legacy_layout(kwargs)
+
+    if kwargs.pop("legacy_layout"):
+        update_args_for_legacy_layout(kwargs)
 
     if kwargs.get('sync', False):
         return do_sync(**kwargs)
@@ -126,8 +128,7 @@ def run_update(**kwargs) -> bool:
 
 def create_parser(**_kwargs):
     parser = wptcommandline.create_parser_update()
-    parser.add_argument("--layout-2020", "--with-layout-2020", default=True, action="store_true",
-                        help="Use expected results for the 2020 layout engine")
-    parser.add_argument("--layout-2013", "--with-layout-2013", default=False, action="store_true",
-                        help="Use expected results for the 2013 layout engine")
+    parser.add_argument("--legacy-layout", "--layout-2013", "--with-layout-2013",
+                        default=False, action="store_true",
+                        help="Use expected results for the legacy layout engine")
     return parser


### PR DESCRIPTION
This also prints a better message when starting tests.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change command-line arguments.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
