### PR TITLE
Fix Servo taking a long time to start on MacOS after a recompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5071,8 +5071,9 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 dependencies = [
+ "once_cell",
  "servo-media-audio",
  "servo-media-player",
  "servo-media-streams",
@@ -5083,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 dependencies = [
  "boxfnonce",
  "byte-slice-cast",
@@ -5190,7 +5191,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -5202,7 +5203,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -5211,12 +5212,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 dependencies = [
  "boxfnonce",
  "lazy_static",
@@ -5293,7 +5294,7 @@ dependencies = [
 [[package]]
 name = "servo_media_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8ea11a849d5c2f0e469d1d1ccad93a74fbd81462"
+source = "git+https://github.com/servo/media#97515f64c551e37854c6e29eff93988c4d0ee152"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -112,24 +112,26 @@ mod media_platform {
 
     #[cfg(any(windows, target_os = "macos"))]
     pub fn init() {
-        let mut plugin_dir = std::env::current_exe().unwrap();
-        plugin_dir.pop();
+        ServoMedia::init_with_backend(|| {
+            let mut plugin_dir = std::env::current_exe().unwrap();
+            plugin_dir.pop();
 
-        if cfg!(target_os = "macos") {
-            plugin_dir.push("lib");
-        }
+            if cfg!(target_os = "macos") {
+                plugin_dir.push("lib");
+            }
 
-        let backend = match GStreamerBackend::init_with_plugins(
-            plugin_dir,
-            &gstreamer_plugins::GSTREAMER_PLUGINS,
-        ) {
-            Ok(b) => b,
-            Err(e) => {
-                eprintln!("Error initializing GStreamer: {:?}", e);
-                std::process::exit(1);
-            },
-        };
-        ServoMedia::init_with_backend(backend);
+            let backend = match GStreamerBackend::init_with_plugins(
+                plugin_dir,
+                &gstreamer_plugins::GSTREAMER_PLUGINS,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("Error initializing GStreamer: {:?}", e);
+                    std::process::exit(1);
+                },
+            };
+            backend
+        });
     }
 
     #[cfg(not(any(windows, target_os = "macos")))]

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -120,7 +120,7 @@ mod media_platform {
                 plugin_dir.push("lib");
             }
 
-            let backend = match GStreamerBackend::init_with_plugins(
+            match GStreamerBackend::init_with_plugins(
                 plugin_dir,
                 &gstreamer_plugins::GSTREAMER_PLUGINS,
             ) {
@@ -129,8 +129,7 @@ mod media_platform {
                     eprintln!("Error initializing GStreamer: {:?}", e);
                     std::process::exit(1);
                 },
-            };
-            backend
+            }
         });
     }
 


### PR DESCRIPTION
With [#405](https://github.com/servo/media/pull/405) changes in `servo/media` we move initialization of the media engine to a background thread. This allows GStreamer plugin cache initialization to happen off the main thread. This PR updates the `init` function in `libservo` to adapt the behavior of `init_with_backend`

Co-authored-by: Martin Robinson <mrobinson@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30717 
