### PR TITLE
servoshell: add fullscreen option

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -134,6 +134,9 @@ pub struct Opts {
 
     /// True to enable minibrowser
     pub minibrowser: bool,
+
+    /// True to open the window in fullscreen mode
+    pub fullscreen: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -430,6 +433,7 @@ pub fn default_opts() -> Opts {
         local_script_source: None,
         print_pwm: false,
         minibrowser: true,
+        fullscreen: false,
     }
 }
 
@@ -569,6 +573,8 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "",
     );
     opts.optflag("", "no-minibrowser", "Open minibrowser");
+
+    opts.optflag("", "fullscreen", "open the window in fullscreen mode");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -785,6 +791,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         local_script_source: opt_match.opt_str("local-script-source"),
         print_pwm: opt_match.opt_present("print-pwm"),
         minibrowser: !opt_match.opt_present("no-minibrowser"),
+        fullscreen: opt_match.opt_present("fullscreen"),
     };
 
     set_options(opts);
@@ -817,3 +824,4 @@ pub fn set_options(opts: Opts) {
 pub fn get() -> RwLockReadGuard<'static, Opts> {
     OPTIONS.read().unwrap()
 }
+

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -560,7 +560,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
     opts.optopt(
         "",
         "config-dir",
-        "config directory following xdg spec on linux platform",
+        "Config directory following xdg spec on linux platform",
         "",
     );
     opts.optflag("v", "version", "Display servo version information");
@@ -573,8 +573,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "",
     );
     opts.optflag("", "no-minibrowser", "Open minibrowser");
-
-    opts.optflag("", "fullscreen", "open the window in fullscreen mode");
+    opts.optflag("", "fullscreen", "Open the window in fullscreen mode");
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -824,4 +823,3 @@ pub fn set_options(opts: Opts) {
 pub fn get() -> RwLockReadGuard<'static, Opts> {
     OPTIONS.read().unwrap()
 }
-

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3702,6 +3702,10 @@ impl Document {
 
     // https://fullscreen.spec.whatwg.org/#exit-fullscreen
     pub fn exit_fullscreen(&self) -> Rc<Promise> {
+        // Send EmbedderMsg first
+        let event = EmbedderMsg::SetFullscreenState(false);
+        self.send_to_embedder(event);
+
         let global = self.global();
         // Step 1
         let in_realm_proof = AlreadyInRealm::assert();
@@ -3718,9 +3722,6 @@ impl Document {
 
         let window = self.window();
         // Step 8
-        let event = EmbedderMsg::SetFullscreenState(false);
-        self.send_to_embedder(event);
-
         // Step 9
         let trusted_element = Trusted::new(&*element);
         let trusted_promise = TrustedPromise::new(promise.clone());

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -92,6 +92,7 @@ impl Window {
         // unstyled content is white and chrome often has a transparent background). See issue
         // #9996.
         let visible = opts.output_file.is_none() && !no_native_titlebar;
+        let fullscreen = opts.fullscreen;
 
         let win_size: DeviceIntSize = (win_size.to_f32() * window_creation_scale_factor()).to_i32();
         let width = win_size.to_untyped().width;
@@ -102,6 +103,7 @@ impl Window {
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
             .with_inner_size(PhysicalSize::new(width as f64, height as f64))
+            .with_maximized(fullscreen)
             .with_visible(visible);
 
         let winit_window = window_builder

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -102,6 +102,7 @@ impl Window {
             .with_title("Servo".to_string())
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
+            .with_maximized(fullscreen)
             .with_inner_size(PhysicalSize::new(width as f64, height as f64))
             .with_visible(visible);
 

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -142,7 +142,7 @@ impl Window {
             .expect("Failed to create WR surfman");
 
         debug!("Created window {:?}", winit_window.id());
-        let window = Window {
+        Window {
             winit_window,
             webrender_surfman,
             event_queue: RefCell::new(vec![]),
@@ -160,10 +160,8 @@ impl Window {
             xr_window_poses: RefCell::new(vec![]),
             modifiers_state: Cell::new(ModifiersState::empty()),
             toolbar_height: Cell::new(Default::default()),
-        };
-        window
+        }
     }
-
     fn handle_received_character(&self, mut ch: char) {
         info!("winit received character: {:?}", ch);
         if ch.is_control() {

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -103,7 +103,6 @@ impl Window {
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
             .with_inner_size(PhysicalSize::new(width as f64, height as f64))
-            .with_maximized(fullscreen)
             .with_visible(visible);
 
         let winit_window = window_builder
@@ -141,7 +140,7 @@ impl Window {
             .expect("Failed to create WR surfman");
 
         debug!("Created window {:?}", winit_window.id());
-        Window {
+        let window = Window {
             winit_window,
             webrender_surfman,
             event_queue: RefCell::new(vec![]),
@@ -159,7 +158,9 @@ impl Window {
             xr_window_poses: RefCell::new(vec![]),
             modifiers_state: Cell::new(ModifiersState::empty()),
             toolbar_height: Cell::new(Default::default()),
-        }
+        };
+        window.set_fullscreen(fullscreen);
+        window
     }
 
     fn handle_received_character(&self, mut ch: char) {


### PR DESCRIPTION
These changes add a cli option to start servo in fullscreen mode. As requested in #30599.
It is currently in draft form as we need to have further discussions to determine whether we truly need it.
```sh
servo --fullscreen
```
No tests for now.
