### PR TITLE
No extern crate test/tidy & better RUSTFLAGS handling in mach

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -481,14 +481,16 @@ class CommandBase(object):
         elif self.config["build"]["incremental"] is not None:
             env["CARGO_INCREMENTAL"] = "0"
 
+        env['RUSTFLAGS'] = env.get('RUSTFLAGS', "")
+
         if self.config["build"]["rustflags"]:
-            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " " + self.config["build"]["rustflags"]
+            env['RUSTFLAGS'] += " " + self.config["build"]["rustflags"]
 
         # Turn on rust's version of lld if we are on x86 Linux.
         # TODO(mrobinson): Gradually turn this on for more platforms, when support stabilizes.
         # See https://github.com/rust-lang/rust/issues/39915
         if not self.cross_compile_target and effective_target == "x86_64-unknown-linux-gnu":
-            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + servo.platform.get().linker_flag()
+            env['RUSTFLAGS'] += " " + servo.platform.get().linker_flag()
 
         if not (self.config["build"]["ccache"] == ""):
             env['CCACHE'] = self.config["build"]["ccache"]
@@ -497,7 +499,7 @@ class CommandBase(object):
         if self.cross_compile_target and (
             self.cross_compile_target.startswith('arm')
                 or self.cross_compile_target.startswith('aarch64')):
-            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C target-feature=+neon"
+            env['RUSTFLAGS'] += " -C target-feature=+neon"
 
         env["CARGO_TARGET_DIR"] = servo.util.get_target_dir()
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -499,7 +499,6 @@ class CommandBase(object):
                 or self.cross_compile_target.startswith('aarch64')):
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C target-feature=+neon"
 
-        env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -W unused-extern-crates"
         env["CARGO_TARGET_DIR"] = servo.util.get_target_dir()
 
         if self.config["build"]["thinlto"]:

--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -108,7 +108,6 @@ class CheckTidiness(unittest.TestCase):
         errors = tidy.collect_errors_for_files(iterFile('rust_tidy.rs'), [], [tidy.check_rust], print_text=False)
         self.assertTrue('mod declaration is not in alphabetical order' in next(errors)[2])
         self.assertEqual('mod declaration spans multiple lines', next(errors)[2])
-        self.assertTrue('extern crate declaration is not in alphabetical order' in next(errors)[2])
         self.assertTrue('derivable traits list is not in alphabetical order' in next(errors)[2])
         self.assertEqual('found an empty line following a {', next(errors)[2])
         self.assertEqual('use &[T] instead of &Vec<T>', next(errors)[2])

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -538,7 +538,6 @@ def check_rust(file_name, lines):
 
     prev_open_brace = False
     multi_line_string = False
-    prev_crate = {}
     prev_mod = {}
     prev_feature_name = ""
     indent = 0

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -640,22 +640,6 @@ def check_rust(file_name, lines):
             yield (idx + 1, "found an empty line following a {")
         prev_open_brace = line.endswith("{")
 
-        # check alphabetical order of extern crates
-        if line.startswith("extern crate "):
-            # strip "extern crate " from the begin and ";" from the end
-            crate_name = line[13:-1]
-            if indent not in prev_crate:
-                prev_crate[indent] = ""
-            if prev_crate[indent] > crate_name and check_alphabetical_order:
-                yield(idx + 1, decl_message.format("extern crate declaration")
-                      + decl_expected.format(prev_crate[indent])
-                      + decl_found.format(crate_name))
-            prev_crate[indent] = crate_name
-
-        if line == "}":
-            for i in [i for i in prev_crate.keys() if i > indent]:
-                del prev_crate[i]
-
         # check alphabetical order of feature attributes in lib.rs files
         if is_lib_rs_file:
             match = re.search(r"#!\[feature\((.*)\)\]", line)


### PR DESCRIPTION
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they remove obsolete tidy and rust flags.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
