### PR TITLE
Add taplo to etc/shell.nix

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -22,6 +22,7 @@ clangStdenv.mkDerivation rec {
     gst_all_1.gst-plugins-bad
 
     rustup
+    taplo
     llvmPackages.bintools # provides lld
 
     # Build utilities


### PR DESCRIPTION
This addresses the 'Could not find `taplo` ...' message
when running `./mach test-tidy` on NixOS.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>
