### PR TITLE
Fix scale factor of egui context

### DIFF
--- a/ports/servoshell/egui_glue.rs
+++ b/ports/servoshell/egui_glue.rs
@@ -61,9 +61,12 @@ impl EguiGlow {
             })
             .unwrap();
 
+        let mut egui_winit = egui_winit::State::new(event_loop);
+        egui_winit.set_pixels_per_point(2.);
+
         Self {
             egui_ctx: Default::default(),
-            egui_winit: egui_winit::State::new(event_loop),
+            egui_winit,
             painter,
             shapes: Default::default(),
             textures_delta: Default::default(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
The toolbar is way too small in some of my devices, and I found it hasn't set the proper scale factor(pixels_per_point) yet.