### PR TITLE
Fix pinch zoom and enable it for TouchpadMagnify events

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -548,8 +548,8 @@ where
                 self.compositor.on_zoom_reset_window_event();
             },
 
-            EmbedderEvent::PinchZoom(magnification) => {
-                self.compositor.on_pinch_zoom_window_event(magnification);
+            EmbedderEvent::PinchZoom(zoom) => {
+                self.compositor.on_pinch_zoom_window_event(zoom);
             },
 
             EmbedderEvent::Navigation(top_level_browsing_context_id, direction) => {

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -462,6 +462,12 @@ impl WindowPortsMethods for Window {
                     .borrow_mut()
                     .push(EmbedderEvent::Touch(phase, id, point));
             },
+            winit::event::WindowEvent::TouchpadMagnify { delta, .. } => {
+                let magnification = delta as f32 + 1.0;
+                self.event_queue
+                    .borrow_mut()
+                    .push(EmbedderEvent::PinchZoom(magnification));
+            },
             winit::event::WindowEvent::CloseRequested => {
                 self.event_queue.borrow_mut().push(EmbedderEvent::Quit);
             },


### PR DESCRIPTION
Pinch zoom was broken because pinch zoom events were triggered at -1, -1
in the compositor. This change:

1. Differentiates between magnify and scroll events in the compositor to
   remove the question of where to trigger them.
2. Converts winit TouchpadMagnify events into pinch zoom events so that
   this works properly on MacOS.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it is very difficult to test interaction in Servo currently.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
