### PR TITLE
Fix upload-nightly to use correct path

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -47,22 +47,22 @@ sys.path.append(path.join(path.dirname(__file__), "..", "..",
 
 PACKAGES = {
     'android': [
-        'android/armv7-linux-androideabi/release/servoapp.apk',
-        'android/armv7-linux-androideabi/release/servoview.aar',
+        'android/armv7-linux-androideabi/production/servoapp.apk',
+        'android/armv7-linux-androideabi/production/servoview.aar',
     ],
     'linux': [
-        'release/servo-tech-demo.tar.gz',
+        'production/servo-tech-demo.tar.gz',
     ],
     'mac': [
-        'release/servo-tech-demo.dmg',
+        'production/servo-tech-demo.dmg',
     ],
     'maven': [
         'android/gradle/servoview/maven/org/mozilla/servoview/servoview-armv7/',
         'android/gradle/servoview/maven/org/mozilla/servoview/servoview-x86/',
     ],
     'windows-msvc': [
-        r'release\msi\Servo.exe',
-        r'release\msi\Servo.zip',
+        r'production\msi\Servo.exe',
+        r'production\msi\Servo.zip',
     ],
 }
 


### PR DESCRIPTION
Nightly builds now use production profile and thus will
be available under target/production

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix nightly CI job