### PR TITLE
Remove logic for skipping duplicate workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,23 +48,6 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            // Never skip workflow runs for pull requests, merge groups, or manually triggered
-            // workfows / try jobs, which might need to actually run / retry WPT tests.
-            if (!['issue_comment', 'merge_group', 'pull_request', 'workflow_run', 'workflow_call'].includes(context.eventName)) {
-              // Skip the run if an identical run already exists. This helps to avoid running
-              // the workflow over and over again for the same commit hash.
-              if ((await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "main.yml",
-                head_sha: context.sha,
-                status: "success",
-              })).data.workflow_runs.length > 0) {
-                console.log("Skipping workflow, because of duplicate job.");
-                return { platform: "none" };
-              }
-            }
-
             // We need to pick defaults if the inputs are not provided. Unprovided inputs
             // are empty strings in this template.
             let platform = "${{ inputs.platform }}" || "linux";


### PR DESCRIPTION
This logic was more important when bors was triggering duplicate
workflows. Now that we've switched away from bors, benefit is much more
marginal. In addition, it adds a bunch of complexity to an already
complicated workflow. We can always re-add it later if we notice too
many duplicated workflows.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change the CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
