### PR TITLE
Improve intrinsic sizing and white-space handling around forced line breaks

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -707,6 +707,22 @@ impl InlineFormattingContext {
                                         self.pending_whitespace + advance;
                                     self.pending_whitespace = Length::zero();
                                 } else {
+                                    let white_space =
+                                        text_run.parent_style.get_inherited_text().white_space;
+                                    if white_space.preserve_newlines() {
+                                        let last_byte = text_run
+                                            .text
+                                            .as_bytes()
+                                            .get(run.range.end().to_usize() - 1);
+                                        if last_byte == Some(&b'\n') {
+                                            self.had_non_whitespace_content_yet = true;
+                                            self.current_line.max_content += advance;
+                                            self.forced_line_break();
+                                            self.current_line = ContentSizes::zero();
+                                            continue;
+                                        }
+                                    }
+
                                     // Discard any leading whitespace in the IFC. This will always be trimmed.
                                     if !self.had_non_whitespace_content_yet {
                                         continue;

--- a/tests/wpt/meta/css/CSS2/text/white-space-mixed-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-mixed-003.xht.ini
@@ -1,2 +1,0 @@
-[white-space-mixed-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-004.html.ini
@@ -13,3 +13,6 @@
 
   [#target > div 6]
     expected: FAIL
+
+  [#target > div 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-overflow-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-overflow-002.html.ini
@@ -25,6 +25,3 @@
 
   [.target > * 12]
     expected: FAIL
-
-  [.target > * 10]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-overflow-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-overflow-003.html.ini
@@ -25,6 +25,3 @@
 
   [.target > * 12]
     expected: FAIL
-
-  [.target > * 8]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-break/line-break-anywhere-and-white-space-006.html.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-anywhere-and-white-space-006.html.ini
@@ -1,2 +1,0 @@
-[line-break-anywhere-and-white-space-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/pre-line-051.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/pre-line-051.html.ini
@@ -1,2 +1,0 @@
-[pre-line-051.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/pre-line-052.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/pre-line-052.html.ini
@@ -1,2 +1,0 @@
-[pre-line-052.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/pre-wrap-051.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/pre-wrap-051.html.ini
@@ -1,2 +1,0 @@
-[pre-wrap-051.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/pre-wrap-052.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/pre-wrap-052.html.ini
@@ -1,2 +1,0 @@
-[pre-wrap-052.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-019.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-019.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-019.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-020.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-020.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-020.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-pre-051.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-pre-051.html.ini
@@ -1,2 +1,0 @@
-[white-space-pre-051.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-pre-052.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-pre-052.html.ini
@@ -1,2 +1,0 @@
-[white-space-pre-052.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-zero-fontsize-001.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-zero-fontsize-001.html.ini
@@ -1,2 +1,0 @@
-[white-space-zero-fontsize-001.html]
-  expected: FAIL


### PR DESCRIPTION
This change fixes a few issues:

 - Intrinsic sizing should take into account forced line breaks.
 - Non-preserved white-space should never trigger a line break. This type of white-space can hang off the end of the line and be trimmed later. Hanging white-space is already ignored for the purposes of placing lines among floats.
 - Line breaks should immediately trigger new positioning among floats.

These changes seem a little unrelated, but fixing one of these issues triggers failures due to the other ones. Fixing all of these together leads to test progressions. 

Fixes #30350.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30350.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
