### PR TITLE
Remove Servo `window.trap()` extension

### DIFF
--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -141,8 +141,6 @@ partial interface Window {
   [Pref="dom.servo_helpers.enabled"]
   undefined gc();
   [Pref="dom.servo_helpers.enabled"]
-  undefined trap();
-  [Pref="dom.servo_helpers.enabled"]
   undefined js_backtrace();
 };
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1103,11 +1103,6 @@ impl WindowMethods for Window {
     }
 
     #[allow(unsafe_code)]
-    fn Trap(&self) {
-        unsafe { ::std::intrinsics::breakpoint() }
-    }
-
-    #[allow(unsafe_code)]
     fn Js_backtrace(&self) {
         unsafe {
             capture_stack!(in(*self.get_cx()) let stack);

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![feature(core_intrinsics)]
 #![feature(drain_filter)]
 #![feature(once_cell)]
 #![feature(plugin)]


### PR DESCRIPTION
This Servo-specific extension is unused by any code in the repository
and removing it allows us to remove use of nightly only reliance on
rust intrinsics. This is a step toward supporting stable rust.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this simply removes an unused Servo-only feature.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
