### PR TITLE
Layout 2013: Don't make gradient display items for zero-sized gradients

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -138,8 +138,10 @@ pub fn clip(
 
 /// Determines where to place an element background image or gradient.
 ///
-/// Photos have their resolution as intrinsic size while gradients have
+/// Images have their resolution as intrinsic size while gradients have
 /// no intrinsic size.
+///
+/// Return `None` if the background size is zero, otherwise a [`BackgroundPlacement`].
 pub fn placement(
     bg: &Background,
     viewport_size: Size2D<Au>,
@@ -149,7 +151,7 @@ pub fn placement(
     border_padding: SideOffsets2D<Au>,
     border_radii: BorderRadius,
     index: usize,
-) -> BackgroundPlacement {
+) -> Option<BackgroundPlacement> {
     let bg_attachment = *get_cyclic(&bg.background_attachment.0, index);
     let bg_clip = *get_cyclic(&bg.background_clip.0, index);
     let bg_origin = *get_cyclic(&bg.background_origin.0, index);
@@ -180,6 +182,9 @@ pub fn placement(
     };
 
     let mut tile_size = compute_background_image_size(bg_size, bounds.size, intrinsic_size);
+    if tile_size.is_empty() {
+        return None;
+    }
 
     let mut tile_spacing = Size2D::zero();
     let own_position = bounds.size - tile_size;
@@ -206,14 +211,18 @@ pub fn placement(
         clip_rect.size.height,
     );
 
-    BackgroundPlacement {
+    if tile_size.is_empty() {
+        return None;
+    }
+
+    Some(BackgroundPlacement {
         bounds,
         tile_size,
         tile_spacing,
         clip_rect,
         clip_radii,
         fixed,
-    }
+    })
 }
 
 fn tile_image_round(

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -829,9 +829,10 @@ impl Fragment {
             index,
         );
 
-        if placement.tile_size.is_empty() {
-            return;
-        }
+        let placement = match placement {
+            Some(placement) => placement,
+            None => return,
+        };
 
         state.clipping_and_scrolling_scope(|state| {
             if !placement.clip_radii.is_zero() {
@@ -950,6 +951,11 @@ impl Fragment {
             border::radii(absolute_bounds, style.get_border()),
             index,
         );
+
+        let placement = match placement {
+            Some(placement) => placement,
+            None => return,
+        };
 
         state.clipping_and_scrolling_scope(|state| {
             if !placement.clip_radii.is_zero() {


### PR DESCRIPTION
Before WebRender would ignore these, but newer version of WebRender have
issues with them. This change simply prevents legacy layout from
creating display items for these types of gradients. This is already the
behavior of non-legacy layout.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this does not change visible behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
