### PR TITLE
Fix intermittent crashes in paint worklets

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -29,6 +29,7 @@
 //! The `unsafe_no_jsmanaged_fields!()` macro adds an empty implementation of
 //! `JSTraceable` to a datatype.
 
+use std::cell::OnceCell;
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -86,6 +87,12 @@ unsafe impl<T: CustomTraceable> CustomTraceable for Box<T> {
 unsafe impl<T: CustomTraceable> CustomTraceable for DomRefCell<T> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         (*self).borrow().trace(trc)
+    }
+}
+
+unsafe impl<T: JSTraceable> CustomTraceable for OnceCell<T> {
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
+        self.get().map(|value| value.trace(tracer));
     }
 }
 

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-alpha.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-alpha.https.html.ini
@@ -1,2 +1,2 @@
 [background-image-alpha.https.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-multiple.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-multiple.https.html.ini
@@ -1,2 +1,0 @@
-[background-image-multiple.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-tiled.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-image-tiled.https.html.ini
@@ -1,3 +1,3 @@
 [background-image-tiled.https.html]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/background-repeat-x.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/background-repeat-x.https.html.ini
@@ -1,2 +1,0 @@
-[background-repeat-x.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/custom-property-animation-on-main-thread.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/custom-property-animation-on-main-thread.https.html.ini
@@ -1,2 +1,2 @@
 [custom-property-animation-on-main-thread.https.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-001.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-background-image-001.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-002.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-background-image-002.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-001.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-background-image-tiled-001.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-002.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-background-image-tiled-002.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-background-image-tiled-003.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-background-image-tiled-003.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-001.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-border-image-001.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-002.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-border-image-002.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-003.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-border-image-003.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-004.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-004.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-border-image-004.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-005.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-border-image-005.https.html.ini
@@ -1,2 +1,0 @@
-[geometry-border-image-005.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-with-float-size.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/geometry-with-float-size.https.html.ini
@@ -1,3 +1,3 @@
 [geometry-with-float-size.https.html]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/canvas-transform.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/canvas-transform.https.html.ini
@@ -1,2 +1,2 @@
 [canvas-transform.https.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/device-pixel-ratio.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/device-pixel-ratio.https.html.ini
@@ -1,3 +1,3 @@
 [device-pixel-ratio.https.html]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-constructor-error.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-constructor-error.https.html.ini
@@ -1,2 +1,0 @@
-[invalid-image-constructor-error.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-paint-error.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-paint-error.https.html.ini
@@ -1,2 +1,0 @@
-[invalid-image-paint-error.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-pending-script.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/invalid-image-pending-script.https.html.ini
@@ -1,2 +1,0 @@
-[invalid-image-pending-script.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/non-registered-property-value.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/non-registered-property-value.https.html.ini
@@ -1,2 +1,0 @@
-[non-registered-property-value.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/overdraw.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/overdraw.https.html.ini
@@ -1,2 +1,0 @@
-[overdraw.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-arguments.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-arguments.https.html.ini
@@ -1,2 +1,2 @@
 [paint-arguments.https.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments-var.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments-var.https.html.ini
@@ -1,2 +1,2 @@
 [paint-function-arguments-var.https.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-arguments.https.html.ini
@@ -1,2 +1,2 @@
 [paint-function-arguments.https.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-this-value.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint-function-this-value.https.html.ini
@@ -1,2 +1,0 @@
-[paint-function-this-value.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-canvasFilter.tentative.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-canvasFilter.tentative.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-canvasFilter.tentative.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-composite.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-composite.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-composite.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-conicGradient.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-conicGradient.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-conicGradient.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-filter.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-filter.https.html.ini
@@ -1,2 +1,2 @@
 [paint2d-filter.https.html]
-  expected: CRASH
+  expected: TIMEOUT

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-gradient.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-gradient.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-gradient.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-image.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-image.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-image.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-paths.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-paths.https.html.ini
@@ -1,4 +1,4 @@
 [paint2d-paths.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17597
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-rects.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-rects.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-rects.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-reset.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-reset.https.html.ini
@@ -1,2 +1,2 @@
 [paint2d-reset.https.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-roundRect.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-roundRect.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-roundRect.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-shadows.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-shadows.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-shadows.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-transform.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-transform.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-transform.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-001.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-001.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-002.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-002.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-003.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-003.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-004.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-004.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-004.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-005.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-005.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-005.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-006.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-006.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-006.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-007.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-007.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-007.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-008.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-008.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-008.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-009.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-009.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-009.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-010.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-010.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-010.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-011.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-011.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-011.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-012.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-012.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-012.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-013.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-013.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-013.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-014.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-014.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-014.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-015.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-015.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-015.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-016.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-016.https.html.ini
@@ -1,4 +1,3 @@
 [parse-input-arguments-016.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17852
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-017.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-017.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-017.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-018.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-018.https.html.ini
@@ -1,3 +1,3 @@
 [parse-input-arguments-018.https.html]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-019.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-019.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-019.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-020.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-020.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-020.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-021.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-021.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-021.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-022.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/parse-input-arguments-022.https.html.ini
@@ -1,2 +1,0 @@
-[parse-input-arguments-022.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/roundrect.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/roundrect.https.html.ini
@@ -1,2 +1,0 @@
-[roundrect.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-001.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-001.https.html.ini
@@ -1,2 +1,0 @@
-[setTransform-001.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-002.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-002.https.html.ini
@@ -1,2 +1,0 @@
-[setTransform-002.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-003.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-003.https.html.ini
@@ -1,2 +1,0 @@
-[setTransform-003.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-004.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/setTransform-004.https.html.ini
@@ -1,2 +1,0 @@
-[setTransform-004.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/style-background-image.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/style-background-image.https.html.ini
@@ -1,4 +1,4 @@
 [style-background-image.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17378
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/style-before-pseudo.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/style-before-pseudo.https.html.ini
@@ -1,4 +1,4 @@
 [style-before-pseudo.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17854
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/style-first-letter-pseudo.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/style-first-letter-pseudo.https.html.ini
@@ -1,4 +1,4 @@
 [style-first-letter-pseudo.https.html]
   type: reftest
   bug: https://github.com/servo/servo/issues/17854
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-after-load.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-after-load.https.html.ini
@@ -1,2 +1,0 @@
-[valid-image-after-load.https.html]
-  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-before-load.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/valid-image-before-load.https.html.ini
@@ -1,2 +1,0 @@
-[valid-image-before-load.https.html]
-  expected: CRASH

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet.html.ini
@@ -1,2 +1,2 @@
 [test_paint_worklet.html]
-  expected: CRASH
+  expected: PASS

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_size.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_size.html.ini
@@ -1,3 +1,3 @@
 [test_paint_worklet_size.html]
   type: reftest
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_timeout.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/worklets/test_paint_worklet_timeout.html.ini
@@ -1,4 +1,4 @@
 [test_paint_worklet_timeout.html]
   type: testharness
   prefs: [dom.worklet.timeout_ms:10]
-  expected: CRASH
+  expected: PASS


### PR DESCRIPTION
Garbage collection means that the worklets might drop after the script
thread has been cleaned up. The worklet now caches the thread pool in the
DOM object itself which should prevent it from needing to access script
thread TLS when being cleaned up. The value is stored as a OnceCell to
maintain the same lazy thread pool creation pattern as before.

Fixes #25838.
Fixes #25258.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25838 and fix #25258.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
