### PR TITLE
Implement support for the `drop-shadow` filter

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -62,7 +62,7 @@ use crate::display_list::items::{
     PushTextShadowDisplayItem, StackingContext, StackingContextType, StickyFrameData,
     TextOrientation, WebRenderImageInfo,
 };
-use crate::display_list::{border, gradient, ToLayout};
+use crate::display_list::{border, gradient, FilterToLayout, ToLayout};
 use crate::flow::{BaseFlow, Flow, FlowFlags};
 use crate::flow_ref::FlowRef;
 use crate::fragment::{
@@ -1975,8 +1975,14 @@ impl Fragment {
             .translate(-border_box_offset.to_vector());
 
         // Create the filter pipeline.
+        let current_color = self.style().clone_color();
         let effects = self.style().get_effects();
-        let mut filters: Vec<FilterOp> = effects.filter.0.iter().map(ToLayout::to_layout).collect();
+        let mut filters: Vec<FilterOp> = effects
+            .filter
+            .0
+            .iter()
+            .map(|filter| FilterToLayout::to_layout(filter, &current_color))
+            .collect();
         if effects.opacity != 1.0 {
             filters.push(FilterOp::Opacity(effects.opacity.into(), effects.opacity));
         }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -6,7 +6,7 @@ pub use self::builder::{
     BorderPaintingMode, DisplayListBuildState, IndexableText, StackingContextCollectionFlags,
     StackingContextCollectionState,
 };
-pub use self::conversions::ToLayout;
+pub use self::conversions::{FilterToLayout, ToLayout};
 
 mod background;
 mod border;

--- a/components/layout_2020/display_list/conversions.rs
+++ b/components/layout_2020/display_list/conversions.rs
@@ -6,7 +6,9 @@ use style::computed_values::mix_blend_mode::T as ComputedMixBlendMode;
 use style::computed_values::text_decoration_style::T as ComputedTextDecorationStyle;
 use style::computed_values::transform_style::T as ComputedTransformStyle;
 use style::values::computed::{Filter as ComputedFilter, Length};
-use webrender_api::{units, FilterOp, LineStyle, MixBlendMode, TransformStyle};
+use style::values::RGBA;
+use webrender_api::units::LayoutVector2D;
+use webrender_api::{units, FilterOp, LineStyle, MixBlendMode, Shadow, TransformStyle};
 
 use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize};
 
@@ -15,9 +17,14 @@ pub trait ToWebRender {
     fn to_webrender(&self) -> Self::Type;
 }
 
-impl ToWebRender for ComputedFilter {
+pub trait FilterToWebRender {
+    type Type;
+    fn to_webrender(&self, current_color: &RGBA) -> Self::Type;
+}
+
+impl FilterToWebRender for ComputedFilter {
     type Type = FilterOp;
-    fn to_webrender(&self) -> Self::Type {
+    fn to_webrender(&self, current_color: &RGBA) -> Self::Type {
         match *self {
             ComputedFilter::Blur(radius) => FilterOp::Blur(radius.px(), radius.px()),
             ComputedFilter::Brightness(amount) => FilterOp::Brightness(amount.0),
@@ -28,13 +35,17 @@ impl ToWebRender for ComputedFilter {
             ComputedFilter::Opacity(amount) => FilterOp::Opacity(amount.0.into(), amount.0),
             ComputedFilter::Saturate(amount) => FilterOp::Saturate(amount.0),
             ComputedFilter::Sepia(amount) => FilterOp::Sepia(amount.0),
-            // Statically check that DropShadow is impossible.
-            ComputedFilter::DropShadow(ref shadow) => match *shadow {},
+            ComputedFilter::DropShadow(ref shadow) => FilterOp::DropShadow(Shadow {
+                blur_radius: shadow.blur.px(),
+                offset: LayoutVector2D::new(shadow.horizontal.px(), shadow.vertical.px()),
+                color: super::rgba(shadow.color.clone().into_rgba(*current_color)),
+            }),
             // Statically check that Url is impossible.
             ComputedFilter::Url(ref url) => match *url {},
         }
     }
 }
+
 impl ToWebRender for ComputedMixBlendMode {
     type Type = MixBlendMode;
     fn to_webrender(&self) -> Self::Type {

--- a/components/layout_2020/display_list/conversions.rs
+++ b/components/layout_2020/display_list/conversions.rs
@@ -7,7 +7,6 @@ use style::computed_values::text_decoration_style::T as ComputedTextDecorationSt
 use style::computed_values::transform_style::T as ComputedTransformStyle;
 use style::values::computed::{Filter as ComputedFilter, Length};
 use style::values::RGBA;
-use webrender_api::units::LayoutVector2D;
 use webrender_api::{units, FilterOp, LineStyle, MixBlendMode, Shadow, TransformStyle};
 
 use crate::geom::{PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize};
@@ -37,7 +36,7 @@ impl FilterToWebRender for ComputedFilter {
             ComputedFilter::Sepia(amount) => FilterOp::Sepia(amount.0),
             ComputedFilter::DropShadow(ref shadow) => FilterOp::DropShadow(Shadow {
                 blur_radius: shadow.blur.px(),
-                offset: LayoutVector2D::new(shadow.horizontal.px(), shadow.vertical.px()),
+                offset: units::LayoutVector2D::new(shadow.horizontal.px(), shadow.vertical.px()),
                 color: super::rgba(shadow.color.clone().into_rgba(*current_color)),
             }),
             // Statically check that Url is impossible.

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -23,7 +23,7 @@ use webrender_api::ScrollSensitivity;
 
 use super::DisplayList;
 use crate::cell::ArcRefCell;
-use crate::display_list::conversions::ToWebRender;
+use crate::display_list::conversions::{FilterToWebRender, ToWebRender};
 use crate::display_list::DisplayListBuilder;
 use crate::fragment_tree::{
     AnonymousFragment, BoxFragment, ContainingBlockManager, Fragment, FragmentTree,
@@ -341,11 +341,12 @@ impl StackingContext {
         }
 
         // Create the filter pipeline.
+        let current_color = style.clone_color();
         let mut filters: Vec<wr::FilterOp> = effects
             .filter
             .0
             .iter()
-            .map(ToWebRender::to_webrender)
+            .map(|filter| FilterToWebRender::to_webrender(filter, &current_color))
             .collect();
         if effects.opacity != 1.0 {
             filters.push(wr::FilterOp::Opacity(

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -749,7 +749,7 @@ impl Animate for AnimatedFilter {
     ) -> Result<Self, ()> {
         use crate::values::animated::animate_multiplicative_factor;
         match (self, other) {
-            % for func in ['Blur', 'Grayscale', 'HueRotate', 'Invert', 'Sepia']:
+            % for func in ['Blur', 'DropShadow', 'Grayscale', 'HueRotate', 'Invert', 'Sepia']:
             (&Filter::${func}(ref this), &Filter::${func}(ref other)) => {
                 Ok(Filter::${func}(this.animate(other, procedure)?))
             },
@@ -759,11 +759,6 @@ impl Animate for AnimatedFilter {
                 Ok(Filter::${func}(animate_multiplicative_factor(this, other, procedure)?))
             },
             % endfor
-            % if engine == "gecko":
-            (&Filter::DropShadow(ref this), &Filter::DropShadow(ref other)) => {
-                Ok(Filter::DropShadow(this.animate(other, procedure)?))
-            },
-            % endif
             _ => Err(()),
         }
     }
@@ -773,15 +768,12 @@ impl Animate for AnimatedFilter {
 impl ToAnimatedZero for AnimatedFilter {
     fn to_animated_zero(&self) -> Result<Self, ()> {
         match *self {
-            % for func in ['Blur', 'Grayscale', 'HueRotate', 'Invert', 'Sepia']:
+            % for func in ['Blur', 'DropShadow', 'Grayscale', 'HueRotate', 'Invert', 'Sepia']:
             Filter::${func}(ref this) => Ok(Filter::${func}(this.to_animated_zero()?)),
             % endfor
             % for func in ['Brightness', 'Contrast', 'Opacity', 'Saturate']:
             Filter::${func}(_) => Ok(Filter::${func}(1.)),
             % endfor
-            % if engine == "gecko":
-            Filter::DropShadow(ref this) => Ok(Filter::DropShadow(this.to_animated_zero()?)),
-            % endif
             _ => Err(()),
         }
     }

--- a/components/style/values/animated/effects.rs
+++ b/components/style/values/animated/effects.rs
@@ -24,4 +24,4 @@ pub type AnimatedFilter =
 
 /// An animated value for a single `filter`.
 #[cfg(not(feature = "gecko"))]
-pub type AnimatedFilter = GenericFilter<Angle, Number, Number, Length, Impossible, Impossible>;
+pub type AnimatedFilter = GenericFilter<Angle, Number, Number, Length, AnimatedSimpleShadow, Impossible>;

--- a/components/style/values/computed/effects.rs
+++ b/components/style/values/computed/effects.rs
@@ -36,7 +36,7 @@ pub type Filter = GenericFilter<
     NonNegativeNumber,
     ZeroToOneNumber,
     NonNegativeLength,
-    Impossible,
+    SimpleShadow,
     Impossible,
 >;
 

--- a/components/style/values/generics/effects.rs
+++ b/components/style/values/generics/effects.rs
@@ -92,6 +92,7 @@ pub use self::GenericFilter as Filter;
 ///
 /// Contrary to the canonical order from the spec, the color is serialised
 /// first, like in Gecko and Webkit.
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,

--- a/components/style/values/generics/effects.rs
+++ b/components/style/values/generics/effects.rs
@@ -110,9 +110,9 @@ pub use self::GenericFilter as Filter;
 pub struct GenericSimpleShadow<Color, SizeLength, ShapeLength> {
     /// Color.
     pub color: Color,
-    /// Horizontal radius.
+    /// Horizontal offset.
     pub horizontal: SizeLength,
-    /// Vertical radius.
+    /// Vertical offset.
     pub vertical: SizeLength,
     /// Blur radius.
     pub blur: ShapeLength,

--- a/components/style/values/generics/effects.rs
+++ b/components/style/values/generics/effects.rs
@@ -92,7 +92,6 @@ pub use self::GenericFilter as Filter;
 ///
 /// Contrary to the canonical order from the spec, the color is serialised
 /// first, like in Gecko and Webkit.
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,

--- a/components/style/values/generics/effects.rs
+++ b/components/style/values/generics/effects.rs
@@ -110,9 +110,9 @@ pub use self::GenericFilter as Filter;
 pub struct GenericSimpleShadow<Color, SizeLength, ShapeLength> {
     /// Color.
     pub color: Color,
-    /// Horizontal offset.
+    /// Horizontal radius.
     pub horizontal: SizeLength,
-    /// Vertical offset.
+    /// Vertical radius.
     pub vertical: SizeLength,
     /// Blur radius.
     pub blur: ShapeLength,

--- a/components/style/values/specified/effects.rs
+++ b/components/style/values/specified/effects.rs
@@ -47,7 +47,7 @@ pub type SpecifiedFilter = GenericFilter<
     NonNegativeFactor,
     ZeroToOneFactor,
     NonNegativeLength,
-    Impossible,
+    SimpleShadow,
     Impossible,
 >;
 

--- a/tests/wpt/meta-legacy-layout/css/css-masking/clip/clip-filter-order.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-masking/clip/clip-filter-order.html.ini
@@ -1,0 +1,2 @@
+[clip-filter-order.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/animation/filter-interpolation-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/animation/filter-interpolation-002.html.ini
@@ -68,22 +68,13 @@
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0) should be [hue-rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0.6) should be [blur(10px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.25) should be [hue-rotate(45deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0) should be [opacity(1) hue-rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (1.5) should be [blur(10px)\]]
@@ -95,13 +86,7 @@
   [Web Animations: property <filter> from [drop-shadow(20px 10px blue)\] to [drop-shadow(20px 10px green)\] at (2147483648) should be [drop-shadow(20px 10px #00FF00\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0.5) should be [hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (1) should be [hue-rotate(180deg)\]]
@@ -116,13 +101,7 @@
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.5) should be [opacity(0.75) hue-rotate(90deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (1.5) should be [blur(10px)\]]
@@ -149,9 +128,6 @@
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0) should be [grayscale(0) blur(0px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (1.5) should be [hue-rotate(-90deg)\]]
     expected: FAIL
 
@@ -168,9 +144,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0.5) should be [blur(8px) hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0.6) should be [blur(10px)\]]
@@ -191,9 +164,6 @@
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1) should be [opacity(0.5) hue-rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0) should be [blur(6px) hue-rotate(0deg)\]]
     expected: FAIL
 
@@ -206,34 +176,19 @@
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (1.5) should be [blur(12px) hue-rotate(270deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (1.5) should be [hue-rotate(270deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (-0.3) should be [grayscale(0) blur(0px)\]]

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/animation/filter-interpolation-003.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/animation/filter-interpolation-003.html.ini
@@ -161,9 +161,6 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [none\] at (1.5) should be [opacity(1)\]]
     expected: FAIL
 
@@ -186,9 +183,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (-1) should be [grayscale(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (1.5) should be [blur(5px)\]]
@@ -227,9 +221,6 @@
   [Web Animations: property <filter> from [initial\] to [sepia(1)\] at (0) should be [sepia(0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [initial\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
@@ -263,25 +254,16 @@
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (1) should be [invert(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (-0.3) should be [blur(5px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (0) should be [grayscale(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [url("#svgfilter")\]]
@@ -323,12 +305,6 @@
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [none\] at (1) should be [contrast(1)\]]
     expected: FAIL
 
@@ -368,9 +344,6 @@
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (-0.3) should be [url("#svgfilter")\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.5) should be [blur(5px)\]]
     expected: FAIL
 
@@ -402,9 +375,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (1.5) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (-1) should be [invert(0)\]]
@@ -440,12 +410,6 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0.5) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
@@ -456,9 +420,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (1) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.6) should be [blur(5px)\]]
@@ -488,9 +449,6 @@
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.3) should be [blur(5px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [saturate(0)\] to [none\] at (1.5) should be [saturate(1.5)\]]
     expected: FAIL
 
@@ -507,9 +465,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0.6) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (1) should be [none\]]

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/animation/filter-interpolation-004.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/animation/filter-interpolation-004.html.ini
@@ -161,12 +161,6 @@
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (0) should be [grayscale(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
@@ -179,19 +173,10 @@
   [Web Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0) should be [hue-rotate()\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (0) should be [invert(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1) should be [brightness()\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1.5) should be [contrast(1.5)\]]
@@ -209,13 +194,7 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1.5) should be [brightness(1.5)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (-1) should be [invert(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
@@ -236,9 +215,6 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (1) should be [opacity()\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (-1) should be [opacity(0)\]]
     expected: FAIL
 
@@ -251,9 +227,6 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0) should be [opacity(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [sepia(0)\] to [sepia()\] at (1) should be [sepia()\]]
     expected: FAIL
 
@@ -264,15 +237,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [saturate(0)\] to [saturate()\] at (-1) should be [saturate(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (1) should be [grayscale()\]]
@@ -314,9 +278,6 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0.5) should be [opacity(0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (0) should be [contrast(0)\]]
     expected: FAIL
 
@@ -326,16 +287,10 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (-1) should be [brightness(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (-1) should be [contrast(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
@@ -349,4 +304,3 @@
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1) should be [contrast()\]]
     expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/filters-drop-shadow-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/filters-drop-shadow-001.html.ini
@@ -1,2 +1,0 @@
-[filters-drop-shadow-001.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/parsing/filter-computed.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/parsing/filter-computed.html.ini
@@ -16,10 +16,3 @@
 
   [Property filter value 'blur(10px) url("https://www.example.com/picture.svg#f") contrast(20) brightness(30)']
     expected: FAIL
-
-  [Property filter value 'drop-shadow(1px 2px)']
-    expected: FAIL
-
-  [Property filter value 'drop-shadow(rgb(4, 5, 6) 1px 2px 0px)']
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/css/filter-effects/parsing/filter-parsing-valid.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/filter-effects/parsing/filter-parsing-valid.html.ini
@@ -1,23 +1,11 @@
 [filter-parsing-valid.html]
-  [e.style['filter'\] = "drop-shadow(1px 2px)" should set the property value]
-    expected: FAIL
-
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(1px 2px)"]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(1px 2px 3px)" should set the property value]
     expected: FAIL
 
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(1px 2px 3px)"]
     expected: FAIL
 
-  [e.style['filter'\] = "drop-shadow(0 0 0)" should set the property value]
-    expected: FAIL
-
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(0 0 0)"]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(1px 2px rgb(4, 5, 6))" should set the property value]
     expected: FAIL
 
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(1px 2px rgb(4, 5, 6))"]
@@ -47,15 +35,8 @@
   [Serialization should round-trip after setting e.style['filter'\] = "blur(10px) url(\\"picture.svg#f\\") contrast(20) brightness(30)"]
     expected: FAIL
 
-  [e.style['filter'\] = "drop-shadow(rgb(4, 5, 6) 1px 2px)" should set the property value]
-    expected: FAIL
-
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(rgb(4, 5, 6) 1px 2px)"]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(rgba(4, 5, 6, 0.75) 1px 2px 3px)" should set the property value]
     expected: FAIL
 
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(rgba(4, 5, 6, 0.75) 1px 2px 3px)"]
     expected: FAIL
-

--- a/tests/wpt/meta/css/css-masking/clip/clip-filter-order.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip/clip-filter-order.html.ini
@@ -1,0 +1,2 @@
+[clip-filter-order.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/animation/filter-interpolation-002.html.ini
+++ b/tests/wpt/meta/css/filter-effects/animation/filter-interpolation-002.html.ini
@@ -17,19 +17,10 @@
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0) should be [hue-rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.25) should be [hue-rotate(45deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0) should be [opacity(1) hue-rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (1.5) should be [blur(10px)\]]
@@ -41,13 +32,7 @@
   [Web Animations: property <filter> from [drop-shadow(20px 10px blue)\] to [drop-shadow(20px 10px green)\] at (2147483648) should be [drop-shadow(20px 10px #00FF00\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0.5) should be [hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (1) should be [hue-rotate(180deg)\]]
@@ -62,13 +47,7 @@
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.5) should be [opacity(0.75) hue-rotate(90deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [drop-shadow(20px 10px blue)\] to [drop-shadow(20px 10px green)\] at (2147483648) should be [drop-shadow(20px 10px #00FF00\]]
@@ -86,9 +65,6 @@
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (-0.5) should be [opacity(1) hue-rotate(-90deg)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (1.5) should be [hue-rotate(-90deg)\]]
     expected: FAIL
 
@@ -102,9 +78,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0.5) should be [blur(8px) hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0.6) should be [blur(10px)\]]
@@ -122,9 +95,6 @@
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1) should be [opacity(0.5) hue-rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0) should be [blur(6px) hue-rotate(0deg)\]]
     expected: FAIL
 
@@ -134,34 +104,19 @@
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (1.5) should be [blur(12px) hue-rotate(270deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #004100)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (1.5) should be [hue-rotate(270deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px currentcolor)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0.6) should be [blur(10px)\]]

--- a/tests/wpt/meta/css/filter-effects/animation/filter-interpolation-003.html.ini
+++ b/tests/wpt/meta/css/filter-effects/animation/filter-interpolation-003.html.ini
@@ -14,9 +14,6 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [none\] at (1.5) should be [opacity(1)\]]
     expected: FAIL
 
@@ -39,9 +36,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (-1) should be [grayscale(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (1.5) should be [blur(5px)\]]
@@ -80,9 +74,6 @@
   [Web Animations: property <filter> from [initial\] to [sepia(1)\] at (0) should be [sepia(0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [initial\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
@@ -116,25 +107,16 @@
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (1) should be [invert(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (-0.3) should be [blur(5px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (0) should be [grayscale(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [url("#svgfilter")\]]
@@ -176,12 +158,6 @@
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [none\] at (1) should be [contrast(1)\]]
     expected: FAIL
 
@@ -221,9 +197,6 @@
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (-0.3) should be [url("#svgfilter")\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.5) should be [blur(5px)\]]
     expected: FAIL
 
@@ -255,9 +228,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (1.5) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (-1) should be [invert(0)\]]
@@ -293,12 +263,6 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0.5) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
@@ -309,9 +273,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (1) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.6) should be [blur(5px)\]]
@@ -341,9 +302,6 @@
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.3) should be [blur(5px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [saturate(0)\] to [none\] at (1.5) should be [saturate(1.5)\]]
     expected: FAIL
 
@@ -360,9 +318,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0.6) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (1) should be [none\]]

--- a/tests/wpt/meta/css/filter-effects/animation/filter-interpolation-004.html.ini
+++ b/tests/wpt/meta/css/filter-effects/animation/filter-interpolation-004.html.ini
@@ -5,12 +5,6 @@
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (0) should be [grayscale(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
@@ -23,19 +17,10 @@
   [Web Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0) should be [hue-rotate()\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (0) should be [invert(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1) should be [brightness()\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1.5) should be [contrast(1.5)\]]
@@ -53,13 +38,7 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1.5) should be [brightness(1.5)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (-1) should be [invert(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
@@ -80,9 +59,6 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (1) should be [opacity()\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (-1) should be [opacity(0)\]]
     expected: FAIL
 
@@ -95,9 +71,6 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0) should be [opacity(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [sepia(0)\] to [sepia()\] at (1) should be [sepia()\]]
     expected: FAIL
 
@@ -108,15 +81,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [saturate(0)\] to [saturate()\] at (-1) should be [saturate(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (1) should be [grayscale()\]]
@@ -158,9 +122,6 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0.5) should be [opacity(0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (0) should be [contrast(0)\]]
     expected: FAIL
 
@@ -170,16 +131,10 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (-1) should be [brightness(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (-1) should be [contrast(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
@@ -193,4 +148,3 @@
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1) should be [contrast()\]]
     expected: FAIL
-

--- a/tests/wpt/meta/css/filter-effects/filters-drop-shadow-001.html.ini
+++ b/tests/wpt/meta/css/filter-effects/filters-drop-shadow-001.html.ini
@@ -1,2 +1,0 @@
-[filters-drop-shadow-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/parsing/filter-computed.html.ini
+++ b/tests/wpt/meta/css/filter-effects/parsing/filter-computed.html.ini
@@ -1,10 +1,3 @@
 [filter-computed.html]
   [Property filter value 'blur(10px) url("https://www.example.com/picture.svg#f") contrast(20) brightness(30)']
     expected: FAIL
-
-  [Property filter value 'drop-shadow(1px 2px)']
-    expected: FAIL
-
-  [Property filter value 'drop-shadow(rgb(4, 5, 6) 1px 2px 0px)']
-    expected: FAIL
-

--- a/tests/wpt/meta/css/filter-effects/parsing/filter-parsing-valid.html.ini
+++ b/tests/wpt/meta/css/filter-effects/parsing/filter-parsing-valid.html.ini
@@ -2,27 +2,8 @@
   [e.style['filter'\] = "url(\\"https://www.example.com/picture.svg#f\\")" should set the property value]
     expected: FAIL
 
-  [e.style['filter'\] = "drop-shadow(0 0 0)" should set the property value]
-    expected: FAIL
-
   [e.style['filter'\] = "url(picture.svg#f)" should set the property value]
     expected: FAIL
 
   [e.style['filter'\] = "blur(10px) url(\\"picture.svg#f\\") contrast(20) brightness(30)" should set the property value]
     expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(rgba(4, 5, 6, 0.75) 1px 2px 3px)" should set the property value]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(rgb(4, 5, 6) 1px 2px)" should set the property value]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(1px 2px 3px)" should set the property value]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(1px 2px)" should set the property value]
-    expected: FAIL
-
-  [e.style['filter'\] = "drop-shadow(1px 2px rgb(4, 5, 6))" should set the property value]
-    expected: FAIL
-


### PR DESCRIPTION
Huh, I'm genuinely surprised that nobody had implemented it so far;

This PR implements the WebRender conversions that are necessary in order to make `drop-shadow` work; However, with the goal of making `currentColor` work, the code is uh, not really as nice as I wish, since filter conversions ended needing to be split into its own trait and its own method that accepts a current color; I assume that there is a nicer way of doing this, and yeah, pointers to the right direction would be appreciated

The results, however, are pretty nice though!
![Cropped screenshot of Cookie Clicker showing the drop shadows working on Servo](https://github.com/servo/servo/assets/85590273/7c415982-bec3-4462-b2d9-d67ae6c11970)

About test results, `css/css-color/currentcolor-003.html` got a bit closer to passing (although `currentColor` handling still needs improvements) and I assume `css/filter-effects/filters-drop-shadow-003.html` still fails due to positioning issues

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #5187

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
