### PR TITLE
Layout 2020: Rename `flow_relative` types to `Logical...`

### DIFF
--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -6,7 +6,7 @@
 
 use style::properties::longhands::flex_direction::computed_value::T as FlexDirection;
 
-use crate::geom::flow_relative::{Rect, Sides, Vec2};
+use crate::geom::{LogicalRect, LogicalSides, LogicalVec2};
 
 #[derive(Clone, Copy)]
 pub(super) struct FlexRelativeVec2<T> {
@@ -98,8 +98,8 @@ impl FlexAxis {
         }
     }
 
-    pub fn vec2_to_flex_relative<T>(self, flow_relative: Vec2<T>) -> FlexRelativeVec2<T> {
-        let Vec2 { inline, block } = flow_relative;
+    pub fn vec2_to_flex_relative<T>(self, flow_relative: LogicalVec2<T>) -> FlexRelativeVec2<T> {
+        let LogicalVec2 { inline, block } = flow_relative;
         match self {
             FlexAxis::Row => FlexRelativeVec2 {
                 main: inline,
@@ -112,14 +112,14 @@ impl FlexAxis {
         }
     }
 
-    pub fn vec2_to_flow_relative<T>(self, flex_relative: FlexRelativeVec2<T>) -> Vec2<T> {
+    pub fn vec2_to_flow_relative<T>(self, flex_relative: FlexRelativeVec2<T>) -> LogicalVec2<T> {
         let FlexRelativeVec2 { main, cross } = flex_relative;
         match self {
-            FlexAxis::Row => Vec2 {
+            FlexAxis::Row => LogicalVec2 {
                 inline: main,
                 block: cross,
             },
-            FlexAxis::Column => Vec2 {
+            FlexAxis::Column => LogicalVec2 {
                 block: main,
                 inline: cross,
             },
@@ -135,7 +135,7 @@ macro_rules! sides_mapping_methods {
             },
         )+
     ) => {
-        pub fn sides_to_flex_relative<T>(self, flow_relative: Sides<T>) -> FlexRelativeSides<T> {
+        pub fn sides_to_flex_relative<T>(self, flow_relative: LogicalSides<T>) -> FlexRelativeSides<T> {
             match self {
                 $(
                     $variant => FlexRelativeSides {
@@ -145,10 +145,10 @@ macro_rules! sides_mapping_methods {
             }
         }
 
-        pub fn sides_to_flow_relative<T>(self, flex_relative: FlexRelativeSides<T>) -> Sides<T> {
+        pub fn sides_to_flow_relative<T>(self, flex_relative: FlexRelativeSides<T>) -> LogicalSides<T> {
             match self {
                 $(
-                    $variant => Sides {
+                    $variant => LogicalSides {
                         $( $flow_relative_side: flex_relative.$flex_relative_side, )+
                     },
                 )+
@@ -235,7 +235,7 @@ pub(super) fn rect_to_flow_relative<T>(
     main_start_cross_start_sides_are: MainStartCrossStart,
     base_rect_size: FlexRelativeVec2<T>,
     rect: FlexRelativeRect<T>,
-) -> Rect<T>
+) -> LogicalRect<T>
 where
     T: Copy + std::ops::Add<Output = T> + std::ops::Sub<Output = T>,
 {
@@ -258,14 +258,14 @@ where
     let flow_relative_base_rect_size = flex_axis.vec2_to_flow_relative(base_rect_size);
 
     // Finally, convert back to (start corner, size)
-    let start_corner = Vec2 {
+    let start_corner = LogicalVec2 {
         inline: flow_relative_offsets.inline_start,
         block: flow_relative_offsets.block_start,
     };
-    let end_corner_position = Vec2 {
+    let end_corner_position = LogicalVec2 {
         inline: flow_relative_base_rect_size.inline - flow_relative_offsets.inline_end,
         block: flow_relative_base_rect_size.block - flow_relative_offsets.block_end,
     };
     let size = &end_corner_position - &start_corner;
-    Rect { start_corner, size }
+    LogicalRect { start_corner, size }
 }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -26,7 +26,7 @@ use crate::formatting_contexts::{
 use crate::fragment_tree::{
     BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment,
 };
-use crate::geom::flow_relative::{Rect, Sides, Vec2};
+use crate::geom::{LogicalRect, LogicalSides, LogicalVec2};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::replaced::ReplacedContent;
 use crate::sizing::{self, ContentSizes};
@@ -587,7 +587,7 @@ impl BlockLevelBox {
                     // This is incorrect, however we do not know the
                     // correct positioning until later, in place_block_level_fragment,
                     // and this value will be adjusted there
-                    Vec2::zero(),
+                    LogicalVec2::zero(),
                     containing_block,
                 );
                 let hoisted_fragment = hoisted_box.fragment.clone();
@@ -771,14 +771,14 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         sequential_layout_state.adjoin_assign(&CollapsedMargin::new(margin.block_end));
     }
 
-    let content_rect = Rect {
-        start_corner: Vec2 {
+    let content_rect = LogicalRect {
+        start_corner: LogicalVec2 {
             block: pbm.padding.block_start +
                 pbm.border.block_start +
                 clearance.unwrap_or_else(Length::zero),
             inline: pbm.padding.inline_start + pbm.border.inline_start + margin.inline_start,
         },
-        size: Vec2 {
+        size: LogicalVec2 {
             block: block_size,
             inline: containing_block_for_children.inline_size,
         },
@@ -842,12 +842,12 @@ impl NonReplacedFormattingContext {
                 .clamp_between_extremums(min_box_size.block, max_box_size.block)
         });
 
-        let content_rect = Rect {
-            start_corner: Vec2 {
+        let content_rect = LogicalRect {
+            start_corner: LogicalVec2 {
                 block: pbm.padding.block_start + pbm.border.block_start,
                 inline: pbm.padding.inline_start + pbm.border.inline_start + margin.inline_start,
             },
-            size: Vec2 {
+            size: LogicalVec2 {
                 block: block_size,
                 inline: containing_block_for_children.inline_size,
             },
@@ -919,7 +919,7 @@ impl NonReplacedFormattingContext {
                     style: &self.style,
                 },
             );
-            content_size = Vec2 {
+            content_size = LogicalVec2 {
                 inline: inline_size,
                 block: block_size.auto_is(|| {
                     layout
@@ -950,7 +950,7 @@ impl NonReplacedFormattingContext {
             });
 
             // Create a PlacementAmongFloats using the minimum size in all dimensions as the object size.
-            let minimum_size_of_block = &Vec2 {
+            let minimum_size_of_block = &LogicalVec2 {
                 inline: min_box_size.inline,
                 block: block_size.auto_is(|| min_box_size.block),
             } + &pbm.padding_border_sums;
@@ -983,7 +983,7 @@ impl NonReplacedFormattingContext {
                     },
                 );
 
-                content_size = Vec2 {
+                content_size = LogicalVec2 {
                     inline: proposed_inline_size,
                     block: block_size.auto_is(|| {
                         layout
@@ -1030,7 +1030,7 @@ impl NonReplacedFormattingContext {
             );
         }
 
-        let margin = Sides {
+        let margin = LogicalSides {
             inline_start: margin_inline_start,
             inline_end: margin_inline_end,
             block_start: margin_block_start,
@@ -1053,8 +1053,8 @@ impl NonReplacedFormattingContext {
         );
         sequential_layout_state.adjoin_assign(&CollapsedMargin::new(margin.block_end));
 
-        let content_rect = Rect {
-            start_corner: Vec2 {
+        let content_rect = LogicalRect {
+            start_corner: LogicalVec2 {
                 block: pbm.padding.block_start +
                     pbm.border.block_start +
                     clearance.unwrap_or_else(Length::zero),
@@ -1140,21 +1140,21 @@ fn layout_in_flow_replaced_block_level<'a>(
         );
     };
 
-    let margin = Sides {
+    let margin = LogicalSides {
         inline_start: margin_inline_start,
         inline_end: margin_inline_end,
         block_start: margin_block_start,
         block_end: margin_block_end,
     };
 
-    let start_corner = Vec2 {
+    let start_corner = LogicalVec2 {
         block: pbm.padding.block_start +
             pbm.border.block_start +
             clearance.unwrap_or_else(Length::zero),
         inline: pbm.padding.inline_start + pbm.border.inline_start + margin.inline_start,
     };
 
-    let content_rect = Rect {
+    let content_rect = LogicalRect {
         start_corner,
         size: content_size,
     };
@@ -1175,9 +1175,9 @@ fn layout_in_flow_replaced_block_level<'a>(
 struct ContainingBlockPaddingBorderAndMargin<'a> {
     containing_block: ContainingBlock<'a>,
     pbm: PaddingBorderMargin,
-    min_box_size: Vec2<Length>,
-    max_box_size: Vec2<Option<Length>>,
-    margin: Sides<Length>,
+    min_box_size: LogicalVec2<Length>,
+    max_box_size: LogicalVec2<Option<Length>>,
+    margin: LogicalSides<Length>,
 }
 
 /// Given the style for in in flow box and its containing block, determine the containing
@@ -1213,7 +1213,7 @@ fn solve_containing_block_padding_border_and_margin_for_in_flow_box<'a>(
     let inline_margins =
         solve_inline_margins_for_in_flow_block_level(containing_block, &pbm, inline_size);
     let block_margins = solve_block_margins_for_in_flow_block_level(&pbm);
-    let margin = Sides {
+    let margin = LogicalSides {
         inline_start: inline_margins.0,
         inline_end: inline_margins.1,
         block_start: block_margins.0,
@@ -1256,7 +1256,7 @@ fn solve_clearance_and_inline_margins_avoiding_floats(
     containing_block: &ContainingBlock,
     block_start_margin: &CollapsedMargin,
     pbm: &PaddingBorderMargin,
-    size: Vec2<Length>,
+    size: LogicalVec2<Length>,
     style: &Arc<ComputedValues>,
 ) -> (Option<Length>, (Length, Length)) {
     let (clearance, placement_rect) = sequential_layout_state
@@ -1284,7 +1284,7 @@ fn solve_inline_margins_avoiding_floats(
     containing_block: &ContainingBlock,
     pbm: &PaddingBorderMargin,
     inline_size: Length,
-    placement_rect: Rect<Length>,
+    placement_rect: LogicalRect<Length>,
 ) -> (Length, Length) {
     let inline_adjustment = placement_rect.start_corner.inline -
         sequential_layout_state
@@ -1424,7 +1424,7 @@ impl PlacementState {
                 }
             },
             Fragment::AbsoluteOrFixedPositioned(fragment) => {
-                let offset = Vec2 {
+                let offset = LogicalVec2 {
                     block: self.current_margin.solve() + self.current_block_direction_position,
                     inline: Length::new(0.),
                 };

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -22,8 +22,7 @@ use crate::flow::inline::InlineLevelBox;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::FragmentTree;
-use crate::geom::flow_relative::Vec2;
-use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalSize};
+use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::replaced::ReplacedContent;
 use crate::style_ext::{ComputedValuesExt, Display, DisplayGeneratingBox, DisplayInside};
@@ -274,7 +273,7 @@ impl BoxTree {
             PhysicalSize::new(Length::new(viewport.width), Length::new(viewport.height)),
         );
         let initial_containing_block = DefiniteContainingBlock {
-            size: Vec2 {
+            size: LogicalVec2 {
                 inline: physical_containing_block.size.width,
                 block: physical_containing_block.size.height,
             },

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -13,8 +13,9 @@ use style::Zero;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment};
 use crate::cell::ArcRefCell;
-use crate::geom::flow_relative::{Rect, Sides};
-use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize};
+use crate::geom::{
+    LogicalRect, LogicalSides, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
+};
 
 #[derive(Serialize)]
 pub(crate) struct BoxFragment {
@@ -27,11 +28,11 @@ pub(crate) struct BoxFragment {
     /// From the containing block’s start corner…?
     /// This might be broken when the containing block is in a different writing mode:
     /// https://drafts.csswg.org/css-writing-modes/#orthogonal-flows
-    pub content_rect: Rect<Length>,
+    pub content_rect: LogicalRect<Length>,
 
-    pub padding: Sides<Length>,
-    pub border: Sides<Length>,
-    pub margin: Sides<Length>,
+    pub padding: LogicalSides<Length>,
+    pub border: LogicalSides<Length>,
+    pub margin: LogicalSides<Length>,
 
     /// When the `clear` property is not set to `none`, it may introduce clearance.
     /// Clearance is some extra spacing that is added above the top margin,
@@ -55,10 +56,10 @@ impl BoxFragment {
         base_fragment_info: BaseFragmentInfo,
         style: ServoArc<ComputedValues>,
         children: Vec<Fragment>,
-        content_rect: Rect<Length>,
-        padding: Sides<Length>,
-        border: Sides<Length>,
-        margin: Sides<Length>,
+        content_rect: LogicalRect<Length>,
+        padding: LogicalSides<Length>,
+        border: LogicalSides<Length>,
+        margin: LogicalSides<Length>,
         clearance: Option<Length>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
     ) -> BoxFragment {
@@ -89,10 +90,10 @@ impl BoxFragment {
         base_fragment_info: BaseFragmentInfo,
         style: ServoArc<ComputedValues>,
         children: Vec<Fragment>,
-        content_rect: Rect<Length>,
-        padding: Sides<Length>,
-        border: Sides<Length>,
-        margin: Sides<Length>,
+        content_rect: LogicalRect<Length>,
+        padding: LogicalSides<Length>,
+        border: LogicalSides<Length>,
+        margin: LogicalSides<Length>,
         clearance: Option<Length>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
         overconstrained: PhysicalSize<bool>,
@@ -142,11 +143,11 @@ impl BoxFragment {
         )
     }
 
-    pub fn padding_rect(&self) -> Rect<Length> {
+    pub fn padding_rect(&self) -> LogicalRect<Length> {
         self.content_rect.inflate(&self.padding)
     }
 
-    pub fn border_rect(&self) -> Rect<Length> {
+    pub fn border_rect(&self) -> LogicalRect<Length> {
         self.padding_rect().inflate(&self.border)
     }
 

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -19,8 +19,7 @@ use webrender_api::{FontInstanceKey, ImageKey};
 
 use super::{BaseFragment, BoxFragment, ContainingBlockManager, HoistedSharedFragment, Tag};
 use crate::cell::ArcRefCell;
-use crate::geom::flow_relative::{Rect, Sides};
-use crate::geom::PhysicalRect;
+use crate::geom::{LogicalRect, LogicalSides, PhysicalRect};
 use crate::style_ext::ComputedValuesExt;
 
 #[derive(Serialize)]
@@ -68,7 +67,7 @@ pub(crate) struct CollapsedMargin {
 #[derive(Serialize)]
 pub(crate) struct AnonymousFragment {
     pub base: BaseFragment,
-    pub rect: Rect<Length>,
+    pub rect: LogicalRect<Length>,
     pub children: Vec<ArcRefCell<Fragment>>,
     pub mode: WritingMode,
 
@@ -104,7 +103,7 @@ pub(crate) struct TextFragment {
     pub base: BaseFragment,
     #[serde(skip_serializing)]
     pub parent_style: ServoArc<ComputedValues>,
-    pub rect: Rect<Length>,
+    pub rect: LogicalRect<Length>,
     pub font_metrics: FontMetrics,
     #[serde(skip_serializing)]
     pub font_key: FontInstanceKey,
@@ -118,7 +117,7 @@ pub(crate) struct ImageFragment {
     pub base: BaseFragment,
     #[serde(skip_serializing)]
     pub style: ServoArc<ComputedValues>,
-    pub rect: Rect<Length>,
+    pub rect: LogicalRect<Length>,
     #[serde(skip_serializing)]
     pub image_key: ImageKey,
 }
@@ -128,7 +127,7 @@ pub(crate) struct IFrameFragment {
     pub base: BaseFragment,
     pub pipeline_id: PipelineId,
     pub browsing_context_id: BrowsingContextId,
-    pub rect: Rect<Length>,
+    pub rect: LogicalRect<Length>,
     #[serde(skip_serializing)]
     pub style: ServoArc<ComputedValues>,
 }
@@ -247,7 +246,7 @@ impl Fragment {
 }
 
 impl AnonymousFragment {
-    pub fn new(rect: Rect<Length>, children: Vec<Fragment>, mode: WritingMode) -> Self {
+    pub fn new(rect: LogicalRect<Length>, children: Vec<Fragment>, mode: WritingMode) -> Self {
         // FIXME(mrobinson, bug 25564): We should be using the containing block
         // here to properly convert scrollable overflow to physical geometry.
         let containing_block = PhysicalRect::zero();
@@ -320,7 +319,7 @@ impl IFrameFragment {
 }
 
 impl CollapsedBlockMargins {
-    pub fn from_margin(margin: &Sides<Length>) -> Self {
+    pub fn from_margin(margin: &LogicalSides<Length>) -> Self {
         Self {
             collapsed_through: false,
             start: CollapsedMargin::new(margin.block_start),

--- a/components/layout_2020/fragment_tree/hoisted_shared_fragment.rs
+++ b/components/layout_2020/fragment_tree/hoisted_shared_fragment.rs
@@ -7,7 +7,7 @@ use style::values::computed::{Length, LengthPercentage};
 
 use super::Fragment;
 use crate::cell::ArcRefCell;
-use crate::geom::flow_relative::Vec2;
+use crate::geom::LogicalVec2;
 
 /// A reference to a Fragment which is shared between `HoistedAbsolutelyPositionedBox`
 /// and its placeholder `AbsoluteOrFixedPositionedFragment` in the original tree position.
@@ -15,11 +15,11 @@ use crate::geom::flow_relative::Vec2;
 #[derive(Serialize)]
 pub(crate) struct HoistedSharedFragment {
     pub fragment: Option<ArcRefCell<Fragment>>,
-    pub box_offsets: Vec2<AbsoluteBoxOffsets>,
+    pub box_offsets: LogicalVec2<AbsoluteBoxOffsets>,
 }
 
 impl HoistedSharedFragment {
-    pub(crate) fn new(box_offsets: Vec2<AbsoluteBoxOffsets>) -> Self {
+    pub(crate) fn new(box_offsets: LogicalVec2<AbsoluteBoxOffsets>) -> Self {
         HoistedSharedFragment {
             fragment: None,
             box_offsets,
@@ -31,7 +31,7 @@ impl HoistedSharedFragment {
     /// In some cases `inset: auto`-positioned elements do not know their precise
     /// position until after they're hoisted. This lets us adjust auto values
     /// after the fact.
-    pub(crate) fn adjust_offsets(&mut self, offsets: Vec2<Length>) {
+    pub(crate) fn adjust_offsets(&mut self, offsets: LogicalVec2<Length>) {
         self.box_offsets.inline.adjust_offset(offsets.inline);
         self.box_offsets.block.adjust_offset(offsets.block);
     }

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -30,7 +30,7 @@ pub use fragment_tree::FragmentTree;
 use style::properties::ComputedValues;
 use style::values::computed::{Length, LengthOrAuto};
 
-use crate::geom::flow_relative::Vec2;
+use crate::geom::LogicalVec2;
 
 pub struct ContainingBlock<'a> {
     inline_size: Length,
@@ -39,7 +39,7 @@ pub struct ContainingBlock<'a> {
 }
 
 struct DefiniteContainingBlock<'a> {
-    size: Vec2<Length>,
+    size: LogicalVec2<Length>,
     style: &'a ComputedValues,
 }
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -19,8 +19,7 @@ use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{
     AbsoluteBoxOffsets, BoxFragment, CollapsedBlockMargins, Fragment, HoistedSharedFragment,
 };
-use crate::geom::flow_relative::{Rect, Sides, Vec2};
-use crate::geom::{LengthOrAuto, LengthPercentageOrAuto};
+use crate::geom::{LengthOrAuto, LengthPercentageOrAuto, LogicalRect, LogicalSides, LogicalVec2};
 use crate::style_ext::{ComputedValuesExt, DisplayInside};
 use crate::{ContainingBlock, DefiniteContainingBlock};
 
@@ -68,7 +67,7 @@ impl AbsolutelyPositionedBox {
 
     pub(crate) fn to_hoisted(
         self_: ArcRefCell<Self>,
-        initial_start_corner: Vec2<Length>,
+        initial_start_corner: LogicalVec2<Length>,
         containing_block: &ContainingBlock,
     ) -> HoistedAbsolutelyPositionedBox {
         fn absolute_box_offsets(
@@ -94,7 +93,7 @@ impl AbsolutelyPositionedBox {
         let box_offsets = {
             let box_ = self_.borrow();
             let box_offsets = box_.context.style().box_offsets(containing_block);
-            Vec2 {
+            LogicalVec2 {
                 inline: absolute_box_offsets(
                     initial_start_corner.inline,
                     box_offsets.inline_start,
@@ -183,7 +182,7 @@ impl PositioningContext {
     /// See documentation for [adjust_static_position_of_hoisted_fragments].
     pub(crate) fn adjust_static_position_of_hoisted_fragments_with_offset(
         &mut self,
-        start_offset: &Vec2<CSSPixelLength>,
+        start_offset: &LogicalVec2<CSSPixelLength>,
         index: PositioningContextLength,
     ) {
         let update_fragment_if_needed = |hoisted_fragment: &mut HoistedAbsolutelyPositionedBox| {
@@ -249,10 +248,10 @@ impl PositioningContext {
         layout_context: &LayoutContext,
         new_fragment: &mut BoxFragment,
     ) {
-        let padding_rect = Rect {
+        let padding_rect = LogicalRect {
             size: new_fragment.content_rect.size.clone(),
             // Ignore the content rect’s position in its own containing block:
-            start_corner: Vec2::zero(),
+            start_corner: LogicalVec2::zero(),
         }
         .inflate(&new_fragment.padding);
         let containing_block = DefiniteContainingBlock {
@@ -490,7 +489,7 @@ impl HoistedAbsolutelyPositionedBox {
                     None,
                     &pbm,
                 );
-                Vec2 {
+                LogicalVec2 {
                     inline: LengthOrAuto::LengthPercentage(used_size.inline),
                     block: LengthOrAuto::LengthPercentage(used_size.block),
                 }
@@ -518,7 +517,7 @@ impl HoistedAbsolutelyPositionedBox {
             avoid_negative_margin_start: false,
             box_offsets: &shared_fragment.box_offsets.block,
         };
-        let overconstrained = Vec2 {
+        let overconstrained = LogicalVec2 {
             inline: inline_axis_solver.is_overconstrained_for_size(computed_size.inline),
             block: block_axis_solver.is_overconstrained_for_size(computed_size.block),
         };
@@ -592,7 +591,7 @@ impl HoistedAbsolutelyPositionedBox {
                     }
 
                     struct Result {
-                        content_size: Vec2<CSSPixelLength>,
+                        content_size: LogicalVec2<CSSPixelLength>,
                         fragments: Vec<Fragment>,
                     }
 
@@ -625,7 +624,7 @@ impl HoistedAbsolutelyPositionedBox {
                         );
                         let block_size = size.auto_is(|| independent_layout.content_block_size);
                         Result {
-                            content_size: Vec2 {
+                            content_size: LogicalVec2 {
                                 inline: inline_size,
                                 block: block_size,
                             },
@@ -664,7 +663,7 @@ impl HoistedAbsolutelyPositionedBox {
                 },
             };
 
-            let margin = Sides {
+            let margin = LogicalSides {
                 inline_start: inline_axis.margin_start,
                 inline_end: inline_axis.margin_end,
                 block_start: block_axis.margin_start,
@@ -685,8 +684,8 @@ impl HoistedAbsolutelyPositionedBox {
                 },
             };
 
-            let content_rect = Rect {
-                start_corner: Vec2 {
+            let content_rect = LogicalRect {
+                start_corner: LogicalVec2 {
                     inline: inline_start,
                     block: block_start,
                 },
@@ -860,7 +859,7 @@ fn vec_append_owned<T>(a: &mut Vec<T>, mut b: Vec<T>) {
 pub(crate) fn relative_adjustement(
     style: &ComputedValues,
     containing_block: &ContainingBlock,
-) -> Vec2<Length> {
+) -> LogicalVec2<Length> {
     // "If the height of the containing block is not specified explicitly (i.e.,
     // it depends on content height), and this element is not absolutely
     // positioned, the value computes to 'auto'.""
@@ -880,7 +879,7 @@ pub(crate) fn relative_adjustement(
             (LengthOrAuto::LengthPercentage(start), _) => start,
         }
     }
-    Vec2 {
+    LogicalVec2 {
         inline: adjust(box_offsets.inline_start, box_offsets.inline_end),
         block: adjust(box_offsets.block_start, box_offsets.block_end),
     }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -19,7 +19,7 @@ use style::Zero;
 use webrender_api as wr;
 
 use crate::geom::{
-    flow_relative, LengthOrAuto, LengthPercentageOrAuto, PhysicalSides, PhysicalSize,
+    LengthOrAuto, LengthPercentageOrAuto, LogicalSides, LogicalVec2, PhysicalSides, PhysicalSize,
 };
 use crate::ContainingBlock;
 
@@ -58,21 +58,21 @@ pub(crate) enum DisplayInside {
 /// Percentages resolved but not `auto` margins
 #[derive(Clone)]
 pub(crate) struct PaddingBorderMargin {
-    pub padding: flow_relative::Sides<Length>,
-    pub border: flow_relative::Sides<Length>,
-    pub margin: flow_relative::Sides<LengthOrAuto>,
+    pub padding: LogicalSides<Length>,
+    pub border: LogicalSides<Length>,
+    pub margin: LogicalSides<LengthOrAuto>,
 
     /// Pre-computed sums in each axis
-    pub padding_border_sums: flow_relative::Vec2<Length>,
+    pub padding_border_sums: LogicalVec2<Length>,
 }
 
 impl PaddingBorderMargin {
     pub(crate) fn zero() -> Self {
         Self {
-            padding: flow_relative::Sides::zero(),
-            border: flow_relative::Sides::zero(),
-            margin: flow_relative::Sides::zero(),
-            padding_border_sums: flow_relative::Vec2::zero(),
+            padding: LogicalSides::zero(),
+            border: LogicalSides::zero(),
+            margin: LogicalSides::zero(),
+            padding_border_sums: LogicalVec2::zero(),
         }
     }
 }
@@ -83,47 +83,44 @@ pub(crate) trait ComputedValuesExt {
     fn box_offsets(
         &self,
         containing_block: &ContainingBlock,
-    ) -> flow_relative::Sides<LengthPercentageOrAuto<'_>>;
+    ) -> LogicalSides<LengthPercentageOrAuto<'_>>;
     fn box_size(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>>;
+    ) -> LogicalVec2<LengthPercentageOrAuto<'_>>;
     fn min_box_size(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>>;
+    ) -> LogicalVec2<LengthPercentageOrAuto<'_>>;
     fn max_box_size(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Vec2<Option<&LengthPercentage>>;
+    ) -> LogicalVec2<Option<&LengthPercentage>>;
     fn content_box_size(
         &self,
         containing_block: &ContainingBlock,
         pbm: &PaddingBorderMargin,
-    ) -> flow_relative::Vec2<LengthOrAuto>;
+    ) -> LogicalVec2<LengthOrAuto>;
     fn content_min_box_size(
         &self,
         containing_block: &ContainingBlock,
         pbm: &PaddingBorderMargin,
-    ) -> flow_relative::Vec2<LengthOrAuto>;
+    ) -> LogicalVec2<LengthOrAuto>;
     fn content_max_box_size(
         &self,
         containing_block: &ContainingBlock,
         pbm: &PaddingBorderMargin,
-    ) -> flow_relative::Vec2<Option<Length>>;
+    ) -> LogicalVec2<Option<Length>>;
     fn padding_border_margin(&self, containing_block: &ContainingBlock) -> PaddingBorderMargin;
     fn padding(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Sides<&LengthPercentage>;
-    fn border_width(
-        &self,
-        containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Sides<Length>;
+    ) -> LogicalSides<&LengthPercentage>;
+    fn border_width(&self, containing_block_writing_mode: WritingMode) -> LogicalSides<Length>;
     fn margin(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Sides<LengthPercentageOrAuto<'_>>;
+    ) -> LogicalSides<LengthPercentageOrAuto<'_>>;
     fn has_transform_or_perspective(&self) -> bool;
     fn effective_z_index(&self) -> i32;
     fn establishes_block_formatting_context(&self) -> bool;
@@ -160,9 +157,9 @@ impl ComputedValuesExt for ComputedValues {
     fn box_offsets(
         &self,
         containing_block: &ContainingBlock,
-    ) -> flow_relative::Sides<LengthPercentageOrAuto<'_>> {
+    ) -> LogicalSides<LengthPercentageOrAuto<'_>> {
         let position = self.get_position();
-        flow_relative::Sides::from_physical(
+        LogicalSides::from_physical(
             &PhysicalSides::new(
                 position.top.as_ref(),
                 position.right.as_ref(),
@@ -176,9 +173,9 @@ impl ComputedValuesExt for ComputedValues {
     fn box_size(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>> {
+    ) -> LogicalVec2<LengthPercentageOrAuto<'_>> {
         let position = self.get_position();
-        flow_relative::Vec2::from_physical_size(
+        LogicalVec2::from_physical_size(
             &PhysicalSize::new(
                 size_to_length(&position.width),
                 size_to_length(&position.height),
@@ -190,9 +187,9 @@ impl ComputedValuesExt for ComputedValues {
     fn min_box_size(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>> {
+    ) -> LogicalVec2<LengthPercentageOrAuto<'_>> {
         let position = self.get_position();
-        flow_relative::Vec2::from_physical_size(
+        LogicalVec2::from_physical_size(
             &PhysicalSize::new(
                 size_to_length(&position.min_width),
                 size_to_length(&position.min_height),
@@ -204,7 +201,7 @@ impl ComputedValuesExt for ComputedValues {
     fn max_box_size(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Vec2<Option<&LengthPercentage>> {
+    ) -> LogicalVec2<Option<&LengthPercentage>> {
         fn unwrap(max_size: &MaxSize<NonNegativeLengthPercentage>) -> Option<&LengthPercentage> {
             match max_size {
                 MaxSize::LengthPercentage(length) => Some(&length.0),
@@ -212,7 +209,7 @@ impl ComputedValuesExt for ComputedValues {
             }
         }
         let position = self.get_position();
-        flow_relative::Vec2::from_physical_size(
+        LogicalVec2::from_physical_size(
             &PhysicalSize::new(unwrap(&position.max_width), unwrap(&position.max_height)),
             containing_block_writing_mode,
         )
@@ -222,13 +219,13 @@ impl ComputedValuesExt for ComputedValues {
         &self,
         containing_block: &ContainingBlock,
         pbm: &PaddingBorderMargin,
-    ) -> flow_relative::Vec2<LengthOrAuto> {
+    ) -> LogicalVec2<LengthOrAuto> {
         let box_size = self
             .box_size(containing_block.style.writing_mode)
             .percentages_relative_to(containing_block);
         match self.get_position().box_sizing {
             BoxSizing::ContentBox => box_size,
-            BoxSizing::BorderBox => flow_relative::Vec2 {
+            BoxSizing::BorderBox => LogicalVec2 {
                 // These may be negative, but will later be clamped by `min-width`/`min-height`
                 // which is clamped to zero.
                 inline: box_size.inline.map(|i| i - pbm.padding_border_sums.inline),
@@ -241,13 +238,13 @@ impl ComputedValuesExt for ComputedValues {
         &self,
         containing_block: &ContainingBlock,
         pbm: &PaddingBorderMargin,
-    ) -> flow_relative::Vec2<LengthOrAuto> {
+    ) -> LogicalVec2<LengthOrAuto> {
         let min_box_size = self
             .min_box_size(containing_block.style.writing_mode)
             .percentages_relative_to(containing_block);
         match self.get_position().box_sizing {
             BoxSizing::ContentBox => min_box_size,
-            BoxSizing::BorderBox => flow_relative::Vec2 {
+            BoxSizing::BorderBox => LogicalVec2 {
                 // Clamp to zero to make sure the used size components are non-negative
                 inline: min_box_size
                     .inline
@@ -263,7 +260,7 @@ impl ComputedValuesExt for ComputedValues {
         &self,
         containing_block: &ContainingBlock,
         pbm: &PaddingBorderMargin,
-    ) -> flow_relative::Vec2<Option<Length>> {
+    ) -> LogicalVec2<Option<Length>> {
         let max_box_size = self
             .max_box_size(containing_block.style.writing_mode)
             .percentages_relative_to(containing_block);
@@ -272,7 +269,7 @@ impl ComputedValuesExt for ComputedValues {
             BoxSizing::BorderBox => {
                 // This may be negative, but will later be clamped by `min-width`
                 // which itself is clamped to zero.
-                flow_relative::Vec2 {
+                LogicalVec2 {
                     inline: max_box_size
                         .inline
                         .map(|i| i - pbm.padding_border_sums.inline),
@@ -291,7 +288,7 @@ impl ComputedValuesExt for ComputedValues {
             .percentages_relative_to(cbis);
         let border = self.border_width(containing_block.style.writing_mode);
         PaddingBorderMargin {
-            padding_border_sums: flow_relative::Vec2 {
+            padding_border_sums: LogicalVec2 {
                 inline: padding.inline_sum() + border.inline_sum(),
                 block: padding.block_sum() + border.block_sum(),
             },
@@ -306,9 +303,9 @@ impl ComputedValuesExt for ComputedValues {
     fn padding(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Sides<&LengthPercentage> {
+    ) -> LogicalSides<&LengthPercentage> {
         let padding = self.get_padding();
-        flow_relative::Sides::from_physical(
+        LogicalSides::from_physical(
             &PhysicalSides::new(
                 &padding.padding_top.0,
                 &padding.padding_right.0,
@@ -319,12 +316,9 @@ impl ComputedValuesExt for ComputedValues {
         )
     }
 
-    fn border_width(
-        &self,
-        containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Sides<Length> {
+    fn border_width(&self, containing_block_writing_mode: WritingMode) -> LogicalSides<Length> {
         let border = self.get_border();
-        flow_relative::Sides::from_physical(
+        LogicalSides::from_physical(
             &PhysicalSides::new(
                 border.border_top_width.0,
                 border.border_right_width.0,
@@ -338,9 +332,9 @@ impl ComputedValuesExt for ComputedValues {
     fn margin(
         &self,
         containing_block_writing_mode: WritingMode,
-    ) -> flow_relative::Sides<LengthPercentageOrAuto<'_>> {
+    ) -> LogicalSides<LengthPercentageOrAuto<'_>> {
         let margin = self.get_margin();
-        flow_relative::Sides::from_physical(
+        LogicalSides::from_physical(
             &PhysicalSides::new(
                 margin.margin_top.as_ref(),
                 margin.margin_right.as_ref(),

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -14,7 +14,7 @@ use layout_2020::flow::float::{
     ContainingBlockPositionInfo, FloatBand, FloatBandNode, FloatBandTree, FloatContext, FloatSide,
     PlacementInfo,
 };
-use layout_2020::geom::flow_relative::{Rect, Vec2};
+use layout_2020::geom::{LogicalRect, LogicalVec2};
 use lazy_static::lazy_static;
 use quickcheck::{Arbitrary, Gen};
 use style::values::computed::{Clear, Length};
@@ -352,7 +352,7 @@ impl Arbitrary for FloatInput {
         let clear = u8::arbitrary(generator);
         FloatInput {
             info: PlacementInfo {
-                size: Vec2 {
+                size: LogicalVec2 {
                     inline: Length::new(width as f32),
                     block: Length::new(height as f32),
                 },
@@ -424,7 +424,7 @@ struct FloatPlacement {
 // Information about the placement of a float.
 #[derive(Clone)]
 struct PlacedFloat {
-    origin: Vec2<Length>,
+    origin: LogicalVec2<Length>,
     info: PlacementInfo,
     ceiling: Length,
     containing_block_info: ContainingBlockPositionInfo,
@@ -453,8 +453,8 @@ impl Drop for FloatPlacement {
 }
 
 impl PlacedFloat {
-    fn rect(&self) -> Rect<Length> {
-        Rect {
+    fn rect(&self) -> LogicalRect<Length> {
+        LogicalRect {
             start_corner: self.origin.clone(),
             size: self.info.size.clone(),
         }


### PR DESCRIPTION
This makes the names of flow relative geometry consistent with what is
used in the style crate and removes them from a module. With this change
it's more obvious what makes these types different from the ones in
`euclid`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
