### PR TITLE
minibrowser: implement HiDPI support

### DIFF
--- a/ports/servoshell/platform/windows/servo.exe.manifest
+++ b/ports/servoshell/platform/windows/servo.exe.manifest
@@ -17,7 +17,11 @@
 
   <asmv3:application>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>true</dpiAware>
+      <!-- enable per-monitor dpi awareness where possible -->
+      <!-- https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process -->
+      <!-- https://stackoverflow.com/q/23551112 -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
This patch makes the minibrowser behave correctly under HiDPI and mixed-dpi environments, by plumbing the servoshell Window’s scale factor into egui during context creation and on ScaleFactorChanged events.

* 694349f9cb001951624f00c9fcf12cfab9b3bace exposes our calculated scale factor as Window­Ports­Methods­::hidpi­_factor
* bc5ff50fc42f29fa953ff0025071feeaacd3df8d plumbs that into egui during context creation
* a9e9c9c3ead95b5d831375a0d80d95586491e0da multiplies that by the scale factor in Window­::get­_coordinates, which affects where Servo and WebRender will put the viewport, while marking the toolbar_height fields as DeviceIndependentPixel to prevent future regressions
* 69138c0b248c4dd77a9ad4279a3fd20c49939014 multiplies toolbar_height by the scale factor in the CursorMoved handler, which affects the relative coordinates of input events, while using euclid’s Size2D and Length types to prevent future regressions
* b90e315c995a4b3bfa4f4d448788aea22b014174 intercepts Scale­Factor­Changed events so we can set egui’s scale factor manually, because we don’t always want to use the device scale factor

To test this manually:

1. Run Servo on a HiDPI monitor with `RUST_LOG=warn,servo::app=info`
2. Go to `data:text/html,<body style=margin:0>BODY` and check that:
    1. text in the toolbar is at a reasonable size and not too small
    2. text in the page is at the size you would expect for unstyled text
    3. none of the word “BODY” is cut off by the toolbar
3. If you have a mixed-dpi setup, move the window to your other monitor and:
    1. check the same things as above
    2. check that the logs contain [INFO] window scale factor changed to &lt;new dpi>, setting scale factor to &lt;new dpi>
4. Repeat with --device-pixel-ratio 1 and check that:
    1. text in the toolbar and page is too small on your HiDPI monitor
    2. those log messages always end with “setting scale factor to 1”

Test results:

* ☑️ X11 with Xft.dpi: {96,192} (note that X11 doesn’t seem to support mixed-dpi)
* ☑️ Wayland with wlr-randr --output DP-2 --scale 1 --output DP-3 --scale 2
* **macOS not yet tested, please help!**
* ☑️ Windows build 19045 with one 100% monitor and one 200% monitor

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30341

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the minibrowser is not currently testable, but euclid’s type safety is now used where possible