### PR TITLE
constellation: crash to a new “sad tab” error page

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2842,7 +2842,6 @@ where
             new_browsing_context_info: None,
             window_size,
         });
-
     }
 
     fn handle_log_entry(

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2844,7 +2844,8 @@ where
             top_level_browsing_context_id,
             browsing_context_id,
             new_pipeline_id,
-            // pipeline already closed, so Yes avoids harmless but useless close
+            // Pipeline already closed by close_browsing_context_children, so we can pass Yes here
+            // to avoid closing again in handle_activate_document_msg (though it would be harmless)
             replace: Some(NeedsToReload::Yes(old_pipeline_id, old_load_data)),
             new_browsing_context_info: None,
             window_size,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2817,12 +2817,14 @@ where
         warn!("creating replacement pipeline for crash page");
 
         let new_pipeline_id = PipelineId::new();
-        let mut new_load_data = old_load_data.clone();
-        new_load_data.crash = Some(if let Some(backtrace) = backtrace {
-            format!("{}\n{}", reason, backtrace)
-        } else {
-            reason
-        });
+        let new_load_data = LoadData {
+            crash: Some(
+                backtrace
+                    .map(|b| format!("{}\n{}", reason, b))
+                    .unwrap_or(reason),
+            ),
+            ..old_load_data.clone()
+        };
 
         let sandbox = IFrameSandboxState::IFrameSandboxed;
         let is_private = false;

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -61,6 +61,7 @@ pub enum Resource {
     RippyPNG,
     MediaControlsCSS,
     MediaControlsJS,
+    Crash,
 }
 
 pub trait ResourceReaderMethods {
@@ -96,6 +97,7 @@ fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
                 Resource::RippyPNG => "rippy.png",
                 Resource::MediaControlsCSS => "media-controls.css",
                 Resource::MediaControlsJS => "media-controls.js",
+                Resource::Crash => "crash.html",
             };
             let mut path = env::current_exe().unwrap();
             path = path.canonicalize().unwrap();

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -61,7 +61,7 @@ pub enum Resource {
     RippyPNG,
     MediaControlsCSS,
     MediaControlsJS,
-    Crash,
+    CrashHTML,
 }
 
 pub trait ResourceReaderMethods {
@@ -97,7 +97,7 @@ fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
                 Resource::RippyPNG => "rippy.png",
                 Resource::MediaControlsCSS => "media-controls.css",
                 Resource::MediaControlsJS => "media-controls.js",
-                Resource::Crash => "crash.html",
+                Resource::CrashHTML => "crash.html",
             };
             let mut path = env::current_exe().unwrap();
             path = path.canonicalize().unwrap();

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -196,8 +196,10 @@ pub async fn main_fetch(
     let mut response = None;
 
     // Servo internal: return a crash error when a crash error page is needed
-    if request.crash {
-        response = Some(Response::network_error(NetworkError::Crash));
+    if let Some(ref details) = request.crash {
+        response = Some(Response::network_error(NetworkError::Crash(
+            details.clone(),
+        )));
     }
 
     // Step 2.

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -195,6 +195,11 @@ pub async fn main_fetch(
     // Step 1.
     let mut response = None;
 
+    // crash
+    if request.crash {
+        response = Some(Response::network_error(NetworkError::Internal("crash".into())));
+    }
+
     // Step 2.
     if request.local_urls_only {
         if !matches!(

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -195,9 +195,9 @@ pub async fn main_fetch(
     // Step 1.
     let mut response = None;
 
-    // crash
+    // Servo internal: return a crash error when a crash error page is needed
     if request.crash {
-        response = Some(Response::network_error(NetworkError::Internal("crash".into())));
+        response = Some(Response::network_error(NetworkError::Crash));
     }
 
     // Step 2.

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -761,7 +761,7 @@ pub enum NetworkError {
     /// SSL validation error, to be converted to Resource::BadCertHTML in the HTML parser
     SslValidation(String, Vec<u8>),
     /// Crash error, to be converted to Resource::Crash in the HTML parser
-    Crash,
+    Crash(String),
 }
 
 impl NetworkError {

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -758,8 +758,10 @@ pub enum NetworkError {
     /// Could be any of the internal errors, like unsupported scheme, connection errors, etc.
     Internal(String),
     LoadCancelled,
-    /// SSL validation error that has to be handled in the HTML parser
+    /// SSL validation error, to be converted to Resource::BadCertHTML in the HTML parser
     SslValidation(String, Vec<u8>),
+    /// Crash error, to be converted to Resource::Crash in the HTML parser
+    Crash,
 }
 
 impl NetworkError {

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -758,9 +758,9 @@ pub enum NetworkError {
     /// Could be any of the internal errors, like unsupported scheme, connection errors, etc.
     Internal(String),
     LoadCancelled,
-    /// SSL validation error, to be converted to Resource::BadCertHTML in the HTML parser
+    /// SSL validation error, to be converted to Resource::BadCertHTML in the HTML parser.
     SslValidation(String, Vec<u8>),
-    /// Crash error, to be converted to Resource::Crash in the HTML parser
+    /// Crash error, to be converted to Resource::Crash in the HTML parser.
     Crash(String),
 }
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -254,7 +254,7 @@ pub struct RequestBuilder {
     pub initiator: Initiator,
     pub https_state: HttpsState,
     pub response_tainting: ResponseTainting,
-    pub crash: bool,
+    pub crash: Option<String>,
 }
 
 impl RequestBuilder {
@@ -285,7 +285,7 @@ impl RequestBuilder {
             csp_list: None,
             https_state: HttpsState::None,
             response_tainting: ResponseTainting::Basic,
-            crash: false,
+            crash: None,
         }
     }
 
@@ -384,7 +384,7 @@ impl RequestBuilder {
         self
     }
 
-    pub fn crash(mut self, crash: bool) -> Self {
+    pub fn crash(mut self, crash: Option<String>) -> Self {
         self.crash = crash;
         self
     }
@@ -496,7 +496,7 @@ pub struct Request {
     #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
     pub csp_list: Option<CspList>,
     pub https_state: HttpsState,
-    pub crash: bool,
+    pub crash: Option<String>,
 }
 
 impl Request {
@@ -537,7 +537,7 @@ impl Request {
             response_tainting: ResponseTainting::Basic,
             csp_list: None,
             https_state: https_state,
-            crash: false,
+            crash: None,
         }
     }
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -254,6 +254,7 @@ pub struct RequestBuilder {
     pub initiator: Initiator,
     pub https_state: HttpsState,
     pub response_tainting: ResponseTainting,
+    pub crash: bool,
 }
 
 impl RequestBuilder {
@@ -284,6 +285,7 @@ impl RequestBuilder {
             csp_list: None,
             https_state: HttpsState::None,
             response_tainting: ResponseTainting::Basic,
+            crash: false,
         }
     }
 
@@ -382,6 +384,11 @@ impl RequestBuilder {
         self
     }
 
+    pub fn crash(mut self, crash: bool) -> Self {
+        self.crash = crash;
+        self
+    }
+
     pub fn build(self) -> Request {
         let mut request = Request::new(
             self.url.clone(),
@@ -415,6 +422,7 @@ impl RequestBuilder {
         request.parser_metadata = self.parser_metadata;
         request.csp_list = self.csp_list;
         request.response_tainting = self.response_tainting;
+        request.crash = self.crash;
         request
     }
 }
@@ -488,6 +496,7 @@ pub struct Request {
     #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
     pub csp_list: Option<CspList>,
     pub https_state: HttpsState,
+    pub crash: bool,
 }
 
 impl Request {
@@ -528,6 +537,7 @@ impl Request {
             response_tainting: ResponseTainting::Basic,
             csp_list: None,
             https_state: https_state,
+            crash: false,
         }
     }
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -254,6 +254,7 @@ pub struct RequestBuilder {
     pub initiator: Initiator,
     pub https_state: HttpsState,
     pub response_tainting: ResponseTainting,
+    /// Servo internal: if crash details are present, trigger a crash error page with these details
     pub crash: Option<String>,
 }
 
@@ -496,6 +497,7 @@ pub struct Request {
     #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
     pub csp_list: Option<CspList>,
     pub https_state: HttpsState,
+    /// Servo internal: if crash details are present, trigger a crash error page with these details
     pub crash: Option<String>,
 }
 

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -254,7 +254,7 @@ pub struct RequestBuilder {
     pub initiator: Initiator,
     pub https_state: HttpsState,
     pub response_tainting: ResponseTainting,
-    /// Servo internal: if crash details are present, trigger a crash error page with these details
+    /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
 }
 
@@ -497,7 +497,7 @@ pub struct Request {
     #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
     pub csp_list: Option<CspList>,
     pub https_state: HttpsState,
-    /// Servo internal: if crash details are present, trigger a crash error page with these details
+    /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
 }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -787,7 +787,7 @@ impl FetchResponseListener for ParserContext {
                 match &error {
                     NetworkError::SslValidation(..) |
                     NetworkError::Internal(..) |
-                    NetworkError::Crash => {
+                    NetworkError::Crash(..) => {
                         let mut meta = Metadata::default(self.url.clone());
                         let mime: Option<Mime> = "text/html".parse().ok();
                         meta.set_content_type(mime.as_ref());
@@ -896,9 +896,10 @@ impl FetchResponseListener for ParserContext {
                     parser.push_string_input_chunk(page);
                     parser.parse_sync();
                 },
-                Some(NetworkError::Crash) => {
+                Some(NetworkError::Crash(details)) => {
                     self.is_synthesized_document = true;
                     let page = resources::read_string(Resource::CrashHTML);
+                    let page = page.replace("${details}", &details);
                     parser.push_string_input_chunk(page);
                     parser.parse_sync();
                 },

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -898,7 +898,7 @@ impl FetchResponseListener for ParserContext {
                 },
                 Some(NetworkError::Crash) => {
                     self.is_synthesized_document = true;
-                    let page = resources::read_string(Resource::Crash);
+                    let page = resources::read_string(Resource::CrashHTML);
                     parser.push_string_input_chunk(page);
                     parser.parse_sync();
                 },

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -890,10 +890,17 @@ impl FetchResponseListener for ParserContext {
                 }
                 if let Some(reason) = network_error {
                     self.is_synthesized_document = true;
-                    let page = resources::read_string(Resource::NetErrorHTML);
-                    let page = page.replace("${reason}", &reason);
-                    parser.push_string_input_chunk(page);
-                    parser.parse_sync();
+                    if reason == "crash" {
+                        // TODO use a separate enum variant instead of keying on reason
+                        let page = resources::read_string(Resource::Crash);
+                        parser.push_string_input_chunk(page);
+                        parser.parse_sync();
+                    } else {
+                        let page = resources::read_string(Resource::NetErrorHTML);
+                        let page = page.replace("${reason}", &reason);
+                        parser.push_string_input_chunk(page);
+                        parser.parse_sync();
+                    }
                 }
             },
             (mime::TEXT, mime::XML, _) |

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -129,7 +129,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
         csp_list: None,
         https_state: request.https_state,
         response_tainting: request.response_tainting,
-        crash: false,
+        crash: None,
     }
 }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -129,6 +129,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
         csp_list: None,
         https_state: request.https_state,
         response_tainting: request.response_tainting,
+        crash: false,
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3843,7 +3843,8 @@ impl ScriptThread {
             .headers(load_data.headers)
             .body(load_data.data)
             .redirect_mode(RedirectMode::Manual)
-            .origin(incomplete.origin.immutable().clone());
+            .origin(incomplete.origin.immutable().clone())
+            .crash(load_data.crash);
 
         let context = ParserContext::new(id, load_data.url);
         self.incomplete_parser_contexts

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3870,6 +3870,7 @@ impl ScriptThread {
     ) {
         match fetch_metadata {
             Ok(_) => (),
+            Err(NetworkError::Crash(..)) => (),
             Err(ref e) => {
                 warn!("Network error: {:?}", e);
             },

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -184,6 +184,9 @@ pub struct LoadData {
     pub srcdoc: String,
     /// The inherited context is Secure, None if not inherited
     pub inherited_secure_context: Option<bool>,
+
+    /// Whether we are reloading to a crash error page.
+    pub crash: bool,
 }
 
 /// The result of evaluating a javascript scheme url.
@@ -218,6 +221,7 @@ impl LoadData {
             referrer_policy: referrer_policy,
             srcdoc: "".to_string(),
             inherited_secure_context,
+            crash: false,
         }
     }
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -185,7 +185,7 @@ pub struct LoadData {
     /// The inherited context is Secure, None if not inherited
     pub inherited_secure_context: Option<bool>,
 
-    /// Crash details, if we are reloading to a crash error page.
+    /// Servo internal: if crash details are present, trigger a crash error page with these details
     pub crash: Option<String>,
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -185,7 +185,7 @@ pub struct LoadData {
     /// The inherited context is Secure, None if not inherited
     pub inherited_secure_context: Option<bool>,
 
-    /// Servo internal: if crash details are present, trigger a crash error page with these details
+    /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -185,8 +185,8 @@ pub struct LoadData {
     /// The inherited context is Secure, None if not inherited
     pub inherited_secure_context: Option<bool>,
 
-    /// Whether we are reloading to a crash error page.
-    pub crash: bool,
+    /// Crash details, if we are reloading to a crash error page.
+    pub crash: Option<String>,
 }
 
 /// The result of evaluating a javascript scheme url.
@@ -221,7 +221,7 @@ impl LoadData {
             referrer_policy: referrer_policy,
             srcdoc: "".to_string(),
             inherited_secure_context,
-            crash: false,
+            crash: None,
         }
     }
 }

--- a/ports/gstplugin/resources.rs
+++ b/ports/gstplugin/resources.rs
@@ -35,6 +35,7 @@ fn filename(file: Resource) -> &'static str {
         Resource::RippyPNG => "rippy.png",
         Resource::MediaControlsCSS => "media-controls.css",
         Resource::MediaControlsJS => "media-controls.js",
+        Resource::Crash => "crash.html",
     }
 }
 

--- a/ports/gstplugin/resources.rs
+++ b/ports/gstplugin/resources.rs
@@ -35,7 +35,7 @@ fn filename(file: Resource) -> &'static str {
         Resource::RippyPNG => "rippy.png",
         Resource::MediaControlsCSS => "media-controls.css",
         Resource::MediaControlsJS => "media-controls.js",
-        Resource::Crash => "crash.html",
+        Resource::CrashHTML => "crash.html",
     }
 }
 

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -920,6 +920,7 @@ impl ResourceReaderMethods for ResourceReaderInstance {
             Resource::MediaControlsJS => {
                 &include_bytes!("../../../../resources/media-controls.js")[..]
             },
+            Resource::Crash => &include_bytes!("../../../../resources/crash.html")[..],
         })
     }
 

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -920,7 +920,7 @@ impl ResourceReaderMethods for ResourceReaderInstance {
             Resource::MediaControlsJS => {
                 &include_bytes!("../../../../resources/media-controls.js")[..]
             },
-            Resource::Crash => &include_bytes!("../../../../resources/crash.html")[..],
+            Resource::CrashHTML => &include_bytes!("../../../../resources/crash.html")[..],
         })
     }
 

--- a/ports/servoshell/resources.rs
+++ b/ports/servoshell/resources.rs
@@ -30,6 +30,7 @@ fn filename(file: Resource) -> &'static str {
         Resource::RippyPNG => "rippy.png",
         Resource::MediaControlsCSS => "media-controls.css",
         Resource::MediaControlsJS => "media-controls.js",
+        Resource::Crash => "crash.html",
     }
 }
 

--- a/ports/servoshell/resources.rs
+++ b/ports/servoshell/resources.rs
@@ -30,7 +30,7 @@ fn filename(file: Resource) -> &'static str {
         Resource::RippyPNG => "rippy.png",
         Resource::MediaControlsCSS => "media-controls.css",
         Resource::MediaControlsJS => "media-controls.js",
-        Resource::Crash => "crash.html",
+        Resource::CrashHTML => "crash.html",
     }
 }
 

--- a/resources/crash.html
+++ b/resources/crash.html
@@ -1,9 +1,8 @@
-<html>
-<body>
-  <!-- TODO not this -->
-  <p>uh oh! servo has made a big fucky wucky! a widdle fucko boingo!</p>
+<p>Servo crashed!</p>
 
-  <!-- TODO does this resubmit POST or otherwise preserve the LoadData? -->
-  <button onclick="location.reload()">Reload</button>
-</body>
-</html>
+<!-- NOTE: unlike in Firefox and Chrome, this reloads POST as GET -->
+<!-- see whatwg/html#6600 + whatwg/html#3215 -->
+<button onclick="location.reload()">Reload</button>
+
+<pre><plaintext>
+${details}

--- a/resources/crash.html
+++ b/resources/crash.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+  <!-- TODO not this -->
+  <p>uh oh! servo has made a big fucky wucky! a widdle fucko boingo!</p>
+
+  <!-- TODO does this resubmit POST or otherwise preserve the LoadData? -->
+  <button onclick="location.reload()">Reload</button>
+</body>
+</html>


### PR DESCRIPTION
Servo historically recovered from crashes by navigating forwards to an about:failure page, but we never got around to reimplementing about:failure in the fetch-based network stack, so it turned into an “Unexpected scheme” error.

That approach was less than ideal though, because navigating forwards trashes your forward history. Even if we were to navigate with replacement, the location bar would show “about:failure” instead of the original URL, and we would lose the original LoadData containing the request body and headers and so on. In both cases, it would be tricky to make the reload command work properly or add a reload button to the error page.

This patch replaces our use of about:failure with an error page that behaves similarly to a network error.

![image](https://github.com/servo/servo/assets/465303/ab0ac9cc-7dcc-4776-b8f6-7c47f64499df)

When the constellation detects a panic, we create a replacement pipeline as before, but we now reload the page in place with the same LoadData except with .crash set to the crash details. This gets plumbed through RequestBuilder and Request to the fetch code, which converts it to a NetworkError::Crash, which the HTML parser renders as a new kind of error page. The user can then view the reason and backtrace if any, and click a button to reload the page.

To test this manually, go to `data:text/html,<script>document.write()</script>` after applying the patch below:

```diff
diff --git a/components/script/dom/document.rs b/components/script/dom/document.rs
index c3d83be696..bbaab2182d 100644
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5127,6 +5127,7 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/multipage/#dom-document-write
     fn Write(&self, text: Vec<DOMString>) -> ErrorResult {
+        panic!();
         if !self.is_html_document() {
             // Step 1.
             return Err(Error::InvalidState);
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #17187

<!-- Either: -->
- [ ] There are tests for these changes OR
    - **feedback on how we can test this would be appreciated :)**
- [ ] These changes do not require tests because ___