### PR TITLE
Fix libsimpleservo build

### DIFF
--- a/ports/libsimpleservo/api/build.rs
+++ b/ports/libsimpleservo/api/build.rs
@@ -62,13 +62,9 @@ fn main() {
             .unwrap();
     }
 
-    // Merge prefs.json and package-prefs.json
     let mut default_prefs = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     default_prefs.push("../../../resources/prefs.json");
-    let mut prefs: Value = serde_json::from_reader(File::open(&default_prefs).unwrap()).unwrap();
-    let mut pkg_prefs = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    pkg_prefs.push("../../../resources/package-prefs.json");
-    let pkg_prefs: Value = serde_json::from_reader(File::open(&pkg_prefs).unwrap()).unwrap();
+    let prefs: Value = serde_json::from_reader(File::open(&default_prefs).unwrap()).unwrap();
     let file = File::create(&dest.join("prefs.json")).unwrap();
     serde_json::to_writer(file, &prefs).unwrap();
 }

--- a/ports/libsimpleservo/api/src/gl_glue.rs
+++ b/ports/libsimpleservo/api/src/gl_glue.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![allow(bare_trait_objects)] // Until https://github.com/brendanzab/gl-rs/pull/493
-
+                              //
 pub type ServoGl = std::rc::Rc<dyn servo::gl::Gl>;
 
 #[cfg(any(target_os = "android", target_os = "windows"))]
@@ -12,6 +12,7 @@ pub mod egl {
     use std::ffi::CString;
     use std::os::raw::c_void;
 
+    use log::info;
     use servo::gl::GlesFns;
 
     pub type EGLNativeWindowType = *const libc::c_void;
@@ -73,6 +74,7 @@ pub mod gl {
         CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName,
     };
     use core_foundation::string::CFString;
+    use log::info;
     use servo::gl::GlFns;
 
     pub fn init() -> Result<crate::gl_glue::ServoGl, &'static str> {
@@ -104,6 +106,7 @@ pub mod gl {
     use std::os::raw::c_void;
 
     use libloading::{Library, Symbol};
+    use log::info;
     use servo::gl::GlFns;
 
     pub fn init() -> Result<crate::gl_glue::ServoGl, &'static str> {

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 
 use getopts::Options;
 use ipc_channel::ipc::IpcSender;
+use log::{debug, info, warn};
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, EmbedderEvent, EmbedderMethods, MouseWindowEvent,
     WindowMethods,
@@ -40,7 +41,7 @@ use servo::webrender_api::ScrollLocation;
 use servo::webrender_surfman::WebrenderSurfman;
 use servo::{self, gl, BrowserId, Servo};
 use servo_media::player::context as MediaPlayerContext;
-use surfman::{Adapter, Connection, SurfaceType};
+use surfman::{Connection, SurfaceType};
 
 thread_local! {
     pub static SERVO: RefCell<Option<ServoGlue>> = RefCell::new(None);

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -18,7 +18,8 @@ use std::sync::{Mutex, RwLock};
 #[cfg(not(target_os = "windows"))]
 use env_logger;
 use keyboard_types::Key;
-use log::LevelFilter;
+use lazy_static::lazy_static;
+use log::{debug, error, info, warn, LevelFilter};
 use simpleservo::{
     self, gl_glue, ContextMenuResult, Coordinates, DeviceIntRect, EventLoopWaker, HostTrait,
     InitOptions, InputMethodType, MediaSessionActionType, MediaSessionPlaybackState, MouseButton,

--- a/ports/libsimpleservo/capi/src/prefs.rs
+++ b/ports/libsimpleservo/capi/src/prefs.rs
@@ -12,6 +12,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 
+use log::debug;
+
 use crate::simpleservo::{self, PrefValue};
 
 thread_local! {


### PR DESCRIPTION
It seems the build has been broken on desktop platforms. This is a
preliminary fix to getting this build on the bots.

This is mainly missing includes, but `package-prefs.json` is no longer
processed because that was only used for the UWP port (now removed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's just a build fix.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
