### PR TITLE
Parse canvas colors as <color>

### DIFF
--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -5,9 +5,9 @@
 use canvas_traits::canvas::{
     CanvasGradientStop, FillOrStrokeStyle, LinearGradientStyle, RadialGradientStyle,
 };
-use cssparser::{Color as CSSColor, Parser, ParserInput, RGBA};
 use dom_struct::dom_struct;
 
+use crate::canvas_state::parse_color;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasGradientMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
@@ -53,17 +53,9 @@ impl CanvasGradientMethods for CanvasGradient {
             return Err(Error::IndexSize);
         }
 
-        let mut input = ParserInput::new(&color);
-        let mut parser = Parser::new(&mut input);
-        let color = CSSColor::parse(&mut parser);
-        let color = if parser.is_exhausted() {
-            match color {
-                Ok(CSSColor::Rgba(rgba)) => rgba,
-                Ok(CSSColor::CurrentColor) => RGBA::new(0, 0, 0, 1.0),
-                _ => return Err(Error::Syntax),
-            }
-        } else {
-            return Err(Error::Syntax);
+        let color = match parse_color(None, &color) {
+            Ok(color) => color,
+            Err(_) => return Err(Error::Syntax),
         };
 
         self.stops.borrow_mut().push(CanvasGradientStop {


### PR DESCRIPTION
This will allow supporting color-mix() and the new color functions like in the CSS 'color' property (once that functionality is enabled).

This is according to the HTML spec:
https://html.spec.whatwg.org/multipage/infrastructure.html#parsed-as-a-css-color-value

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because the new color functions are currently disabled.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
