### PR TITLE
Add EndeavourOS as a supported platform

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -131,6 +131,7 @@ class Linux(Base):
             'arch linux',
             'arch',
             'artix',
+            'endeavouros',
             'centos linux',
             'centos',
             'debian gnu/linux',


### PR DESCRIPTION

Add EndeavourOS, an arch based system, to the distro list.