### PR TITLE
Flow inlines around floats

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -105,11 +105,11 @@ where
     }
 }
 
-impl flow_relative::Vec2<Length> {
+impl<T: Zero> flow_relative::Vec2<T> {
     pub fn zero() -> Self {
         Self {
-            inline: Length::zero(),
-            block: Length::zero(),
+            inline: T::zero(),
+            block: T::zero(),
         }
     }
 }
@@ -155,7 +155,7 @@ impl flow_relative::Vec2<Option<&'_ LengthPercentage>> {
     }
 }
 
-impl flow_relative::Rect<Length> {
+impl<T: Zero> flow_relative::Rect<T> {
     pub fn zero() -> Self {
         Self {
             start_corner: flow_relative::Vec2::zero(),
@@ -342,6 +342,17 @@ where
             inline_end: self.inline_end + other.inline_end,
             block_start: self.block_start + other.block_start,
             block_end: self.block_end + other.block_end,
+        }
+    }
+}
+
+impl<T: Zero> flow_relative::Sides<T> {
+    pub(crate) fn zero() -> flow_relative::Sides<T> {
+        flow_relative::Sides {
+            inline_start: T::zero(),
+            inline_end: T::zero(),
+            block_start: T::zero(),
+            block_end: T::zero(),
         }
     }
 }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -65,6 +65,17 @@ pub(crate) struct PaddingBorderMargin {
     pub padding_border_sums: flow_relative::Vec2<Length>,
 }
 
+impl PaddingBorderMargin {
+    pub(crate) fn zero() -> Self {
+        Self {
+            padding: flow_relative::Sides::zero(),
+            border: flow_relative::Sides::zero(),
+            margin: flow_relative::Sides::zero(),
+            padding_border_sums: flow_relative::Vec2::zero(),
+        }
+    }
+}
+
 pub(crate) trait ComputedValuesExt {
     fn inline_size_is_length(&self) -> bool;
     fn inline_box_offsets_are_both_non_auto(&self) -> bool;

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-wrap-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-wrap-001.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-wrap-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5514-brdr-lw-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5514-brdr-lw-001.xht.ini
@@ -1,2 +1,0 @@
-[c5514-brdr-lw-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5525-fltblck-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5525-fltblck-000.xht.ini
@@ -1,2 +1,0 @@
-[c5525-fltblck-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5525-fltinln-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5525-fltinln-000.xht.ini
@@ -1,2 +1,0 @@
-[c5525-fltinln-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5525-fltmrgn-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5525-fltmrgn-000.xht.ini
@@ -1,2 +1,0 @@
-[c5525-fltmrgn-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5525-fltwidth-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5525-fltwidth-001.xht.ini
@@ -1,2 +1,0 @@
-[c5525-fltwidth-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c5526-fltclr-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c5526-fltclr-000.xht.ini
@@ -1,2 +1,0 @@
-[c5526-fltclr-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/adjoining-float-nested-forced-clearance-003.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/adjoining-float-nested-forced-clearance-003.html.ini
@@ -1,2 +1,0 @@
-[adjoining-float-nested-forced-clearance-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-applies-to-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-applies-to-012.xht.ini
@@ -1,2 +1,0 @@
-[clear-applies-to-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-inline-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-inline-001.xht.ini
@@ -1,2 +1,0 @@
-[clear-inline-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-029.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-029.xht.ini
@@ -1,2 +1,0 @@
-[floats-029.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-030.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-030.xht.ini
@@ -1,2 +1,0 @@
-[floats-030.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-031.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-031.xht.ini
@@ -1,2 +1,0 @@
-[floats-031.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-036.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-036.xht.ini
@@ -1,2 +1,0 @@
-[floats-036.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-040.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-040.xht.ini
@@ -1,2 +1,0 @@
-[floats-040.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-114.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-114.xht.ini
@@ -1,2 +1,0 @@
-[floats-114.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-122.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-122.xht.ini
@@ -1,2 +1,0 @@
-[floats-122.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-132.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-132.xht.ini
@@ -1,2 +1,0 @@
-[floats-132.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-133.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-133.xht.ini
@@ -1,2 +1,0 @@
-[floats-133.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-134.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-134.xht.ini
@@ -1,2 +1,0 @@
-[floats-134.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-136.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-136.xht.ini
@@ -1,2 +1,0 @@
-[floats-136.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-139.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-139.xht.ini
@@ -1,2 +1,0 @@
-[floats-139.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/float-no-content-beside-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/float-no-content-beside-001.html.ini
@@ -1,2 +1,0 @@
-[float-no-content-beside-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/float-nowrap-5.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/float-nowrap-5.html.ini
@@ -1,2 +1,0 @@
-[float-nowrap-5.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/float-nowrap-6.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/float-nowrap-6.html.ini
@@ -1,2 +1,0 @@
-[float-nowrap-6.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-004.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-004.html.ini
@@ -1,2 +1,0 @@
-[floats-placement-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-007.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-007.html.ini
@@ -1,2 +1,0 @@
-[floats-placement-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-003.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-004-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-004-ref.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-004-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-004-ref2.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-004-ref2.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-004-ref2.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-placement-vertical-004.xht.ini
@@ -1,2 +1,0 @@
-[floats-placement-vertical-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-left-table.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-002-left-table.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-002-left-table.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-001l.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-bfc-001l.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-001r.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-001r.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-bfc-001r.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-002l.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-002l.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-bfc-002l.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-bfc-003l.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-001l.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-001l.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-inline-001l.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-001r.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-001r.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-inline-001r.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-002l.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-002l.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-inline-002l.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-002r.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-002r.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-inline-002r.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-003l.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-003l.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-inline-003l.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-003r.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-top-below-inline-003r.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-top-below-inline-003r.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-zero-height-wrap-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-zero-height-wrap-001.xht.ini
@@ -1,2 +1,0 @@
-[floats-zero-height-wrap-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/hit-test-floats-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/hit-test-floats-001.html.ini
@@ -1,3 +1,0 @@
-[hit-test-floats-001.html]
-  [hit-test-floats-001]
-    expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-012.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-013.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-015.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inlines-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inlines-013.xht.ini
@@ -1,2 +1,0 @@
-[inlines-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/positioning-float-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/positioning-float-001.xht.ini
@@ -1,2 +1,0 @@
-[positioning-float-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-013.xht.ini
@@ -1,2 +1,0 @@
-[text-indent-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-wrap-001-ref-inline-margin.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-wrap-001-ref-inline-margin.xht.ini
@@ -1,2 +1,0 @@
-[text-indent-wrap-001-ref-inline-margin.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-012.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-012.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-017.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-017.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-017.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-004.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-004.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-replaced-004.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_a.html.ini
@@ -1,2 +1,0 @@
-[block_formatting_context_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_complex_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_complex_a.html.ini
@@ -1,2 +1,0 @@
-[block_formatting_context_complex_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/block_formatting_context_relative_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/block_formatting_context_relative_a.html.ini
@@ -1,2 +1,0 @@
-[block_formatting_context_relative_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/content_color.html.ini
+++ b/tests/wpt/mozilla/meta/css/content_color.html.ini
@@ -1,2 +1,0 @@
-[content_color.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/floats_inline_margins_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/floats_inline_margins_a.html.ini
@@ -1,2 +1,0 @@
-[floats_inline_margins_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/floats_percentage_width_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/floats_percentage_width_a.html.ini
@@ -1,2 +1,0 @@
-[floats_percentage_width_a.html]
-  expected: FAIL


### PR DESCRIPTION
This implements the rest of the bulk of float support. Now inline
elements flow around floats and floats can be pushed down by inline
elements before them.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->

Fixes #29825.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
