### PR TITLE
Media query resolution

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -1,4 +1,5 @@
 -moz-content-preferred-color-scheme
+-moz-device-pixel-ratio
 -moz-gtk-csd-close-button-position
 -moz-gtk-csd-maximize-button-position
 -moz-gtk-csd-menu-radius
@@ -37,6 +38,7 @@ datachannel
 date
 datetime-local
 dir
+device-pixel-ratio
 durationchange
 email
 emptied
@@ -108,6 +110,7 @@ rejectionhandled
 removetrack
 reset
 resize
+resolution
 resourcetimingbufferfull
 right
 rtl

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -12,6 +12,7 @@ use crate::media_queries::MediaType;
 use crate::properties::ComputedValues;
 use crate::values::computed::CSSPixelLength;
 use crate::values::computed::Context;
+use crate::values::computed::Resolution;
 use crate::values::specified::font::FONT_MEDIUM_PX;
 use crate::values::specified::ViewportVariant;
 use crate::values::KeyframesName;
@@ -252,9 +253,19 @@ fn eval_scan(_: &Context, _: Option<Scan>) -> bool {
     false
 }
 
+/// https://drafts.csswg.org/mediaqueries-4/#resolution
+fn eval_resolution(context: &Context) -> Resolution {
+    Resolution::from_dppx(context.device().device_pixel_ratio.0)
+}
+
+/// https://compat.spec.whatwg.org/#css-media-queries-webkit-device-pixel-ratio
+fn eval_device_pixel_ratio(context: &Context) -> f32 {
+    eval_resolution(context).dppx()
+}
+
 lazy_static! {
     /// A list with all the media features that Servo supports.
-    pub static ref MEDIA_FEATURES: [QueryFeatureDescription; 2] = [
+    pub static ref MEDIA_FEATURES: [QueryFeatureDescription; 5] = [
         feature!(
             atom!("width"),
             AllowsRanges::Yes,
@@ -265,6 +276,24 @@ lazy_static! {
             atom!("scan"),
             AllowsRanges::No,
             keyword_evaluator!(eval_scan, Scan),
+            FeatureFlags::empty(),
+        ),
+        feature!(
+            atom!("resolution"),
+            AllowsRanges::Yes,
+            Evaluator::Resolution(eval_resolution),
+            FeatureFlags::empty(),
+        ),
+        feature!(
+            atom!("device-pixel-ratio"),
+            AllowsRanges::Yes,
+            Evaluator::Float(eval_device_pixel_ratio),
+            FeatureFlags::WEBKIT_PREFIX,
+        ),
+        feature!(
+            atom!("-moz-device-pixel-ratio"),
+            AllowsRanges::Yes,
+            Evaluator::Float(eval_device_pixel_ratio),
             FeatureFlags::empty(),
         ),
     ];

--- a/tests/wpt/meta-legacy-layout/css/mediaqueries/match-media-parsing.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/mediaqueries/match-media-parsing.html.ini
@@ -17,24 +17,6 @@
   [Test parsing '  color ), ( color' with matchMedia]
     expected: FAIL
 
-  [Test parsing '(min-resolution: 1x)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 2x)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(max-resolution: 7x)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 2dppx)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 600dpi)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 77dpcm)' with matchMedia]
-    expected: FAIL
-
   [Test parsing '(min-resolution: calc(1x))' with matchMedia]
     expected: FAIL
 

--- a/tests/wpt/meta/css/mediaqueries/match-media-parsing.html.ini
+++ b/tests/wpt/meta/css/mediaqueries/match-media-parsing.html.ini
@@ -17,31 +17,13 @@
   [Test parsing '  color ), ( color' with matchMedia]
     expected: FAIL
 
-  [Test parsing '(min-resolution: 1x)' with matchMedia]
-    expected: FAIL
-
   [Test parsing '(min-resolution: calc(1x))' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 2x)' with matchMedia]
     expected: FAIL
 
   [Test parsing '(resolution: calc(2x))' with matchMedia]
     expected: FAIL
 
-  [Test parsing '(max-resolution: 7x)' with matchMedia]
-    expected: FAIL
-
   [Test parsing '(max-resolution: calc(7x))' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 2dppx)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 600dpi)' with matchMedia]
-    expected: FAIL
-
-  [Test parsing '(resolution: 77dpcm)' with matchMedia]
     expected: FAIL
 
   [Test parsing '(resolution: calc(1x + 2x))' with matchMedia]


### PR DESCRIPTION
We have all data needed for this already present, so it was just matter of exposing it.

You can manually test it with https://sagudev.github.io/briefcase/mediaq-resolution.html and zooming on site.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
