### PR TITLE
Fix running servoshell and unit tests through a symlink

### DIFF
--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -44,25 +44,6 @@ pub fn sandbox_access_files_dirs() -> Vec<PathBuf> {
         .sandbox_access_files_dirs()
 }
 
-pub fn filename(file: Resource) -> &'static str {
-    match file {
-        Resource::Preferences => "prefs.json",
-        Resource::BluetoothBlocklist => "gatt_blocklist.txt",
-        Resource::DomainList => "public_domains.txt",
-        Resource::HstsPreloadList => "hsts_preload.json",
-        Resource::BadCertHTML => "badcert.html",
-        Resource::NetErrorHTML => "neterror.html",
-        Resource::UserAgentCSS => "user-agent.css",
-        Resource::ServoCSS => "servo.css",
-        Resource::PresentationalHintsCSS => "presentational-hints.css",
-        Resource::QuirksModeCSS => "quirks-mode.css",
-        Resource::RippyPNG => "rippy.png",
-        Resource::MediaControlsCSS => "media-controls.css",
-        Resource::MediaControlsJS => "media-controls.js",
-        Resource::CrashHTML => "crash.html",
-    }
-}
-
 pub enum Resource {
     Preferences,
     BluetoothBlocklist,
@@ -78,6 +59,27 @@ pub enum Resource {
     MediaControlsCSS,
     MediaControlsJS,
     CrashHTML,
+}
+
+impl Resource {
+    pub fn filename(&self) -> &'static str {
+        match self {
+            Resource::Preferences => "prefs.json",
+            Resource::BluetoothBlocklist => "gatt_blocklist.txt",
+            Resource::DomainList => "public_domains.txt",
+            Resource::HstsPreloadList => "hsts_preload.json",
+            Resource::BadCertHTML => "badcert.html",
+            Resource::NetErrorHTML => "neterror.html",
+            Resource::UserAgentCSS => "user-agent.css",
+            Resource::ServoCSS => "servo.css",
+            Resource::PresentationalHintsCSS => "presentational-hints.css",
+            Resource::QuirksModeCSS => "quirks-mode.css",
+            Resource::RippyPNG => "rippy.png",
+            Resource::MediaControlsCSS => "media-controls.css",
+            Resource::MediaControlsJS => "media-controls.js",
+            Resource::CrashHTML => "crash.html",
+        }
+    }
 }
 
 pub trait ResourceReaderMethods {
@@ -136,9 +138,8 @@ fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
             vec![]
         }
         fn read(&self, file: Resource) -> Vec<u8> {
-            let file = filename(file);
             let mut path = resources_dir_path_for_tests().expect("Can't find resources directory");
-            path.push(file);
+            path.push(file.filename());
             std::fs::read(path).expect("Can't read file")
         }
     }

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -108,17 +108,20 @@ fn resources_dir_path_for_tests() -> PathBuf {
         return PathBuf::from(path);
     }
 
+    // Try ./resources in the current directory, then each of its ancestors.
     let mut path = std::env::current_dir().unwrap();
-    while path.pop() {
+    loop {
         path.push("resources");
         if path.is_dir() {
             *dir = Some(path);
             return dir.clone().unwrap();
         }
         path.pop();
-    }
 
-    panic!("Can't find resources directory")
+        if !path.pop() {
+            panic!("Can't find resources directory")
+        }
+    }
 }
 
 fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -108,24 +108,6 @@ fn resources_dir_path_for_tests() -> PathBuf {
         return PathBuf::from(path);
     }
 
-    let mut path = std::env::current_exe().unwrap();
-    while path.pop() {
-        path.push("resources");
-        if path.is_dir() {
-            *dir = Some(path);
-            return dir.clone().unwrap();
-        }
-        path.pop();
-
-        // Check for Resources on mac when using a case sensitive filesystem.
-        path.push("Resources");
-        if path.is_dir() {
-            *dir = Some(path);
-            return dir.clone().unwrap();
-        }
-        path.pop();
-    }
-
     let mut path = std::env::current_dir().unwrap();
     while path.pop() {
         path.push("resources");

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Once, RwLock};
 
 use lazy_static::lazy_static;
@@ -14,11 +14,6 @@ lazy_static! {
 
 pub fn set(reader: Box<dyn ResourceReaderMethods + Sync + Send>) {
     *RES.write().unwrap() = Some(reader);
-}
-
-pub fn set_for_tests() {
-    static ONCE: Once = Once::new();
-    ONCE.call_once(|| set(resources_for_tests()));
 }
 
 pub fn read_bytes(res: Resource) -> Vec<u8> {
@@ -49,6 +44,25 @@ pub fn sandbox_access_files_dirs() -> Vec<PathBuf> {
         .sandbox_access_files_dirs()
 }
 
+pub fn filename(file: Resource) -> &'static str {
+    match file {
+        Resource::Preferences => "prefs.json",
+        Resource::BluetoothBlocklist => "gatt_blocklist.txt",
+        Resource::DomainList => "public_domains.txt",
+        Resource::HstsPreloadList => "hsts_preload.json",
+        Resource::BadCertHTML => "badcert.html",
+        Resource::NetErrorHTML => "neterror.html",
+        Resource::UserAgentCSS => "user-agent.css",
+        Resource::ServoCSS => "servo.css",
+        Resource::PresentationalHintsCSS => "presentational-hints.css",
+        Resource::QuirksModeCSS => "quirks-mode.css",
+        Resource::RippyPNG => "rippy.png",
+        Resource::MediaControlsCSS => "media-controls.css",
+        Resource::MediaControlsJS => "media-controls.js",
+        Resource::CrashHTML => "crash.html",
+    }
+}
+
 pub enum Resource {
     Preferences,
     BluetoothBlocklist,
@@ -72,10 +86,47 @@ pub trait ResourceReaderMethods {
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf>;
 }
 
+// Can’t #[cfg(test)] the following because it breaks tests in dependent crates.
+
+pub fn set_for_tests() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| set(resources_for_tests()));
+}
+
+lazy_static::lazy_static! {
+    static ref CMD_RESOURCE_DIR: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+}
+
+fn resources_dir_path_for_tests() -> std::io::Result<PathBuf> {
+    // This needs to be called before the process is sandboxed
+    // as we only give permission to read inside the resources directory,
+    // not the permissions the "search" for the resources directory.
+    let mut dir = CMD_RESOURCE_DIR.lock().unwrap();
+    if let Some(ref path) = *dir {
+        return Ok(PathBuf::from(path));
+    }
+
+    let mut path = std::env::current_exe()?.parent().unwrap().to_owned();
+    path.push("resources");
+    if path.is_dir() {
+        *dir = Some(path);
+        return Ok(dir.clone().unwrap());
+    }
+
+    // Check for Resources on mac when using a case sensitive filesystem.
+    path.pop();
+    path.push("Resources");
+    if path.is_dir() {
+        *dir = Some(path);
+        return Ok(dir.clone().unwrap());
+    }
+
+    let path = Path::new("resources").to_owned();
+    *dir = Some(path);
+    Ok(dir.clone().unwrap())
+}
+
 fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
-    use std::env;
-    use std::fs::File;
-    use std::io::Read;
     struct ResourceReader;
     impl ResourceReaderMethods for ResourceReader {
         fn sandbox_access_files(&self) -> Vec<PathBuf> {
@@ -85,38 +136,10 @@ fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
             vec![]
         }
         fn read(&self, file: Resource) -> Vec<u8> {
-            let file = match file {
-                Resource::Preferences => "prefs.json",
-                Resource::BluetoothBlocklist => "gatt_blocklist.txt",
-                Resource::DomainList => "public_domains.txt",
-                Resource::HstsPreloadList => "hsts_preload.json",
-                Resource::BadCertHTML => "badcert.html",
-                Resource::NetErrorHTML => "neterror.html",
-                Resource::UserAgentCSS => "user-agent.css",
-                Resource::ServoCSS => "servo.css",
-                Resource::PresentationalHintsCSS => "presentational-hints.css",
-                Resource::QuirksModeCSS => "quirks-mode.css",
-                Resource::RippyPNG => "rippy.png",
-                Resource::MediaControlsCSS => "media-controls.css",
-                Resource::MediaControlsJS => "media-controls.js",
-                Resource::CrashHTML => "crash.html",
-            };
-            let mut path = env::current_exe().unwrap();
-            path = path.canonicalize().unwrap();
-            while path.pop() {
-                path.push("resources");
-                if path.is_dir() {
-                    break;
-                }
-                path.pop();
-            }
+            let file = filename(file);
+            let mut path = resources_dir_path_for_tests().expect("Can't find resources directory");
             path.push(file);
-            let mut buffer = vec![];
-            File::open(path)
-                .expect(&format!("Can't find file: {}", file))
-                .read_to_end(&mut buffer)
-                .expect("Can't read file");
-            buffer
+            std::fs::read(path).expect("Can't read file")
         }
     }
     Box::new(ResourceReader)

--- a/ports/gstplugin/resources.rs
+++ b/ports/gstplugin/resources.rs
@@ -6,37 +6,17 @@
 // TODO: move this to somewhere where it can be shared.
 // https://github.com/servo/servo/issues/24853
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{env, fs, io};
 
-use lazy_static::lazy_static;
-use servo::embedder_traits::resources::{self, Resource};
+use servo::embedder_traits::resources::{self, filename, Resource};
 
-lazy_static! {
-    static ref CMD_RESOURCE_DIR: Mutex<Option<String>> = Mutex::new(None);
+lazy_static::lazy_static! {
+    static ref CMD_RESOURCE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
 }
 
 struct ResourceReader;
-
-fn filename(file: Resource) -> &'static str {
-    match file {
-        Resource::Preferences => "prefs.json",
-        Resource::BluetoothBlocklist => "gatt_blocklist.txt",
-        Resource::DomainList => "public_domains.txt",
-        Resource::HstsPreloadList => "hsts_preload.json",
-        Resource::BadCertHTML => "badcert.html",
-        Resource::NetErrorHTML => "neterror.html",
-        Resource::UserAgentCSS => "user-agent.css",
-        Resource::ServoCSS => "servo.css",
-        Resource::PresentationalHintsCSS => "presentational-hints.css",
-        Resource::QuirksModeCSS => "quirks-mode.css",
-        Resource::RippyPNG => "rippy.png",
-        Resource::MediaControlsCSS => "media-controls.css",
-        Resource::MediaControlsJS => "media-controls.js",
-        Resource::CrashHTML => "crash.html",
-    }
-}
 
 pub fn init() {
     resources::set(Box::new(ResourceReader));
@@ -51,28 +31,24 @@ fn resources_dir_path() -> io::Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
 
-    // FIXME: Find a way to not rely on the executable being
-    // under `<servo source>[/$target_triple]/target/debug`
-    // or `<servo source>[/$target_triple]/target/release`.
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // Follow symlink
-    path = path.canonicalize()?;
-
-    while path.pop() {
-        path.push("resources");
-        if path.is_dir() {
-            break;
-        }
-        path.pop();
-        // Check for Resources on mac when using a case sensitive filesystem.
-        path.push("Resources");
-        if path.is_dir() {
-            break;
-        }
-        path.pop();
+    let mut path = env::current_exe()?.parent().unwrap().to_owned();
+    path.push("resources");
+    if path.is_dir() {
+        *dir = Some(path);
+        return Ok(dir.clone().unwrap());
     }
-    *dir = Some(path.to_str().unwrap().to_owned());
-    Ok(path)
+
+    // Check for Resources on mac when using a case sensitive filesystem.
+    path.pop();
+    path.push("Resources");
+    if path.is_dir() {
+        *dir = Some(path);
+        return Ok(dir.clone().unwrap());
+    }
+
+    let path = Path::new("resources").to_owned();
+    *dir = Some(path);
+    Ok(dir.clone().unwrap())
 }
 
 impl resources::ResourceReaderMethods for ResourceReader {
@@ -80,7 +56,7 @@ impl resources::ResourceReaderMethods for ResourceReader {
         let file = filename(file);
         let mut path = resources_dir_path().expect("Can't find resources directory");
         path.push(file);
-        fs::read(path.clone()).expect(&format!("Can't read file {:?}", path))
+        fs::read(path).expect("Can't read file")
     }
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> {
         vec![resources_dir_path().expect("Can't find resources directory")]

--- a/ports/gstplugin/resources.rs
+++ b/ports/gstplugin/resources.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{env, fs, io};
 
-use servo::embedder_traits::resources::{self, filename, Resource};
+use servo::embedder_traits::resources::{self, Resource};
 
 lazy_static::lazy_static! {
     static ref CMD_RESOURCE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
@@ -53,9 +53,8 @@ fn resources_dir_path() -> io::Result<PathBuf> {
 
 impl resources::ResourceReaderMethods for ResourceReader {
     fn read(&self, file: Resource) -> Vec<u8> {
-        let file = filename(file);
         let mut path = resources_dir_path().expect("Can't find resources directory");
-        path.push(file);
+        path.push(file.filename());
         fs::read(path).expect("Can't read file")
     }
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> {

--- a/ports/gstplugin/resources.rs
+++ b/ports/gstplugin/resources.rs
@@ -6,9 +6,9 @@
 // TODO: move this to somewhere where it can be shared.
 // https://github.com/servo/servo/issues/24853
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Mutex;
-use std::{env, fs, io};
+use std::{env, fs};
 
 use servo::embedder_traits::resources::{self, Resource};
 
@@ -22,43 +22,59 @@ pub fn init() {
     resources::set(Box::new(ResourceReader));
 }
 
-fn resources_dir_path() -> io::Result<PathBuf> {
+fn resources_dir_path() -> PathBuf {
     // This needs to be called before the process is sandboxed
     // as we only give permission to read inside the resources directory,
     // not the permissions the "search" for the resources directory.
     let mut dir = CMD_RESOURCE_DIR.lock().unwrap();
     if let Some(ref path) = *dir {
-        return Ok(PathBuf::from(path));
+        return PathBuf::from(path);
     }
 
-    let mut path = env::current_exe()?.parent().unwrap().to_owned();
-    path.push("resources");
-    if path.is_dir() {
-        *dir = Some(path);
-        return Ok(dir.clone().unwrap());
+    // Try ./resources and ./Resources relative to the directory containing the
+    // canonicalised executable path, then each of its ancestors.
+    let mut path = env::current_exe().unwrap().canonicalize().unwrap();
+    while path.pop() {
+        path.push("resources");
+        if path.is_dir() {
+            *dir = Some(path);
+            return dir.clone().unwrap();
+        }
+        path.pop();
+
+        // Check for Resources on mac when using a case sensitive filesystem.
+        path.push("Resources");
+        if path.is_dir() {
+            *dir = Some(path);
+            return dir.clone().unwrap();
+        }
+        path.pop();
     }
 
-    // Check for Resources on mac when using a case sensitive filesystem.
-    path.pop();
-    path.push("Resources");
-    if path.is_dir() {
-        *dir = Some(path);
-        return Ok(dir.clone().unwrap());
-    }
+    // Try ./resources in the current directory, then each of its ancestors.
+    let mut path = std::env::current_dir().unwrap();
+    loop {
+        path.push("resources");
+        if path.is_dir() {
+            *dir = Some(path);
+            return dir.clone().unwrap();
+        }
+        path.pop();
 
-    let path = Path::new("resources").to_owned();
-    *dir = Some(path);
-    Ok(dir.clone().unwrap())
+        if !path.pop() {
+            panic!("Can't find resources directory")
+        }
+    }
 }
 
 impl resources::ResourceReaderMethods for ResourceReader {
     fn read(&self, file: Resource) -> Vec<u8> {
-        let mut path = resources_dir_path().expect("Can't find resources directory");
+        let mut path = resources_dir_path();
         path.push(file.filename());
         fs::read(path).expect("Can't read file")
     }
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> {
-        vec![resources_dir_path().expect("Can't find resources directory")]
+        vec![resources_dir_path()]
     }
     fn sandbox_access_files(&self) -> Vec<PathBuf> {
         vec![]

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -6,10 +6,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 
-use getopts::{Matches, Options};
-use servo::config::opts::{self, ArgumentParsingResult};
+use getopts::Matches;
+use servo::config::opts;
 use servo::config::prefs::{self, PrefValue};
-use servo::embedder_traits;
 use servo::servo_config::basedir;
 
 pub fn register_user_prefs(opts_matches: &Matches) {
@@ -61,16 +60,15 @@ pub fn register_user_prefs(opts_matches: &Matches) {
     prefs::add_user_prefs(userprefs);
 }
 
-// Use for test
-#[allow(dead_code)]
+#[cfg(test)]
 fn test_parse_pref(arg: &str) {
-    embedder_traits::resources::set_for_tests();
-    let mut opts = Options::new();
+    servo::embedder_traits::resources::set_for_tests();
+    let mut opts = getopts::Options::new();
     opts.optmulti("", "pref", "", "");
     let args = vec!["servo".to_string(), "--pref".to_string(), arg.to_string()];
     let matches = match opts::from_cmdline_args(opts, &args) {
-        ArgumentParsingResult::ContentProcess(m, _) => m,
-        ArgumentParsingResult::ChromeProcess(m) => m,
+        opts::ArgumentParsingResult::ContentProcess(m, _) => m,
+        opts::ArgumentParsingResult::ChromeProcess(m) => m,
     };
     register_user_prefs(&matches);
 }

--- a/ports/servoshell/resources.rs
+++ b/ports/servoshell/resources.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{env, fs, io};
 
-use servo::embedder_traits::resources::{self, filename, Resource};
+use servo::embedder_traits::resources::{self, Resource};
 
 lazy_static::lazy_static! {
     static ref CMD_RESOURCE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
@@ -49,9 +49,8 @@ fn resources_dir_path() -> io::Result<PathBuf> {
 
 impl resources::ResourceReaderMethods for ResourceReader {
     fn read(&self, file: Resource) -> Vec<u8> {
-        let file = filename(file);
         let mut path = resources_dir_path().expect("Can't find resources directory");
-        path.push(file);
+        path.push(file.filename());
         fs::read(path).expect("Can't read file")
     }
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> {


### PR DESCRIPTION
Servo relies on several external files in /resources/, and the loading of these resources is delegated to the embedder. In this repo, libsimpleservo compiles them in with include_bytes!(), while the other three (servoshell, gstplugin, and unit tests) try to read them from the filesystem at runtime.

Our current logic for searching for the resources directory tries to accommodate both local dev in this repo (../../resources relative to servo, or a further ancestor in the case of unit tests) and nightly builds (resources relative to servo, or Resources relative to a further ancestor in the case of macOS):

1. let _path_ = the current executable path
2. canonicalise _path_, resolving any symlinks
3. let _path_ = parent of _path_
4. try _path_/resources
5. try _path_/Resources
6. go to step 3

But this fails if target is symlinked to another filesystem, like I recently did to exclude it from my backups:

```
% ls -l target
lrwxrwxrwx 1 delan users 25 Sep 28 15:34 target -> /cuffs/build/servo/target
```

This patch adds (or replaces those with, for unit tests) a few steps as follows:

7. let _path_ = the current directory
8. try _path_/resources
9. let _path_ = parent of _path_
10. go to step 8

The new logic:

* allows servoshell and unit tests to be run with a symlinked target directory
* does not require any special environment variables, so you can run target/debug/servo in e.g. renderdoc
* does not affect the behaviour of our nightly releases

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30536

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___