### PR TITLE
fix WebGPU runtime dependencies on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,11 @@ Run Servo with the command:
 
 * `GStreamer` >=1.16
 * `gst-plugins-bad` >=1.16
-
+* `libXcursor`
+* `libXrandr`
+* `libXi`
+* `libxkbcommon`
+* `vulkan-loader`
 
 ## Developing
 

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -44,8 +44,15 @@ clangStdenv.mkDerivation rec {
   # Enable colored cargo and rustc output
   TERMINFO = "${ncurses.out}/share/terminfo";
 
-  # Fix missing libraries errors (those libraries aren't linked against, so we need to dynamically supply them)
-  LD_LIBRARY_PATH = lib.makeLibraryPath [ xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon ];
+  # Provide libraries that aren’t linked against but somehow required
+  LD_LIBRARY_PATH = lib.makeLibraryPath [
+    # Fixes missing library errors
+    xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon
+
+    # [WARN  script::dom::gpu] Could not get GPUAdapter ("NotFound")
+    # TLA Err: Error: Couldn't request WebGPU adapter.
+    vulkan-loader
+  ];
 
   shellHook = ''
     # Fix invalid option errors during linking

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -16,7 +16,15 @@ import distro
 from .. import util
 from .base import Base
 
-# Please keep these in sync with the packages in README.md
+# Please keep these in sync with the packages on the wiki, using the instructions below
+# https://github.com/servo/servo/wiki/Building
+
+# https://packages.debian.org
+# https://packages.ubuntu.com
+# 1. open devtools
+# 2. paste in the whole APT_PKGS = [...]
+# 3. copy(`sudo apt install ${APT_PKGS.join(" ")}`)
+# 4. paste into https://github.com/servo/servo/wiki/Building#debian-based-distributions
 APT_PKGS = ['git', 'curl', 'libx11-dev', 'libfreetype6-dev',
             'libgl1-mesa-dri', 'libglib2.0-dev', 'xorg-dev', 'gperf', 'g++',
             'build-essential', 'cmake', 'liblzma-dev', 'libxmu6', 'libxmu-dev',
@@ -25,7 +33,13 @@ APT_PKGS = ['git', 'curl', 'libx11-dev', 'libfreetype6-dev',
             'libharfbuzz-dev', 'ccache', 'clang', 'libunwind-dev',
             'libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',
             'libgstreamer-plugins-bad1.0-dev',
-            'libunwind-dev', 'llvm-dev']
+            'libunwind-dev', 'llvm-dev', 'libvulkan1']
+
+# https://packages.fedoraproject.org
+# 1. open devtools
+# 2. paste in the whole DNF_PKGS = [...]
+# 3. copy(`sudo dnf install ${DNF_PKGS.join(" ")}`)
+# 4. paste into https://github.com/servo/servo/wiki/Building#fedora
 DNF_PKGS = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
             'libunwind-devel', 'mesa-libGL-devel', 'mesa-libEGL-devel',
             'glib2-devel', 'libX11-devel', 'libXrandr-devel', 'gperf',
@@ -35,7 +49,13 @@ DNF_PKGS = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
             'clang', 'clang-libs', 'llvm', 'python3-devel',
             'gstreamer1-devel', 'gstreamer1-plugins-base-devel',
             'gstreamer1-plugins-bad-free-devel', 'libjpeg-turbo-devel',
-            'zlib', 'libjpeg']
+            'zlib', 'libjpeg', 'vulkan-loader']
+
+# https://voidlinux.org/packages/
+# 1. open devtools
+# 2. paste in the whole XBPS_PKGS = [...]
+# 3. copy(`sudo xbps-install ${XBPS_PKGS.join(" ")}`)
+# 4. paste into https://github.com/servo/servo/wiki/Building#void-linux
 XBPS_PKGS = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
              'libunwind-devel', 'MesaLib-devel', 'glib-devel', 'pkg-config',
              'libX11-devel', 'libXrandr-devel', 'gperf', 'bzip2-devel',
@@ -43,7 +63,7 @@ XBPS_PKGS = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
              'cmake', 'libXcursor-devel', 'libXmu-devel', 'dbus-devel',
              'ncurses-devel', 'harfbuzz-devel', 'ccache', 'glu-devel',
              'clang', 'gstreamer1-devel',
-             'gst-plugins-base1-devel', 'gst-plugins-bad1-devel']
+             'gst-plugins-base1-devel', 'gst-plugins-bad1-devel', 'vulkan-loader']
 
 GSTREAMER_URL = \
     "https://github.com/servo/servo-build-deps/releases/download/linux/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz"


### PR DESCRIPTION
WebGPU on Linux relies on libvulkan.so.1, so this patch adds vulkan-loader or equivalent to:

* README.md § Runtime dependencies
* LD_LIBRARY_PATH in etc/shell.nix
* APT_PKGS in linux.py, and [wiki § Debian](https://github.com/servo/servo/wiki/Building#debian-based-distributions)
* DNF_PKGS in linux.py, and [wiki § Fedora](https://github.com/servo/servo/wiki/Building#fedora)
* XBPS_PKGS in linux.py, and [wiki § Void Linux](https://github.com/servo/servo/wiki/Building#void-linux)
* [wiki § Arch](https://github.com/servo/servo/wiki/Building#arch)
* [wiki § openSUSE](https://github.com/servo/servo/wiki/Building#opensuse)
* [wiki § Gentoo](https://github.com/servo/servo/wiki/Building#gentoo)

I’ve also updated [the wiki page](https://github.com/servo/servo/wiki/Building) to include other changes that were made in APT_PKGS + DNF_PKGS + XBPS_PKGS but not yet synced to the wiki. The syncing process is tedious to do by hand, so I’ve also added instructions to make future syncing as easy as possible. **[Click here](https://github.com/servo/servo/wiki/Building/_compare/891bfc880baa8ed16d6f982a624b1d297fc764b4...4f5f974bf1008b0136ac52d43136dd729fbdd5e9) to see my wiki changes.**

It may be worth replacing all of these with Nix someday, since Nix can run on any Linux distro.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes