### PR TITLE
Fix filter clipping caused by `overflow: hidden`

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -425,8 +425,6 @@ impl StackingContext {
             None => return false,
         };
 
-        let clip_id: Option<wr::ClipId> = self.clip_chain_id.map(|id| wr::ClipId::ClipChain(id));
-
         // WebRender only uses the stacking context to apply certain effects. If we don't
         // actually need to create a stacking context, just avoid creating one.
         let effects = style.get_effects();
@@ -437,6 +435,8 @@ impl StackingContext {
         {
             return false;
         }
+
+        let clip_id = self.clip_chain_id.map(wr::ClipId::ClipChain);
 
         // Create the filter pipeline.
         let current_color = style.clone_color();

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -271,7 +271,7 @@ pub struct StackingContext {
     /// things like preserve-3d.
     spatial_id: wr::SpatialId,
 
-    /// The clip chain id of this fragment if it has one. Used for filter clipping.
+    /// The clip chain id of this stacking context if it has one. Used for filter clipping.
     clip_chain_id: Option<wr::ClipChainId>,
 
     /// The fragment that established this stacking context.

--- a/tests/wpt/meta/css/filter-effects/blur-clip-stacking-context-001.html.ini
+++ b/tests/wpt/meta/css/filter-effects/blur-clip-stacking-context-001.html.ini
@@ -1,2 +1,0 @@
-[blur-clip-stacking-context-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/drop-shadow-clipped-001.html.ini
+++ b/tests/wpt/meta/css/filter-effects/drop-shadow-clipped-001.html.ini
@@ -1,2 +1,0 @@
-[drop-shadow-clipped-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/filter-effects/will-change-blur-filter-under-clip.html.ini
+++ b/tests/wpt/meta/css/filter-effects/will-change-blur-filter-under-clip.html.ini
@@ -1,2 +1,0 @@
-[will-change-blur-filter-under-clip.html]
-  expected: FAIL


### PR DESCRIPTION
This is an attempt to fix filter clipping which well, had limited success;
I suspect that feeding the clip chain id to the stacking context is only one piece of the puzzle (although maybe an important one), considering that while it does fix clipping caused by `overflow: hidden`, clipping caused by `clip` still doesn't affect CSS filters;

Please do note that once again, I wasn't able to test everything

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
