### PR TITLE
Fix transform assertion failures in Layout 2013 and Layout 2020

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -1573,7 +1573,7 @@ impl Fragment {
         }
 
         // If this fragment takes up no space, we don't need to build any display items for it.
-        if self.has_non_invertible_transform() {
+        if self.has_non_invertible_transform_or_zero_scale() {
             return;
         }
 
@@ -2419,7 +2419,7 @@ impl BlockFlow {
         flags: StackingContextCollectionFlags,
     ) {
         // This block flow produces no stacking contexts if it takes up no space.
-        if self.has_non_invertible_transform() {
+        if self.has_non_invertible_transform_or_zero_scale() {
             return;
         }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -277,7 +277,7 @@ pub trait Flow: HasBaseFlow + fmt::Debug + Sync + Send + 'static {
         might_have_floats_in_or_out
     }
 
-    fn has_non_invertible_transform(&self) -> bool {
+    fn has_non_invertible_transform_or_zero_scale(&self) -> bool {
         if !self.class().is_block_like() ||
             self.as_block()
                 .fragment
@@ -290,7 +290,9 @@ pub trait Flow: HasBaseFlow + fmt::Debug + Sync + Send + 'static {
             return false;
         }
 
-        self.as_block().fragment.has_non_invertible_transform()
+        self.as_block()
+            .fragment
+            .has_non_invertible_transform_or_zero_scale()
     }
 
     fn get_overflow_in_parent_coordinates(&self) -> Overflow {
@@ -1176,7 +1178,7 @@ impl BaseFlow {
         state: &mut StackingContextCollectionState,
     ) {
         for kid in self.children.iter_mut() {
-            if !kid.has_non_invertible_transform() {
+            if !kid.has_non_invertible_transform_or_zero_scale() {
                 kid.collect_stacking_contexts(state);
             }
         }

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2760,9 +2760,11 @@ impl Fragment {
     }
 
     /// Returns true if this fragment has a transform applied that causes it to take up no space.
-    pub fn has_non_invertible_transform(&self) -> bool {
+    pub fn has_non_invertible_transform_or_zero_scale(&self) -> bool {
         self.transform_matrix(&Rect::default())
-            .map_or(false, |matrix| !matrix.is_invertible())
+            .map_or(false, |matrix| {
+                !matrix.is_invertible() || matrix.m11 == 0. || matrix.m22 == 0.
+            })
     }
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1882,7 +1882,7 @@ impl Flow for InlineFlow {
         for fragment in self.fragments.fragments.iter_mut() {
             // If a particular fragment would establish a stacking context but has a transform
             // applied that causes it to take up no space, we can skip it entirely.
-            if fragment.has_non_invertible_transform() {
+            if fragment.has_non_invertible_transform_or_zero_scale() {
                 continue;
             }
             state.containing_block_clipping_and_scrolling = previous_cb_clipping_and_scrolling;

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -345,7 +345,7 @@ pub struct BuildDisplayList<'a> {
 impl<'a> BuildDisplayList<'a> {
     #[inline]
     pub fn traverse(&mut self, flow: &mut dyn Flow) {
-        if flow.has_non_invertible_transform() {
+        if flow.has_non_invertible_transform_or_zero_scale() {
             return;
         }
 

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -787,8 +787,10 @@ impl Fragment {
 
                 // If this fragment has a transform applied that makes it take up no space
                 // then we don't need to create any stacking contexts for it.
-                let has_non_invertible_transform =
-                    fragment.has_non_invertible_transform(&containing_block.rect.to_untyped());
+                let has_non_invertible_transform = fragment
+                    .has_non_invertible_transform_or_zero_scale(
+                        &containing_block.rect.to_untyped(),
+                    );
                 if has_non_invertible_transform {
                     return;
                 }
@@ -1258,10 +1260,10 @@ impl BoxFragment {
     }
 
     /// Returns true if the given style contains a transform that is not invertible.
-    fn has_non_invertible_transform(&self, containing_block: &Rect<Length>) -> bool {
+    fn has_non_invertible_transform_or_zero_scale(&self, containing_block: &Rect<Length>) -> bool {
         let list = &self.style.get_box().transform;
         match list.to_transform_3d_matrix(Some(containing_block)) {
-            Ok(t) => !t.0.is_invertible(),
+            Ok(t) => !t.0.is_invertible() || t.0.m11 == 0. || t.0.m22 == 0.,
             Err(_) => false,
         }
     }

--- a/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-001.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-scene-001.html]
-  expected: CRASH

--- a/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/crashtests/preserve3d-scene-002.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-scene-002.html]
-  expected: CRASH


### PR DESCRIPTION
Layout asserts that it never creates stacking contexts that have a zero
scale, yet it doesn't prevent the creation of those stacking contexts.
This change stops their creation at an earlier stage.

Fixes #30118.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
