### PR TITLE
Add a concurrency group to try jobs

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -8,6 +8,8 @@ jobs:
   parse-comment:
     name: Trigger Try
     runs-on: ubuntu-latest
+    concurrency:
+      group: try-${{ github.event.number }}
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
     steps:


### PR DESCRIPTION
This should prevent multiple `parse-comment` jobs from running at the
same time for the same pull request, reducing the number of duplicate
builds when multiple labels are applied.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they adjust the CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
