### PR TITLE
fix typo in debugging.md from servo to Servo

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,7 +1,7 @@
 # Servo debugging guide
 
 There are a few ways to debug Servo. `mach` supports a `--debug` flag that
-searches a suitable debugger for you and runs servo with the appropriate
+searches a suitable debugger for you and runs Servo with the appropriate
 arguments under it:
 
 ```


### PR DESCRIPTION
This PR fixes typos in docs/debugging.md file.

The following typos have been fixed:
``` servo ``` -> ```Servo```

No other changes have been made.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they simply fix a typo.
