### PR TITLE
Matrix in main workflow & try string v3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,8 @@
 [flake8]
 ignore =
-    W291,  # trailing whitespace; the standard tidy process will enforce no trailing whitespace
-    W503,  # linebreak before binary operator; replaced by W504 - linebreak after binary operator
-    E501,  # 80 character line length; the standard tidy process will enforce line length
+    # trailing whitespace; the standard tidy process will enforce no trailing whitespace
+    W291,
+    # linebreak before binary operator; replaced by W504 - linebreak after binary operator
+    W503,
+    # 80 character line length; the standard tidy process will enforce line length
+    E501

--- a/.github/workflows/dispatch-os.yml
+++ b/.github/workflows/dispatch-os.yml
@@ -1,0 +1,43 @@
+name: Dispatch OS
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      profile:
+        required: true
+        type: string
+      wpt-layout:
+        required: true
+        type: string
+      unit-tests:
+        required: true
+        type: boolean
+
+jobs:
+  win:
+    if: ${{ inputs.os == 'windows' }}
+    uses: ./.github/workflows/windows.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      unit-tests: ${{ inputs.unit-tests }}
+
+  mac:
+    if: ${{ inputs.os == 'mac' }}
+    uses: ./.github/workflows/mac.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      wpt-layout: ${{ inputs.wpt-layout }}
+      unit-tests: ${{ inputs.unit-tests }}
+
+  linux:
+    if: ${{ inputs.os == 'linux' }}
+    uses: ./.github/workflows/linux.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      wpt-layout: ${{ inputs.wpt-layout }}
+      unit-tests: ${{ inputs.unit-tests }}

--- a/.github/workflows/dispatch-os.yml
+++ b/.github/workflows/dispatch-os.yml
@@ -8,6 +8,9 @@ on:
       profile:
         required: true
         type: string
+      wpt:
+        required: true
+        type: string
       wpt-layout:
         required: true
         type: string
@@ -32,6 +35,7 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-layout: ${{ inputs.wpt-layout }}
       unit-tests: ${{ inputs.unit-tests }}
+      wpt: ${{ inputs.wpt }}
 
   linux:
     if: ${{ inputs.os == 'linux' }}
@@ -41,3 +45,4 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-layout: ${{ inputs.wpt-layout }}
       unit-tests: ${{ inputs.unit-tests }}
+      wpt: ${{ inputs.wpt }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           ./mach update-wpt --sync --patch
       - name: Run tests
-        if: ${{ !inputs.wpt-sync == 'true' }}
+        if: ${{ inputs.wpt-sync != 'true' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
@@ -88,7 +88,7 @@ jobs:
             --always-succeed
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
-        if: ${{ always() && !inputs.wpt-sync == 'true' }}
+        if: ${{ always() && inputs.wpt-sync != 'true' }}
         with:
           name: wpt-filtered-results-linux-${{ inputs.layout }}
           path: |

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -5,9 +5,9 @@ on:
       profile:
         required: true
         type: string
-      wpt:
+      wpt-sync:
         required: false
-        type: string
+        type: boolean
       layout:
         required: true
         type: string
@@ -63,11 +63,11 @@ jobs:
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
           python3 ./mach bootstrap-gstreamer
       - name: Sync from upstream WPT
-        if: ${{ inputs.wpt == 'sync' }}
+        if: ${{ inputs.wpt-sync == 'true' }}
         run: |
           ./mach update-wpt --sync --patch
       - name: Run tests
-        if: ${{ inputs.wpt != 'sync' }}
+        if: ${{ !inputs.wpt-sync == 'true' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
@@ -79,7 +79,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
       - name: Run tests (sync)
-        if: ${{ inputs.wpt == 'sync' }}
+        if: ${{ inputs.wpt-sync == 'true' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
@@ -88,7 +88,7 @@ jobs:
             --always-succeed
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
-        if: ${{ always() && inputs.wpt != 'sync' }}
+        if: ${{ always() && !inputs.wpt-sync == 'true' }}
         with:
           name: wpt-filtered-results-linux-${{ inputs.layout }}
           path: |
@@ -96,14 +96,14 @@ jobs:
             unexpected-test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ failure() && inputs.wpt != 'sync' }}
+        if: ${{ failure() && inputs.wpt-sync != 'true' }}
         with:
           name: wpt-logs-linux-${{ inputs.layout }}
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.wpt == 'sync' }}
+        if: ${{ inputs.wpt-sync == 'true' }}
         with:
           name: wpt-logs-linux-${{ inputs.layout }}
           path: |
@@ -113,7 +113,7 @@ jobs:
   report-test-results:
     name: Report WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && (github.ref_name == 'try-wpt' || github.ref_name == 'try-wpt-2020' || inputs.wpt == 'test') }}
+    if: ${{ always() && !cancelled() && (github.ref_name == 'try-wpt' || github.ref_name == 'try-wpt-2020' || inputs.wpt-sync != 'true') }}
     needs:
       - "linux-wpt"
     steps:

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -113,7 +113,7 @@ jobs:
   report-test-results:
     name: Report WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && (github.ref_name == 'try-wpt' || github.ref_name == 'try-wpt-2020' || inputs.wpt-sync != 'true') }}
+    if: ${{ always() && !cancelled() && inputs.wpt-sync != 'true' }}
     needs:
       - "linux-wpt"
     steps:

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -5,6 +5,10 @@ on:
       profile:
         required: true
         type: string
+      wpt:
+        default: ""
+        required: false
+        type: string
       wpt-sync:
         required: false
         type: boolean
@@ -69,7 +73,7 @@ jobs:
       - name: Run tests
         if: ${{ inputs.wpt-sync != 'true' }}
         run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${{ inputs.wpt }} \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,9 +6,10 @@ on:
         required: false
         default: "release"
         type: string
-      wpt:
+      wpt-sync:
         required: false
-        type: string
+        default: false
+        type: boolean
       layout:
         required: false
         type: string
@@ -31,10 +32,9 @@ on:
         type: choice
         options: ["release", "debug", "production"]
       wpt:
-        default: "test"
+        default: false
         required: false
-        type: choice
-        options: ["test", "sync"]
+        type: boolean
       layout:
         required: false
         type: choice
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/linux-wpt.yml
     with:
       profile: ${{ inputs.profile }}
-      wpt: ${{ inputs.wpt }}
+      wpt-sync: ${{ inputs.wpt-sync == 'true' }}
       layout: "layout-2020"
     secrets: inherit
 
@@ -159,7 +159,7 @@ jobs:
     uses: ./.github/workflows/linux-wpt.yml
     with:
       profile: ${{ inputs.profile }}
-      wpt: ${{ inputs.wpt }}
+      wpt-sync: ${{ inputs.wpt-sync == 'true' }}
       layout: "layout-2013"
     secrets: inherit
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: false
         type: boolean
-      layout:
+      wpt-layout:
         required: false
         type: string
       unit-tests:
@@ -35,7 +35,7 @@ on:
         default: false
         required: false
         type: boolean
-      layout:
+      wpt-layout:
         required: false
         type: choice
         options: ["none", "2013", "2020", "all"]
@@ -140,7 +140,7 @@ jobs:
           path: target.tar.gz
 
   wpt-2020:
-    if: ${{ inputs.layout == '2020' || inputs.layout == 'all' }}
+    if: ${{ inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
     name: Linux WPT Tests 2020
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
@@ -151,7 +151,7 @@ jobs:
     secrets: inherit
 
   wpt-2013:
-    if: ${{ inputs.layout == '2013' || inputs.layout == 'all' }}
+    if: ${{ inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
     name: Linux WPT Tests 2013
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
-      wpt:
+      wpt-sync:
         default: false
         required: false
         type: boolean
@@ -47,8 +47,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["try-linux", "try-wpt", "try-wpt-2020"]
 
 env:
   RUST_BACKTRACE: 1
@@ -100,7 +98,7 @@ jobs:
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
-        if: ${{ inputs.unit-tests || github.ref_name == 'try-linux' }}
+        if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 20
@@ -142,7 +140,7 @@ jobs:
           path: target.tar.gz
 
   wpt-2020:
-    if: ${{ github.ref_name == 'try-wpt-2020' || inputs.layout == '2020' || inputs.layout == 'all' }}
+    if: ${{ inputs.layout == '2020' || inputs.layout == 'all' }}
     name: Linux WPT Tests 2020
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
@@ -153,7 +151,7 @@ jobs:
     secrets: inherit
 
   wpt-2013:
-    if: ${{ github.ref_name == 'try-wpt' || inputs.layout == '2013' || inputs.layout == 'all' }}
+    if: ${{ inputs.layout == '2013' || inputs.layout == 'all' }}
     name: Linux WPT Tests 2013
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,10 @@ on:
         required: false
         default: "release"
         type: string
+      wpt:
+        default: ""
+        required: false
+        type: string
       wpt-sync:
         required: false
         default: false
@@ -31,6 +35,10 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
+      wpt:
+        default: ""
+        required: false
+        type: string
       wpt-sync:
         default: false
         required: false
@@ -148,6 +156,7 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-sync: ${{ inputs.wpt-sync == 'true' }}
       layout: "layout-2020"
+      wpt: ${{ inputs.wpt }}
     secrets: inherit
 
   wpt-2013:
@@ -159,6 +168,7 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-sync: ${{ inputs.wpt-sync == 'true' }}
       layout: "layout-2013"
+      wpt: ${{ inputs.wpt }}
     secrets: inherit
 
   result:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -6,6 +6,10 @@ on:
       profile:
         required: true
         type: string
+      wpt:
+        default: ""
+        required: false
+        type: string
       layout:
         required: true
         type: string
@@ -49,7 +53,7 @@ jobs:
         run: python3 ./mach smoketest --${{ inputs.profile }}
       - name: Run tests
         run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${{ inputs.wpt }} \
             --${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -40,8 +40,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["try-mac", "try-wpt-mac", "try-wpt-mac-2020"]
 
 env:
   RUST_BACKTRACE: 1
@@ -97,7 +95,7 @@ jobs:
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
-        if: ${{ inputs.unit-tests || github.ref_name == 'try-mac' }}
+        if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 20 # https://github.com/servo/servo/issues/30275
@@ -143,7 +141,7 @@ jobs:
           path: target.tar.gz
 
   wpt-2020:
-    if: ${{ github.ref_name == 'try-wpt-mac-2020' || inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
+    if: ${{ inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
     name: Mac WPT Tests 2020
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
@@ -153,7 +151,7 @@ jobs:
     secrets: inherit
 
   wpt-2013:
-    if: ${{ github.ref_name == 'try-wpt-mac' || inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
+    if: ${{ inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
     name: Mac WPT Tests 2013
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: "release"
         type: string
+      wpt:
+        default: ""
+        required: false
+        type: string
       wpt-layout:
         required: false
         type: string
@@ -28,6 +32,10 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
+      wpt:
+        default: ""
+        required: false
+        type: string
       wpt-layout:
         required: false
         type: choice
@@ -148,6 +156,7 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       layout: "layout-2020"
+      wpt: ${{ inputs.wpt }}
     secrets: inherit
 
   wpt-2013:
@@ -158,6 +167,7 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       layout: "layout-2013"
+      wpt: ${{ inputs.wpt }}
     secrets: inherit
 
   result:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,6 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       profile: "release"
-      wpt: 'test'
       layout: ${{ fromJson(needs.decision.outputs.configuration).layout }}
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
                     "layout": "none",
                     "profile": "release",
                     "unit_tests": true,
+                    "wpt": "",
                   },
                 ],
               };
@@ -91,6 +92,7 @@ jobs:
                   "layout": "all",
                   "profile": "release",
                   "unit_tests": true,
+                  "wpt": "",
                 },
                 {
                   "os": "windows",
@@ -98,6 +100,7 @@ jobs:
                   "layout": "none", // not used
                   "profile": "release",
                   "unit_tests": true,
+                  "wpt": "",
                 },
                 {
                   "os": "mac",
@@ -105,6 +108,7 @@ jobs:
                   "layout": "none",
                   "profile": "release",
                   "unit_tests": true,
+                  "wpt": "",
                 }
               ],
             };
@@ -143,6 +147,7 @@ jobs:
       wpt-layout: ${{ matrix.layout }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
+      wpt: ${{ matrix.wpt }}
 
   build-result:
     name: Result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     # random force pushes.
     branches: ["main", "try"]
   pull_request:
-    types: ['opened', 'synchronize']
+    types: ["opened", "synchronize"]
     branches: ["**"]
   merge_group:
     types: [checks_requested]
@@ -18,16 +18,18 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      platform:
+      profile:
         required: false
-        type: choice
-        options: ["linux", "windows", "macos", "all"]
+        default: false
+        type: boolean
       layout:
         required: false
+        default: "all"
         type: choice
         options: ["none", "2013", "2020", "all"]
       unit-tests:
         required: false
+        default: true
         type: boolean
 
 jobs:
@@ -50,65 +52,97 @@ jobs:
               return configuration;
             }
 
-            // We need to pick defaults if the inputs are not provided. Unprovided inputs
-            // are empty strings in this template.
-            let platform = "${{ inputs.platform }}" || "linux";
-            let layout = "${{ inputs.layout }}" || "none";
-            let unit_tests = Boolean(${{ inputs.unit-tests }})
+            // try builds can also have config in last commit msg
+            if (${{ github.ref_name == 'try' }}) {
+              let commit_msg = context.payload.head_commit.message;
+              try {
+                var o = JSON.parse(commit_msg.split('\n').slice(-1));
 
-            // Merge queue runs and pushes to `main` should always trigger a full build and test.
-            if (["push", "merge_group"].includes(context.eventName)) {
-              platform = "all";
-              layout = "all";
-              unit_tests = true;
+                if (o && typeof o === "object") {
+                  console.log("Using try commit configuration: " + JSON.stringify(o));
+                  return o;
+                }
+              }
+              catch (e) { }
             }
 
-            let platforms = [];
-            if (platform == "all") {
-              platforms = [ "linux", "windows", "macos" ];
-            } else {
-              platforms = [ platform ];
+            if (context.eventName == "pull_request") {
+              return {
+                "fail_fast": false,
+                "matrix": [
+                  {
+                    "os": "linux",
+                    "name": "Linux",
+                    "layout": "none",
+                    "profile": "release",
+                    "unit_tests": true,
+                  },
+                ],
+              };
             }
 
-            let returnValue =  {
-              platforms,
-              layout,
-              unit_tests,
+            // If we reach here we are likely doing full run
+            configuration = {
+              "fail_fast": false,
+              "matrix": [
+                {
+                  "os": "linux",
+                  "name": "Linux",
+                  "layout": "all",
+                  "profile": "release",
+                  "unit_tests": true,
+                },
+                {
+                  "os": "windows",
+                  "name": "Windows",
+                  "layout": "none", // not used
+                  "profile": "release",
+                  "unit_tests": true,
+                },
+                {
+                  "os": "mac",
+                  "name": "MacOS",
+                  "layout": "none",
+                  "profile": "release",
+                  "unit_tests": true,
+                }
+              ],
             };
 
-            console.log("Using configuration: " + JSON.stringify(returnValue));
-            return returnValue;
+            // Make merge queue fast
+            if (context.eventName == "merge_group") {
+              configuration.fail_fast = true;
+            }
 
-  build-win:
-    name: Windows
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'windows') }}
-    uses: ./.github/workflows/windows.yml
-    with:
-      profile: "release"
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
-    secrets: inherit
+            // override stuff by user provided
+            if (context.eventName == "workflow_dispatch") {
+              configuration.matrix.linux.layout = "${{ inputs.layout }}";
+              let unit_tests = Boolean(${{ inputs.unit-tests }});
+              let profile = '${{ inputs.profile }}';
+              for (const platform of configuration.matrix) {
+                platform.profile = profile;
+                platfrom.unit_tests = unit_tests;
+              }
+            }
 
-  build-mac:
-    name: Mac
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'macos') }}
-    uses: ./.github/workflows/mac.yml
-    with:
-      profile: "release"
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
-    secrets: inherit
+            console.log("Using configuration: " + JSON.stringify(configuration));
+            return configuration;
 
-  build-linux:
-    name: Linux
+  build:
     needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'linux') }}
-    uses: ./.github/workflows/linux.yml
-    with:
-      profile: "release"
-      layout: ${{ fromJson(needs.decision.outputs.configuration).layout }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ fromJson(needs.decision.outputs.configuration).fail_fast }}
+      matrix:
+        include: ${{ fromJson(needs.decision.outputs.configuration).matrix }}
+    # we need dipatch os because workflows do not support uses: ${}
+    uses: ./.github/workflows/dispatch-os.yml
     secrets: inherit
+    with:
+      os: ${{ matrix.os }}
+      wpt-layout: ${{ matrix.layout }}
+      profile: ${{ matrix.profile }}
+      unit-tests: ${{ matrix.unit_tests }}
 
   build-result:
     name: Result
@@ -117,14 +151,9 @@ jobs:
     # needs all build to detect cancellation
     needs:
       - "decision"
-      - "build-win"
-      - "build-mac"
-      - "build-linux"
+      - "build"
 
     steps:
-      - name: Mark skipped jobs as successful
-        if: ${{ fromJson(needs.decision.outputs.configuration).platforms[0] != null }}
-        run: exit 0
       - name: Mark the job as successful
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -15,7 +15,7 @@ jobs:
     name: Linux
     uses: ./.github/workflows/linux.yml
     with:
-      wpt: 'sync'
+      wpt-sync: true
       layout: 'all'
       unit-tests: false
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -97,19 +97,30 @@ jobs:
       - name: Parse Try string
         if: ${{ steps.try_string.outputs.result }}
         id: configuration
-        run: python ./etc/try_parser.py ${{ steps.try_string.outputs.result }}
+        run: |
+          out=$(python ./etc/try_parser.py ${{ steps.try_string.outputs.result }})
+          echo "result=${out}" >> $GITHUB_OUTPUT
 
-  run-try:
-    name: Run Try
-    if: ${{ needs.parse-comment.outputs.try_string }}
+  # we cannot call main.yml because we hit workflow neesting limit
+  build:
     needs: ["parse-comment"]
-    uses: ./.github/workflows/main.yml
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ fromJson(needs.parse-comment.outputs.configuration).fail_fast }}
+      matrix:
+        include: ${{ fromJson(needs.parse-comment.outputs.configuration).matrix }}
+    # we need dipatch os because workflows do not support uses: ${}
+    uses: ./.github/workflows/dispatch-os.yml
+    secrets: inherit
     with:
-      configuration: ${{ needs.parse-comment.outputs.configuration }}
+      os: ${{ matrix.os }}
+      wpt-layout: ${{ matrix.layout }}
+      profile: ${{ matrix.profile }}
+      unit-tests: ${{ matrix.unit_tests }}
 
   results:
     name: Results
-    needs: ["parse-comment", "run-try"]
+    needs: ["parse-comment", "build"]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -117,6 +117,7 @@ jobs:
       wpt-layout: ${{ matrix.layout }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
+      wpt: ${{ matrix.wpt }}
 
   results:
     name: Results

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -3,6 +3,11 @@ name: Try
 on:
   pull_request_target:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      try_string:
+        type: string
+        required: true
 
 jobs:
   parse-comment:
@@ -12,9 +17,11 @@ jobs:
       group: try-${{ github.event.number }}
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
+      try_string: ${{ steps.try_string.outputs.result }}
     steps:
-      - uses: actions/github-script@v6
-        id: configuration
+      - name: Get Try string
+        uses: actions/github-script@v6
+        id: try_string
         with:
           script: |
             function makeComment(body) {
@@ -27,94 +34,34 @@ jobs:
                 })
             }
 
-            function combineWPTLayoutOptions(layout, newLayout) {
-                let has2013 = layout == "2013" || layout == "all";
-                let has2020 = layout == "2020" || layout == "all";
-                let adding2013 = newLayout == "2013";
-                let adding2020 = newLayout == "2020";
+            let try_string = ""
 
-                if ((adding2020 && has2020) || (adding2013 && has2013)) {
-                  return layout;
+            if (context.eventName == "pull_request_target") {
+              for (const label of context.payload.pull_request.labels) {
+                if (!label.name.startsWith("T-")) {
+                  continue;
                 }
-                if (adding2020) {
-                  return has2013 ? "all" : "2020";
-                }
-                if (adding2013) {
-                  return has2020 ? "all" : "2013";
-                }
-                return layout;
-            }
 
-            function addPlatformToConfiguration(platform, configuration) {
-              if (!configuration.platforms.includes(platform)) {
-                configuration.platforms.push(platform);
+                // Try to remove the label. If that fails, it's likely that another
+                // workflow has already processed it or a user has removed it.
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: label.name,
+                  });
+                } catch (exception) {
+                  console.log("Assuming '" + label.name + "' is already removed: " + exception);
+                  continue;
+                }
+
+                console.log("Found label: " + label.name);
+                try_string += " " + label.name.slice(2); // "T-" removed
               }
             }
 
-            function updateConfigurationFromString(tryString, configuration) {
-                if (tryString.includes("full")) {
-                  configuration.platforms = ["linux", "macos", "windows"];
-                  configuration.unit_tests = true;
-                  configuration.layout = "all";
-                  return configuration;
-                }
-
-                if (tryString.includes("linux")) {
-                  addPlatformToConfiguration("linux", configuration);
-                  configuration.unit_tests = true;
-                } else if (tryString.includes("macos")) {
-                  addPlatformToConfiguration("macos", configuration);
-                  configuration.unit_tests = true;
-                } else if (tryString.includes("win")) {
-                  addPlatformToConfiguration("windows", configuration);
-                  configuration.unit_tests = true;
-                }
-
-                if (tryString.includes("wpt")) {
-                  addPlatformToConfiguration("linux", configuration);
-                  if (tryString.includes("2020")) {
-                    configuration.layout = combineWPTLayoutOptions(configuration.layout, "2020");
-                  } else {
-                    configuration.layout = combineWPTLayoutOptions(configuration.layout, "2013");
-                  }
-                }
-            }
-
-            let configuration = {
-              platforms: [],
-              layout: "none",
-              unit_tests: false,
-            };
-
-            let try_labels = [];
-            for (const label of context.payload.pull_request.labels) {
-              if (!label.name.startsWith("T-")) {
-                continue;
-              }
-
-              // Try to remove the label. If that fails, it's likely that another
-              // workflow has already processed it or a user has removed it.
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  name: label.name,
-                });
-              } catch (exception) {
-                console.log("Assuming '" + label.name + "' is already removed: " + exception);
-                continue;
-              }
-
-              console.log("Found label: " + label.name);
-              updateConfigurationFromString(label.name, configuration);
-            }
-
-            console.log(JSON.stringify(configuration));
-
-            if (configuration.platforms.length == 0) {
-                return { platforms: [] };
-            }
+            console.log(try_string);
 
             let username = context.payload.sender.login;
             let result = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -124,7 +71,7 @@ jobs:
             });
             if (!result.data.user.permissions.push) {
               makeComment('🔒 User @' + username + ' does not have permission to trigger try jobs.');
-              return { platforms: [] };
+              return "";
             }
 
             const url = context.serverUrl +
@@ -132,15 +79,30 @@ jobs:
               "/" + context.repo.repo +
               "/actions/runs/" + context.runId;
             const formattedURL = "[#" + context.runId + "](" + url + ")";
-            let platformsString = configuration.platforms.toString();
-            makeComment("🔨 Triggering try run (" + formattedURL + ") with platforms=" +
-                        platformsString + " and layout=" + configuration.layout);
-            return configuration;
+            makeComment("🔨 Triggering try run (" + formattedURL + ")");
+
+            return try_string;
+      # TODO: download try_parser manually
+      - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        with:
+          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          fetch-depth: 2
+      - name: Parse Try string
+        if: ${{ steps.try_string.outputs.result }}
+        id: configuration
+        run: python ./etc/try_parser.py ${{ steps.try_string.outputs.result }}
 
   run-try:
     name: Run Try
+    if: ${{ needs.parse-comment.outputs.try_string }}
     needs: ["parse-comment"]
-    if: ${{ fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
     uses: ./.github/workflows/main.yml
     with:
       configuration: ${{ needs.parse-comment.outputs.configuration }}
@@ -149,7 +111,7 @@ jobs:
     name: Results
     needs: ["parse-comment", "run-try"]
     runs-on: ubuntu-latest
-    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
+    if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
       - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,8 +32,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["try-windows"]
 
 env:
   RUST_BACKTRACE: 1
@@ -89,7 +87,7 @@ jobs:
       - name: Smoketest
         run: python mach smoketest --angle --${{ inputs.profile }}
       - name: Unit tests
-        if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
+        if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -372,6 +372,12 @@ If you need to create a new test file, it should be located in `tests/wpt/mozill
 ./mach test-wpt --manifest-update
 ```
 
+### Running tests via GitHub Actions
+
+Running whole WPT suite is resource intensive and tedious task. Instead of using your computer resources, you can enable Workflows in personal fork and then send your patches to try branch. To make things easier you can use `./mach try` that will automatically send git `HEAD` (patches that are committed in current checkout) to try branch and run full CI build, using same config as it's used for landing things in servo/servo.
+
+For advance try runs see: [try guide](./try.md)
+
 ### Debugging a test
 
 See the [debugging guide](./debugging.md) to get started in how to debug Servo.

--- a/docs/try.md
+++ b/docs/try.md
@@ -1,0 +1,40 @@
+# Try builds
+
+Instead of using your computer resources, you can enable Workflows in personal fork and then use try builds to test patches before sanding PR to servo.
+
+## Triggering try runs
+
+You can trigger try runs via:
+
+- adding `T-` labels on PR (servo organization members only)
+- running `mach try [try string]` command
+
+`mach try` will  send git `HEAD` (patches that are committed in current checkout) to try branch.
+
+## Try strings
+
+Try string can contain:
+
+- `fail-fast` as marker keyword that will set [matrix fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to true
+- config tuples: `name(option=value, option2=value)` (`name()` or `name` is also valid if name is preset)
+
+### Options
+
+- `os` (possible values: `linux` (default), `windows` or `mac`)
+- `layout` (selects layout for wpt tests; possible values: `all`, `2020`, `2013`, `none`)
+- `unit-tests` (default `true`)
+- `profile` (`release` [default], `debug`, `production`)
+
+### Presets
+
+- `linux` (does not run any wpt tests)
+- `mac`
+- `win` or `windows`
+- `wpt` or `linux-wpt` (runs wpt tests for `both` layouts on linux)
+- `wpt-2013` or `linux-wpt-2013` (runs wpt tests on `2013` layout)
+- `wpt-2020` or `linux-wpt-2020` (runs wpt tests on `2020` layout)
+- `mac-wpt`
+- `mac-wpt-2013`
+- `mac-wpt-2020`
+
+Using tuple config with presets you can override presets options.

--- a/docs/try.md
+++ b/docs/try.md
@@ -16,16 +16,16 @@ You can trigger try runs via:
 
 Try string can contain:
 
-- `full` keyword that will be expanded to `linux mac windows`
+- `full`/`try` keyword that will be expanded to `linux mac windows`
 - `fail-fast` as marker keyword that will set [matrix fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to true
-- config tuples: `name(option=value, option2=value)` (`name()` or `name` is also valid if name is preset)
+- config tuples: `name(option=value, option2=value)` (`name` is also valid if `name` is preset)
 
 ### Options
 
 - `os` (possible values: `linux` (default), `windows` or `mac`)
 - `layout` (selects layout for wpt tests; possible values: `all`, `2020`, `2013`, `none`)
-- `unit-tests` (default `true`)
-- `profile` (`release` [default], `debug`, `production`)
+- `unit-tests` (default: `true`)
+- `profile` (`release` (default), `debug`, `production`)
 
 ### Presets
 

--- a/docs/try.md
+++ b/docs/try.md
@@ -7,6 +7,7 @@ Instead of using your computer resources, you can enable Workflows in personal f
 You can trigger try runs via:
 
 - adding `T-` labels on PR (servo organization members only)
+- dispatching workflows from personal fork
 - running `mach try [try string]` command
 
 `mach try` will  send git `HEAD` (patches that are committed in current checkout) to try branch.
@@ -15,6 +16,7 @@ You can trigger try runs via:
 
 Try string can contain:
 
+- `full` keyword that will be expanded to `linux mac windows`
 - `fail-fast` as marker keyword that will set [matrix fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to true
 - config tuples: `name(option=value, option2=value)` (`name()` or `name` is also valid if name is preset)
 
@@ -31,6 +33,7 @@ Try string can contain:
 - `mac`
 - `win` or `windows`
 - `wpt` or `linux-wpt` (runs wpt tests for `both` layouts on linux)
+- `webgpu` (runs WebGPU CTS on linux with layout2020 and production profile)
 - `wpt-2013` or `linux-wpt-2013` (runs wpt tests on `2013` layout)
 - `wpt-2020` or `linux-wpt-2020` (runs wpt tests on `2020` layout)
 - `mac-wpt`

--- a/etc/try_parser.py
+++ b/etc/try_parser.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import json
+
+from enum import Enum
+
+
+# lexer
+class TokenType(Enum):
+    Illegal = 0
+    Eof = 1
+    #
+    Comma = 2
+    SemiColon = 3
+    Assign = 4
+    # ()
+    Lparen = 5
+    Rparen = 6
+    #
+    String = 7
+    # Keyword
+    FailFast = 8
+    Full = 9
+    Try = 10  # nop token
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+class Token:
+    m_type: TokenType
+    m_lit: str
+
+    def __init__(self, typ: TokenType, lit: str):
+        self.m_type: TokenType = typ
+        self.m_lit: str = lit
+
+    def is_seperator(self) -> bool:
+        return self.m_type in [TokenType.Comma, TokenType.SemiColon]
+
+    def __str__(self) -> str:
+        return str(self.m_type) + ": '" + self.m_lit + "'"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Token):
+            return self.m_lit == other.m_lit and self.m_type == other.m_type
+        return False
+
+
+class Lexer:
+    input: str = ""
+    pos: int = 0
+    read_pos: int = 0
+    ch: str = '\0'
+    _peek_token: Token = Token(TokenType.Eof, "EOF")
+
+    def __init__(self, s: str) -> None:
+        self.input = s
+        self.read_char()
+        self._next_token()
+
+    def read_char(self) -> None:
+        self.ch = '\0' if self.read_pos >= len(self.input) else self.input[self.read_pos]
+        self.pos = self.read_pos
+        self.read_pos += 1
+
+    def skip_whitespace(self) -> None:
+        while self.ch.isspace():
+            self.read_char()
+
+    def read_string(self, end: str = '"') -> str:
+        pos = self.pos + 1
+        while True:
+            self.read_char()
+            if self.ch == end or self.ch == '\0':
+                break
+        return self.input[pos:self.pos]
+
+    def read_ident(self) -> str:
+        pos = self.pos
+        while self.ch.isalnum() or (self.ch == '-' or self.ch == '_'):
+            self.read_char()
+        return self.input[pos:self.pos]
+
+    def keyword(self, s: str) -> TokenType:
+        if s == "fail-fast":
+            return TokenType.FailFast
+        elif s == "full":
+            return TokenType.Full
+        elif s == "try":
+            return TokenType.Try
+        else:
+            return TokenType.String
+
+    def next_token(self) -> Token:
+        t = self._peek_token
+        self._next_token()
+        return t
+
+    def peek_token(self) -> Token:
+        return self._peek_token
+
+    def _next_token(self) -> None:
+        self.skip_whitespace()
+        tok: Token
+        if self.ch == '=':
+            tok = Token(TokenType.Assign, self.ch)
+        elif self.ch == '"' or self.ch == "'":
+            tok = Token(TokenType.String, self.read_string(self.ch))
+        elif self.ch == '(':
+            tok = Token(TokenType.Lparen, self.ch)
+        elif self.ch == ')':
+            tok = Token(TokenType.Rparen, self.ch)
+        elif self.ch == ',':
+            tok = Token(TokenType.Comma, self.ch)
+        elif self.ch == ';':
+            tok = Token(TokenType.SemiColon, self.ch)
+        elif self.ch == '\0':
+            tok = Token(TokenType.Eof, "EOF")
+        else:
+            c = self.ch
+            if not c.isalnum():
+                self.read_char()
+                tok = Token(TokenType.Illegal, c)
+            else:
+                s = self.read_ident()
+                tok = Token(self.keyword(s), s)
+            self._peek_token = tok
+            return
+
+        self.read_char()
+        self._peek_token = tok
+
+    def collect(self) -> list[Token]:
+        tokens = list()
+        while self.peek_token().m_type != TokenType.Eof:
+            tokens.append(self.next_token())
+        tokens.append(self.next_token())
+        return tokens
+
+
+class Layout(str, Enum):
+    none = 'none'
+    layout2013 = '2013'
+    layout2020 = '2020'
+    all = 'all'
+
+    @staticmethod
+    def parse(s: str):
+        s = s.lower()
+        if s == 'none':
+            return Layout.none
+        elif s == 'all':
+            return Layout.all
+        elif "legacy" in s or "2013" in s:
+            return Layout.layout2013
+        elif "2020" in s:
+            return Layout.layout2020
+        else:
+            raise RuntimeError("Wrong layout option")
+
+
+class OS(str, Enum):
+    linux = 'linux'
+    mac = 'mac'
+    win = 'windows'
+
+    @staticmethod
+    def parse(s: str):
+        s = s.lower()
+        if s == 'linux':
+            return OS.linux
+        elif "mac" in s:
+            return OS.mac
+        elif "win" in s:
+            return OS.win
+        else:
+            raise RuntimeError("Wrong OS")
+
+
+class JobConfig(object):
+    """
+    Represents one config tuple
+
+    name(os=_, layout=_, ...)
+    """
+
+    def __init__(self, name: str, os: OS, layout: Layout = Layout.none,
+                 profile: str = "release", unit_test: bool = True):
+        self.os: OS = os
+        self.name: str = name
+        self.layout: Layout = layout
+        self.profile: str = profile
+        self.unit_tests: bool = unit_test
+
+    @staticmethod
+    def parse(name: str, overrides: dict[str, str]):
+        job = preset(name)
+        if job is None:
+            job = JobConfig(name, OS.linux)
+        for k, v in overrides.items():
+            if k == "os":
+                job.os = OS.parse(v)
+            elif k == "layout":
+                job.layout = Layout.parse(v)
+            elif k == "profile":
+                job.profile = v
+            elif k == "unit-tests":
+                job.unit_tests = (v.lower() == "true")
+            else:
+                raise RuntimeError(f"Unknown key `{k}`")
+        return job
+
+
+# preset from name
+def preset(s: str) -> JobConfig | None:
+    s = s.lower()
+
+    if s == "linux":
+        return JobConfig("Linux", OS.linux)
+    elif s == "mac":
+        return JobConfig("MacOS", OS.mac)
+    elif s in ["win", "windows"]:
+        return JobConfig("Windows", OS.win)
+    elif s in ["wpt", "linux-wpt"]:
+        return JobConfig("Linux WPT", OS.linux, layout=Layout.all)
+    elif s in ["wpt-2013", "linux-wpt-2013"]:
+        return JobConfig("Linux WPT legacy-layout", OS.linux, layout=Layout.layout2013)
+    elif s in ["wpt-2020", "linux-wpt-2020"]:
+        return JobConfig("Linux WPT layout-2020", OS.linux, layout=Layout.layout2020)
+    elif s in ["mac-wpt", "wpt-mac"]:
+        return JobConfig("MacOS WPT", OS.mac, layout=Layout.all)
+    elif s == "mac-wpt-2013":
+        return JobConfig("MacOS WPT legacy-layout", OS.mac, layout=Layout.layout2013)
+    elif s == "mac-wpt-2020":
+        return JobConfig("MacOS WPT layout-2020", OS.mac, layout=Layout.layout2020)
+    else:
+        return None
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, (Config, JobConfig)):
+            return o.__dict__
+        return json.JSONEncoder.default(self, o)
+
+
+class Config(object):
+    def __init__(self, s: str | None = None):
+        self.fail_fast: bool = False
+        self.matrix: list[JobConfig] = list()
+        if s:
+            self.parse(s)
+
+    def parse(self, s: str):
+        s = s.strip()
+        # if no input provided default to full build
+        if not s:
+            s = "full"
+        lex = Lexer(s)
+        while lex.peek_token().m_type != TokenType.Eof:
+            token = lex.next_token()
+            if token.m_type == TokenType.String:
+                name = token.m_lit
+                overrides: dict[str, str] = dict()
+                if lex.peek_token().m_type == TokenType.Lparen:
+                    lex.next_token()  # skip over (
+                    # read tuple
+                    while (lex.peek_token().m_type not in [TokenType.Rparen, TokenType.Eof]):
+                        key = lex.next_token().m_lit
+                        lex.next_token()  # over =
+                        val = lex.next_token().m_lit
+                        overrides[key] = val
+                        # last one has no comma
+                        if lex.peek_token().is_seperator():
+                            lex.next_token()  # over , or ;
+                    lex.next_token()  # skip over )
+                    if lex.peek_token().is_seperator():
+                        lex.next_token()  # over , or ;
+                self.matrix.append(JobConfig.parse(name, overrides))
+            elif token.m_type == TokenType.FailFast:
+                self.fail_fast = True
+            elif token.m_type == TokenType.Full:
+                self.matrix.append(JobConfig("Linux", OS.linux))
+                self.matrix.append(JobConfig("MacOS", OS.mac))
+                self.matrix.append(JobConfig("Windows", OS.win))
+            else:
+                pass
+
+    def toJSON(self) -> str:
+        return json.dumps(self, cls=Encoder)
+
+
+def main():
+    import sys
+    conf = Config()
+    conf.parse(" ".join(sys.argv[1:]))
+    print(conf.toJSON())
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/try_parser.py
+++ b/etc/try_parser.py
@@ -165,7 +165,7 @@ class Layout(str, Enum):
         s = s.lower()
         if s == 'none':
             return Layout.none
-        elif s == 'all':
+        elif s == 'all' or s == 'both':
             return Layout.all
         elif "legacy" in s or "2013" in s:
             return Layout.layout2013
@@ -190,7 +190,7 @@ class OS(str, Enum):
         elif "win" in s:
             return OS.win
         else:
-            raise RuntimeError("Wrong OS")
+            raise RuntimeError("Wrong OS; only `linux`, `mac` and `windows` are supported")
 
 
 class JobConfig(object):
@@ -220,10 +220,10 @@ class JobConfig(object):
                 job.layout = Layout.parse(v)
             elif k == "profile":
                 job.profile = v
-            elif k == "unit-tests":
+            elif k == "unit-tests" or k == "unit-test":
                 job.unit_tests = (v.lower() == "true")
             else:
-                raise RuntimeError(f"Unknown key `{k}`")
+                raise RuntimeError(f"Unknown key `{k}`; only `os`, `layout`, `profile` and `unit-tests` are supported.")
         return job
 
 

--- a/etc/try_parser.py
+++ b/etc/try_parser.py
@@ -201,12 +201,13 @@ class JobConfig(object):
     """
 
     def __init__(self, name: str, os: OS, layout: Layout = Layout.none,
-                 profile: str = "release", unit_test: bool = True):
+                 profile: str = "release", unit_test: bool = True, wpt: str = ""):
         self.os: OS = os
         self.name: str = name
         self.layout: Layout = layout
         self.profile: str = profile
         self.unit_tests: bool = unit_test
+        self.wpt: str = wpt
 
     @staticmethod
     def parse(name: str, overrides: dict[str, str]):
@@ -220,6 +221,8 @@ class JobConfig(object):
                 job.layout = Layout.parse(v)
             elif k == "profile":
                 job.profile = v
+            elif k == "wpt":
+                job.wpt = v
             elif k == "unit-tests" or k == "unit-test":
                 job.unit_tests = (v.lower() == "true")
             else:
@@ -249,6 +252,10 @@ def preset(s: str) -> JobConfig | None:
         return JobConfig("MacOS WPT legacy-layout", OS.mac, layout=Layout.layout2013)
     elif s == "mac-wpt-2020":
         return JobConfig("MacOS WPT layout-2020", OS.mac, layout=Layout.layout2020)
+    elif s == "webgpu":
+        return JobConfig("WebGPU CTS", OS.linux, layout=Layout.layout2020, wpt="_webgpu",
+                         profile="production",  # WebGPU works to slow with debug assert
+                         unit_test=False)  # production profile does not work with unit-tests
     else:
         return None
 

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import unittest
+from try_parser import Config, Lexer, Token, TokenType
+
+EOF = Token(TokenType.Eof, "EOF")
+LPAREN = Token(TokenType.Lparen, "(")
+RPAREN = Token(TokenType.Rparen, ")")
+COMMA = Token(TokenType.Comma, ",")
+EQ = Token(TokenType.Assign, "=")
+
+
+def string(s: str) -> Token:
+    return Token(TokenType.String, s)
+
+
+class TestLexer(unittest.TestCase):
+    def test_string(self):
+        self.assertListEqual(Lexer("linux").collect(), [string("linux"), EOF])
+
+    def test_tuple(self):
+        self.assertListEqual(Lexer("linux(key=value, key2=\"val2\")").collect(),
+                             [string("linux"), LPAREN,
+                              string("key"), EQ, string("value"), COMMA,
+                              string("key2"), EQ, string("val2"), RPAREN,
+                              EOF])
+
+
+class TestParser(unittest.TestCase):
+    def test_string(self):
+        self.assertEqual(Config("linux").toJSON(),
+                         '{"fail_fast": false, "matrix": \
+[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true}]}')
+
+    def test_tuple0(self):
+        conf = Config("linux()")
+        self.assertEqual(conf.toJSON(),
+                         '{"fail_fast": false, "matrix": \
+[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true}]}')
+
+    def test_tuple1(self):
+        conf = Config("linux(profile='debug')")
+        self.assertEqual(conf.matrix[0].profile, "debug")
+
+    def test_tuple2(self):
+        conf = Config("linux(profile=debug, unit-tests=false);")
+        self.assertEqual(conf.matrix[0].profile, 'debug')
+        self.assertEqual(conf.matrix[0].unit_tests, False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -39,13 +39,13 @@ class TestParser(unittest.TestCase):
     def test_string(self):
         self.assertEqual(Config("linux").toJSON(),
                          '{"fail_fast": false, "matrix": \
-[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true}]}')
+[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true, "wpt": ""}]}')
 
     def test_tuple0(self):
         conf = Config("linux()")
         self.assertEqual(conf.toJSON(),
                          '{"fail_fast": false, "matrix": \
-[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true}]}')
+[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true, "wpt": ""}]}')
 
     def test_tuple1(self):
         conf = Config("linux(profile='debug')")

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -28,8 +28,10 @@ class TestParser(unittest.TestCase):
         self.assertEqual(conf.matrix[0].profile, 'debug')
         self.assertEqual(conf.matrix[0].unit_tests, False)
 
-# linux(key=value, key2="val2", key3='val3')
-# mac linux(profile=debug, unit-tests=false) windows()
+    def test_special(self):
+        conf = Config("fail-fast try")
+        self.assertEqual(conf.fail_fast, True)
+        self.assertEqual(len(conf.matrix), 3)
 
 
 if __name__ == "__main__":

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -10,29 +10,7 @@
 # except according to those terms.
 
 import unittest
-from try_parser import Config, Lexer, Token, TokenType
-
-EOF = Token(TokenType.Eof, "EOF")
-LPAREN = Token(TokenType.Lparen, "(")
-RPAREN = Token(TokenType.Rparen, ")")
-COMMA = Token(TokenType.Comma, ",")
-EQ = Token(TokenType.Assign, "=")
-
-
-def string(s: str) -> Token:
-    return Token(TokenType.String, s)
-
-
-class TestLexer(unittest.TestCase):
-    def test_string(self):
-        self.assertListEqual(Lexer("linux").collect(), [string("linux"), EOF])
-
-    def test_tuple(self):
-        self.assertListEqual(Lexer("linux(key=value, key2=\"val2\")").collect(),
-                             [string("linux"), LPAREN,
-                              string("key"), EQ, string("value"), COMMA,
-                              string("key2"), EQ, string("val2"), RPAREN,
-                              EOF])
+from try_parser import Config
 
 
 class TestParser(unittest.TestCase):
@@ -41,20 +19,17 @@ class TestParser(unittest.TestCase):
                          '{"fail_fast": false, "matrix": \
 [{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true, "wpt": ""}]}')
 
-    def test_tuple0(self):
-        conf = Config("linux()")
-        self.assertEqual(conf.toJSON(),
-                         '{"fail_fast": false, "matrix": \
-[{"os": "linux", "name": "Linux", "layout": "none", "profile": "release", "unit_tests": true, "wpt": ""}]}')
-
     def test_tuple1(self):
         conf = Config("linux(profile='debug')")
         self.assertEqual(conf.matrix[0].profile, "debug")
 
     def test_tuple2(self):
-        conf = Config("linux(profile=debug, unit-tests=false);")
+        conf = Config("linux(profile=debug, unit-tests=false)")
         self.assertEqual(conf.matrix[0].profile, 'debug')
         self.assertEqual(conf.matrix[0].unit_tests, False)
+
+# linux(key=value, key2="val2", key3='val3')
+# mac linux(profile=debug, unit-tests=false) windows()
 
 
 if __name__ == "__main__":

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -329,6 +329,16 @@ class MachCommands(CommandBase):
         print("Running tidy tests...")
         passed = tidy.run_tests() and passed
 
+        def test_try_parser():
+            import unittest
+            verbosity = 1 if logging.getLogger().level >= logging.WARN else 2
+            sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "etc"))
+            import try_parser_test
+            suite = unittest.TestLoader().loadTestsFromModule(try_parser_test)
+            return unittest.TextTestRunner(verbosity=verbosity).run(suite).wasSuccessful()
+        print("Running try_parser tests...")
+        passed = test_try_parser() and passed
+
         print("Running WPT tests...")
         passed = wpt.run_tests() and passed
 


### PR DESCRIPTION
Rewrite of CI logic to allow more powerful try builds, lays groundwork for some future extensions

This PR removes some calling endpoints (try branches) for basic workflows (like linux and mac) and instead provides unified entry point for all try runs (only `try` branch remains operative). This is achieved using empty commits on try branch that have configuration encoded within. Same try string parser is shared between try comments and `mach try` invocations. Labels are still operational and are calling presets (that are also available via try strings).

Another important addition is usage of matrix which allow as to limit number of concurrent runs and fails-fast option.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30667
- [x] These changes do have test in try_parser_test.py

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
