### PR TITLE
Update mozjs and setuptools

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -70,10 +70,6 @@ jobs:
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
-      - name: Select Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
       - name: Install taplo
         uses: baptiste0928/cargo-install@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,7 +3611,7 @@ checksum = "903970ae2f248d7275214cf8f387f8ba0c4ea7e3d87a320e85493db60ce28616"
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#ec63ca39efb346c414e0f55ef26e63c0b17ee69a"
+source = "git+https://github.com/servo/mozjs#f452fb2e642e158893a094b62956b5f40e015c3e"
 dependencies = [
  "bindgen 0.68.1",
  "cc",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.68.2"
-source = "git+https://github.com/servo/mozjs#ec63ca39efb346c414e0f55ef26e63c0b17ee69a"
+source = "git+https://github.com/servo/mozjs#f452fb2e642e158893a094b62956b5f40e015c3e"
 dependencies = [
  "bindgen 0.68.1",
  "cc",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,8 @@ blessings == 1.7
 distro == 1.4
 mozinfo == 1.2.1
 mozlog == 7.1.0
-setuptools == 65.5.1
+setuptools == 68.2.2; python_version >= "3.8"
+setuptools == 65.5.1; python_version < "3.8"
 toml == 0.9.2
 dataclasses == 0.8; python_version < "3.7"
 


### PR DESCRIPTION
This should fix issues with Python 3.12 on Mac builders.

<!-- Please describe your changes on the following line: -->

Co-authored-by: Samson <16504129+sagudev@users.noreply.github.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix the build on Python 3.12 builders.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
