### PR TITLE
Fix crash from service worker

### DIFF
--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -373,6 +373,7 @@ impl ServiceWorkerGlobalScope {
                     };
 
                 let scope = global.upcast::<WorkerGlobalScope>();
+                let _ac = enter_realm(&*scope);
 
                 unsafe {
                     // Handle interrupt requests


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I've added `enter_realm` before `dispatch_activate` but still got 9 fails after running
```shell
./mach test-wpt tests/wpt/mozilla/tests/mozilla/service-workers/service-worker-registration.https.html
```
Maybe I missed something else?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30141  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
