### PR TITLE
Treat the `keygen` element as obsolete

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -308,6 +308,8 @@ pub fn create_native_html_element(
         // https://html.spec.whatwg.org/multipage/#other-elements,-attributes-and-apis:isindex-2
         local_name!("isindex") => make!(HTMLUnknownElement),
         local_name!("kbd") => make!(HTMLElement),
+        // https://html.spec.whatwg.org/multipage/#keygen
+        local_name!("keygen") => make!(HTMLUnknownElement),
         local_name!("label") => make!(HTMLLabelElement),
         local_name!("legend") => make!(HTMLLegendElement),
         local_name!("li") => make!(HTMLLIElement),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3951,7 +3951,6 @@ impl Element {
         match node.type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLButtonElement)) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLInputElement)) |
-            // NodeTypeId::Element(ElementTypeId::HTMLKeygenElement) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOptionElement)) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLSelectElement)) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLTextAreaElement))

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3949,12 +3949,21 @@ impl Element {
     fn click_event_filter_by_disabled_state(&self) -> bool {
         let node = self.upcast::<Node>();
         match node.type_id() {
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLButtonElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLInputElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOptionElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLSelectElement)) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLTextAreaElement))
-                if self.disabled_state() => true,
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLButtonElement,
+            )) |
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLInputElement,
+            )) |
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLOptionElement,
+            )) |
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLSelectElement,
+            )) |
+            NodeTypeId::Element(ElementTypeId::HTMLElement(
+                HTMLElementTypeId::HTMLTextAreaElement,
+            )) if self.disabled_state() => true,
             _ => false,
         }
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -650,7 +650,6 @@ impl HTMLElement {
 
     // https://html.spec.whatwg.org/multipage/#category-label
     pub fn is_labelable_element(&self) -> bool {
-        // Note: HTMLKeygenElement is omitted because Servo doesn't currently implement it
         match self.upcast::<Node>().type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(type_id)) => match type_id {
                 HTMLElementTypeId::HTMLInputElement => {
@@ -670,12 +669,6 @@ impl HTMLElement {
 
     // https://html.spec.whatwg.org/multipage/#category-listed
     pub fn is_listed_element(&self) -> bool {
-        // Servo does not implement HTMLKeygenElement
-        // https://github.com/servo/servo/issues/2782
-        if self.upcast::<Element>().local_name() == &local_name!("keygen") {
-            return true;
-        }
-
         match self.upcast::<Node>().type_id() {
             NodeTypeId::Element(ElementTypeId::HTMLElement(type_id)) => match type_id {
                 HTMLElementTypeId::HTMLButtonElement |

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -366,10 +366,7 @@ impl HTMLFormElementMethods for HTMLFormElement {
                             elem.downcast::<HTMLTextAreaElement>().unwrap().form_owner()
                         },
                         _ => {
-                            debug_assert!(
-                                !elem.downcast::<HTMLElement>().unwrap().is_listed_element() ||
-                                    elem.local_name() == &local_name!("keygen")
-                            );
+                            debug_assert!(!elem.downcast::<HTMLElement>().unwrap().is_listed_element());
                             return false;
                         },
                     },
@@ -1287,11 +1284,6 @@ impl HTMLFormElement {
                 )) => {
                     child.downcast::<HTMLInputElement>().unwrap().reset();
                 },
-                // TODO HTMLKeygenElement unimplemented
-                //NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLKeygenElement)) => {
-                //    // Unimplemented
-                //    {}
-                //}
                 NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLSelectElement,
                 )) => {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -366,7 +366,10 @@ impl HTMLFormElementMethods for HTMLFormElement {
                             elem.downcast::<HTMLTextAreaElement>().unwrap().form_owner()
                         },
                         _ => {
-                            debug_assert!(!elem.downcast::<HTMLElement>().unwrap().is_listed_element());
+                            debug_assert!(!elem
+                                .downcast::<HTMLElement>()
+                                .unwrap()
+                                .is_listed_element());
                             return false;
                         },
                     },

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -521,13 +521,6 @@ impl Tokenizer {
 
                 if let Some(control) = control {
                     control.set_form_owner_from_parser(&form);
-                } else {
-                    // TODO remove this code when keygen is implemented.
-                    assert_eq!(
-                        node.NodeName(),
-                        "KEYGEN",
-                        "Unknown form-associatable element"
-                    );
                 }
             },
             ParseOperation::Pop { node } => {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1182,13 +1182,6 @@ impl TreeSink for Sink {
 
         if let Some(control) = control {
             control.set_form_owner_from_parser(&form);
-        } else {
-            // TODO remove this code when keygen is implemented.
-            assert_eq!(
-                node.NodeName(),
-                "KEYGEN",
-                "Unknown form-associatable element"
-            );
         }
     }
 

--- a/resources/iso-8859-8.css
+++ b/resources/iso-8859-8.css
@@ -18,6 +18,6 @@ tbody, tfoot, tr, td, th, dir, dd, dl, dt, menu, ol, ul, li, [dir=ltr i],
   unicode-bidi: bidi-override;
 }
 input:not([type=submit i]):not([type=reset i]):not([type=button i]),
-textarea, keygen {
+textarea {
   unicode-bidi: normal;
 }

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -250,7 +250,7 @@ table:matches(
 }
 
 
-input, select, option, optgroup, button, textarea, keygen {
+input, select, option, optgroup, button, textarea {
   text-indent: initial;
   text-transform: none;
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13256,7 +13256,7 @@
      ]
     ],
     "htmlfieldsetelement_elements.html": [
-     "ee0ea4ae15f1f9cd4e1cdb76c5f4c9f13e139bef",
+     "cb5757555f2f7c52803e50c6cd4f191f49dda4c5",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/htmlfieldsetelement_elements.html
+++ b/tests/wpt/mozilla/tests/mozilla/htmlfieldsetelement_elements.html
@@ -7,6 +7,7 @@
     <fieldset>
       <button>Click!</button>
     </fieldset>
+    <!-- The keygen element should not be recognized as a listed element -->
     <keygen name="key">
     <textarea>
       A
@@ -31,17 +32,16 @@
   <script>
   test(function() {
     var fs = document.getElementById("fs");
-    assert_equals(fs.elements.length, 10);
+    assert_equals(fs.elements.length, 9);
     assert_true(fs.elements[0] instanceof HTMLInputElement, "Should be HTMLInputElement");
     assert_true(fs.elements[1] instanceof HTMLFieldSetElement, "Should be HTMLFieldSetElement");
     assert_true(fs.elements[2] instanceof HTMLButtonElement, "Should be HTMLButtonElement");
-    assert_true(fs.elements[3] instanceof HTMLUnknownElement, "Should be HTMLUnknownElement");
-    assert_true(fs.elements[4] instanceof HTMLTextAreaElement, "Should be HTMLTextAreaElement");
-    assert_true(fs.elements[5] instanceof HTMLSelectElement, "Should be HTMLSelectElement");
+    assert_true(fs.elements[3] instanceof HTMLTextAreaElement, "Should be HTMLTextAreaElement");
+    assert_true(fs.elements[4] instanceof HTMLSelectElement, "Should be HTMLSelectElement");
+    assert_true(fs.elements[5] instanceof HTMLInputElement, "Should be HTMLInputElement");
     assert_true(fs.elements[6] instanceof HTMLInputElement, "Should be HTMLInputElement");
-    assert_true(fs.elements[7] instanceof HTMLInputElement, "Should be HTMLInputElement");
-    assert_true(fs.elements[8] instanceof HTMLOutputElement, "Should be HTMLOutputElement");
-    assert_true(fs.elements[9] instanceof HTMLObjectElement, "Should be HTMLObjectElement");
+    assert_true(fs.elements[7] instanceof HTMLOutputElement, "Should be HTMLOutputElement");
+    assert_true(fs.elements[8] instanceof HTMLObjectElement, "Should be HTMLObjectElement");
   });
   </script>
 </html>


### PR DESCRIPTION
oh my god lmao it was so funny to suddenly see `HTMLKeygenElement` with no context at all while swimming at servo code
*ahem*

I've dug deeper, and it turns out it was an ancient form of a crypto API whose support was being worked on in the early days of Servo (with issue #2782 tracking it) until it was deprecated. After 7 years? It appears that it has been completely removed from everything, with it being completely absent on [CanIUse](https://caniuse.com/) while [Firefox's source code](https://searchfox.org) has barely given anything;

So, I went ahead, grabbed the HTML specification, and did my best to scrub out the silly `keygen` element; I did try to run tests in order to see if anything (especially the massive wall of `FAIL`s on `wpt/tests/html/dom/reflection-forms.html` with Layout 2013) changed, but it appears that nothing would budge; I did try running a bigger set of tests, but that did crash the IDE despite the computer taking it somewhat fine

I'm not completely sure if this PR indeed did the trick, so yeah, reviews are appreciated

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
<!-- oh dear, I need one of these -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___