### PR TITLE
Make LineItems a token stream on the root

### DIFF
--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -475,8 +475,8 @@ where
             self.ongoing_inline_boxes_stack.push(InlineBox {
                 base_fragment_info: info.into(),
                 style: info.style.clone(),
-                first_fragment: true,
-                last_fragment: false,
+                is_first_fragment: true,
+                is_last_fragment: false,
                 children: vec![],
             });
 
@@ -498,7 +498,7 @@ where
                 .ongoing_inline_boxes_stack
                 .pop()
                 .expect("no ongoing inline level box found");
-            inline_box.last_fragment = true;
+            inline_box.is_last_fragment = true;
             ArcRefCell::new(InlineLevelBox::InlineBox(inline_box))
         } else {
             self.ongoing_inline_formatting_context.ends_with_whitespace = false;
@@ -537,13 +537,13 @@ where
                     let fragmented = InlineBox {
                         base_fragment_info: ongoing.base_fragment_info,
                         style: ongoing.style.clone(),
-                        first_fragment: ongoing.first_fragment,
+                        is_first_fragment: ongoing.is_first_fragment,
                         // The fragmented boxes before the block level element
                         // are obviously not the last fragment.
-                        last_fragment: false,
+                        is_last_fragment: false,
                         children: std::mem::take(&mut ongoing.children),
                     };
-                    ongoing.first_fragment = false;
+                    ongoing.is_first_fragment = false;
                     fragmented
                 });
 

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-empty-001.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-empty-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-006-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-006-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-006.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-nested-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-nested-002.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-nested-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001a.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-whitespace-001a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-whitespace-001b.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-whitespace-001b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/emptyspan-1.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/emptyspan-1.html.ini
@@ -1,2 +1,0 @@
-[emptyspan-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/split-inner-inline-2.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/split-inner-inline-2.html.ini
@@ -1,2 +1,0 @@
-[split-inner-inline-2.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1a.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1a.html.ini
@@ -1,2 +1,0 @@
-[whitespace-present-1a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1b.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/whitespace-present-1b.html.ini
@@ -1,2 +1,0 @@
-[whitespace-present-1b.html]
-  expected: FAIL


### PR DESCRIPTION
Flattening the LineItem tree into a token stream will allow for handling
the case where an unbreakable line segment spans multiple inline boxes
which might have different hierarchies. This change also fixes the
handling of the second anonymous fragment of a block-in-inline-split.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
