### PR TITLE
Bootstrap pkg-config and cmake on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ Sessionx.vim
 # Layout debugger trace files
 layout_trace*
 
+# Package managers
+support/macos/Brewfile.lock.json
+
 # direnv
 .envrc

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ manually, try the [manual build setup][manual-build].
 - Install [Xcode](https://developer.apple.com/xcode/)
 - Install [Homebrew](https://brew.sh/)
 - Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- Run `pip install virtualenv`
+- Run `pip3 install virtualenv`
 - Run `./mach bootstrap`<br/>
   *Note: This will install the recommended version of GStreamer globally on your system.*
 

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -55,7 +55,19 @@ class MacOS(Base):
         return True
 
     def _platform_bootstrap(self, _force: bool) -> bool:
-        return self._platform_bootstrap_gstreamer(False)
+        installed_something = False
+        try:
+            brewfile = os.path.join(util.SERVO_ROOT, "support", "macos", "Brewfile")
+            output = subprocess.check_output(
+                ['brew', 'bundle', 'install', "--file", brewfile]
+            ).decode("utf-8")
+            print(output)
+            installed_something = "Installing" in output
+        except subprocess.CalledProcessError as e:
+            print("Could not run homebrew. Is it installed?")
+            raise e
+        installed_something |= self._platform_bootstrap_gstreamer(False)
+        return installed_something
 
     def _platform_bootstrap_gstreamer(self, force: bool) -> bool:
         if not force and self.is_gstreamer_installed(cross_compilation_target=None):

--- a/support/macos/Brewfile
+++ b/support/macos/Brewfile
@@ -1,0 +1,2 @@
+brew "cmake"
+brew "pkg-config"


### PR DESCRIPTION
These need to be installed in order to build so we can install them via
Homebrew. Do this by simply restoring the Homebrew bootstrapping logic
we had in place previously.

Fixes #30354.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just update the boostrap scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
