### PR TITLE
Fix WPT import by overriding product name to servo

### DIFF
--- a/python/wpt/manifestupdate.py
+++ b/python/wpt/manifestupdate.py
@@ -34,6 +34,7 @@ def create_parser():
 def update(check_clean=True, rebuild=False, **kwargs):
     logger = wptlogging.setup(kwargs, {"mach": sys.stdout})
     kwargs = {"config": os.path.join(WPT_PATH, "config.ini"),
+              "product": "servo",
               "manifest_path": os.path.join(WPT_PATH, "meta"),
               "tests_root": None,
               "metadata_root": None}

--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -103,8 +103,8 @@ def update_tests(**kwargs) -> int:
         if key not in args or args[key] is None:
             args[key] = value
 
-    set_if_none(kwargs, "product", "servo")
     set_if_none(kwargs, "config", os.path.join(WPT_PATH, "config.ini"))
+    kwargs["product"] = "servo"
     kwargs["store_state"] = False
 
     wptcommandline.set_from_config(kwargs)


### PR DESCRIPTION
Upstream WPT update script has bug where 'product' defaults to 'firefox' and this causes import of uninstalled python modules specific to firefox runners.

Fixes #30452

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30452 
- [x] These changes do not require tests because they fix failing CI job
