### PR TITLE
Only access hit test items for the current epoch in the compositor

### DIFF
--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -31,6 +31,19 @@ impl Into<WebRenderEpoch> for Epoch {
     }
 }
 
+pub trait WebRenderEpochToU16 {
+    fn as_u16(&self) -> u16;
+}
+
+impl WebRenderEpochToU16 for WebRenderEpoch {
+    /// The value of this [`Epoch`] as a u16 value. Note that if this Epoch's
+    /// value is more than u16::MAX, then the return value will be modulo
+    /// u16::MAX.
+    fn as_u16(&self) -> u16 {
+        (self.0 % u16::MAX as u32) as u16
+    }
+}
+
 /// A unique ID for every stacking context.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct StackingContextId(

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -7,6 +7,7 @@
 //           This might be achieved by sharing types between WR and Servo display lists, or
 //           completely converting layout to directly generate WebRender display lists, for example.
 
+use gfx_traits::WebRenderEpochToU16;
 use log::trace;
 use msg::constellation_msg::PipelineId;
 use script_traits::compositor::{CompositorDisplayListInfo, ScrollTreeNodeId, ScrollableNodeInfo};
@@ -190,7 +191,7 @@ impl DisplayItem {
                     clip_id: ClipId::ClipChain(current_clip_chain_id),
                     flags: PrimitiveFlags::default(),
                 },
-                (hit_test_index as u64, 0u16),
+                (hit_test_index as u64, state.compositor_info.epoch.as_u16()),
             );
         };
 

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -9,6 +9,7 @@ use embedder_traits::Cursor;
 use euclid::{Point2D, SideOffsets2D, Size2D};
 use fnv::FnvHashMap;
 use gfx::text::glyph::GlyphStore;
+use gfx_traits::WebRenderEpochToU16;
 use msg::constellation_msg::BrowsingContextId;
 use net_traits::image_cache::UsePlaceholder;
 use script_traits::compositor::{CompositorDisplayListInfo, ScrollTreeNodeId};
@@ -180,7 +181,10 @@ impl<'a> DisplayListBuilder<'a> {
             Some(cursor(inherited_ui.cursor.keyword, auto_cursor)),
             self.current_scroll_node_id,
         );
-        Some((hit_test_index as u64, 0u16))
+        Some((
+            hit_test_index as u64,
+            self.display_list.compositor_info.epoch.as_u16(),
+        ))
     }
 }
 


### PR DESCRIPTION
When display lists update quickly, a hit test result might be returned
for a previous display list / list of hit test items. When that happens,
ignore the hit test result.

This fixes a crash, but there might be situations where we can do
something better, such as wait for display list processing to finish
before performing the hit test. A future change might do this for events
like mouse clicks and touch events that should never be thrown away.
Ultimately, the best thing is likely moving hit testing back to layout
or script so a valid hit test can always be performed against the
current DOM.

Fixes #29796.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29796.
- [x] These changes do not require tests because there still isn't a good way to test behavior of rapidly changing display lists and mouse movement over the compositor.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
