### PR TITLE
Stop sending " " to linebreaker for replaced content

### DIFF
--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -220,7 +220,7 @@ impl<'a> TextRun {
             if text.len() == 0 {
                 return (glyphs, true);
             }
-            *breaker = Some(LineBreakLeafIter::new(&text, 0));
+            *breaker = Some(LineBreakLeafIter::new(text, 0));
         }
 
         let breaker = breaker.as_mut().unwrap();

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-002.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-002.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-009.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-009.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-001.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-001.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-replaced-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-006.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-006.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-replaced-006.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/linebox/soft-wrap-opportunity-after-replaced-content-crash.html
+++ b/tests/wpt/tests/css/CSS2/linebox/soft-wrap-opportunity-after-replaced-content-crash.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <link rel="help" href="https://github.com/servo/servo/issues/30703">
+    <link rel="author" href="mailto:mrobinson@igalia.com">
+    <body>
+        <br><img>&nbsp;
+    </body>
+</html>
+


### PR DESCRIPTION
We previously sent a " " to the linebreaker in order to ensure that the
next text had a soft wrap opportunity at the start. Calling `next(" ")`
without waiting until the returned index was 1, violated some
invariants of linebreaker ultimately causing a panic.

Instead of using the linebreaker for this, simply keep a flag in the
IFC layout state, which avoids the problem entirely. This also fixes
some issues with linebreaking before character classes that should
not offer soft-wrap opportunities.

Fixes #30703.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30703.
- [x] There are tests for these changes
