### PR TITLE
Replace the time crate with std::time in components/compositing

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -42,7 +42,6 @@ use script_traits::{
 };
 use servo_geometry::{DeviceIndependentPixel, FramebufferUintLength};
 use style_traits::{CSSPixel, DevicePixel, PinchZoomFactor};
-use time::{now, precise_time_ns, precise_time_s};
 use webrender;
 use webrender::{CaptureBits, RenderApi, Transaction};
 use webrender_api::units::{
@@ -1753,7 +1752,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         // we get the current time, inform the layout thread about it and remove the
         // pending metric from the list.
         if !self.pending_paint_metrics.is_empty() {
-            let paint_time = precise_time_ns();
+            let paint_time = profile_time::elapsed_since_epoch().as_nanos() as u64;
             let mut to_remove = Vec::new();
             // For each pending paint metrics pipeline id
             for (id, pending_epoch) in &self.pending_paint_metrics {
@@ -1975,7 +1974,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         }
 
         // If a pinch-zoom happened recently, ask for tiles at the new resolution
-        if self.zoom_action && precise_time_s() - self.zoom_time > 0.3 {
+        if self.zoom_action && profile_time::elapsed_since_epoch().as_secs() - self.zoom_time > 0.3 {
             self.zoom_action = false;
         }
 
@@ -2055,7 +2054,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     pub fn capture_webrender(&mut self) {
-        let capture_id = now().to_timespec().sec.to_string();
+        let capture_id = profile_time::elapsed_since_epoch().as_secs().to_string();
         let available_path = [env::current_dir(), Ok(env::temp_dir())]
             .iter()
             .filter_map(|val| {

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use ipc_channel::ipc::IpcSender;
 use log::warn;
@@ -139,11 +139,17 @@ where
     if opts::get().debug.signpost {
         signpost::start(category as u32, &[0, 0, 0, (category as usize) >> 4]);
     }
-    let start_time = elapsed_since_epoch().as_nanos();
+    let start_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
 
     let val = callback();
 
-    let end_time = elapsed_since_epoch().as_nanos();
+    let end_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
     if opts::get().debug.signpost {
         signpost::end(category as u32, &[0, 0, 0, (category as usize) >> 4]);
     }
@@ -166,10 +172,4 @@ pub fn send_profile_data(
     end_time: u64,
 ) {
     profiler_chan.send(ProfilerMsg::Time((category, meta), (start_time, end_time)));
-}
-
-pub(crate) fn elapsed_since_epoch() -> Duration {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
 }


### PR DESCRIPTION
Replaces the `time` crate in the `components/compositing` package with `std::time`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes contribute to #30150
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
