### PR TITLE
Fix PlacementAmongFloats to avoid missing some bands

### DIFF
--- a/tests/wpt/meta-legacy-layout/css/CSS2/floats/floats-wrap-bfc-008.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/CSS2/floats/floats-wrap-bfc-008.html.ini
@@ -1,0 +1,2 @@
+[floats-wrap-bfc-008.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-001.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-fit-001.xht]
-  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/floats/floats-wrap-bfc-008.html
+++ b/tests/wpt/tests/css/CSS2/floats/floats-wrap-bfc-008.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>CSS Test: BFC root after 2 floats</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#floats">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The BFC root doesn't fit next to the 1st float, but fits next to the 2nd one,
+  so it should be placed next to the 2nd one.">
+<style>
+.wrapper {
+  width: 100px;
+}
+.float {
+  float: left;
+  height: 50px;
+  background: green;
+}
+.bfc {
+  overflow: hidden;
+  width: 50px;
+  height: 50px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="wrapper">
+  <div class="float" style="width: 100px"></div>
+  <div class="float" style="width: 50px"></div>
+  <div class="bfc" style=""></div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
PlacementAmongFloats would stop iterating when current_bands would be empty, even if next_band wasn't at infinity.

Then the BFC root or replaced block was placed after all the floats, even if it could fit next to some of them.

This patch moves the next_band into current_bands so that the loop keeps considering bands.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #30276
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
