### PR TITLE
fix: typo in textinput.rs

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -486,7 +486,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 vec![DOMString::from(to_insert)]
             };
 
-            // FIXME(ajeffrey): effecient append for DOMStrings
+            // FIXME(ajeffrey): efficient append for DOMStrings
             let mut new_line = prefix.to_owned();
 
             new_line.push_str(&insert_lines[0]);
@@ -496,7 +496,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             self.edit_point.index = insert_lines[last_insert_lines_index].len_utf8();
             self.edit_point.line = start.line + last_insert_lines_index;
 
-            // FIXME(ajeffrey): effecient append for DOMStrings
+            // FIXME(ajeffrey): efficient append for DOMStrings
             insert_lines[last_insert_lines_index].push_str(suffix);
 
             let mut new_lines = vec![];


### PR DESCRIPTION
This PR fixes typos in **components/script/textinput.rs** file.

Following typos have been fixed:

`effecient` -> `efficient`

No other changes.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they simply fix a typo.
