### PR TITLE
Stop using distutils

### DIFF
--- a/python/mach/setup.py
+++ b/python/mach/setup.py
@@ -3,10 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+
+from setuptools import setup
 
 
 VERSION = '1.0.0'

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -9,7 +9,6 @@ import platform
 import sys
 import shutil
 
-from distutils.spawn import find_executable
 from subprocess import Popen
 from tempfile import TemporaryFile
 
@@ -90,7 +89,7 @@ PYTHON_NAMES = ["python-2.7", "python2.7", "python2", "python"]
 
 def _get_exec_path(names, is_valid_path=lambda _path: True):
     for name in names:
-        path = find_executable(name)
+        path = shutil.which(name)
         if path and is_valid_path(path):
             return path
     return None

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -37,7 +37,6 @@ import tidy
 
 from servo.command_base import BuildType, CommandBase, call, check_call
 from servo.util import delete
-from distutils.dir_util import copy_tree
 
 SCRIPT_PATH = os.path.split(__file__)[0]
 PROJECT_TOPLEVEL_PATH = os.path.abspath(os.path.join(SCRIPT_PATH, "..", ".."))
@@ -793,7 +792,7 @@ tests/wpt/mozilla/tests for Servo-only tests""" % reference_path)
             file.write(filedata)
         # copy
         delete(path.join(tdir, "webgpu"))
-        copy_tree(path.join(clone_dir, "out-wpt"), path.join(tdir, "webgpu"))
+        shutil.copytree(path.join(clone_dir, "out-wpt"), path.join(tdir, "webgpu"))
         # update commit
         commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=clone_dir).decode()
         with open(path.join(tdir, "checkout_commit.txt"), 'w') as file:


### PR DESCRIPTION
This is removed from Python 3.12 so we can no longer rely on it. All of
this functionality is either in `setuptools` or `shutil`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix the Mac build.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
