### PR TITLE
Implement recreate_context for WebGPU canvas and fix handle_wgpu_msg crash

### DIFF
--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -104,7 +104,7 @@ impl HTMLCanvasElement {
                 },
                 CanvasContext::WebGL(ref context) => context.recreate(size),
                 CanvasContext::WebGL2(ref context) => context.recreate(size),
-                CanvasContext::WebGPU(_) => unimplemented!(),
+                CanvasContext::WebGPU(ref context) => context.recreate(),
             }
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2102,6 +2102,7 @@ impl ScriptThread {
                 result,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
+                let _ac = enter_realm(&*global);
                 global.handle_wgpu_msg(device, scope_id, result);
             },
             WebGPUMsg::CleanDevice {

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html.ini
@@ -1,2 +1,2 @@
 [canvas_complex_rgba8unorm_store.https.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_image_rendering.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_image_rendering.https.html.ini
@@ -1,2 +1,2 @@
 [canvas_image_rendering.https.html]
-  expected: CRASH
+  expected: TIMEOUT


### PR DESCRIPTION
This makes wgpu examples work.

~~Depends on https://github.com/servo/servo/pull/30406~~. DONE

### Current state of webgpu examples

Works on reload:
- [x] https://mdn.github.io/dom-examples/webgpu-compute-demo/
- [x] https://mdn.github.io/dom-examples/webgpu-render-demo/ (works partially: only blue background; same is in FF so it's probably wgpu problem)
- [x] [Conway's Game of Life](https://sagudev.github.io/briefcase/first-webgpu/9-endgame.html) fixed for naga from https://codelabs.developers.google.com/your-first-webgpu-app

Does not work on reload (but works on freshly opened servo; see #30417):
- [x] https://wgpu.rs/examples-gpu/?example=cube
- [x] https://wgpu.rs/examples-gpu/?example=hello-compute
- [x] https://wgpu.rs/examples-gpu/?example=hello-triangle
- [x] https://wgpu.rs/examples-gpu/?example=mipmap
- [x] https://wgpu.rs/examples-gpu/?example=shadow

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes in examples and webgpu-cts

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
