### PR TITLE
Pass `--document-private-items` as rustdoc flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,3 +39,6 @@ linker = "lld-link.exe"
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "10.10"
+
+[build]
+rustdocflags = ["--document-private-items"]

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -269,6 +269,7 @@ class PostBuildCommands(CommandBase):
                         copy2(full_name, destination)
 
         env = self.build_env(is_build=True)
+        env['RUSTDOCFLAGS'] = "--document-private-items"
         returncode = self.run_cargo_build_like_command("doc", params, env=env, **kwargs)
         if returncode:
             return returncode

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -269,7 +269,6 @@ class PostBuildCommands(CommandBase):
                         copy2(full_name, destination)
 
         env = self.build_env(is_build=True)
-        env['RUSTDOCFLAGS'] = "--document-private-items"
         returncode = self.run_cargo_build_like_command("doc", params, env=env, **kwargs)
         if returncode:
             return returncode


### PR DESCRIPTION
This was removed in https://github.com/servo/servo/pull/29895, but as [noted on zulip](https://servo.zulipchat.com/#narrow/stream/263398-general/topic/Documentation.20missing.20for.20some.20script.20types.3F), this caused some docs to be missing.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
