### PR TITLE
Set LIBCLANG_PATH instead of msys deletion in windows wotkflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,10 @@ env:
   SHELL: /bin/bash
   CCACHE: "ccache"
   CARGO_TARGET_DIR: C:\\a\\servo\\servo\\target
+  # clang_sys will search msys path before Program Files\LLVM
+  # so we need to override this behaviour until we update clang-sys
+  # https://github.com/KyleMayes/clang-sys/issues/150
+  LIBCLANG_PATH: C:\\Program Files\\LLVM\\bin
 
 jobs:
   build:
@@ -55,8 +59,6 @@ jobs:
           Start-BitsTransfer -Source https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip -Destination C:\\wix311-binaries.zip
           Expand-Archive C:\\wix311-binaries.zip -DestinationPath C:\\wix
           echo "C:\\wix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Remove msys from PATH # see https://github.com/actions/runner-images/issues/2208
-        run: Remove-Item -LiteralPath "C:\msys64\" -Force -Recurse
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
       - name: Bootstrap


### PR DESCRIPTION
until we get newer clang-sys due to https://github.com/KyleMayes/clang-sys/issues/150

Deleting msys takes 10 minutes!


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
