### PR TITLE
Remove some stray references to OpenSSL

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -33,8 +33,6 @@ Building Servo is quite easy. Install the prerequisites described in the [README
 ./mach build -d
 ```
 
-*Note: on Mac, you might run into an SSL issue while compiling. You'll find a solution to this problem [here](https://github.com/sfackler/rust-openssl/issues/255).*
-
 There are three main build profiles, which you can build and use independently of one another:
 
 * debug builds, which allow you to use a debugger (lldb)

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -13,7 +13,7 @@ clangStdenv.mkDerivation rec {
 
   buildInputs = [
     # Native dependencies
-    fontconfig freetype openssl libunwind
+    fontconfig freetype libunwind
     xorg.libxcb
     xorg.libX11
 

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -51,8 +51,6 @@ class Base:
                 f"gst-plugin-scanner{self.executable_suffix()}",
             )
             env["GST_PLUGIN_SYSTEM_PATH"] = os.path.join(gstreamer_root, "lib", "gstreamer-1.0")
-            if self.is_macos:
-                env["OPENSSL_INCLUDE_DIR"] = os.path.join(gstreamer_root, "Headers")
 
         # If we are not cross-compiling GStreamer must be installed for the system. In
         # the cross-compilation case, we might be picking it up from another directory.


### PR DESCRIPTION
These were left over from the change to use rustls.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
