### PR TITLE
Revert "Enable grouping of patch updates in Dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  groups:
-    patch-updates:
-      update-types:
-       - patch
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
Reverts servo/servo#30208

There have been no new patch updates from dependabot in the last
couple of days. Based on the [logs], it seems dependabot has been timing
out, which could be related to the recently enabled grouping functionality.

[logs]: https://github.com/servo/servo/network/updates/715904495