### PR TITLE
[NFC] servoshell: clarify that device_pixels_per_px is an override

### DIFF
--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -47,7 +47,7 @@ enum PumpResult {
 impl App {
     pub fn run(
         no_native_titlebar: bool,
-        device_pixels_per_px: Option<f32>,
+        device_pixel_ratio_override: Option<f32>,
         user_agent: Option<String>,
         url: Option<String>,
     ) {
@@ -55,13 +55,16 @@ impl App {
 
         // Implements window methods, used by compositor.
         let window = if opts::get().headless {
-            headless_window::Window::new(opts::get().initial_window_size, device_pixels_per_px)
+            headless_window::Window::new(
+                opts::get().initial_window_size,
+                device_pixel_ratio_override,
+            )
         } else {
             Rc::new(headed_window::Window::new(
                 opts::get().initial_window_size,
                 &events_loop,
                 no_native_titlebar,
-                device_pixels_per_px,
+                device_pixel_ratio_override,
             ))
         };
 

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -60,7 +60,7 @@ pub struct Window {
     keys_down: RefCell<HashMap<VirtualKeyCode, Key>>,
     animation_state: Cell<AnimationState>,
     fullscreen: Cell<bool>,
-    device_pixels_per_px: Option<f32>,
+    device_pixel_ratio_override: Option<f32>,
     xr_window_poses: RefCell<Vec<Rc<XRWindowPose>>>,
     modifiers_state: Cell<ModifiersState>,
 }
@@ -82,7 +82,7 @@ impl Window {
         win_size: Size2D<u32, DeviceIndependentPixel>,
         events_loop: &EventsLoop,
         no_native_titlebar: bool,
-        device_pixels_per_px: Option<f32>,
+        device_pixel_ratio_override: Option<f32>,
     ) -> Window {
         let opts = opts::get();
 
@@ -157,7 +157,7 @@ impl Window {
             inner_size: Cell::new(inner_size),
             primary_monitor,
             screen_size,
-            device_pixels_per_px,
+            device_pixel_ratio_override,
             xr_window_poses: RefCell::new(vec![]),
             modifiers_state: Cell::new(ModifiersState::empty()),
             toolbar_height: Cell::new(0.0),
@@ -291,8 +291,8 @@ impl Window {
     }
 
     fn servo_hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-        match self.device_pixels_per_px {
-            Some(device_pixels_per_px) => Scale::new(device_pixels_per_px),
+        match self.device_pixel_ratio_override {
+            Some(override_value) => Scale::new(override_value),
             _ => match opts::get().output_file {
                 Some(_) => Scale::new(1.0),
                 None => self.device_hidpi_factor(),

--- a/ports/servoshell/headless_window.rs
+++ b/ports/servoshell/headless_window.rs
@@ -25,13 +25,13 @@ pub struct Window {
     webrender_surfman: WebrenderSurfman,
     animation_state: Cell<AnimationState>,
     fullscreen: Cell<bool>,
-    device_pixels_per_px: Option<f32>,
+    device_pixel_ratio_override: Option<f32>,
 }
 
 impl Window {
     pub fn new(
         size: Size2D<u32, DeviceIndependentPixel>,
-        device_pixels_per_px: Option<f32>,
+        device_pixel_ratio_override: Option<f32>,
     ) -> Rc<dyn WindowPortsMethods> {
         // Initialize surfman
         let connection = Connection::new().expect("Failed to create connection");
@@ -47,15 +47,15 @@ impl Window {
             webrender_surfman,
             animation_state: Cell::new(AnimationState::Idle),
             fullscreen: Cell::new(false),
-            device_pixels_per_px,
+            device_pixel_ratio_override,
         };
 
         Rc::new(window)
     }
 
     fn servo_hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-        match self.device_pixels_per_px {
-            Some(device_pixels_per_px) => Scale::new(device_pixels_per_px),
+        match self.device_pixel_ratio_override {
+            Some(override_value) => Scale::new(override_value),
             _ => Scale::new(1.0),
         }
     }

--- a/ports/servoshell/main2.rs
+++ b/ports/servoshell/main2.rs
@@ -121,7 +121,7 @@ pub fn main() {
     let clean_shutdown = opts_matches.opt_present("clean-shutdown");
     let do_not_use_native_titlebar =
         opts_matches.opt_present("no-native-titlebar") || !(pref!(shell.native_titlebar.enabled));
-    let device_pixels_per_px = opts_matches.opt_str("device-pixel-ratio").map(|dppx_str| {
+    let device_pixel_ratio_override = opts_matches.opt_str("device-pixel-ratio").map(|dppx_str| {
         dppx_str.parse().unwrap_or_else(|err| {
             error!("Error parsing option: --device-pixel-ratio ({})", err);
             process::exit(1);
@@ -138,7 +138,7 @@ pub fn main() {
 
     App::run(
         do_not_use_native_titlebar,
-        device_pixels_per_px,
+        device_pixel_ratio_override,
         user_agent,
         url_opt.map(|s| s.to_string()),
     );


### PR DESCRIPTION
App and the Window types have parameters and fields called device_pixels_per_px, which sound like they contain the device pixel ratio, but they actually only contain the override given in --device-pixel-ratio (if any). The actual device pixel ratio is calculated in Window::servo_hidpi_factor.

This patch clarifies that this is the case by renaming those to device_pixel_ratio_override.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to #30341

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes