### PR TITLE
Remove `__future__` imports that are no longer necessary

### DIFF
--- a/etc/ci/chaos_monkey_test.py
+++ b/etc/ci/chaos_monkey_test.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import absolute_import, print_function
-
 import json
 import sys
 from subprocess import Popen, PIPE

--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import absolute_import, print_function
-
 import os
 import re
 import subprocess

--- a/mach
+++ b/mach
@@ -9,8 +9,6 @@
 ''':' && if [ ! -z "$MSYSTEM" ] ; then exec python "$0" "$@" ; else which python3 > /dev/null 2> /dev/null && exec python3 "$0" "$@" || exec python "$0" "$@" ; fi
 '''
 
-from __future__ import print_function, unicode_literals
-
 import os
 import sys
 

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import print_function, unicode_literals
-
 import os
 import platform
 import sys

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import base64
 import glob
 import json

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import print_function, unicode_literals
-
 import datetime
 import locale
 import os

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -7,7 +7,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import print_function, annotations
+from __future__ import annotations
 
 import contextlib
 from enum import Enum

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -7,7 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import print_function, unicode_literals
 from os import path, listdir, getcwd
 
 import signal

--- a/python/servo/mutation/mutator.py
+++ b/python/servo/mutation/mutator.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import print_function
-
 import fileinput
 import re
 import random

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 from datetime import datetime
 from github import Github
 

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import print_function, unicode_literals
-
 import json
 import os
 import os.path as path

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import print_function, unicode_literals
-
 import argparse
 import logging
 import re

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -7,8 +7,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import hashlib
 import os
 import os.path

--- a/tests/jquery/run_jquery.py
+++ b/tests/jquery/run_jquery.py
@@ -4,8 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import re
 import subprocess

--- a/tests/power/PowerMeasure.py
+++ b/tests/power/PowerMeasure.py
@@ -12,8 +12,6 @@
 # Do not forget to run the script in servo/tests/power folder
 # --------------------------------------------------------#
 
-from __future__ import print_function, unicode_literals
-
 import os
 from os import path
 import time


### PR DESCRIPTION
These are no longer necessary as we always use Python 3.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
