### PR TITLE
Temporarily convert existing cfg(debug_assertions) crashes to warnings

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -2108,9 +2108,12 @@ impl WebGLImpl {
                         error!("JS backtrace from failed WebGL API:\n{}", backtrace);
                     }
                 }
-                panic!(
-                    "Unexpected WebGL error: 0x{:x} ({}) [{:?}]",
-                    error, error, command
+                // TODO(servo#30568) revert to panic!() once underlying bug is fixed
+                log::warn!(
+                    "debug assertion failed! Unexpected WebGL error: 0x{:x} ({}) [{:?}]",
+                    error,
+                    error,
+                    command
                 );
             }
         }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3168,10 +3168,11 @@ where
         // https://github.com/rust-lang/rust/issues/59159
         let browsing_context_size = browsing_context.size;
         let browsing_context_is_visible = browsing_context.is_visible;
-        debug_assert_eq!(
-            browsing_context_size,
-            load_info.window_size.initial_viewport
-        );
+        // TODO(servo#30571) revert to debug_assert_eq!() once underlying bug is fixed
+        #[cfg(debug_assertions)]
+        if !(browsing_context_size == load_info.window_size.initial_viewport) {
+            log::warn!("debug assertion failed! browsing_context_size == load_info.window_size.initial_viewport");
+        }
 
         // Create the new pipeline, attached to the parent and push to pending changes
         self.new_pipeline(

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1762,7 +1762,11 @@ impl BlockFlow {
         }
 
         // If you remove the might_have_floats_in conditional, this will go off.
-        debug_assert!(!self.is_inline_flex_item());
+        // TODO(servo#30572) revert to debug_assert!() once underlying bug is fixed
+        #[cfg(debug_assertions)]
+        if !(!self.is_inline_flex_item()) {
+            log::warn!("debug assertion failed! !self.is_inline_flex_item()");
+        }
 
         // Compute the available space for us, based on the actual floats.
         let rect = self.base.floats.available_rect(

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -163,7 +163,9 @@ impl Floats {
 
     /// Adjusts the recorded offset of the flow relative to the first float.
     pub fn translate(&mut self, delta: LogicalSize<Au>) {
-        self.offset = self.offset + delta
+        // TODO(servo#30577) revert once underlying bug is fixed
+        // self.offset = self.offset + delta
+        self.offset = self.offset.add_or_warn(delta)
     }
 
     /// Returns the position of the last float in flow coordinates.

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -1376,7 +1376,11 @@ impl MutableOwnedFlowUtils for FlowRef {
         let base = FlowRef::deref_mut(self).mut_base();
 
         for descendant_link in abs_descendants.descendant_links.iter_mut() {
-            debug_assert!(!descendant_link.has_reached_containing_block);
+            // TODO(servo#30573) revert to debug_assert!() once underlying bug is fixed
+            #[cfg(debug_assertions)]
+            if !(!descendant_link.has_reached_containing_block) {
+                log::warn!("debug assertion failed! !descendant_link.has_reached_containing_block");
+            }
             let descendant_base = FlowRef::deref_mut(&mut descendant_link.flow).mut_base();
             descendant_base.absolute_cb.set(this.clone());
         }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1517,7 +1517,9 @@ impl Fragment {
         if let Some(ref inline_fragment_context) = self.inline_context {
             for node in &inline_fragment_context.nodes {
                 if node.style.get_box().position == Position::Relative {
-                    rel_pos = rel_pos + from_style(&*node.style, containing_block_size);
+                    // TODO(servo#30577) revert once underlying bug is fixed
+                    // rel_pos = rel_pos + from_style(&*node.style, containing_block_size);
+                    rel_pos = rel_pos.add_or_warn(from_style(&*node.style, containing_block_size));
                 }
             }
         }

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -544,7 +544,11 @@ impl StackingContext {
             first
         } else {
             // This should only happen if the root element has `display: none`
-            debug_panic!("`CanvasBackground::for_root_element` should have returned `style: None`");
+            // TODO(servo#30569) revert to debug_panic!() once underlying bug is fixed
+            log::warn!(
+                "debug assertion failed! `CanvasBackground::for_root_element` should have returned `style: None`",
+            );
+            return;
         };
 
         let StackingContextContent::Fragment { fragment, scroll_node_id, containing_block, .. }

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -258,10 +258,11 @@ impl BoxFragment {
             return PhysicalSides::new(top, right, bottom, left);
         }
 
-        debug_assert!(
-            position == ComputedPosition::Fixed || position == ComputedPosition::Absolute,
-            "Got unknown position."
-        );
+        // TODO(servo#30570) revert to debug_assert!() once underlying bug is fixed
+        #[cfg(debug_assertions)]
+        if !(position == ComputedPosition::Fixed || position == ComputedPosition::Absolute) {
+            log::warn!("debug assertion failed! Got unknown position.");
+        }
 
         let resolve = |value: &LengthPercentageOrAuto, container_length| {
             value

--- a/components/style/logical_geometry.rs
+++ b/components/style/logical_geometry.rs
@@ -570,6 +570,22 @@ impl<T: Add<T, Output = T>> Add for LogicalSize<T> {
     }
 }
 
+// TODO(servo#30577) remove this once underlying bugs are fixed
+impl<T: Add<T, Output = T>> LogicalSize<T> {
+    #[inline]
+    pub fn add_or_warn(self, other: LogicalSize<T>) -> LogicalSize<T> {
+        #[cfg(debug_assertions)]
+        if !(self.debug_writing_mode.mode == other.debug_writing_mode.mode) {
+            log::warn!("debug assertion failed! self.debug_writing_mode.mode == other.debug_writing_mode.mode");
+        }
+        LogicalSize {
+            debug_writing_mode: self.debug_writing_mode,
+            inline: self.inline + other.inline,
+            block: self.block + other.block,
+        }
+    }
+}
+
 impl<T: Sub<T, Output = T>> Sub for LogicalSize<T> {
     type Output = LogicalSize<T>;
 


### PR DESCRIPTION
#30509 enables debug assertions in local dev builds and on CI, but existing debug assertions mean that hundreds of tests would now crash, and @mrobinson and I believe that updating their expectations accordingly risks worsening our test coverage until the underlying bugs are fixed.

This patch temporarily converts the offending assertions to warnings.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to #30568
- [x] These changes are related to #30569
- [x] These changes are related to #30570
- [x] These changes are related to #30571
- [x] These changes are related to #30572
- [x] These changes are related to #30573
- [x] These changes are related to #30577

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___