### PR TITLE
Clean up a bit of the canvas backend abstractions

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -3,8 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
-#[allow(unused_imports)]
-use std::marker::PhantomData;
 use std::mem;
 use std::sync::{Arc, Mutex};
 

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::marker::PhantomData;
-
 use canvas_traits::canvas::*;
 use cssparser::RGBA;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D, Vector2D};

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -15,9 +15,8 @@ use raqote::PathOp;
 
 use crate::canvas_data;
 use crate::canvas_data::{
-    Backend, CanvasPaintState, Color, CompositionOp, DrawOptions, ExtendMode, Filter,
-    GenericDrawTarget, GenericPathBuilder, GradientStop, GradientStops, Path, SourceSurface,
-    StrokeOptions, SurfaceFormat,
+    Backend, CanvasPaintState, Color, CompositionOp, DrawOptions, Filter, GenericDrawTarget,
+    GenericPathBuilder, GradientStop, GradientStops, Path, SourceSurface, StrokeOptions,
 };
 use crate::canvas_paint_thread::AntialiasMode;
 
@@ -85,7 +84,7 @@ impl<'a> CanvasPaintState<'a> {
             draw_options: DrawOptions::Raqote(raqote::DrawOptions::new()),
             fill_style: canvas_data::Pattern::Raqote(pattern.clone()),
             stroke_style: canvas_data::Pattern::Raqote(pattern),
-            stroke_opts: StrokeOptions::Raqote(Default::default(), PhantomData),
+            stroke_opts: StrokeOptions::Raqote(Default::default()),
             transform: Transform2D::identity(),
             shadow_offset_x: 0.0,
             shadow_offset_y: 0.0,
@@ -267,30 +266,30 @@ impl canvas_data::Pattern<'_> {
     }
 }
 
-impl<'a> StrokeOptions<'a> {
+impl StrokeOptions {
     pub fn set_line_width(&mut self, _val: f32) {
         match self {
-            StrokeOptions::Raqote(options, _) => options.width = _val,
+            StrokeOptions::Raqote(options) => options.width = _val,
         }
     }
     pub fn set_miter_limit(&mut self, _val: f32) {
         match self {
-            StrokeOptions::Raqote(options, _) => options.miter_limit = _val,
+            StrokeOptions::Raqote(options) => options.miter_limit = _val,
         }
     }
     pub fn set_line_join(&mut self, val: LineJoinStyle) {
         match self {
-            StrokeOptions::Raqote(options, _) => options.join = val.to_raqote_style(),
+            StrokeOptions::Raqote(options) => options.join = val.to_raqote_style(),
         }
     }
     pub fn set_line_cap(&mut self, val: LineCapStyle) {
         match self {
-            StrokeOptions::Raqote(options, _) => options.cap = val.to_raqote_style(),
+            StrokeOptions::Raqote(options) => options.cap = val.to_raqote_style(),
         }
     }
     pub fn as_raqote(&self) -> &raqote::StrokeStyle {
         match self {
-            StrokeOptions::Raqote(options, _) => options,
+            StrokeOptions::Raqote(options) => options,
         }
     }
 }
@@ -389,11 +388,7 @@ impl GenericDrawTarget for raqote::DrawTarget {
     // Somehow a duplicate of `create_gradient_stops()` with different types.
     // It feels cumbersome to convert GradientStop back and forth just to use
     // `create_gradient_stops()`, so I'll leave this here for now.
-    fn create_gradient_stops(
-        &self,
-        gradient_stops: Vec<GradientStop>,
-        _extend_mode: ExtendMode,
-    ) -> GradientStops {
+    fn create_gradient_stops(&self, gradient_stops: Vec<GradientStop>) -> GradientStops {
         let mut stops = gradient_stops
             .into_iter()
             .map(|item| item.as_raqote().clone())
@@ -406,19 +401,10 @@ impl GenericDrawTarget for raqote::DrawTarget {
     fn create_path_builder(&self) -> Box<dyn GenericPathBuilder> {
         Box::new(PathBuilder::new())
     }
-    fn create_similar_draw_target(
-        &self,
-        size: &Size2D<i32>,
-        _format: SurfaceFormat,
-    ) -> Box<dyn GenericDrawTarget> {
+    fn create_similar_draw_target(&self, size: &Size2D<i32>) -> Box<dyn GenericDrawTarget> {
         Box::new(raqote::DrawTarget::new(size.width, size.height))
     }
-    fn create_source_surface_from_data(
-        &self,
-        data: &[u8],
-        _size: Size2D<i32>,
-        _stride: i32,
-    ) -> Option<SourceSurface> {
+    fn create_source_surface_from_data(&self, data: &[u8]) -> Option<SourceSurface> {
         Some(SourceSurface::Raqote(data.to_vec()))
     }
     #[allow(unsafe_code)]
@@ -588,9 +574,6 @@ impl GenericDrawTarget for raqote::DrawTarget {
             &DrawOptions::Raqote(draw_options),
         );
     }
-    fn get_format(&self) -> SurfaceFormat {
-        SurfaceFormat::Raqote(())
-    }
     fn get_size(&self) -> Size2D<i32> {
         Size2D::new(self.width(), self.height())
     }
@@ -696,8 +679,8 @@ impl GenericDrawTarget for raqote::DrawTarget {
 impl Filter {
     fn to_raqote(&self) -> raqote::FilterMode {
         match self {
-            Filter::Linear => raqote::FilterMode::Bilinear,
-            Filter::Point => raqote::FilterMode::Nearest,
+            Filter::Bilinear => raqote::FilterMode::Bilinear,
+            Filter::Nearest => raqote::FilterMode::Nearest,
         }
     }
 }


### PR DESCRIPTION
This cleans up a bit of the Azure that was left behind after its removal. While I would have done a more drastic clean-up in order to reflect a scenario where there is a raqote and a tiny_skia backend, I have kept in mind possible alternatives routes (see #30636), so I've went for a lighter approach that may be intensified once progress on that area is made

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] These changes do not require tests
