### PR TITLE
Add timeout to unit tests on mac

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -79,6 +79,7 @@ jobs:
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-mac' }}
+        timeout-minutes: 30 # https://github.com/servo/servo/issues/30275
         run: python3 ./mach test-unit --release
       - name: Package
         run: python3 ./mach package --release


### PR DESCRIPTION
Workaround for https://github.com/servo/servo/issues/30275

Whole mq pipeline is slowed down by one faulty run for 6h.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
