### PR TITLE
Remove usage of `drain_filter`

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -448,7 +448,7 @@ impl EventTarget {
 
         let listener = EventListenerType::Additive(listener.clone());
         if let Some(entries) = handlers.get_mut(ty) {
-            entries.drain_filter(|e| e.listener == listener && e.once);
+            entries.retain(|e| e.listener != listener || !e.once)
         }
     }
 

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![feature(drain_filter)]
 #![feature(once_cell)]
 #![feature(plugin)]
 #![feature(register_tool)]


### PR DESCRIPTION
This is a step on the way toward supporting stable rust.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
