### PR TITLE
Refactor the `translatable` attribute lightly

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -558,10 +558,9 @@ impl Element {
 
     // https://html.spec.whatwg.org/multipage/#translation-mode
     pub fn is_translate_enabled(&self) -> bool {
-        // TODO change this to local_name! when html5ever updates
-        let name = &LocalName::from("translate");
+        let name = &html5ever::local_name!("translate");
         if self.has_attribute(name) {
-            match &*self.get_string_attribute(name) {
+            match_ignore_ascii_case! { &*self.get_string_attribute(name),
                 "yes" | "" => return true,
                 "no" => return false,
                 _ => {},
@@ -572,7 +571,7 @@ impl Element {
                 return elem.is_translate_enabled();
             }
         }
-        true // whatwg/html#5239
+        true
     }
 
     // https://html.spec.whatwg.org/multipage/#the-directionality

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -516,8 +516,7 @@ impl HTMLElementMethods for HTMLElement {
     // https://html.spec.whatwg.org/multipage/#dom-translate
     fn SetTranslate(&self, yesno: bool) {
         self.upcast::<Element>().set_string_attribute(
-            // TODO change this to local_name! when html5ever updates
-            &LocalName::from("translate"),
+            &html5ever::local_name!("translate"),
             match yesno {
                 true => DOMString::from("yes"),
                 false => DOMString::from("no"),

--- a/tests/wpt/meta-legacy-layout/html/dom/elements/global-attributes/translate-enumerated-ascii-case-insensitive.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/elements/global-attributes/translate-enumerated-ascii-case-insensitive.html.ini
@@ -1,4 +1,0 @@
-[translate-enumerated-ascii-case-insensitive.html]
-  [keyword yes]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/dom/elements/global-attributes/translate-enumerated-ascii-case-insensitive.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/translate-enumerated-ascii-case-insensitive.html.ini
@@ -1,3 +1,0 @@
-[translate-enumerated-ascii-case-insensitive.html]
-  [keyword yes]
-    expected: FAIL


### PR DESCRIPTION
This PR is pretty similar to #30094: a random piece of code is cleared off its TODOs;

This time around, however, I went ahead and fixed how the `translate` attribute's value was parsed, making the `match` ASCII case-insensitive (as specified) and fixing 2 `FAIL`s in the process

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
