### PR TITLE
Unit tests are becoming more flaky, so retry them

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,6 +102,7 @@ jobs:
         if: ${{ inputs.unit-tests || github.ref_name == 'try-linux' }}
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 20
           max_attempts: 2 # https://github.com/servo/servo/issues/30683
           command: python ./mach test-unit ${{ env.cargo_profile_option }}
       - name: Rename build timing

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,7 +100,10 @@ jobs:
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-linux' }}
-        run: python3 ./mach test-unit ${{ env.cargo_profile_option }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 2 # https://github.com/servo/servo/issues/30683
+          command: python ./mach test-unit ${{ env.cargo_profile_option }}
       - name: Rename build timing
         run: cp -r target/cargo-timings target/cargo-timings-linux
       - name: Archive build timing

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -93,8 +93,11 @@ jobs:
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-mac' }}
-        timeout-minutes: 30 # https://github.com/servo/servo/issues/30275
-        run: python3 ./mach test-unit ${{ env.cargo_profile_option }}
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 20 # https://github.com/servo/servo/issues/30275
+          max_attempts: 3 # https://github.com/servo/servo/issues/30683
+          command: python3 ./mach test-unit ${{ env.cargo_profile_option }}
       - name: Build mach package
         run: python3 ./mach package ${{ env.cargo_profile_option }}
       - name: Run smoketest for mach package

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
-          command: python mach test-unit ${{ env.cargo_profile_option }}
+          command: python mach test-unit ${{ env.cargo_profile_option }} -- -- --test-threads=1
       - name: Rename build timing
         run: cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Archive build timing

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,6 +87,7 @@ jobs:
         if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: python mach test-unit ${{ env.cargo_profile_option }}
       - name: Rename build timing

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,10 @@ jobs:
         run: python mach smoketest --angle ${{ env.cargo_profile_option }}
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
-        run: python mach test-unit ${{ env.cargo_profile_option }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3 # https://github.com/servo/servo/issues/30683
+          command: python mach test-unit ${{ env.cargo_profile_option }}
       - name: Rename build timing
         run: cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Archive build timing


### PR DESCRIPTION
Especially net test on mac and now also on windows, but I've also seen flaky unit tests on linux.

Hopefully this would make mq faster as there should be less faulty fails.

Temporary solution for https://github.com/servo/servo/issues/30683

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because there are CI resilient changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
