### PR TITLE
docs: add table of contents to HACKING_QUICKSTART

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -1,11 +1,28 @@
 # Hacking Servo - Quickstart
 
 This guide covers the basic things one needs to know to start hacking Servo.
-It doesn't cover how Servo works (see the [documentation](#documentation) section for that),
-but describes how to setup your environment to compile, run, and debug Servo. For information
-on the [Github Workflow](https://github.com/servo/servo/wiki/Github-workflow) and some helpful
-[Git Tips](https://github.com/servo/servo/wiki/Github-workflow#git-tips), see the
-[Wiki](https://github.com/servo/servo/wiki).
+It doesn't cover how Servo works or how to use Git effectively (see the [documentation](#documentation) section for those),
+but describes how to set up your environment to compile, run, and debug Servo.
+
+* [Building Servo](#building-servo)
+* [Running Servo](#running-servo)
+* [mach](#mach)
+    * [mach and Servo options](#mach-and-servo-options)
+* [Some basic Rust](#some-basic-rust)
+    * [Cargo and crates](#cargo-and-crates)
+    * [Working on a crate](#working-on-a-crate)
+* [Editor support](#editor-support)
+    * [Visual Studio Code](#visual-studio-code)
+* [Debugging](#debugging)
+    * [Logging](#logging)
+    * [println!()](#println)
+    * [Debugger](#debugger)
+* [Tests](#tests)
+    * [Updating a test](#updating-a-test)
+    * [Add a new test](#add-a-new-test)
+    * [Debugging a test](#debugging-a-test)
+* [Documentation](#documentation)
+* [Ask questions](#ask-questions)
 
 ## Building Servo
 
@@ -37,7 +54,7 @@ The servo binary is located in `target/debug/servo` (or `target/release/servo`).
 
 If you build with `-d`, run with `-d`. If you build with `-r`, run with `-r`.
 
-## ./mach
+## mach
 
 `mach` is a python utility that does plenty of things to make our life easier (build, run, run tests, update dependencies… see `./mach --help`). Beside editing files and git commands, everything else is done via `mach`.
 
@@ -47,7 +64,7 @@ If you build with `-d`, run with `-d`. If you build with `-r`, run with `-r`.
 
 The `--`  separates `mach` options from `servo` options. This is not required, but we recommend it. `mach` and `servo` have some options with the same name (`--help`, `--debug`), so the `--` makes it clear where options apply.
 
-## Mach and Servo options
+### mach and Servo options
 
 This guide only covers the most important options. Be sure to look at all the available mach commands and the servo options:
 
@@ -73,7 +90,7 @@ For more exhaustive documentation:
 - [doc.rust-lang.org](https://doc.rust-lang.org)
 - [rust by example](https://doc.rust-lang.org/stable/rust-by-example)
 
-## Cargo and Crates
+### Cargo and crates
 
 A Rust library is called a crate. Servo uses plenty of crates. These crates are dependencies. They are listed in files called `Cargo.toml`. Servo is split into components and ports (see `components` and `ports` directories). Each has its own dependencies, and each has its own `Cargo.toml` file.
 
@@ -98,7 +115,7 @@ This file should not be edited by hand. In a normal Rust project, to update the 
 
 See [Cargo's documentation about Cargo.toml and Cargo.lock files](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html).
 
-## Working on a Crate
+### Working on a crate
 
 As explained above, Servo depends on a lot of libraries, which makes it very modular. While working on a bug in Servo, you'll often end up in one of its dependencies. You will then want to compile your own version of the dependency (and maybe compiling against the HEAD of the library will fix the issue!).
 
@@ -205,7 +222,7 @@ Then configure either your sysroot path or proc macro server path in `.vscode/se
 
 ## Debugging
 
-### Logging:
+### Logging
 
 Before starting the debugger right away, you might want to get some information about what's happening, how, and when. Luckily, Servo comes with plenty of logs that will help us. Type these 2 commands:
 
@@ -325,7 +342,7 @@ To check code tidiness:
 ./mach test-tidy
 ```
 
-### Updating a test:
+### Updating a test
 
 In some cases, extensive tests for the feature you're working on already exist under tests/wpt:
 
@@ -338,7 +355,7 @@ it's likely that your feature had tests in wpt already.
 
 Include this commit in your pull request.
 
-### Add a new test:
+### Add a new test
 
 If you need to create a new test file, it should be located in `tests/wpt/mozilla/tests` or in `tests/wpt/web-platform-tests` if it's something that doesn't depend on servo-only features. You'll then need to update the list of tests and the list of expected results:
 
@@ -350,7 +367,7 @@ If you need to create a new test file, it should be located in `tests/wpt/mozill
 
 See the [debugging guide](./debugging.md) to get started in how to debug Servo.
 
-## Documentation:
+## Documentation
 
 - Servo's directory structure: [ORGANIZATION.md](./ORGANIZATION.md)
 - https://doc.servo.org/servo/index.html

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -1,8 +1,9 @@
 # Hacking Servo - Quickstart
 
 This guide covers the basic things one needs to know to start hacking Servo.
-It doesn't cover how Servo works or how to use Git effectively (see the [documentation](#documentation) section for those),
-but describes how to set up your environment to compile, run, and debug Servo.
+It doesn't cover how Servo works or how to use Git effectively (see the
+[documentation](#documentation) section for those), but describes how to
+set up your environment to compile, run, and debug Servo.
 
 * [Building Servo](#building-servo)
 * [Running Servo](#running-servo)


### PR DESCRIPTION
Our hacking quickstart guide is getting pretty long. That’s not a bad thing, and it’s arguably better than splitting the docs into a taxonomy of small files that no one will understand or remember, but it needs some navigation.

This patch adds a table of contents.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are in the documentation