### PR TITLE
Add documentation to a few pref configs

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -511,7 +511,7 @@ mod gen {
                     #[serde(rename = "shell.native-titlebar.enabled")]
                     enabled: bool,
                 },
-                /// URL string of the search engine webpage like google and duckduckgo.
+                /// URL string of the search engine page (for example <https://google.com> or and <https://duckduckgo.com>.
                 searchpage: String,
             },
             webgl: {

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -145,6 +145,7 @@ mod gen {
             },
             dom: {
                 webgpu: {
+                    /// Enable WebGPU APIs.
                     enabled: bool,
                 },
                 bluetooth: {
@@ -274,6 +275,7 @@ mod gen {
                     enabled: bool,
                 },
                 webgl2: {
+                    /// Enable WebGL2 APIs.
                     enabled: bool,
                 },
                 webrtc: {
@@ -490,12 +492,14 @@ mod gen {
             },
             shell: {
                 background_color: {
+                    /// The background color of shell's viewport. This will be used by OpenGL's `glClearColor`.
                     #[serde(rename = "shell.background-color.rgba")]
                     rgba: [f64; 4],
                 },
                 crash_reporter: {
                     enabled: bool,
                 },
+                /// URL string of the homepage.
                 homepage: String,
                 keep_screen_on: {
                     enabled: bool,
@@ -503,9 +507,11 @@ mod gen {
                 #[serde(rename = "shell.native-orientation")]
                 native_orientation: String,
                 native_titlebar: {
+                    /// Enable native window's titlebar and decorations.
                     #[serde(rename = "shell.native-titlebar.enabled")]
                     enabled: bool,
                 },
+                /// URL string of the search engine webpage like google and duckduckgo.
                 searchpage: String,
             },
             webgl: {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Initial attempt to add documentation to `pref` types. Only the last field of the config can be documented due to proc-macro. (For example, `shell.homepage`'s `homepage` field) I'm only confident of adding these doc comments for now. We can add more later if there are people who understand what other prefs mean. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this is about adding doc comments. But the `./mach doc` command should pass.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
