### PR TITLE
Use `IpcSharedMemory` for `Canvas2dMsg::DrawImage`

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -451,6 +451,7 @@ impl<'a> CanvasData<'a> {
         dest_rect: Rect<f64>,
         source_rect: Rect<f64>,
         smoothing_enabled: bool,
+        premultiply: bool,
     ) {
         // We round up the floating pixel values to draw the pixels
         let source_rect = source_rect.ceil();
@@ -469,6 +470,7 @@ impl<'a> CanvasData<'a> {
                 source_rect.size,
                 dest_rect,
                 smoothing_enabled,
+                premultiply,
                 &draw_options,
             );
         };
@@ -1306,18 +1308,24 @@ pub struct CanvasPaintState<'a> {
 /// image_size: The size of the image to be written
 /// dest_rect: Area of the destination target where the pixels will be copied
 /// smoothing_enabled: It determines if smoothing is applied to the image result
+/// premultiply: Determines whenever the image data should be premultiplied or not
 fn write_image(
     draw_target: &mut dyn GenericDrawTarget,
     mut image_data: Vec<u8>,
     image_size: Size2D<f64>,
     dest_rect: Rect<f64>,
     smoothing_enabled: bool,
+    premultiply: bool,
     draw_options: &DrawOptions,
 ) {
     if image_data.is_empty() {
         return;
     }
-    pixels::rgba8_premultiply_inplace(&mut image_data);
+
+    if premultiply {
+        pixels::rgba8_premultiply_inplace(&mut image_data);
+    }
+
     let image_rect = Rect::new(Point2D::zero(), image_size);
 
     // From spec https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -446,7 +446,7 @@ impl<'a> CanvasData<'a> {
 
     pub fn draw_image(
         &mut self,
-        image_data: Vec<u8>,
+        image_data: &[u8],
         image_size: Size2D<f64>,
         dest_rect: Rect<f64>,
         source_rect: Rect<f64>,
@@ -1308,7 +1308,7 @@ pub struct CanvasPaintState<'a> {
 /// smoothing_enabled: It determines if smoothing is applied to the image result
 fn write_image(
     draw_target: &mut dyn GenericDrawTarget,
-    image_data: Vec<u8>,
+    mut image_data: Vec<u8>,
     image_size: Size2D<f64>,
     dest_rect: Rect<f64>,
     smoothing_enabled: bool,
@@ -1317,6 +1317,7 @@ fn write_image(
     if image_data.is_empty() {
         return;
     }
+    pixels::rgba8_premultiply_inplace(&mut image_data);
     let image_rect = Rect::new(Point2D::zero(), image_size);
 
     // From spec https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -189,7 +189,7 @@ impl<'a> CanvasPaintThread<'a> {
             ),
             Canvas2dMsg::DrawEmptyImage(image_size, dest_rect, source_rect) => {
                 self.canvas(canvas_id).draw_image(
-                    &vec![0; image_size.area() as usize],
+                    &vec![0; image_size.area() as usize * 4],
                     image_size,
                     dest_rect,
                     source_rect,

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -186,6 +186,7 @@ impl<'a> CanvasPaintThread<'a> {
                 dest_rect,
                 source_rect,
                 smoothing_enabled,
+                true,
             ),
             Canvas2dMsg::DrawEmptyImage(image_size, dest_rect, source_rect) => {
                 self.canvas(canvas_id).draw_image(
@@ -193,6 +194,7 @@ impl<'a> CanvasPaintThread<'a> {
                     image_size,
                     dest_rect,
                     source_rect,
+                    false,
                     false,
                 )
             },
@@ -212,6 +214,7 @@ impl<'a> CanvasPaintThread<'a> {
                     dest_rect,
                     source_rect,
                     smoothing,
+                    false,
                 );
             },
             Canvas2dMsg::MoveTo(ref point) => self.canvas(canvas_id).move_to(point),

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -175,22 +175,25 @@ impl<'a> CanvasPaintThread<'a> {
                 .canvas(canvas_id)
                 .is_point_in_path(x, y, fill_rule, chan),
             Canvas2dMsg::DrawImage(
-                imagedata,
                 image_size,
                 dest_rect,
                 source_rect,
                 smoothing_enabled,
-            ) => {
-                let data = imagedata.map_or_else(
-                    || vec![0; image_size.width as usize * image_size.height as usize * 4],
-                    |bytes| bytes.into_vec(),
-                );
+                ref image_data,
+            ) => self.canvas(canvas_id).draw_image(
+                &*image_data,
+                image_size,
+                dest_rect,
+                source_rect,
+                smoothing_enabled,
+            ),
+            Canvas2dMsg::DrawEmptyImage(image_size, dest_rect, source_rect) => {
                 self.canvas(canvas_id).draw_image(
-                    data,
+                    &vec![0; image_size.area() as usize],
                     image_size,
                     dest_rect,
                     source_rect,
-                    smoothing_enabled,
+                    false,
                 )
             },
             Canvas2dMsg::DrawImageInOther(
@@ -204,7 +207,7 @@ impl<'a> CanvasPaintThread<'a> {
                     .canvas(canvas_id)
                     .read_pixels(source_rect.to_u64(), image_size.to_u64());
                 self.canvas(other_canvas_id).draw_image(
-                    image_data.into(),
+                    &image_data,
                     source_rect.size,
                     dest_rect,
                     source_rect,

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -175,11 +175,11 @@ impl<'a> CanvasPaintThread<'a> {
                 .canvas(canvas_id)
                 .is_point_in_path(x, y, fill_rule, chan),
             Canvas2dMsg::DrawImage(
+                ref image_data,
                 image_size,
                 dest_rect,
                 source_rect,
                 smoothing_enabled,
-                ref image_data,
             ) => self.canvas(canvas_id).draw_image(
                 &*image_data,
                 image_size,

--- a/components/canvas_traits/canvas.rs
+++ b/components/canvas_traits/canvas.rs
@@ -41,7 +41,7 @@ pub struct CanvasImageData {
 pub enum Canvas2dMsg {
     Arc(Point2D<f32>, f32, f32, f32, bool),
     ArcTo(Point2D<f32>, Point2D<f32>, f32),
-    DrawImage(Size2D<f64>, Rect<f64>, Rect<f64>, bool, IpcSharedMemory),
+    DrawImage(IpcSharedMemory, Size2D<f64>, Rect<f64>, Rect<f64>, bool),
     DrawEmptyImage(Size2D<f64>, Rect<f64>, Rect<f64>),
     DrawImageInOther(CanvasId, Size2D<f64>, Rect<f64>, Rect<f64>, bool),
     BeginPath,

--- a/components/canvas_traits/canvas.rs
+++ b/components/canvas_traits/canvas.rs
@@ -41,7 +41,8 @@ pub struct CanvasImageData {
 pub enum Canvas2dMsg {
     Arc(Point2D<f32>, f32, f32, f32, bool),
     ArcTo(Point2D<f32>, Point2D<f32>, f32),
-    DrawImage(Option<ByteBuf>, Size2D<f64>, Rect<f64>, Rect<f64>, bool),
+    DrawImage(Size2D<f64>, Rect<f64>, Rect<f64>, bool, IpcSharedMemory),
+    DrawEmptyImage(Size2D<f64>, Rect<f64>, Rect<f64>),
     DrawImageInOther(CanvasId, Size2D<f64>, Rect<f64>, Rect<f64>, bool),
     BeginPath,
     BezierCurveTo(Point2D<f32>, Point2D<f32>, Point2D<f32>),

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -597,11 +597,11 @@ impl CanvasState {
 
         let smoothing_enabled = self.state.borrow().image_smoothing_enabled;
         self.send_canvas_2d_msg(Canvas2dMsg::DrawImage(
+            image_data,
             image_size,
             dest_rect,
             source_rect,
             smoothing_enabled,
-            image_data,
         ));
         self.mark_as_dirty(canvas);
         Ok(())


### PR DESCRIPTION
This replaces the `ByteBuf` used in order to transmit image data to the 2D canvas thread with the image's `IpcSharedMemory`, in a manner similar to how image data is transmitted in WebGL.

The result is a speed-up on `ctx.drawImage` operations which manifests most obviously on Cookie Clicker's early stages (see #30535); There are, however, other bottlenecks, such as text rendering (alleviated by disabling the "Numbers" option) and having the multiple building canvases visible (alleviated by selecting another menu).

This, however, might make an inconsistent freeze caused by selecting a language happen more frequently, but I couldn't determine whenever this is an aggravation of a pre-existing issue or just plain bad luck. Please do double-check my stuff

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially address #30535
- [x] There are tests for these changes
