### PR TITLE
Fix scale factor of egui context

### DIFF
--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -81,7 +81,8 @@ impl App {
             minibrowser: None,
         };
 
-        if opts::get().minibrowser && window.winit_window().is_some() {
+        if opts::get().minibrowser {
+            if let Some(winit_window) = window.winit_window() {
             // Make sure the gl context is made current.
             let webrender_surfman = window.webrender_surfman();
             let webrender_gl = match webrender_surfman.connection().gl_api() {
@@ -97,7 +98,8 @@ impl App {
 
             // Set up egui context for minibrowser ui
             // Adapted from https://github.com/emilk/egui/blob/9478e50d012c5138551c38cbee16b07bc1fcf283/crates/egui_glow/examples/pure_glow.rs
-            app.minibrowser = Some(Minibrowser::new(&webrender_surfman, &events_loop).into());
+            app.minibrowser = Some(Minibrowser::new(&webrender_surfman, &events_loop, winit_window).into());
+            }
         }
 
         if let Some(mut minibrowser) = app.minibrowser() {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -83,22 +83,23 @@ impl App {
 
         if opts::get().minibrowser {
             if let Some(winit_window) = window.winit_window() {
-            // Make sure the gl context is made current.
-            let webrender_surfman = window.webrender_surfman();
-            let webrender_gl = match webrender_surfman.connection().gl_api() {
-                GLApi::GL => unsafe {
-                    gl::GlFns::load_with(|s| webrender_surfman.get_proc_address(s))
-                },
-                GLApi::GLES => unsafe {
-                    gl::GlesFns::load_with(|s| webrender_surfman.get_proc_address(s))
-                },
-            };
-            webrender_surfman.make_gl_context_current().unwrap();
-            debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR);
+                // Make sure the gl context is made current.
+                let webrender_surfman = window.webrender_surfman();
+                let webrender_gl = match webrender_surfman.connection().gl_api() {
+                    GLApi::GL => unsafe {
+                        gl::GlFns::load_with(|s| webrender_surfman.get_proc_address(s))
+                    },
+                    GLApi::GLES => unsafe {
+                        gl::GlesFns::load_with(|s| webrender_surfman.get_proc_address(s))
+                    },
+                };
+                webrender_surfman.make_gl_context_current().unwrap();
+                debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR);
 
-            // Set up egui context for minibrowser ui
-            // Adapted from https://github.com/emilk/egui/blob/9478e50d012c5138551c38cbee16b07bc1fcf283/crates/egui_glow/examples/pure_glow.rs
-            app.minibrowser = Some(Minibrowser::new(&webrender_surfman, &events_loop, winit_window).into());
+                // Set up egui context for minibrowser ui
+                // Adapted from https://github.com/emilk/egui/blob/9478e50d012c5138551c38cbee16b07bc1fcf283/crates/egui_glow/examples/pure_glow.rs
+                app.minibrowser =
+                    Some(Minibrowser::new(&webrender_surfman, &events_loop, winit_window).into());
             }
         }
 

--- a/ports/servoshell/egui_glue.rs
+++ b/ports/servoshell/egui_glue.rs
@@ -52,6 +52,7 @@ impl EguiGlow {
     /// For automatic shader version detection set `shader_version` to `None`.
     pub fn new<E>(
         event_loop: &winit::event_loop::EventLoopWindowTarget<E>,
+        window: &winit::window::Window,
         gl: std::sync::Arc<glow::Context>,
         shader_version: Option<ShaderVersion>,
     ) -> Self {
@@ -61,9 +62,12 @@ impl EguiGlow {
             })
             .unwrap();
 
+        let mut egui_winit = egui_winit::State::new(event_loop);
+        egui_winit.set_pixels_per_point(window.scale_factor() as f32);
+
         Self {
             egui_ctx: Default::default(),
-            egui_winit: egui_winit::State::new(event_loop),
+            egui_winit,
             painter,
             shapes: Default::default(),
             textures_delta: Default::default(),

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -11,6 +11,7 @@ use log::{trace, warn};
 use servo::compositing::windowing::EmbedderEvent;
 use servo::servo_url::ServoUrl;
 use servo::webrender_surfman::WebrenderSurfman;
+use winit::window::Window;
 
 use crate::browser::Browser;
 use crate::egui_glue::EguiGlow;
@@ -34,13 +35,13 @@ pub enum MinibrowserEvent {
 }
 
 impl Minibrowser {
-    pub fn new(webrender_surfman: &WebrenderSurfman, events_loop: &EventsLoop) -> Self {
+    pub fn new(webrender_surfman: &WebrenderSurfman, events_loop: &EventsLoop, window: &Window) -> Self {
         let gl = unsafe {
             glow::Context::from_loader_function(|s| webrender_surfman.get_proc_address(s))
         };
 
         Self {
-            context: EguiGlow::new(events_loop.as_winit(), Arc::new(gl), None),
+            context: EguiGlow::new(events_loop.as_winit(), window, Arc::new(gl), None),
             event_queue: RefCell::new(vec![]),
             toolbar_height: 0f32.into(),
             last_update: Instant::now(),

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -35,7 +35,11 @@ pub enum MinibrowserEvent {
 }
 
 impl Minibrowser {
-    pub fn new(webrender_surfman: &WebrenderSurfman, events_loop: &EventsLoop, window: &Window) -> Self {
+    pub fn new(
+        webrender_surfman: &WebrenderSurfman,
+        events_loop: &EventsLoop,
+        window: &Window,
+    ) -> Self {
         let gl = unsafe {
             glow::Context::from_loader_function(|s| webrender_surfman.get_proc_address(s))
         };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

The toolbar is way too small in some of my devices, because it hasn't set the proper scale factor(pixels_per_point) yet.
This PR trys to pass the winit window for egui to setup context based on it.