### PR TITLE
Fix the location url that reverts to the old value while loading

### DIFF
--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -51,7 +51,7 @@ enum PumpResult {
     /// period, but has to call [`Servo::present`] to perform page flip and tell Servo compositor
     /// to continue rendering.
     Resize,
-    HistoryChanged
+    HistoryChanged,
 }
 
 impl App {
@@ -332,8 +332,10 @@ impl App {
                         if minibrowser.update_location_in_toolbar(browser) {
                             // Update the minibrowser immediately. While we could update by requesting a
                             // redraw, doing so would delay the location update by two frames.
-                            minibrowser
-                                .update(window.winit_window().unwrap(), "update_location_in_toolbar");
+                            minibrowser.update(
+                                window.winit_window().unwrap(),
+                                "update_location_in_toolbar",
+                            );
                         }
                     }
                 },
@@ -423,12 +425,13 @@ impl App {
         let mut history_changed = false;
         loop {
             // Consume and handle those embedder messages.
-            let (new_need_present, new_history_changed) = browser.handle_servo_events(embedder_messages);
+            let (new_need_present, new_history_changed) =
+                browser.handle_servo_events(embedder_messages);
             need_present |= new_need_present;
             history_changed |= new_history_changed;
 
             if history_changed {
-                return Some(PumpResult::HistoryChanged)
+                return Some(PumpResult::HistoryChanged);
             }
 
             // Route embedder events from the Browser to the relevant Servo components,

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -315,21 +315,24 @@ impl App {
                     match present {
                         Present::Immediate => {
                             // The window was resized.
-                            trace!("PumpResult::Resize");
+                            trace!("PumpResult::Present::Immediate");
 
                             // Resizes are unusual in that we need to repaint synchronously.
                             // TODO(servo#30049) can we replace this with the simpler Servo::recomposite?
                             app.servo.as_mut().unwrap().repaint_synchronously();
 
                             if let Some(mut minibrowser) = app.minibrowser() {
-                                minibrowser.update(window.winit_window().unwrap(), "PumpResult::Resize");
+                                minibrowser.update(
+                                    window.winit_window().unwrap(),
+                                    "PumpResult::Present::Immediate",
+                                );
                                 minibrowser.paint(window.winit_window().unwrap());
                             }
                             app.servo.as_mut().unwrap().present();
                         },
                         Present::Deferred => {
                             // The compositor has painted to this frame.
-                            trace!("PumpResult::ReadyToPresent");
+                            trace!("PumpResult::Present::Deferred");
 
                             // Request a winit redraw event, so we can paint the minibrowser and present.
                             // Otherwise, it's in headless mode and we present directly.

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -109,8 +109,15 @@ impl App {
             webrender_surfman.make_gl_context_current().unwrap();
             debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR);
 
-            app.minibrowser =
-                Some(Minibrowser::new(&webrender_surfman, &events_loop, window.as_ref()).into());
+            app.minibrowser = Some(
+                Minibrowser::new(
+                    &webrender_surfman,
+                    &events_loop,
+                    window.as_ref(),
+                    initial_url.clone(),
+                )
+                .into(),
+            );
         }
 
         if let Some(mut minibrowser) = app.minibrowser() {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -299,7 +299,6 @@ impl App {
                     present,
                 } => {
                     if history_changed {
-                        // The history was chnaged.
                         if let Some(mut minibrowser) = app.minibrowser() {
                             let browser = &mut app.browser.borrow_mut();
                             if minibrowser.update_location_in_toolbar(browser) {

--- a/ports/servoshell/browser.rs
+++ b/ports/servoshell/browser.rs
@@ -277,7 +277,7 @@ where
         self.event_queue.push(event);
     }
 
-    /// Returns true iff the caller needs to manually present a new frame.
+    /// Returns true if the caller needs to manually present a new frame.
     pub fn handle_servo_events(&mut self, events: Vec<(Option<BrowserId>, EmbedderMsg)>) -> (bool, bool) {
         let mut need_present = false;
         let mut history_changed = false;

--- a/ports/servoshell/browser.rs
+++ b/ports/servoshell/browser.rs
@@ -50,6 +50,11 @@ pub struct Browser<Window: WindowPortsMethods + ?Sized> {
     shutdown_requested: bool,
 }
 
+pub struct ServoEventResponse {
+    pub need_present: bool,
+    pub history_changed: bool,
+}
+
 impl<Window> Browser<Window>
 where
     Window: WindowPortsMethods + ?Sized,
@@ -281,7 +286,7 @@ where
     pub fn handle_servo_events(
         &mut self,
         events: Vec<(Option<BrowserId>, EmbedderMsg)>,
-    ) -> (bool, bool) {
+    ) -> ServoEventResponse {
         let mut need_present = false;
         let mut history_changed = false;
         for (browser_id, msg) in events {
@@ -543,7 +548,10 @@ where
             }
         }
 
-        (need_present, history_changed)
+        ServoEventResponse {
+            need_present,
+            history_changed,
+        }
     }
 }
 

--- a/ports/servoshell/browser.rs
+++ b/ports/servoshell/browser.rs
@@ -278,8 +278,9 @@ where
     }
 
     /// Returns true iff the caller needs to manually present a new frame.
-    pub fn handle_servo_events(&mut self, events: Vec<(Option<BrowserId>, EmbedderMsg)>) -> bool {
+    pub fn handle_servo_events(&mut self, events: Vec<(Option<BrowserId>, EmbedderMsg)>) -> (bool, bool) {
         let mut need_present = false;
+        let mut history_changed = false;
         for (browser_id, msg) in events {
             trace!(
                 "embedder <- servo EmbedderMsg ({:?}, {:?})",
@@ -456,6 +457,7 @@ where
                 EmbedderMsg::HistoryChanged(urls, current) => {
                     self.current_url = Some(urls[current].clone());
                     self.current_url_string = Some(urls[current].clone().into_string());
+                    history_changed = true;
                 },
                 EmbedderMsg::SetFullscreenState(state) => {
                     self.window.set_fullscreen(state);
@@ -538,7 +540,7 @@ where
             }
         }
 
-        need_present
+        (need_present, history_changed)
     }
 }
 

--- a/ports/servoshell/browser.rs
+++ b/ports/servoshell/browser.rs
@@ -278,7 +278,10 @@ where
     }
 
     /// Returns true if the caller needs to manually present a new frame.
-    pub fn handle_servo_events(&mut self, events: Vec<(Option<BrowserId>, EmbedderMsg)>) -> (bool, bool) {
+    pub fn handle_servo_events(
+        &mut self,
+        events: Vec<(Option<BrowserId>, EmbedderMsg)>,
+    ) -> (bool, bool) {
         let mut need_present = false;
         let mut history_changed = false;
         for (browser_id, msg) in events {

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -143,7 +143,7 @@ impl Minibrowser {
     }
 
     /// Updates the location field from the given [Browser], unless the user has started editing it
-    /// without clicking Go, returning true iff the location has changed (needing an egui update).
+    /// without clicking Go, returning true if the location has changed (needing an egui update).
     pub fn update_location_in_toolbar(
         &mut self,
         browser: &mut Browser<dyn WindowPortsMethods>,
@@ -155,7 +155,7 @@ impl Minibrowser {
 
         match browser.current_url_string() {
             Some(location) if location != self.location.get_mut() => {
-                self.location = RefCell::new(self.location.get_mut().to_string());
+                self.location = RefCell::new(location.to_owned());
                 true
             },
             _ => false,

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -143,7 +143,7 @@ impl Minibrowser {
     }
 
     /// Updates the location field from the given [Browser], unless the user has started editing it
-    /// without clicking Go, returning true if the location has changed (needing an egui update).
+    /// without clicking Go, returning true iff the location has changed (needing an egui update).
     pub fn update_location_in_toolbar(
         &mut self,
         browser: &mut Browser<dyn WindowPortsMethods>,

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -11,6 +11,7 @@ use euclid::Length;
 use log::{trace, warn};
 use servo::compositing::windowing::EmbedderEvent;
 use servo::servo_geometry::DeviceIndependentPixel;
+use servo::servo_url::ServoUrl;
 use servo::webrender_surfman::WebrenderSurfman;
 
 use crate::browser::Browser;

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -40,6 +40,7 @@ impl Minibrowser {
         webrender_surfman: &WebrenderSurfman,
         events_loop: &EventsLoop,
         window: &dyn WindowPortsMethods,
+        initial_url: ServoUrl,
     ) -> Self {
         let gl = unsafe {
             glow::Context::from_loader_function(|s| webrender_surfman.get_proc_address(s))
@@ -56,7 +57,7 @@ impl Minibrowser {
             event_queue: RefCell::new(vec![]),
             toolbar_height: Default::default(),
             last_update: Instant::now(),
-            location: RefCell::new(String::default()),
+            location: RefCell::new(initial_url.to_string()),
             location_dirty: false.into(),
         }
     }
@@ -154,7 +155,7 @@ impl Minibrowser {
 
         match browser.current_url_string() {
             Some(location) if location != self.location.get_mut() => {
-                self.location = RefCell::new(location.to_owned());
+                self.location = RefCell::new(self.location.get_mut().to_string());
                 true
             },
             _ => false,


### PR DESCRIPTION
Changing two things in this PR
1. When we start servo we always have a default_url, see `fn get_default_url()`, right now in the minibrowser the default is set to String::Default(). Changing it to default_url in minibrowser as well
2. To avoid flickering of the url in the location bar, I have introduce `PumpResult::HistoryChanged`, now we only update the url when history has changed ie. `HistoryChanged`

----
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes is part of #30049 
