### PR TITLE
Properly handle degenerate aspect ratios

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -566,11 +566,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             match image {
                 Image::None => {},
                 Image::Gradient(ref gradient) => {
-                    let intrinsic = IntrinsicSizes {
-                        width: None,
-                        height: None,
-                        ratio: None,
-                    };
+                    let intrinsic = IntrinsicSizes::empty();
                     if let Some(layer) =
                         &background::layout_layer(self, &source, builder, index, intrinsic)
                     {
@@ -607,13 +603,10 @@ impl<'a> BuilderForBoxFragment<'a> {
 
                     // FIXME: https://drafts.csswg.org/css-images-4/#the-image-resolution
                     let dppx = 1.0;
-
-                    let intrinsic = IntrinsicSizes {
-                        width: Some(Length::new(width as f32 / dppx)),
-                        height: Some(Length::new(height as f32 / dppx)),
-                        // FIXME https://github.com/w3c/csswg-drafts/issues/4572
-                        ratio: Some(width as f32 / height as f32),
-                    };
+                    let intrinsic = IntrinsicSizes::from_width_and_height(
+                        width as f32 / dppx,
+                        height as f32 / dppx,
+                    );
 
                     if let Some(layer) =
                         background::layout_layer(self, &source, builder, index, intrinsic)


### PR DESCRIPTION
When a replaced element has a degenerate aspect ratio, it should be
handled as if that element did not have an aspect ratio according to
https://drafts.csswg.org/css-images/#natural-aspect-ratio.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
