### PR TITLE
Use `Au` instead of `Length` in flexbox code

### DIFF
--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -63,6 +63,15 @@ impl<T> FlexRelativeSides<T> {
             cross: self.cross_start + self.cross_end,
         }
     }
+
+    pub fn map<U>(&self, f: impl Fn(&T) -> U) -> FlexRelativeSides<U> {
+        FlexRelativeSides {
+            main_start: f(&self.main_start),
+            main_end: f(&self.main_end),
+            cross_start: f(&self.cross_start),
+            cross_end: f(&self.cross_end),
+        }
+    }
 }
 
 /// One of the two bits set by the `flex-direction` property

--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -64,6 +64,7 @@ impl<T> FlexRelativeSides<T> {
         }
     }
 
+    // TODO(#29819): Check if this function can be removed after we convert everything to Au.
     pub fn map<U>(&self, f: impl Fn(&T) -> U) -> FlexRelativeSides<U> {
         FlexRelativeSides {
             main_start: f(&self.main_start),

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -14,7 +14,7 @@ use style::properties::longhands::flex_direction::computed_value::T as FlexDirec
 use style::properties::longhands::flex_wrap::computed_value::T as FlexWrap;
 use style::properties::longhands::justify_content::computed_value::T as JustifyContent;
 use style::values::computed::length::Size;
-use style::values::computed::{CSSPixelLength, Length};
+use style::values::computed::Length;
 use style::values::generics::flex::GenericFlexBasis as FlexBasis;
 use style::values::CSSFloat;
 use style::Zero;
@@ -1329,7 +1329,7 @@ impl FlexItem<'_> {
 fn logical_slides(
     flex_context: &mut FlexContext<'_>,
     item: FlexRelativeSides<Au>,
-) -> LogicalSides<CSSPixelLength> {
+) -> LogicalSides<Length> {
     let value = flex_context.sides_to_flow_relative(item);
 
     LogicalSides::<Length> {
@@ -1341,7 +1341,7 @@ fn logical_slides(
 }
 
 // TODO(#29819): Check if this function can be removed after we convert everything to Au.
-fn flex_relative_slides(value: FlexRelativeSides<CSSPixelLength>) -> FlexRelativeSides<Au> {
+fn flex_relative_slides(value: FlexRelativeSides<Length>) -> FlexRelativeSides<Au> {
     FlexRelativeSides::<Au> {
         cross_start: value.cross_start.into(),
         cross_end: value.cross_end.into(),

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1325,7 +1325,6 @@ impl FlexItem<'_> {
     }
 }
 
-
 // TODO(#29819): Check if this function can be removed after we convert everything to Au.
 fn logical_slides(
     flex_context: &mut FlexContext<'_>,

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1325,6 +1325,8 @@ impl FlexItem<'_> {
     }
 }
 
+
+// TODO(#29819): Check if this function can be removed after we convert everything to Au.
 fn logical_slides(
     flex_context: &mut FlexContext<'_>,
     item: FlexRelativeSides<Au>,
@@ -1339,6 +1341,7 @@ fn logical_slides(
     }
 }
 
+// TODO(#29819): Check if this function can be removed after we convert everything to Au.
 fn flex_relative_slides(value: FlexRelativeSides<CSSPixelLength>) -> FlexRelativeSides<Au> {
     FlexRelativeSides::<Au> {
         cross_start: value.cross_start.into(),

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -5,6 +5,7 @@
 use std::fmt;
 use std::ops::{Add, AddAssign, Sub};
 
+use app_units::Au;
 use serde::Serialize;
 use style::logical_geometry::{
     BlockFlowDirection, InlineBaseDirection, PhysicalCorner, WritingMode,
@@ -21,6 +22,7 @@ pub type PhysicalSize<U> = euclid::Size2D<U, CSSPixel>;
 pub type PhysicalRect<U> = euclid::Rect<U, CSSPixel>;
 pub type PhysicalSides<U> = euclid::SideOffsets2D<U, CSSPixel>;
 pub type LengthOrAuto = AutoOr<Length>;
+pub type AuOrAuto = AutoOr<Au>;
 pub type LengthPercentageOrAuto<'a> = AutoOr<&'a LengthPercentage>;
 
 #[derive(Clone, Serialize)]


### PR DESCRIPTION
This PR modifies `margin`, `padding` and `border` in flexbox code to use `Au` units

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #29819 
