### PR TITLE
Add --document-private-items to Docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compile docs
         run: python3 ./mach doc
         env:
-          RUSTDOCFLAGS: -Z unstable-options --disable-minification
+          RUSTDOCFLAGS: -Z unstable-options --disable-minification --document-private-items
       - name: Upload docs
         run: |
           cd target/doc


### PR DESCRIPTION
Docs CI overrides RUSTDOCFLAGS with it's own flags.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fixup Docs CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
