### PR TITLE
Adjust the missing taplo message

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -60,9 +60,7 @@ TEST_SUITES_BY_PREFIX = {path: k for k, v in TEST_SUITES.items() if "paths" in v
 def format_toml_files_with_taplo(check_only: bool = True) -> int:
     taplo = shutil.which("taplo")
     if taplo is None:
-        print("Taplo is not installed.")
-        print("It should be installed using `./mach bootstrap`, \
-                but it can be installed manually using `cargo install taplo-cli --locked`")
+        print("Could not find `taplo`. Run `./mach bootstrap` or `cargo install taplo-cli --locked`")
         return 1
 
     if check_only:


### PR DESCRIPTION
The current message doesn't have a line break where you would expect it
to and instead has a gap due to the indentation of the code in Python.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just tweak a `./mach` warning.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
