### PR TITLE
Support running custom wpt tests in wpt runs (and add suport for webgpu runs)

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -8,6 +8,8 @@ on:
       wpt-sync:
         required: false
         type: boolean
+      # tests to be run
+      tests:
         required: false
         type: string
       layout:
@@ -72,8 +74,8 @@ jobs:
       - name: Run tests
         if: ${{ !inputs.wpt-sync }}
         run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${cargo_profile_option} --processes $(nproc) --timeout-multiplier 2 \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${cargo_profile_option} \
+            --processes $(nproc) ${{ inputs.tests }} --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
@@ -84,8 +86,8 @@ jobs:
       - name: Run tests (sync)
         if: ${{ inputs.wpt-sync }}
         run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${cargo_profile_option} --processes $(nproc) --timeout-multiplier 2 \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${cargo_profile_option} \
+            --processes $(nproc) ${{ inputs.tests }} --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --always-succeed

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -5,7 +5,9 @@ on:
       production:
         required: false
         type: boolean
-      wpt:
+      wpt-sync:
+        required: false
+        type: boolean
         required: false
         type: string
       layout:
@@ -64,11 +66,11 @@ jobs:
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
           python3 ./mach bootstrap-gstreamer
       - name: Sync from upstream WPT
-        if: ${{ inputs.wpt == 'sync' }}
+        if: ${{ inputs.wpt-sync }}
         run: |
           ./mach update-wpt --sync --patch
       - name: Run tests
-        if: ${{ inputs.wpt != 'sync' }}
+        if: ${{ !inputs.wpt-sync }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             ${cargo_profile_option} --processes $(nproc) --timeout-multiplier 2 \
@@ -80,7 +82,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
       - name: Run tests (sync)
-        if: ${{ inputs.wpt == 'sync' }}
+        if: ${{ inputs.wpt-sync }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             ${cargo_profile_option} --processes $(nproc) --timeout-multiplier 2 \
@@ -89,7 +91,7 @@ jobs:
             --always-succeed
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
-        if: ${{ always() && inputs.wpt != 'sync' }}
+        if: ${{ always() && !inputs.wpt-sync }}
         with:
           name: wpt-filtered-results-linux-${{ inputs.layout }}
           path: |
@@ -97,14 +99,14 @@ jobs:
             unexpected-test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ failure() && inputs.wpt != 'sync' }}
+        if: ${{ failure() && !inputs.wpt-sync }}
         with:
           name: wpt-logs-linux-${{ inputs.layout }}
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.wpt == 'sync' }}
+        if: ${{ inputs.wpt-sync }}
         with:
           name: wpt-logs-linux-${{ inputs.layout }}
           path: |
@@ -114,7 +116,7 @@ jobs:
   report-test-results:
     name: Report WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && (github.ref_name == 'try-wpt' || github.ref_name == 'try-wpt-2020' || inputs.wpt == 'test') }}
+    if: ${{ always() && !cancelled() && (github.ref_name == 'try-wpt' || github.ref_name == 'try-wpt-2020' || !inputs.wpt-sync) }}
     needs:
       - "linux-wpt"
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -151,7 +151,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      production: ${{ inputs.production }}
+      production: ${{ inputs.production == 'true' }}
       tests: "_webgpu"
       layout: "layout-2020"
 
@@ -161,8 +161,8 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      production: ${{ inputs.production }}
-      wpt-sync: ${{ inputs.wpt-sync }}
+      production: ${{ inputs.production == 'true' }}
+      wpt-sync: ${{ inputs.wpt-sync == 'true' }}
       tests: ${{ inputs.tests }}
       layout: "layout-2020"
 
@@ -172,8 +172,8 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      production: ${{ inputs.production }}
-      wpt-sync: ${{ inputs.wpt-sync }}
+      production: ${{ inputs.production == 'true' }}
+      wpt-sync: ${{ inputs.wpt-sync == 'true' }}
       tests: ${{ inputs.tests }}
       layout: "layout-2013"
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,9 @@ on:
       wpt-sync:
         required: false
         type: boolean
+      tests:
+        required: false
+        type: string
       layout:
         required: false
         type: string
@@ -31,6 +34,9 @@ on:
         default: false
         required: false
         type: boolean
+      tests:
+        required: false
+        type: string
       layout:
         required: false
         type: choice
@@ -141,6 +147,7 @@ jobs:
     with:
       production: ${{ inputs.production }}
       wpt-sync: ${{ inputs.wpt-sync }}
+      tests: ${{ inputs.tests }}
       layout: "layout-2020"
 
   wpt-2013:
@@ -151,6 +158,7 @@ jobs:
     with:
       production: ${{ inputs.production }}
       wpt-sync: ${{ inputs.wpt-sync }}
+      tests: ${{ inputs.tests }}
       layout: "layout-2013"
 
   result:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,6 +11,9 @@ on:
       tests:
         required: false
         type: string
+      webgpu:
+        required: false
+        type: boolean
       layout:
         required: false
         type: string
@@ -37,6 +40,9 @@ on:
       tests:
         required: false
         type: string
+      webgpu:
+        required: false
+        type: boolean
       layout:
         required: false
         type: choice
@@ -50,7 +56,7 @@ on:
         default: false
         type: boolean
   push:
-    branches: ["try-linux", "try-wpt", "try-wpt-2020"]
+    branches: ["try-linux", "try-wpt", "try-wpt-2020", "try-webgpu"]
 
 env:
   cargo_profile_option: ${{ inputs.production && '--profile production' || '--release' }}
@@ -139,6 +145,16 @@ jobs:
           name: release-binary
           path: target.tar.gz
 
+  wpt-webgpu:
+    if: ${{ github.ref_name == 'try-webgpu' || inputs.webgpu }}
+    name: Linux WebGPU Tests
+    needs: ["build"]
+    uses: ./.github/workflows/linux-wpt.yml
+    with:
+      production: ${{ inputs.production }}
+      tests: "_webgpu"
+      layout: "layout-2020"
+
   wpt-2020:
     if: ${{ github.ref_name == 'try-wpt-2020' || inputs.layout == '2020' || inputs.layout == 'all' }}
     name: Linux WPT Tests 2020
@@ -170,6 +186,7 @@ jobs:
       - "build"
       - "wpt-2020"
       - "wpt-2013"
+      - "wpt-webgpu"
 
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,9 +5,9 @@ on:
       production:
         required: false
         type: boolean
-      wpt:
+      wpt-sync:
         required: false
-        type: string
+        type: boolean
       layout:
         required: false
         type: string
@@ -27,11 +27,10 @@ on:
       production:
         required: false
         type: boolean
-      wpt:
-        default: "test"
+      wpt-sync:
+        default: false
         required: false
-        type: choice
-        options: ["test", "sync"]
+        type: boolean
       layout:
         required: false
         type: choice
@@ -141,7 +140,7 @@ jobs:
     uses: ./.github/workflows/linux-wpt.yml
     with:
       production: ${{ inputs.production }}
-      wpt: ${{ inputs.wpt }}
+      wpt-sync: ${{ inputs.wpt-sync }}
       layout: "layout-2020"
 
   wpt-2013:
@@ -151,7 +150,7 @@ jobs:
     uses: ./.github/workflows/linux-wpt.yml
     with:
       production: ${{ inputs.production }}
-      wpt: ${{ inputs.wpt }}
+      wpt-sync: ${{ inputs.wpt-sync }}
       layout: "layout-2013"
 
   result:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -6,6 +6,9 @@ on:
       production:
         required: false
         type: boolean
+      tests:
+        required: false
+        type: string
       layout:
         required: true
         type: string
@@ -50,8 +53,8 @@ jobs:
         run: python3 ./mach smoketest ${cargo_profile_option}
       - name: Run tests
         run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${cargo_profile_option} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${cargo_profile_option} \
+            --processes $(sysctl -n hw.logicalcpu) ${{ inputs.tests }} --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -136,7 +136,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
     with:
-      production: ${{ inputs.production }}
+      production: ${{ inputs.production == 'true' }}
       layout: "layout-2020"
       tests: ${{ inputs.tests }}
 
@@ -146,7 +146,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
     with:
-      production: ${{ inputs.production }}
+      production: ${{ inputs.production == 'true' }}
       layout: "layout-2013"
       tests: ${{ inputs.tests }}
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -9,6 +9,9 @@ on:
       wpt-layout:
         required: false
         type: string
+      tests:
+        required: false
+        type: string
       unit-tests:
         required: false
         default: false
@@ -25,6 +28,9 @@ on:
       production:
         required: false
         type: boolean
+      tests:
+        required: false
+        type: string
       wpt-layout:
         required: false
         type: choice
@@ -132,6 +138,7 @@ jobs:
     with:
       production: ${{ inputs.production }}
       layout: "layout-2020"
+      tests: ${{ inputs.tests }}
 
   wpt-2013:
     if: ${{ github.ref_name == 'try-wpt-mac' || inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
@@ -141,6 +148,7 @@ jobs:
     with:
       production: ${{ inputs.production }}
       layout: "layout-2013"
+      tests: ${{ inputs.tests }}
 
   result:
     name: Result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,6 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       production: ${{ fromJson(needs.decision.outputs.configuration).production }}
-      wpt: 'test'
       layout: ${{ fromJson(needs.decision.outputs.configuration).layout }}
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ on:
       unit-tests:
         required: false
         type: boolean
+      webgpu:
+        required: false
+        type: boolean
 
 jobs:
   decision:
@@ -61,6 +64,7 @@ jobs:
               platform = "all";
               layout = "all";
               unit_tests = true;
+              webgpu = false;
             }
 
             let platforms = [];
@@ -75,7 +79,17 @@ jobs:
               platforms,
               layout,
               unit_tests,
+              webgpu: ${{ inputs.webgpu && 'true' || 'false' }},
             };
+
+            if (context.eventName.startsWith("pull_request")) {
+              for (const label of context.payload.pull_request.labels) {
+                // handle webgpu label
+                if (label.name == "A-content/webgpu") {
+                  returnValue.webgpu = true;
+                }
+              }
+            }
 
             console.log("Using configuration: " + JSON.stringify(returnValue));
             return returnValue;
@@ -107,6 +121,7 @@ jobs:
       production: ${{ fromJson(needs.decision.outputs.configuration).production }}
       layout: ${{ fromJson(needs.decision.outputs.configuration).layout }}
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+      webgpu: ${{ fromJson(needs.decision.outputs.configuration).webgpu }}
 
   build-result:
     name: Result

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -15,7 +15,7 @@ jobs:
     name: Linux
     uses: ./.github/workflows/linux.yml
     with:
-      wpt: 'sync'
+      wpt-sync: true
       layout: 'all'
       unit-tests: false
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -85,11 +85,17 @@ jobs:
               platforms: [],
               layout: "none",
               unit_tests: false,
+              webgpu: false,
             };
 
             if (context.eventName == "pull_request_target") {
               let try_labels = [];
               for (const label of context.payload.pull_request.labels) {
+                // handle webgpu label
+                if (label.name == "A-content/webgpu") {
+                  configuration.webgpu = true;
+                }
+
                 if (!label.name.startsWith("T-")) {
                   continue;
                 }

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -32,7 +32,8 @@ VALID_TRY_BRACHES = [
     "try-wpt",
     "try-wpt-2020",
     "try-wpt-mac",
-    "try-wpt-mac-2020"
+    "try-wpt-mac-2020",
+    "try-webgpu",
 ]
 
 


### PR DESCRIPTION
If PR has webgpu label, webgpu subset of wpt test will automatically be run on try/merge.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30144

<!-- Either: -->
I manually tested `./mach try (wpt|webgpu|_)`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
