### PR TITLE
Servoshell as default member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "ports/libsimpleservo/jniapi/",
     "tests/unit/*",
 ]
+default-members = ["ports/servoshell"]
 exclude = [".cargo"]
 
 [workspace.dependencies]


### PR DESCRIPTION
Small part of #29906 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it only changes the default build target.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
