### PR TITLE
mach: use `importlib` module instead of `imp`

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -141,10 +141,10 @@ def _activate_virtualenv(topdir):
     activate_path = os.path.join(virtualenv_path, script_dir, "activate_this.py")
     need_pip_upgrade = False
     if not (os.path.exists(virtualenv_path) and os.path.exists(activate_path)):
-        import imp
+        import importlib
         try:
-            imp.find_module('virtualenv')
-        except ImportError:
+            importlib.import_module('virtualenv')
+        except ModuleNotFoundError:
             sys.exit("Python virtualenv is not installed. Please install it prior to running mach.")
 
         _process_exec([python, "-m", "virtualenv", "-p", python, "--system-site-packages", virtualenv_path])


### PR DESCRIPTION
`imp` module has been deprecated since python 3.4
and has been removed in 3.12. The recommended alternative
is to use the `importlib` module that was introduced in
python 3.1

This is required to fix the CI failures in macos builds
since GitHub runner images for macos-13 now use python 3.12

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>
