### PR TITLE
Replace virtualenv with Python's built-in venv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 2
       - name: Bootstrap
         run: |
-          python3 -m pip install --upgrade pip virtualenv
+          python3 -m pip install --upgrade pip
           sudo apt update
           python3 ./mach bootstrap
       - name: Compile docs

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -57,7 +57,7 @@ jobs:
         run: tar -xzf release-binary/target.tar.gz
       - name: Prep test environment
         run: |
-          python3 -m pip install --upgrade pip virtualenv
+          python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libgl1-mesa-dri mesa-vulkan-drivers libegl1-mesa
           sudo apt install ./libffi6_3.2.1-8_amd64.deb

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,7 +88,7 @@ jobs:
           crate: taplo-cli
           locked: true
       - name: Bootstrap Python
-        run: python3 -m pip install --upgrade pip virtualenv
+        run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies
         run: sudo apt update && python3 ./mach bootstrap
       - name: Tidy

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Prep test environment
         run: |
           gtar -xzf target.tar.gz
-          python3 -m pip install --upgrade pip virtualenv
+          python3 -m pip install --upgrade pip
           python3 ./mach bootstrap
       - name: Smoketest
         run: python3 ./mach smoketest --${{ inputs.profile }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -83,7 +83,7 @@ jobs:
           locked: true
       - name: Bootstrap
         run: |
-          python3 -m pip install --upgrade pip virtualenv
+          python3 -m pip install --upgrade pip
           python3 ./mach bootstrap
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo nightly > rust-toolchain
       - name: Bootstrap
         run: |
-          python3 -m pip install --upgrade pip virtualenv
+          python3 -m pip install --upgrade pip
           sudo apt update
           python3 ./mach bootstrap
       - name: Release build

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/download-artifact@v3
       - name: Prep environment
         run: |
-          python3 -m pip install --upgrade pip virtualenv
+          python3 -m pip install --upgrade pip
           sudo apt update
           python3 ./mach bootstrap
       - name: Add upstream remote

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,7 +74,7 @@ jobs:
           echo "C:\\Program Files (x86)\\WiX Toolset v3.11\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Bootstrap
         run: |
-          python -m pip install --upgrade pip virtualenv
+          python -m pip install --upgrade pip
           python mach fetch
           python mach bootstrap-gstreamer
       - name: Build (${{ inputs.profile }})

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /ports/android/local.properties
 /ports/android/obj
 /python/_virtualenv*
+/python/_venv*
 /python/tidy/servo_tidy.egg-info
 /tests/wpt/sync
 *.pkl

--- a/README.md
+++ b/README.md
@@ -25,18 +25,17 @@ manually, try the [manual build setup][manual-build].
 - Install [Xcode](https://developer.apple.com/xcode/)
 - Install [Homebrew](https://brew.sh/)
 - Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- Run `pip3 install virtualenv`
 - Run `./mach bootstrap`<br/>
   *Note: This will install the recommended version of GStreamer globally on your system.*
 
 ### Linux
 
 - Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- Install Python and virtualenv
-    - **Debian-like:** Run `sudo apt install python3-virtualenv python3-pip`
-    - **Fedora:** Run `sudo dnf install python3 python3-virtualenv python3-pip python3-devel`
-    - **Arch:** Run `sudo pacman -S --needed python python-virtualenv python-pip`
-    - **Gentoo:** Run `sudo emerge dev-python/virtualenv dev-python/pip`
+- Install Python
+    - **Debian-like:** Run `sudo apt install python3-pip`
+    - **Fedora:** Run `sudo dnf install python3 python3-pip python3-devel`
+    - **Arch:** Run `sudo pacman -S --needed python python-pip`
+    - **Gentoo:** Run `sudo emerge dev-python/pip`
 - Run `./mach bootstrap`
 
 ### Windows

--- a/etc/ci/performance/README.md
+++ b/etc/ci/performance/README.md
@@ -113,13 +113,3 @@ If you want to test the data submission code in `submit_to_perfherder.py` withou
 * `vagrant ssh`
   * `./manage.py create_credentials <username> <email> "description"`, the email has to match your logged in user. Remember to log-in through the Web UI once before you run this.
   * Setup your Treeherder client ID and secret as environment variables `TREEHERDER_CLIENT_ID` and `TREEHERDER_CLIENT_SECRET`
-
-# Troubleshooting
-
- If you saw this error message:
-
-```
-venv/bin/activate: line 8: _OLD_VIRTUAL_PATH: unbound variable
-```
-
-That means your `virtualenv` is too old, try run `pip install -U virtualenv` to upgrade (If you installed ubuntu's `python-virtualenv` package, uninstall it first then install it through `pip`)

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -150,6 +150,10 @@ def _activate_virtualenv(topdir):
         sys.real_prefix = sys.prefix
         sys.prefix = virtualenv_path
 
+        # Use the python in our venv for subprocesses, not the python we were originally run with.
+        # Otherwise pip may still try to write to the wrong site-packages directory.
+        python = os.path.join(venv_script_path, "python")
+
     # TODO: Right now, we iteratively install all the requirements by invoking
     # `pip install` each time. If it were the case that there were conflicting
     # requirements, we wouldn't know about them. Once

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -133,7 +133,7 @@ def _activate_virtualenv(topdir):
     virtualenv_path = os.path.join(topdir, "python", "_venv%d.%d" % (sys.version_info[0], sys.version_info[1]))
     python = sys.executable
 
-    if os.environ.get("VIRUTAL_ENV") != virtualenv_path:
+    if os.environ.get("VIRTUAL_ENV") != virtualenv_path:
         venv_script_path = os.path.join(virtualenv_path, _get_virtualenv_script_dir())
         if not os.path.exists(virtualenv_path):
             _process_exec([python, "-m", "venv", "--system-site-packages", virtualenv_path])

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -252,7 +252,7 @@ class MachCommands(CommandBase):
                     subprocess.call(["perl", "-i", "-pe", expr, target_path])
 
     @Command('clean',
-             description='Clean the target/ and python/_virtualenv[version]/ directories',
+             description='Clean the target/ and python/_venv[version]/ directories',
              category='build')
     @CommandArgument('--manifest-path',
                      default=None,
@@ -265,7 +265,7 @@ class MachCommands(CommandBase):
     def clean(self, manifest_path=None, params=[], verbose=False):
         self.ensure_bootstrapped()
 
-        virtualenv_fname = '_virtualenv%d.%d' % (sys.version_info[0], sys.version_info[1])
+        virtualenv_fname = '_venv%d.%d' % (sys.version_info[0], sys.version_info[1])
         virtualenv_path = path.join(self.get_top_dir(), 'python', virtualenv_fname)
         if path.exists(virtualenv_path):
             print('Removing virtualenv directory: %s' % virtualenv_path)

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -36,7 +36,6 @@ from xml.etree.ElementTree import XML
 
 import toml
 
-from mach_bootstrap import _get_exec_path
 from mach.decorators import CommandArgument, CommandArgumentGroup
 from mach.registrar import Registrar
 
@@ -628,8 +627,8 @@ class CommandBase(object):
             host_suffix = "x86_64"
         host = os_type + "-" + host_suffix
 
-        host_cc = env.get('HOST_CC') or _get_exec_path(["clang"]) or _get_exec_path(["gcc"])
-        host_cxx = env.get('HOST_CXX') or _get_exec_path(["clang++"]) or _get_exec_path(["g++"])
+        host_cc = env.get('HOST_CC') or shutil.which(["clang"]) or util.whichget_exec_path(["gcc"])
+        host_cxx = env.get('HOST_CXX') or util.whichget_exec_path(["clang++"]) or util.whichget_exec_path(["g++"])
 
         llvm_toolchain = path.join(env['ANDROID_NDK'], "toolchains", "llvm", "prebuilt", host)
         gcc_toolchain = path.join(env['ANDROID_NDK'], "toolchains",

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -103,8 +103,7 @@ directories = [
     "./tests/wpt/mozilla/tests/mozilla/referrer-policy",
     "./tests/wpt/mozilla/tests/webgl",
     "./python/tidy/tests",
-    "./python/_venv*",
-    "./python/_virtualenv*",
+    "./python/_v*",
     "./python/mach",
     # Generated and upstream code combined with our own. Could use cleanup
     "./target",

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -103,6 +103,7 @@ directories = [
     "./tests/wpt/mozilla/tests/mozilla/referrer-policy",
     "./tests/wpt/mozilla/tests/webgl",
     "./python/tidy/tests",
+    "./python/_venv*",
     "./python/_virtualenv*",
     "./python/mach",
     # Generated and upstream code combined with our own. Could use cleanup


### PR DESCRIPTION
Since we require Python 3.5, we can just utilize Python's built-in `venv` tool for handling virtual environments.