### PR TITLE
Add support for TUXEDO OS in mach bootstrap

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -65,7 +65,7 @@ class Linux(Base):
         distrib = distro.name()
         version = distro.version()
 
-        if distrib in ['LinuxMint', 'Linux Mint', 'KDE neon', 'Pop!_OS']:
+        if distrib in ['LinuxMint', 'Linux Mint', 'KDE neon', 'Pop!_OS', 'TUXEDO OS']:
             if '.' in version:
                 major, _ = version.split('.', 1)
             else:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add support for TUXEDO OS in mach bootstrap.

TUXEDO OS is an Ubuntu-based distro.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it only adds a new item to the supported distros
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
