### PR TITLE
Replace `immeta` dependency with `imsz`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,14 +2863,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "immeta"
-version = "0.4.1"
-source = "git+https://github.com/fabricedesre/immeta.git#7f08e1bd465078baedfb37269aea1612af9bfd5f"
-dependencies = [
- "arrayvec 0.7.4",
- "byteorder",
- "num-traits",
-]
+name = "imsz"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a49eaebc8750bcba241df1e1e47ebb51b81eb35c65e8f11ffa0aebac353f7f"
 
 [[package]]
 name = "indexmap"
@@ -3886,7 +3882,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper_serde",
- "immeta",
+ "imsz",
  "ipc-channel",
  "lazy_static",
  "libflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ hyper = "0.14"
 hyper-rustls = { version = "0.24", default-features = false, features = ["webpki-tokio", "http1", "http2", "tls12", "logging", "acceptor"] }
 hyper_serde = "0.13"
 image = "0.24"
+imsz = "0.2"
 indexmap = { version = "1.0.2", features = ["std"] }
 ipc-channel = "0.17"
 itertools = "0.8"
@@ -111,8 +112,6 @@ opt-level = 3
 
 # This is here to dedupe winapi since mio 0.6 is still using winapi 0.2.
 mio = { git = "https://github.com/servo/mio.git", branch = "servo-mio-0.6.22" }
-# fork that bumps crates since the original repo is archived.
-immeta = { git = "https://github.com/fabricedesre/immeta.git" }
 
 # This is required because we want all dependencies that use WebRender to
 # use our vendored version.

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -34,7 +34,7 @@ http = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "http2", "tcp", "stream"] }
 hyper-rustls = { workspace = true }
 hyper_serde = { workspace = true }
-immeta = "0.4"
+imsz = { workspace = true }
 ipc-channel = { workspace = true }
 lazy_static = { workspace = true }
 libflate = "0.1"

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use embedder_traits::resources::{self, Resource};
-use immeta::load_from_buf;
+use imsz::imsz_from_reader;
 use ipc_channel::ipc::IpcSender;
 use net_traits::image::base::{load_from_memory, Image, ImageMetadata};
 use net_traits::image_cache::{
@@ -608,19 +608,18 @@ impl ImageCache for ImageCacheImpl {
                 let mut store = self.store.lock().unwrap();
                 let pending_load = store.pending_loads.get_by_key_mut(&id).unwrap();
                 pending_load.bytes.extend_from_slice(&data);
+
                 //jmr0 TODO: possibly move to another task?
-                if let None = pending_load.metadata {
-                    if let Ok(metadata) = load_from_buf(&pending_load.bytes.as_slice()) {
-                        let dimensions = metadata.dimensions();
-                        let img_metadata = ImageMetadata {
-                            width: dimensions.width,
-                            height: dimensions.height,
-                        };
-                        for listener in &pending_load.listeners {
-                            listener.respond(ImageResponse::MetadataLoaded(img_metadata.clone()));
-                        }
-                        pending_load.metadata = Some(img_metadata);
+                let mut reader = std::io::Cursor::new(pending_load.bytes.as_slice());
+                if let Ok(info) = imsz_from_reader(&mut reader) {
+                    let img_metadata = ImageMetadata {
+                        width: info.width as u32,
+                        height: info.height as u32,
+                    };
+                    for listener in &pending_load.listeners {
+                        listener.respond(ImageResponse::MetadataLoaded(img_metadata.clone()));
                     }
+                    pending_load.metadata = Some(img_metadata);
                 }
             },
             (FetchResponseMsg::ProcessResponseEOF(result), key) => {


### PR DESCRIPTION
`immeta` is no longer maintained and `imsz` seems to have support for
more image formats as well as having no dependencies itself.


<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
