### PR TITLE
docs: add try job labels to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ so we can correct that!
 See [`HACKING_QUICKSTART.md`](docs/HACKING_QUICKSTART.md) for more information
 on how to start working on Servo.
 
-## Pull Request Checklist
+## Pull request checklist
 
 - Branch from the master branch and, if needed, rebase to the current master
   branch before submitting your pull request. If it doesn't merge cleanly with
@@ -48,6 +48,24 @@ on how to start working on Servo.
   guide](https://github.com/servo/servo/wiki/Testing) for more information.
 
 For specific git instructions, see [GitHub workflow 101](https://github.com/servo/servo/wiki/Github-workflow).
+
+## Running tests in pull requests
+
+When you push to a pull request, GitHub automatically checks that your changes have no compile, lint, or tidy errors.
+
+To run unit tests or Web Platform Tests against a pull request, you can mention [@bors-servo](https://github.com/bors-servo) in a comment, or add one or more labels to your pull request:
+
+| comment | label |
+|---|---|
+| `@bors-servo try`<br>`@bors-servo try=full` | `T-full` |
+| `@bors-servo try=wpt-2013`<br>`@bors-servo try=wpt`<sup>1</sup> | `T-linux-wpt-2013` |
+| `@bors-servo try=wpt-2020` | `T-linux-wpt-2020` |
+| `@bors-servo try=linux` | `T-linux-wpt-2020`<sup>2</sup> |
+| `@bors-servo try=macos` | `T-macos` |
+| `@bors-servo try=windows` | `T-windows` |
+
+1. this will become equivalent to `try=wpt-2020` at some point
+2. unlike `try=linux`, this runs WPT tests too, not just unit tests
 
 ## Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,19 +53,15 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 When you push to a pull request, GitHub automatically checks that your changes have no compile, lint, or tidy errors.
 
-To run unit tests or Web Platform Tests against a pull request, you can mention [@bors-servo](https://github.com/bors-servo) in a comment, or add one or more labels to your pull request:
+To run unit tests or Web Platform Tests against a pull request, add one or more of the labels below to your pull request:
 
-| comment | label |
+| Label | Effect |
 |---|---|
-| `@bors-servo try`<br>`@bors-servo try=full` | `T-full` |
-| `@bors-servo try=wpt-2013`<br>`@bors-servo try=wpt`<sup>1</sup> | `T-linux-wpt-2013` |
-| `@bors-servo try=wpt-2020` | `T-linux-wpt-2020` |
-| `@bors-servo try=linux` | `T-linux-wpt-2020`<sup>2</sup> |
-| `@bors-servo try=macos` | `T-macos` |
-| `@bors-servo try=windows` | `T-windows` |
-
-1. this will become equivalent to `try=wpt-2020` at some point
-2. unlike `try=linux`, this runs WPT tests too, not just unit tests
+| `T-full` | Unit tests: Linux, macOS, Windows<br>Layout tests: Linux, macOS<br>Legacy layout tests: Linux, macOS |
+| `T-linux-wpt-2013` | Unit tests: Linux<br>Legacy layout tests: Linux |
+| `T-linux-wpt-2020` | Unit tests: Linux<br>Layout tests: Linux |
+| `T-macos` | Unit tests: macOS |
+| `T-windows` | Unit tests: Windows |
 
 ## Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 When you push to a pull request, GitHub automatically checks that your changes have no compile, lint, or tidy errors.
 
-To run unit tests or Web Platform Tests against a pull request, add one or more of the labels below to your pull request:
+To run unit tests or Web Platform Tests against a pull request, add one or more of the labels below to your pull request. If you do not have permission to add labels to your pull request, add a comment on your bug requesting that they be added.
 
 | Label | Effect |
 |---|---|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 ## Running tests in pull requests
 
-When you push to a pull request, GitHub automatically checks that your changes have no compile, lint, or tidy errors.
+When you push to a pull request, GitHub automatically checks that your changes have no compilation, lint, or tidy errors.
 
 To run unit tests or Web Platform Tests against a pull request, add one or more of the labels below to your pull request. If you do not have permission to add labels to your pull request, add a comment on your bug requesting that they be added.
 


### PR DESCRIPTION
This patch documents the new try job labels added in #30383 and #30712.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are in the documentation