### PR TITLE
Fix filtered test counts in WPT summaries

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -289,7 +289,7 @@ def filter_intermittents(
     def add_result(output, text, results: List[UnexpectedResult], filter_func) -> None:
         filtered = [str(result) for result in filter(filter_func, results)]
         if filtered:
-            output += [f"{text} ({len(results)}): ", *filtered]
+            output += [f"{text} ({len(filtered)}): ", *filtered]
 
     def is_stable_and_unexpected(result):
         return not result.flaky and not result.issues


### PR DESCRIPTION
Given:

> Ran 4 tests finished in 12.5 seconds.
>   • 2 ran as expected. 0 tests skipped.
>   • 1 tests crashed unexpectedly
>   • 1 tests had unexpected subtest results

Before:

> Flaky unexpected results (4): 
> Stable unexpected results that are known-intermittent (4): 
> Stable unexpected results (4): 

After:

> Flaky unexpected results (2): 
> Stable unexpected results that are known-intermittent (1): 
> Stable unexpected results (1): 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect tooling only