### PR TITLE
bootstrap: Alphabetize and add 'm4' Ubuntu dependency

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -25,15 +25,16 @@ from .base import Base
 # 2. paste in the whole APT_PKGS = [...]
 # 3. copy(`sudo apt install ${APT_PKGS.join(" ")}`)
 # 4. paste into https://github.com/servo/servo/wiki/Building#debian-based-distributions
-APT_PKGS = ['git', 'curl', 'libx11-dev', 'libfreetype6-dev',
-            'libgl1-mesa-dri', 'libglib2.0-dev', 'xorg-dev', 'gperf', 'g++',
-            'build-essential', 'cmake', 'liblzma-dev', 'libxmu6', 'libxmu-dev',
-            "libxcb-render0-dev", "libxcb-shape0-dev", "libxcb-xfixes0-dev",
-            'libgles2-mesa-dev', 'libegl1-mesa-dev', 'libdbus-1-dev',
-            'libharfbuzz-dev', 'ccache', 'clang', 'libunwind-dev',
-            'libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',
-            'libgstreamer-plugins-bad1.0-dev',
-            'libunwind-dev', 'llvm-dev', 'libvulkan1']
+APT_PKGS = [
+    'build-essential', 'ccache', 'clang', 'cmake', 'curl', 'g++', 'git',
+    'gperf', 'libdbus-1-dev', 'libfreetype6-dev', 'libgl1-mesa-dri',
+    'libgles2-mesa-dev', 'libglib2.0-dev', 'libgstreamer-plugins-bad1.0-dev',
+    'libgstreamer-plugins-base1.0-dev', 'libgstreamer1.0-dev',
+    'libharfbuzz-dev', 'liblzma-dev', 'libunwind-dev', 'libunwind-dev',
+    'libvulkan1', 'libx11-dev', 'libxcb-render0-dev', 'libxcb-shape0-dev',
+    'libxcb-xfixes0-dev', 'libxmu-dev', 'libxmu6', 'libegl1-mesa-dev',
+    'llvm-dev', 'm4', 'xorg-dev',
+]
 
 # https://packages.fedoraproject.org
 # 1. open devtools


### PR DESCRIPTION
It looks like `m4` is now required for builds on Debian-like systems.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
