### PR TITLE
Use arboard in servoshell instead of rust-clipboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,9 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac57f2b058a76363e357c056e4f74f1945bf734d37b8b3ef49066c4787dde0fc"
 dependencies = [
- "clipboard-win 4.5.0",
+ "clipboard-win",
+ "core-graphics",
+ "image",
  "log",
  "objc",
  "objc-foundation",
@@ -812,28 +814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "clipboard"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a904646c0340239dcf7c51677b33928bf24fdf424b79a57909c0109075b2e7"
-dependencies = [
- "clipboard-win 2.2.0",
- "objc",
- "objc-foundation",
- "objc_id",
- "x11-clipboard",
-]
-
-[[package]]
-name = "clipboard-win"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -5543,9 +5523,9 @@ dependencies = [
 name = "servoshell"
 version = "0.0.1"
 dependencies = [
+ "arboard",
  "backtrace",
  "cc",
- "clipboard",
  "egui",
  "egui-winit",
  "egui_glow",
@@ -7367,15 +7347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x11-clipboard"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
-dependencies = [
- "xcb",
-]
-
-[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7406,16 +7377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
 dependencies = [
  "nix 0.24.3",
-]
-
-[[package]]
-name = "xcb"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -44,8 +44,8 @@ webgl_backtrace = ["libservo/webgl_backtrace"]
 xr-profile = ["libservo/xr-profile"]
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
+arboard = "3"
 backtrace = { workspace = true }
-clipboard = "0.5"
 egui = "0.22.0"
 egui_glow = { version = "0.22.0", features = ["winit"] }
 egui-winit = { version = "0.22.0", default-features = false, features = ["clipboard", "wayland"] }

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -20,6 +20,7 @@ rand = [
 [ignore]
 # Ignored packages with duplicated versions
 packages = [
+    "ahash",
     "arrayvec",
     "base64",
     "cfg-if",
@@ -80,10 +81,6 @@ packages = [
 
     # Temporarily duplicated until gleam can be upgrded.
     "uuid",
-
-    # winit port minibrowser (servo/servo#30049)
-    "clipboard-win",
-    "ahash",
 ]
 # Files that are ignored for all tidy and lint checks.
 files = [


### PR DESCRIPTION
rust-clipboard is unmaintained, which means that it pulls in very old
dependencies (including a version xcb with 3 critical security
vulnerabilities). In addition, we already depend on arboard. This
removes four crates from our dependency graph.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
