### PR TITLE
Remove use of proc_macro_diagnostics feature

### DIFF
--- a/components/config_plugins/lib.rs
+++ b/components/config_plugins/lib.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![feature(proc_macro_diagnostic)]
-
 use std::collections::{hash_map, HashMap};
 use std::fmt::Write;
 use std::iter;
@@ -23,15 +21,7 @@ pub fn build_structs(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream
     let input: MacroInput = parse_macro_input!(tokens);
     let out = Build::new(&input)
         .build(&input.type_def)
-        .unwrap_or_else(|e| {
-            proc_macro::Diagnostic::spanned(
-                e.span().unwrap(),
-                proc_macro::Level::Error,
-                format!("{}", e),
-            )
-            .emit();
-            TokenStream::new()
-        });
+        .unwrap_or_else(|e| syn::Error::new(e.span(), e).to_compile_error());
     out.into()
 }
 


### PR DESCRIPTION
- Remove use of proc_macro_diagnostics feature

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they change the way a compile error is emitted.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
