### PR TITLE
Consider trailing_whitespace_advance when calling place_line_among_floats()

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -1462,11 +1462,12 @@ impl FloatBox {
         let margin_box = fragment.border_rect().inflate(&fragment.margin);
         let inline_size = margin_box.size.inline.max(Length::zero());
 
+        let inline_position =
+            ifc.current_line.inline_position - ifc.current_line.trailing_whitespace_advance;
         let available_inline_size = match ifc.current_line.placement_among_floats.get() {
             Some(placement_among_floats) => placement_among_floats.size.inline,
             None => ifc.containing_block.inline_size,
-        } - (ifc.current_line.inline_position -
-            ifc.current_line.trailing_whitespace_advance);
+        } - inline_position;
 
         // If this float doesn't fit on the current line or a previous float didn't fit on
         // the current line, we need to place it starting at the next line BUT still as
@@ -1487,7 +1488,7 @@ impl FloatBox {
             // placement among floats for the current line, which may adjust its inline
             // start position.
             let new_placement = ifc.place_line_among_floats(&LogicalVec2 {
-                inline: ifc.current_line.inline_position,
+                inline: inline_position,
                 block: ifc.current_line.max_block_size,
             });
             ifc.current_line

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-006.xht.ini
@@ -1,2 +1,0 @@
-[floats-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/remove-block-between-inline-and-float.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/remove-block-between-inline-and-float.html.ini
@@ -1,2 +1,0 @@
-[remove-block-between-inline-and-float.html]
-  expected: FAIL


### PR DESCRIPTION
After placing a float, FloatBox's layout_into_line_items() was calling place_line_among_floats() with ifc.current_line.inline_position as the width of needed by the contents of the line.

The problem is that this amount includes the trailing whitespace advance and thus it could seem that the in-flow contents wouldn't fit next to the float.

That's not the case, since collapsible whitespace at the end of the line is removed, and preserved whitespace hangs.

So this patch subtracts ifc.current_line.trailing_whitespace_advance when calling place_line_among_floats(), like it was already happening when computing the available_inline_size.

Fixes #30561

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #30561
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
