### PR TITLE
Fix main frame scrolling in quirks mode after WebRender upgrade

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -664,7 +664,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 self.waiting_for_results_of_scroll = true;
 
                 let mut txn = Transaction::new();
-                txn.scroll_node_with_id(point, scroll_id, ScrollClamping::ToContentBounds);
+                txn.scroll_node_with_id(point, scroll_id, ScrollClamping::NoClamping);
                 txn.generate_frame(0);
                 self.webrender_api
                     .send_transaction(self.webrender_document, txn);

--- a/tests/wpt/meta-legacy-layout/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html.ini
@@ -1,0 +1,2 @@
+[background-attachment-fixed-inline-scrolled.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-position/sticky/position-sticky-escape-scroller-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/sticky/position-sticky-escape-scroller-002.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-escape-scroller-002.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-position/sticky/position-sticky-escape-scroller-004.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/sticky/position-sticky-escape-scroller-004.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-escape-scroller-004.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-position/sticky/position-sticky-top-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/sticky/position-sticky-top-002.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-top-002.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-ui/text-overflow-021.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-ui/text-overflow-021.html.ini
@@ -1,2 +1,0 @@
-[text-overflow-021.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/sticky-content.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/sticky-content.html.ini
@@ -1,0 +1,3 @@
+[sticky-content.html]
+  expected: FAIL
+

--- a/tests/wpt/meta/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-attachment-fixed-inline-scrolled.html.ini
@@ -1,0 +1,2 @@
+[background-attachment-fixed-inline-scrolled.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-escape-scroller-002.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-escape-scroller-002.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-escape-scroller-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/filtered-html-is-not-container.html.ini
+++ b/tests/wpt/meta/css/filter-effects/filtered-html-is-not-container.html.ini
@@ -1,0 +1,2 @@
+[filtered-html-is-not-container.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/scroll_root.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/scroll_root.html.ini
@@ -1,2 +1,0 @@
-[scroll_root.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/scrollBy.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/scrollBy.html.ini
@@ -1,3 +1,0 @@
-[scrollBy.html]
-  [Ensure that the window.scrollBy function affects scroll position as expected]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/scroll_root.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/scroll_root.html.ini
@@ -1,2 +1,0 @@
-[scroll_root.html]
-  expected: FAIL


### PR DESCRIPTION
Main frame scrolling after the WebRender upgrade was broken because the
main frame no longer has content size content bounds and quirks mode
leads to a body with zero height.

Fixes #30368.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30368.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
