### PR TITLE
Add a heuristic to detect collapse through in IFCs

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -167,7 +167,7 @@ jobs:
     name: Results
     needs: ["parse-comment", "run-try"]
     runs-on: ubuntu-latest
-    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).try}}
+    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
     steps:
       - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -236,6 +236,7 @@ fn traverse_pseudo_element_contents<'dom, Node>(
                     outside: DisplayOutside::Inline,
                     inside: DisplayInside::Flow {
                         is_list_item: false,
+                        is_table_part: false,
                     },
                 };
                 // `display` is not inherited, so we get the initial value

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -75,7 +75,7 @@ impl IndependentFormattingContext {
         match contents.try_into() {
             Ok(non_replaced) => {
                 let contents = match display_inside {
-                    DisplayInside::Flow { is_list_item } |
+                    DisplayInside::Flow { is_list_item, .. } |
                     DisplayInside::FlowRoot { is_list_item } => {
                         NonReplacedFormattingContextContents::Flow(
                             BlockFormattingContext::construct(

--- a/tests/wpt/tests/css/CSS2/floats/float-in-inline-margin-collapse.html
+++ b/tests/wpt/tests/css/CSS2/floats/float-in-inline-margin-collapse.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>CSS Test: float inside inline surrounded by elements with margins</title>
+<link rel="author" href="mailto:obrufrau@igalia.com" title="Oriol Brufrau">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<link rel="help" href="https://www.w3.org/TR/CSS2/box.html#collapsing-margins">
+<link rel="help" href="https://www.w3.org/TR/CSS2/visuren.html#inline-formatting">
+<link rel="help" href="https://www.w3.org/TR/CSS2/visuren.html#floats">
+<meta name="assert" content="The float is out-of-flow so it doesn't prevent the line box
+  from being empty, and empty line boxes don't prevent margins from collapsing.
+  So the float and the inline-block should appear side by side.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="overflow: hidden; margin-top: -200px; width: 100px">
+  <div style="margin-top: 200px"></div>
+  <div style="background: red">
+    <span>
+      <div style="float: left; width: 50px; height: 100px; background: green"></div>
+    </span>
+    <div style="margin-top: 200px"></div>
+    <div style="display: inline-block; vertical-align: top; width: 50px; height: 100px; background: green"></div>
+  </div>
+</div>


### PR DESCRIPTION
When inline formatting contexts collapse through, margins before and
after can collapse. Previously the IFC code was assuming that margins
never collapses through them. This change adds a heuristic to detect the
most common cases of collapse through. Note that there are still
situations where do not know if an IFC will collapse through until we
actually try to lay it out. A proper implementation would be able to
rewind and relayout to fix float placement.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
