### PR TITLE
Remove support for triggering try from comments

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -30,15 +30,15 @@ jobs:
         chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v3
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,15 +65,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v3
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -28,15 +28,15 @@ jobs:
         chunk_id: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v3
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -58,15 +58,15 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v3
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -3,13 +3,10 @@ name: Try
 on:
   pull_request_target:
     types: [labeled]
-  issue_comment:
-    types: [created]
 
 jobs:
   parse-comment:
-    name: Trigger Try (${{ github.event.name }})
-    if: ${{ github.event_name == 'pull_request_target' || github.event.issue.pull_request  }}
+    name: Trigger Try
     runs-on: ubuntu-latest
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
@@ -87,45 +84,28 @@ jobs:
               unit_tests: false,
             };
 
-            if (context.eventName == "pull_request_target") {
-              let try_labels = [];
-              for (const label of context.payload.pull_request.labels) {
-                if (!label.name.startsWith("T-")) {
-                  continue;
-                }
-
-                // Try to remove the label. If that fails, it's likely that another
-                // workflow has already processed it or a user has removed it.
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    name: label.name,
-                  });
-                } catch (exception) {
-                  console.log("Assuming '" + label.name + "' is already removed: " + exception);
-                  continue;
-                }
-
-                console.log("Found label: " + label.name);
-                updateConfigurationFromString(label.name, configuration);
-              }
-            } else {
-              let tokens = context.payload.comment.body.split(/\s+/);
-              let tagIndex = tokens.indexOf("@bors-servo");
-              if (tagIndex == -1 || tagIndex + 1 >= tokens.length) {
-                return { platforms: [] };
+            let try_labels = [];
+            for (const label of context.payload.pull_request.labels) {
+              if (!label.name.startsWith("T-")) {
+                continue;
               }
 
-
-              let tryString = tokens[tagIndex + 1];
-              console.log("Found try string: '" + tryString + "'");
-              if (tryString == "try") {
-                updateConfigurationFromString("full", configuration);
-              } else {
-                updateConfigurationFromString(tryString, configuration);
+              // Try to remove the label. If that fails, it's likely that another
+              // workflow has already processed it or a user has removed it.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name,
+                });
+              } catch (exception) {
+                console.log("Assuming '" + label.name + "' is already removed: " + exception);
+                continue;
               }
+
+              console.log("Found label: " + label.name);
+              updateConfigurationFromString(label.name, configuration);
             }
 
             console.log(JSON.stringify(configuration));
@@ -167,7 +147,7 @@ jobs:
     name: Results
     needs: ["parse-comment", "run-try"]
     runs-on: ubuntu-latest
-    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).try}}
+    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
     steps:
       - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,15 +51,15 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v3
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
Triggering from labels means that we have less actions running and less
false job failures spamming project members. Plus, we have more
flexibility with labels rather than the backward compatibility we have
set up for bors comments.

<!-- Please describe your changes on the following line: -->


Fixes #30044

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust the CI behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
