### PR TITLE
Replace environmental cargo_profile___ with workflow expressions

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ inputs.wpt != 'sync' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${cargo_profile_option} --processes $(nproc) --timeout-multiplier 2 \
+            ${{ env.cargo_profile_option }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
@@ -83,7 +83,7 @@ jobs:
         if: ${{ inputs.wpt == 'sync' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${cargo_profile_option} --processes $(nproc) --timeout-multiplier 2 \
+            ${{ env.cargo_profile_option }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --always-succeed

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -93,14 +93,14 @@ jobs:
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all
       - name: Release build (${{ inputs.production && 'without' || 'with' }} debug assertions)
-        run: python3 ./mach build ${cargo_profile_option}
+        run: python3 ./mach build ${{ env.cargo_profile_option }}
       - name: Smoketest
-        run: xvfb-run python3 ./mach smoketest ${cargo_profile_option}
+        run: xvfb-run python3 ./mach smoketest ${{ env.cargo_profile_option }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-linux' }}
-        run: python3 ./mach test-unit ${cargo_profile_option}
+        run: python3 ./mach test-unit ${{ env.cargo_profile_option }}
       - name: Rename build timing
         run: cp -r target/cargo-timings target/cargo-timings-linux
       - name: Archive build timing
@@ -112,12 +112,12 @@ jobs:
       - name: Lockfile check
         run: ./etc/ci/lockfile_changed.sh
       - name: Build mach package
-        run: python3 ./mach package ${cargo_profile_option}
+        run: python3 ./mach package ${{ env.cargo_profile_option }}
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v3
         with:
           name: linux
-          path: target/${cargo_profile_name}/servo-tech-demo.tar.gz
+          path: target/${{ env.cargo_profile_name }}/servo-tech-demo.tar.gz
       - name: Upload nightly
         if: ${{ inputs.upload }}
         run: |
@@ -129,7 +129,7 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
-        run: tar -czf target.tar.gz target/${cargo_profile_name}/servo resources
+        run: tar -czf target.tar.gz target/${{ env.cargo_profile_name }}/servo resources
       - name: Upload artifact for target
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -47,11 +47,11 @@ jobs:
           python3 -m pip install --upgrade pip virtualenv
           python3 ./mach bootstrap
       - name: Smoketest
-        run: python3 ./mach smoketest ${cargo_profile_option}
+        run: python3 ./mach smoketest ${{ env.cargo_profile_option }}
       - name: Run tests
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${cargo_profile_option} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
+            ${{ env.cargo_profile_option }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -86,19 +86,19 @@ jobs:
           brew install gnu-tar
       - name: Release build (${{ inputs.production && 'without' || 'with' }} debug assertions)
         run: |
-          python3 ./mach build ${cargo_profile_option}
+          python3 ./mach build ${{ env.cargo_profile_option }}
       - name: Smoketest
-        run: python3 ./mach smoketest ${cargo_profile_option}
+        run: python3 ./mach smoketest ${{ env.cargo_profile_option }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-mac' }}
         timeout-minutes: 30 # https://github.com/servo/servo/issues/30275
-        run: python3 ./mach test-unit ${cargo_profile_option}
+        run: python3 ./mach test-unit ${{ env.cargo_profile_option }}
       - name: Build mach package
-        run: python3 ./mach package ${cargo_profile_option}
+        run: python3 ./mach package ${{ env.cargo_profile_option }}
       - name: Run smoketest for mach package
-        run: ./etc/ci/macos_package_smoketest.sh target/${cargo_profile_name}/servo-tech-demo.dmg
+        run: ./etc/ci/macos_package_smoketest.sh target/${{ env.cargo_profile_name }}/servo-tech-demo.dmg
       - name: Rename build timing
         run: cp -r target/cargo-timings target/cargo-timings-macos
       - name: Archive build timing
@@ -111,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: mac
-          path: target/${cargo_profile_name}/servo-tech-demo.dmg
+          path: target/${{ env.cargo_profile_name }}/servo-tech-demo.dmg
       - name: Upload nightly
         if: ${{ inputs.upload }}
         run: |
@@ -123,7 +123,7 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
-        run: gtar -czf target.tar.gz target/${cargo_profile_name}/servo target/${cargo_profile_name}/*.dylib target/${cargo_profile_name}/lib/*.dylib resources
+        run: gtar -czf target.tar.gz target/${{ env.cargo_profile_name }}/servo target/${{ env.cargo_profile_name }}/*.dylib target/${{ env.cargo_profile_name }}/lib/*.dylib resources
       - name: Upload package for target
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,14 +78,14 @@ jobs:
           python mach fetch
           python mach bootstrap-gstreamer
       - name: Release build (${{ inputs.production && 'without' || 'with' }} debug assertions)
-        run: python mach build ($env:cargo_profile_option -split ' ')
+        run: python mach build ${{ env.cargo_profile_option }}
       - name: Copy resources
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
-        run: python mach smoketest --angle ($env:cargo_profile_option -split ' ')
+        run: python mach smoketest --angle ${{ env.cargo_profile_option }}
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
-        run: python mach test-unit ($env:cargo_profile_option -split ' ')
+        run: python mach test-unit ${{ env.cargo_profile_option }}
       - name: Rename build timing
         run: cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Archive build timing
@@ -95,16 +95,16 @@ jobs:
           # Using a wildcard here ensures that the archive includes the path.
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
-        run: python mach package ($env:cargo_profile_option -split ' ')
+        run: python mach package ${{ env.cargo_profile_option }}
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v3
         with:
           name: win
           # These files are available
-          # MSI Installer: C:\a\servo\servo\target\$env:cargo_profile_name\msi\Installer.msi
-          # Bundle: C:\a\servo\servo\target\$env:cargo_profile_name\msi\Servo.exe
-          # Zip: C:\a\servo\servo\target\$env:cargo_profile_name\msi\Servo.zip
-          path: C:\\a\\servo\\servo\\target\\$env:cargo_profile_name\\msi\\Servo.exe
+          # MSI Installer: C:\a\servo\servo\target\${{ env.cargo_profile_name }}\msi\Installer.msi
+          # Bundle: C:\a\servo\servo\target\${{ env.cargo_profile_name }}\msi\Servo.exe
+          # Zip: C:\a\servo\servo\target\${{ env.cargo_profile_name }}\msi\Servo.zip
+          path: C:\\a\\servo\\servo\\target\\${{ env.cargo_profile_name }}\\msi\\Servo.exe
       - name: Upload nightly
         if: ${{ inputs.upload }}
         run: |


### PR DESCRIPTION
Instead of using those variables from os env context, where we need to be careful about which shell it's used or if it's even used it's better to use workflow expressions (`${{ expr }}`) to facilitate workflow preprocesor before anything is run.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes should fix mac pckg upload https://github.com/servo/servo/actions/runs/6702300916/job/18211086369#step:15:19
- [x] These changes do not require tests because they just fix a CI issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
