### PR TITLE
[NFC] servoshell: fix euclid units associated with winit geometry

### DIFF
--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -527,9 +527,9 @@ fn winit_position_to_euclid_point<T>(position: PhysicalPosition<T>) -> Point2D<T
 
 impl WindowMethods for Window {
     fn get_coordinates(&self) -> EmbedderCoordinates {
-        let win_size = winit_size_to_euclid_size(self.winit_window.outer_size()).to_i32();
-        let win_origin = self.winit_window.outer_position().unwrap_or_default();
-        let win_origin = winit_position_to_euclid_point(win_origin).to_i32();
+        let window_size = winit_size_to_euclid_size(self.winit_window.outer_size()).to_i32();
+        let window_origin = self.winit_window.outer_position().unwrap_or_default();
+        let window_origin = winit_position_to_euclid_point(window_origin).to_i32();
         let inner_size = winit_size_to_euclid_size(self.winit_window.inner_size()).to_f32();
 
         // Subtract the minibrowser toolbar height if any
@@ -543,7 +543,7 @@ impl WindowMethods for Window {
         EmbedderCoordinates {
             viewport,
             framebuffer: viewport.size,
-            window: (win_size, win_origin),
+            window: (window_size, window_origin),
             screen,
             // FIXME: Winit doesn't have API for available size. Fallback to screen size
             screen_avail: screen,

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -46,8 +46,8 @@ use crate::window_trait::{WindowPortsMethods, LINE_HEIGHT};
 pub struct Window {
     winit_window: winit::window::Window,
     webrender_surfman: WebrenderSurfman,
-    screen_size: Size2D<u32, DeviceIndependentPixel>,
-    inner_size: Cell<Size2D<u32, DeviceIndependentPixel>>,
+    screen_size: Size2D<u32, DevicePixel>,
+    inner_size: Cell<Size2D<u32, DevicePixel>>,
     toolbar_height: Cell<f32>,
     mouse_down_button: Cell<Option<winit::event::MouseButton>>,
     mouse_down_point: Cell<Point2D<i32, DevicePixel>>,
@@ -119,13 +119,8 @@ impl Window {
             .nth(0)
             .expect("No monitor detected");
 
-        let PhysicalSize {
-            width: screen_width,
-            height: screen_height,
-        } = primary_monitor.size();
-        let screen_size = Size2D::new(screen_width, screen_height);
-        let PhysicalSize { width, height } = winit_window.inner_size();
-        let inner_size = Size2D::new(width, height);
+        let screen_size = winit_size_to_euclid_size(primary_monitor.size());
+        let inner_size = winit_size_to_euclid_size(winit_window.inner_size());
 
         // Initialize surfman
         let display_handle = winit_window.raw_display_handle();
@@ -522,33 +517,32 @@ impl WindowPortsMethods for Window {
     }
 }
 
+fn winit_size_to_euclid_size<T>(size: PhysicalSize<T>) -> Size2D<T, DevicePixel> {
+    Size2D::new(size.width, size.height)
+}
+
+fn winit_position_to_euclid_point<T>(position: PhysicalPosition<T>) -> Point2D<T, DevicePixel> {
+    Point2D::new(position.x, position.y)
+}
+
 impl WindowMethods for Window {
     fn get_coordinates(&self) -> EmbedderCoordinates {
-        // Needed to convince the type system that winit's physical pixels
-        // are actually device pixels.
-        let dpr: Scale<f32, DeviceIndependentPixel, DevicePixel> = Scale::new(1.0);
-        let PhysicalSize { width, height } = self.winit_window.outer_size();
-        let PhysicalPosition { x, y } = self
-            .winit_window
-            .outer_position()
-            .unwrap_or(PhysicalPosition::new(0, 0));
-        let win_size = (Size2D::new(width as f32, height as f32) * dpr).to_i32();
-        let win_origin = (Point2D::new(x as f32, y as f32) * dpr).to_i32();
-        let screen = (self.screen_size.to_f32() * dpr).to_i32();
-
-        let PhysicalSize { width, height } = self.winit_window.inner_size();
+        let win_size = winit_size_to_euclid_size(self.winit_window.outer_size()).to_i32();
+        let win_origin = self.winit_window.outer_position().unwrap_or_default();
+        let win_origin = winit_position_to_euclid_point(win_origin).to_i32();
+        let inner_size = winit_size_to_euclid_size(self.winit_window.inner_size()).to_f32();
 
         // Subtract the minibrowser toolbar height if any
         let toolbar_height = self.toolbar_height.get();
-        let inner_size = Size2D::new(width as f32, height as f32) * dpr;
         let viewport_size = inner_size - Size2D::new(0f32, toolbar_height);
+
         let viewport_origin = DeviceIntPoint::zero(); // bottom left
         let viewport = DeviceIntRect::new(viewport_origin, viewport_size.to_i32());
+        let screen = self.screen_size.to_i32();
 
-        let framebuffer = DeviceIntSize::from_untyped(viewport.size.to_untyped());
         EmbedderCoordinates {
             viewport,
-            framebuffer,
+            framebuffer: viewport.size,
             window: (win_size, win_origin),
             screen,
             // FIXME: Winit doesn't have API for available size. Fallback to screen size


### PR DESCRIPTION
The headed Window::get_coordinates multiplies screen sizes, window sizes, and window positions by a fake dip-to-dp scale factor to work around the fact that they were incorrectly marked as DeviceIndependentPixel, when winit’s PhysicalSize and PhysicalPosition types should actually be in DevicePixel.

This patch fixes those units and adds helper functions for converting winit types to euclid types, making our geometry calculations simpler and eliminating almost all of the untyped operations.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to #30341

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes