### PR TITLE
Rename messages forwarded from the constellation to the compositor

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -11,8 +11,9 @@ use std::rc::Rc;
 
 use canvas::canvas_paint_thread::ImageUpdate;
 use compositing_traits::{
-    CompositingReason, CompositionPipeline, CompositorMsg, CompositorReceiver, ConstellationMsg,
-    SendableFrameTree, WebrenderCanvasMsg, WebrenderFontMsg, WebrenderMsg,
+    CanvasToCompositorMsg, CompositingReason, CompositionPipeline, CompositorMsg,
+    CompositorReceiver, ConstellationMsg, FontToCompositorMsg, ForwardedToCompositorMsg,
+    SendableFrameTree,
 };
 use crossbeam_channel::Sender;
 use embedder_traits::Cursor;
@@ -640,7 +641,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 }
             },
 
-            (CompositorMsg::Webrender(msg), ShutdownState::NotShuttingDown) => {
+            (CompositorMsg::Forwarded(msg), ShutdownState::NotShuttingDown) => {
                 self.handle_webrender_message(msg);
             },
 
@@ -655,9 +656,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
     /// Accept messages from content processes that need to be relayed to the WebRender
     /// instance in the parent process.
-    fn handle_webrender_message(&mut self, msg: WebrenderMsg) {
+    fn handle_webrender_message(&mut self, msg: ForwardedToCompositorMsg) {
         match msg {
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendInitialTransaction(pipeline)) => {
+            ForwardedToCompositorMsg::Layout(
+                script_traits::ScriptToCompositorMsg::SendInitialTransaction(pipeline),
+            ) => {
                 self.waiting_on_pending_frame = true;
                 let mut txn = Transaction::new();
                 txn.set_display_list(
@@ -672,7 +675,9 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
             },
 
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendScrollNode(point, scroll_id)) => {
+            ForwardedToCompositorMsg::Layout(
+                script_traits::ScriptToCompositorMsg::SendScrollNode(point, scroll_id),
+            ) => {
                 self.waiting_for_results_of_scroll = true;
 
                 let mut txn = Transaction::new();
@@ -682,11 +687,13 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
             },
 
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendDisplayList {
-                display_list_info,
-                display_list_descriptor,
-                display_list_receiver,
-            }) => {
+            ForwardedToCompositorMsg::Layout(
+                script_traits::ScriptToCompositorMsg::SendDisplayList {
+                    display_list_info,
+                    display_list_descriptor,
+                    display_list_receiver,
+                },
+            ) => {
                 let display_list_data = match display_list_receiver.recv() {
                     Ok(display_list_data) => display_list_data,
                     _ => return warn!("Could not recieve WebRender display list."),
@@ -715,7 +722,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
             },
 
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::HitTest(
+            ForwardedToCompositorMsg::Layout(script_traits::ScriptToCompositorMsg::HitTest(
                 pipeline,
                 point,
                 flags,
@@ -737,12 +744,18 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(result);
             },
 
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::GenerateImageKey(sender)) |
-            WebrenderMsg::Net(net_traits::WebrenderImageMsg::GenerateImageKey(sender)) => {
+            ForwardedToCompositorMsg::Layout(
+                script_traits::ScriptToCompositorMsg::GenerateImageKey(sender),
+            ) |
+            ForwardedToCompositorMsg::Net(net_traits::NetToCompositorMsg::GenerateImageKey(
+                sender,
+            )) => {
                 let _ = sender.send(self.webrender_api.generate_image_key());
             },
 
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::UpdateImages(updates)) => {
+            ForwardedToCompositorMsg::Layout(
+                script_traits::ScriptToCompositorMsg::UpdateImages(updates),
+            ) => {
                 let mut txn = Transaction::new();
                 for update in updates {
                     match update {
@@ -767,14 +780,22 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
             },
 
-            WebrenderMsg::Net(net_traits::WebrenderImageMsg::AddImage(key, desc, data)) => {
+            ForwardedToCompositorMsg::Net(net_traits::NetToCompositorMsg::AddImage(
+                key,
+                desc,
+                data,
+            )) => {
                 let mut txn = Transaction::new();
                 txn.add_image(key, desc, data, None);
                 self.webrender_api
                     .send_transaction(self.webrender_document, txn);
             },
 
-            WebrenderMsg::Font(WebrenderFontMsg::AddFontInstance(font_key, size, sender)) => {
+            ForwardedToCompositorMsg::Font(FontToCompositorMsg::AddFontInstance(
+                font_key,
+                size,
+                sender,
+            )) => {
                 let key = self.webrender_api.generate_font_instance_key();
                 let mut txn = Transaction::new();
                 txn.add_font_instance(key, font_key, size, None, None, Vec::new());
@@ -783,7 +804,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(key);
             },
 
-            WebrenderMsg::Font(WebrenderFontMsg::AddFont(data, sender)) => {
+            ForwardedToCompositorMsg::Font(FontToCompositorMsg::AddFont(data, sender)) => {
                 let font_key = self.webrender_api.generate_font_key();
                 let mut txn = Transaction::new();
                 match data {
@@ -795,11 +816,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(font_key);
             },
 
-            WebrenderMsg::Canvas(WebrenderCanvasMsg::GenerateKey(sender)) => {
+            ForwardedToCompositorMsg::Canvas(CanvasToCompositorMsg::GenerateKey(sender)) => {
                 let _ = sender.send(self.webrender_api.generate_image_key());
             },
 
-            WebrenderMsg::Canvas(WebrenderCanvasMsg::UpdateImages(updates)) => {
+            ForwardedToCompositorMsg::Canvas(CanvasToCompositorMsg::UpdateImages(updates)) => {
                 let mut txn = Transaction::new();
                 for update in updates {
                     match update {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -104,8 +104,8 @@ use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use canvas_traits::webgl::WebGLThreads;
 use canvas_traits::ConstellationCanvasMsg;
 use compositing_traits::{
-    CompositorMsg, CompositorProxy, ConstellationMsg as FromCompositorMsg, SendableFrameTree,
-    WebrenderMsg,
+    CompositorMsg, CompositorProxy, ConstellationMsg as FromCompositorMsg,
+    ForwardedToCompositorMsg, SendableFrameTree,
 };
 use crossbeam_channel::{after, never, select, unbounded, Receiver, Sender};
 use devtools_traits::{
@@ -716,8 +716,10 @@ where
                 ROUTER.add_route(
                     webrender_ipc_receiver.to_opaque(),
                     Box::new(move |message| {
-                        let _ = compositor_proxy.send(CompositorMsg::Webrender(
-                            WebrenderMsg::Layout(message.to().expect("conversion failure")),
+                        let _ = compositor_proxy.send(CompositorMsg::Forwarded(
+                            ForwardedToCompositorMsg::Layout(
+                                message.to().expect("conversion failure"),
+                            ),
                         ));
                     }),
                 );
@@ -726,9 +728,11 @@ where
                 ROUTER.add_route(
                     webrender_image_ipc_receiver.to_opaque(),
                     Box::new(move |message| {
-                        let _ = compositor_proxy.send(CompositorMsg::Webrender(WebrenderMsg::Net(
-                            message.to().expect("conversion failure"),
-                        )));
+                        let _ = compositor_proxy.send(CompositorMsg::Forwarded(
+                            ForwardedToCompositorMsg::Net(
+                                message.to().expect("conversion failure"),
+                            ),
+                        ));
                     }),
                 );
 

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -823,23 +823,23 @@ pub fn http_percent_encode(bytes: &[u8]) -> String {
 }
 
 #[derive(Deserialize, Serialize)]
-pub enum WebrenderImageMsg {
+pub enum NetToCompositorMsg {
     AddImage(ImageKey, ImageDescriptor, ImageData),
     GenerateImageKey(IpcSender<ImageKey>),
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-pub struct WebrenderIpcSender(IpcSender<WebrenderImageMsg>);
+pub struct WebrenderIpcSender(IpcSender<NetToCompositorMsg>);
 
 impl WebrenderIpcSender {
-    pub fn new(sender: IpcSender<WebrenderImageMsg>) -> Self {
+    pub fn new(sender: IpcSender<NetToCompositorMsg>) -> Self {
         Self(sender)
     }
 
     pub fn generate_image_key(&self) -> ImageKey {
         let (sender, receiver) = ipc::channel().unwrap();
         self.0
-            .send(WebrenderImageMsg::GenerateImageKey(sender))
+            .send(NetToCompositorMsg::GenerateImageKey(sender))
             .expect("error sending image key generation");
         receiver.recv().expect("error receiving image key result")
     }
@@ -847,7 +847,7 @@ impl WebrenderIpcSender {
     pub fn add_image(&self, key: ImageKey, descriptor: ImageDescriptor, data: ImageData) {
         if let Err(e) = self
             .0
-            .send(WebrenderImageMsg::AddImage(key, descriptor, data))
+            .send(NetToCompositorMsg::AddImage(key, descriptor, data))
         {
             warn!("Error sending image update: {}", e);
         }


### PR DESCRIPTION
The constellation forwards messages from other tasks to the compositor.
Mainly, these are passed to WebRender. This change updates the names of
these messages so it is clearer where they are coming from and where
they are going.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
