### PR TITLE
Add `--production` option to mach

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -2,9 +2,9 @@ name: Linux WPT Tests
 on:
   workflow_call:
     inputs:
-      production:
-        required: false
-        type: boolean
+      profile:
+        required: true
+        type: string
       wpt:
         required: false
         type: string
@@ -13,7 +13,6 @@ on:
         type: string
 
 env:
-  cargo_profile_option: ${{ inputs.production && '--profile production' || '--release' }}
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   WPT_COMMAND_LINE_ARG: "${{ inputs.layout == 'layout-2013' && '--legacy-layout' || '' }}"
@@ -71,7 +70,7 @@ jobs:
         if: ${{ inputs.wpt != 'sync' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${{ env.cargo_profile_option }} --processes $(nproc) --timeout-multiplier 2 \
+            --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
@@ -83,7 +82,7 @@ jobs:
         if: ${{ inputs.wpt == 'sync' }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${{ env.cargo_profile_option }} --processes $(nproc) --timeout-multiplier 2 \
+            --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --always-succeed

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,10 +2,10 @@ name: Linux
 on:
   workflow_call:
     inputs:
-      production:
+      profile:
         required: false
-        default: false
-        type: boolean
+        default: "release"
+        type: string
       wpt:
         required: false
         type: string
@@ -25,10 +25,11 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      production:
+      profile:
         required: false
-        default: false
-        type: boolean
+        default: "release"
+        type: choice
+        options: ["release", "debug", "production"]
       wpt:
         default: "test"
         required: false
@@ -50,8 +51,6 @@ on:
     branches: ["try-linux", "try-wpt", "try-wpt-2020"]
 
 env:
-  cargo_profile_option: ${{ inputs.production && '--profile production' || '--release' }}
-  cargo_profile_name: ${{ inputs.production && 'production' || 'release' }}
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
@@ -90,10 +89,10 @@ jobs:
         run: sudo apt update && python3 ./mach bootstrap
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all
-      - name: Release build (${{ inputs.production && 'without' || 'with' }} debug assertions)
-        run: python3 ./mach build ${{ env.cargo_profile_option }}
+      - name: ${{ inputs.profile }} build
+        run: python3 ./mach build --${{ inputs.profile }}
       - name: Smoketest
-        run: xvfb-run python3 ./mach smoketest ${{ env.cargo_profile_option }}
+        run: xvfb-run python3 ./mach smoketest --${{ inputs.profile }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
@@ -102,7 +101,7 @@ jobs:
         with:
           timeout_minutes: 20
           max_attempts: 2 # https://github.com/servo/servo/issues/30683
-          command: python ./mach test-unit ${{ env.cargo_profile_option }}
+          command: python ./mach test-unit --${{ inputs.profile }}
       - name: Rename build timing
         run: cp -r target/cargo-timings target/cargo-timings-linux
       - name: Archive build timing
@@ -114,12 +113,12 @@ jobs:
       - name: Lockfile check
         run: ./etc/ci/lockfile_changed.sh
       - name: Build mach package
-        run: python3 ./mach package ${{ env.cargo_profile_option }}
+        run: python3 ./mach package --${{ inputs.profile }}
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v3
         with:
           name: linux
-          path: target/${{ env.cargo_profile_name }}/servo-tech-demo.tar.gz
+          path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
       - name: Upload nightly
         if: ${{ inputs.upload }}
         run: |
@@ -131,7 +130,7 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
-        run: tar -czf target.tar.gz target/${{ env.cargo_profile_name }}/servo resources
+        run: tar -czf target.tar.gz target/${{ inputs.profile }}/servo resources
       - name: Upload artifact for target
         uses: actions/upload-artifact@v3
         with:
@@ -144,7 +143,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      production: ${{ inputs.production == 'true' }}
+      profile: ${{ inputs.profile }}
       wpt: ${{ inputs.wpt }}
       layout: "layout-2020"
 
@@ -154,7 +153,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      production: ${{ inputs.production == 'true' }}
+      profile: ${{ inputs.profile }}
       wpt: ${{ inputs.wpt }}
       layout: "layout-2013"
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,7 +89,7 @@ jobs:
         run: sudo apt update && python3 ./mach bootstrap
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all
-      - name: ${{ inputs.profile }} build
+      - name: Build (${{ inputs.profile }})
         run: python3 ./mach build --${{ inputs.profile }}
       - name: Smoketest
         run: xvfb-run python3 ./mach smoketest --${{ inputs.profile }}

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -3,15 +3,14 @@ name: Mac WPT Tests
 on:
   workflow_call:
     inputs:
-      production:
-        required: false
-        type: boolean
+      profile:
+        required: true
+        type: string
       layout:
         required: true
         type: string
 
 env:
-  cargo_profile_option: ${{ inputs.production && '--profile production' || '--release' }}
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   WPT_COMMAND_LINE_ARG: "${{ inputs.layout == 'layout-2013' && '--legacy-layout' || '' }}"
@@ -47,11 +46,11 @@ jobs:
           python3 -m pip install --upgrade pip virtualenv
           python3 ./mach bootstrap
       - name: Smoketest
-        run: python3 ./mach smoketest ${{ env.cargo_profile_option }}
+        run: python3 ./mach smoketest --${{ inputs.profile }}
       - name: Run tests
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            ${{ env.cargo_profile_option }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
+            --${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -3,10 +3,10 @@ name: Mac
 on:
   workflow_call:
     inputs:
-      production:
+      profile:
         required: false
-        default: false
-        type: boolean
+        default: "release"
+        type: string
       wpt-layout:
         required: false
         type: string
@@ -23,10 +23,11 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      production:
+      profile:
         required: false
-        default: false
-        type: boolean
+        default: "release"
+        type: choice
+        options: ["release", "debug", "production"]
       wpt-layout:
         required: false
         type: choice
@@ -43,8 +44,6 @@ on:
     branches: ["try-mac", "try-wpt-mac", "try-wpt-mac-2020"]
 
 env:
-  cargo_profile_option: ${{ inputs.production && '--profile production' || '--release' }}
-  cargo_profile_name: ${{ inputs.production && 'production' || 'release' }}
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
@@ -80,11 +79,11 @@ jobs:
           python3 -m pip install --upgrade pip virtualenv
           python3 ./mach bootstrap
           brew install gnu-tar
-      - name: Release build (${{ inputs.production && 'without' || 'with' }} debug assertions)
+      - name: ${{ inputs.profile }} build
         run: |
-          python3 ./mach build ${{ env.cargo_profile_option }}
+          python3 ./mach build --${{ inputs.profile }}
       - name: Smoketest
-        run: python3 ./mach smoketest ${{ env.cargo_profile_option }}
+        run: python3 ./mach smoketest --${{ inputs.profile }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
@@ -93,11 +92,11 @@ jobs:
         with:
           timeout_minutes: 20 # https://github.com/servo/servo/issues/30275
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
-          command: python3 ./mach test-unit ${{ env.cargo_profile_option }}
+          command: python3 ./mach test-unit --${{ inputs.profile }}
       - name: Build mach package
-        run: python3 ./mach package ${{ env.cargo_profile_option }}
+        run: python3 ./mach package --${{ inputs.profile }}
       - name: Run smoketest for mach package
-        run: ./etc/ci/macos_package_smoketest.sh target/${{ env.cargo_profile_name }}/servo-tech-demo.dmg
+        run: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Rename build timing
         run: cp -r target/cargo-timings target/cargo-timings-macos
       - name: Archive build timing
@@ -110,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: mac
-          path: target/${{ env.cargo_profile_name }}/servo-tech-demo.dmg
+          path: target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Upload nightly
         if: ${{ inputs.upload }}
         run: |
@@ -122,7 +121,7 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
-        run: gtar -czf target.tar.gz target/${{ env.cargo_profile_name }}/servo target/${{ env.cargo_profile_name }}/*.dylib target/${{ env.cargo_profile_name }}/lib/*.dylib resources
+        run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/--${{ inputs.profile }}/*.dylib target/--${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
         uses: actions/upload-artifact@v3
         with:
@@ -135,7 +134,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
     with:
-      production: ${{ inputs.production == 'true' }}
+      profile: ${{ inputs.profile }}
       layout: "layout-2020"
 
   wpt-2013:
@@ -144,7 +143,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
     with:
-      production: ${{ inputs.production == 'true' }}
+      profile: ${{ inputs.profile }}
       layout: "layout-2013"
 
   result:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -121,7 +121,7 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
-        run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/--${{ inputs.profile }}/*.dylib target/--${{ inputs.profile }}/lib/*.dylib resources
+        run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/*.dylib target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -79,7 +79,7 @@ jobs:
           python3 -m pip install --upgrade pip virtualenv
           python3 ./mach bootstrap
           brew install gnu-tar
-      - name: ${{ inputs.profile }} build
+      - name: Build (${{ inputs.profile }})
         run: |
           python3 ./mach build --${{ inputs.profile }}
       - name: Smoketest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,7 @@ jobs:
     if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'windows') }}
     uses: ./.github/workflows/windows.yml
     with:
+      profile: "release"
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
 
   build-mac:
@@ -93,6 +94,7 @@ jobs:
     if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'macos') }}
     uses: ./.github/workflows/mac.yml
     with:
+      profile: "release"
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
 
   build-linux:
@@ -101,6 +103,7 @@ jobs:
     if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'linux') }}
     uses: ./.github/workflows/linux.yml
     with:
+      profile: "release"
       wpt: 'test'
       layout: ${{ fromJson(needs.decision.outputs.configuration).layout }}
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,7 +70,7 @@ jobs:
       - create-draft-release
     uses: ./.github/workflows/windows.yml
     with:
-      production: true
+      profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
@@ -83,7 +83,7 @@ jobs:
       - create-draft-release
     uses: ./.github/workflows/mac.yml
     with:
-      production: true
+      profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
@@ -96,7 +96,7 @@ jobs:
       - create-draft-release
     uses: ./.github/workflows/linux.yml
     with:
-      production: true
+      profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,9 +3,9 @@ name: Windows
 on:
   workflow_call:
     inputs:
-      production:
-        required: false
-        type: boolean
+      profile:
+        required: true
+        type: string
       unit-tests:
         required: false
         default: false
@@ -19,9 +19,11 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      production:
+      profile:
         required: false
-        type: boolean
+        default: "release"
+        options: ["release", "debug", "production"]
+        type: choice
       unit-tests:
         required: false
         default: false
@@ -34,8 +36,6 @@ on:
     branches: ["try-windows"]
 
 env:
-  cargo_profile_option: ${{ inputs.production && '--profile production' || '--release' }}
-  cargo_profile_name: ${{ inputs.production && 'production' || 'release' }}
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   CCACHE: "ccache"
@@ -77,19 +77,19 @@ jobs:
           python -m pip install --upgrade pip virtualenv
           python mach fetch
           python mach bootstrap-gstreamer
-      - name: Release build (${{ inputs.production && 'without' || 'with' }} debug assertions)
-        run: python mach build ${{ env.cargo_profile_option }}
+      - name: ${{ inputs.profile }} build
+        run: python mach build --${{ inputs.profile }}
       - name: Copy resources
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
-        run: python mach smoketest --angle ${{ env.cargo_profile_option }}
+        run: python mach smoketest --angle --${{ inputs.profile }}
       - name: Unit tests
         if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
-          command: python mach test-unit ${{ env.cargo_profile_option }} -- -- --test-threads=1
+          command: python mach test-unit --${{ inputs.profile }} -- -- --test-threads=1
       - name: Rename build timing
         run: cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Archive build timing
@@ -99,16 +99,16 @@ jobs:
           # Using a wildcard here ensures that the archive includes the path.
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
-        run: python mach package ${{ env.cargo_profile_option }}
+        run: python mach package --${{ inputs.profile }}
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v3
         with:
           name: win
           # These files are available
-          # MSI Installer: C:\a\servo\servo\target\${{ env.cargo_profile_name }}\msi\Installer.msi
-          # Bundle: C:\a\servo\servo\target\${{ env.cargo_profile_name }}\msi\Servo.exe
-          # Zip: C:\a\servo\servo\target\${{ env.cargo_profile_name }}\msi\Servo.zip
-          path: C:\\a\\servo\\servo\\target\\${{ env.cargo_profile_name }}\\msi\\Servo.exe
+          # MSI Installer: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Installer.msi
+          # Bundle: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.exe
+          # Zip: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.zip
+          path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\Servo.exe
       - name: Upload nightly
         if: ${{ inputs.upload }}
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,7 +77,7 @@ jobs:
           python -m pip install --upgrade pip virtualenv
           python mach fetch
           python mach bootstrap-gstreamer
-      - name: ${{ inputs.profile }} build
+      - name: Build (${{ inputs.profile }})
         run: python mach build --${{ inputs.profile }}
       - name: Copy resources
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -63,6 +63,9 @@ class BuildType:
     def release() -> BuildType:
         return BuildType(BuildType.Kind.RELEASE, None)
 
+    def prod() -> BuildType:
+        return BuildType(BuildType.Kind.CUSTOM, "production")
+
     def custom(profile: str) -> BuildType:
         return BuildType(BuildType.Kind.CUSTOM, profile)
 
@@ -71,6 +74,9 @@ class BuildType:
 
     def is_release(self) -> bool:
         return self.kind == BuildType.Kind.RELEASE
+
+    def is_prod(self) -> bool:
+        return self.kind == BuildType.Kind.CUSTOM and self.profile == "production"
 
     def is_custom(self) -> bool:
         return self.kind == BuildType.Kind.CUSTOM
@@ -734,6 +740,9 @@ class CommandBase(object):
                 CommandArgument('--dev', '--debug', '-d', group="Build Type",
                                 action='store_true',
                                 help='Build in development mode'),
+                CommandArgument('--prod', '--production', group="Build Type",
+                                action='store_true',
+                                help='Build in release mode without debug assertions'),
                 CommandArgument('--profile', group="Build Type",
                                 help='Build with custom Cargo profile'),
             ]
@@ -798,10 +807,11 @@ class CommandBase(object):
                     # If `build_type` already exists in kwargs we are doing a recursive dispatch.
                     if 'build_type' not in kwargs:
                         kwargs['build_type'] = self.configure_build_type(
-                            kwargs['release'], kwargs['dev'], kwargs['profile'],
+                            kwargs['release'], kwargs['dev'], kwargs['prod'], kwargs['profile'],
                         )
                     kwargs.pop('release', None)
                     kwargs.pop('dev', None)
+                    kwargs.pop('prod', None)
                     kwargs.pop('profile', None)
 
                 if build_configuration:
@@ -819,8 +829,8 @@ class CommandBase(object):
 
         return decorator_function
 
-    def configure_build_type(self, release: bool, dev: bool, profile: Optional[str]) -> BuildType:
-        option_count = release + dev + (profile is not None)
+    def configure_build_type(self, release: bool, dev: bool, prod: bool, profile: Optional[str]) -> BuildType:
+        option_count = release + dev + prod + (profile is not None)
 
         if option_count > 1:
             print("Please specify either --dev (-d) for a development")
@@ -842,6 +852,8 @@ class CommandBase(object):
             return BuildType.release()
         elif dev:
             return BuildType.dev()
+        elif prod:
+            return BuildType.prod()
         else:
             return BuildType.custom(profile)
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -174,8 +174,8 @@ class MachCommands(CommandBase):
                      help="Run in bench mode")
     @CommandArgument('--nocapture', default=False, action="store_true",
                      help="Run tests with nocapture ( show test stdout )")
-    @CommandBase.common_command_arguments(build_configuration=True, build_type=False)
-    def test_unit(self, test_name=None, package=None, bench=False, nocapture=False, **kwargs):
+    @CommandBase.common_command_arguments(build_configuration=True, build_type=True)
+    def test_unit(self, build_type: BuildType, test_name=None, package=None, bench=False, nocapture=False, **kwargs):
         if test_name is None:
             test_name = []
 
@@ -239,6 +239,14 @@ class MachCommands(CommandBase):
 
         # Gather Cargo build timings (https://doc.rust-lang.org/cargo/reference/timings.html).
         args = ["--timings"]
+
+        if build_type.is_release():
+            args += ["--release"]
+        elif build_type.is_dev():
+            pass  # there is no argument for debug
+        else:
+            args += ["--profile", build_type.profile]
+
         for crate in packages:
             args += ["-p", "%s_tests" % crate]
         for crate in in_crate_packages:


### PR DESCRIPTION
this makes workflows easier and in preparation for #30694 production was changed to profile so we can accept debug too.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] These changes do not require tests because it's CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
