### PR TITLE
Fix `MacOsSampler` unused in background_hang_monitor

### DIFF
--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -100,7 +100,10 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
             not(any(target_arch = "arm", target_arch = "aarch64"))
         ))]
         let sampler = crate::sampler_linux::LinuxSampler::new();
-        #[cfg(any(target_os = "android", target_arch = "arm", target_arch = "aarch64"))]
+        #[cfg(all(
+            any(target_os = "android", target_os = "linux"),
+            any(target_arch = "arm", target_arch = "aarch64")
+        ))]
         let sampler = crate::sampler::DummySampler::new();
 
         // When a component is registered, and there's an exit request that


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Mac's sampler isn't used due to conditional compilation in dummy sampler. This PR tries to fix this warning.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix no github issue.
- [x] These changes do not require tests but following warning should not exist.

```
  --> components/background_hang_monitor/background_hang_monitor.rs:97:13
   |
97 |         let sampler = crate::sampler_mac::MacOsSampler::new();
   |             ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sampler`
   |
   = note: `#[warn(unused_variables)]` on by default
```


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
