### PR TITLE
Inherit secrets in the main workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -147,6 +147,7 @@ jobs:
       production: ${{ inputs.production == 'true' }}
       wpt: ${{ inputs.wpt }}
       layout: "layout-2020"
+    secrets: inherit
 
   wpt-2013:
     if: ${{ github.ref_name == 'try-wpt' || inputs.layout == '2013' || inputs.layout == 'all' }}
@@ -157,6 +158,7 @@ jobs:
       production: ${{ inputs.production == 'true' }}
       wpt: ${{ inputs.wpt }}
       layout: "layout-2013"
+    secrets: inherit
 
   result:
     name: Result

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -137,6 +137,7 @@ jobs:
     with:
       production: ${{ inputs.production == 'true' }}
       layout: "layout-2020"
+    secrets: inherit
 
   wpt-2013:
     if: ${{ github.ref_name == 'try-wpt-mac' || inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
@@ -146,6 +147,7 @@ jobs:
     with:
       production: ${{ inputs.production == 'true' }}
       layout: "layout-2013"
+    secrets: inherit
 
   result:
     name: Result

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
     uses: ./.github/workflows/windows.yml
     with:
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+    secrets: inherit
 
   build-mac:
     name: Mac
@@ -94,6 +95,7 @@ jobs:
     uses: ./.github/workflows/mac.yml
     with:
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+    secrets: inherit
 
   build-linux:
     name: Linux
@@ -104,6 +106,7 @@ jobs:
       wpt: 'test'
       layout: ${{ fromJson(needs.decision.outputs.configuration).layout }}
       unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+    secrets: inherit
 
   build-result:
     name: Result


### PR DESCRIPTION
This is an attempt to fix results in the intermittent tracker.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change the CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
