### PR TITLE
Temporarily convert more cfg(debug_assertions) crashes to warnings

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1760,7 +1760,10 @@ impl Flow for InlineFlow {
                         first_fragment.style.logical_border_width())
                     .start;
                     containing_block_positions.push(
-                        padding_box_origin.to_physical(self.base.writing_mode, container_size),
+                        // TODO(servo#30577) revert once underlying bug is fixed
+                        // padding_box_origin.to_physical(self.base.writing_mode, container_size),
+                        padding_box_origin
+                            .to_physical_or_warn(self.base.writing_mode, container_size),
                     );
                 },
                 SpecificFragmentInfo::InlineBlock(_) if fragment.is_positioned() => {

--- a/components/style/logical_geometry.rs
+++ b/components/style/logical_geometry.rs
@@ -771,6 +771,38 @@ impl<T: Copy + Sub<T, Output = T>> LogicalPoint<T> {
         }
     }
 
+    // TODO(servo#30577) remove this once underlying bugs are fixed
+    #[inline]
+    pub fn to_physical_or_warn(&self, mode: WritingMode, container_size: Size2D<T>) -> Point2D<T> {
+        #[cfg(debug_assertions)]
+        if !(self.debug_writing_mode.mode == mode) {
+            log::warn!("debug assertion failed! self.debug_writing_mode.mode == mode");
+        }
+        if mode.is_vertical() {
+            Point2D::new(
+                if mode.is_vertical_lr() {
+                    self.b
+                } else {
+                    container_size.width - self.b
+                },
+                if mode.is_inline_tb() {
+                    self.i
+                } else {
+                    container_size.height - self.i
+                },
+            )
+        } else {
+            Point2D::new(
+                if mode.is_bidi_ltr() {
+                    self.i
+                } else {
+                    container_size.width - self.i
+                },
+                self.b,
+            )
+        }
+    }
+
     #[inline]
     pub fn convert(
         &self,


### PR DESCRIPTION
Same premise as #30578, but I forgot to convert one crash site.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to #30577

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___