### PR TITLE
Make CSSConditionRule's conditionText readonly

### DIFF
--- a/components/script/dom/cssconditionrule.rs
+++ b/components/script/dom/cssconditionrule.rs
@@ -50,15 +50,4 @@ impl CSSConditionRuleMethods for CSSConditionRule {
             unreachable!()
         }
     }
-
-    /// <https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext>
-    fn SetConditionText(&self, text: DOMString) {
-        if let Some(rule) = self.downcast::<CSSMediaRule>() {
-            rule.set_condition_text(text)
-        } else if let Some(rule) = self.downcast::<CSSSupportsRule>() {
-            rule.set_condition_text(text)
-        } else {
-            unreachable!()
-        }
-    }
 }

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use servo_arc::Arc;
-use style::media_queries::MediaList as StyleMediaList;
-use style::parser::ParserContext;
 use style::shared_lock::{Locked, ToCssWithGuard};
-use style::stylesheets::{CssRuleType, MediaRule, Origin};
-use style_traits::{ParsingMode, ToCss};
+use style::stylesheets::MediaRule;
+use style_traits::ToCss;
 
 use crate::dom::bindings::codegen::Bindings::CSSMediaRuleBinding::CSSMediaRuleMethods;
-use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
@@ -74,37 +70,6 @@ impl CSSMediaRule {
         let rule = self.mediarule.read_with(&guard);
         let list = rule.media_queries.read_with(&guard);
         list.to_css_string().into()
-    }
-
-    /// <https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface>
-    pub fn set_condition_text(&self, text: DOMString) {
-        let mut input = ParserInput::new(&text);
-        let mut input = Parser::new(&mut input);
-        let global = self.global();
-        let window = global.as_window();
-        let url = window.get_url();
-        let quirks_mode = window.Document().quirks_mode();
-        let context = ParserContext::new(
-            Origin::Author,
-            &url,
-            Some(CssRuleType::Media),
-            ParsingMode::DEFAULT,
-            quirks_mode,
-            window.css_error_reporter(),
-            None,
-        );
-
-        let new_medialist = StyleMediaList::parse(&context, &mut input);
-        let mut guard = self.cssconditionrule.shared_lock().write();
-
-        // Clone an Arc because we can’t borrow `guard` twice at the same time.
-
-        // FIXME(SimonSapin): allow access to multiple objects with one write guard?
-        // Would need a set of usize pointer addresses or something,
-        // the same object is not accessed more than once.
-        let mqs = Arc::clone(&self.mediarule.write_with(&mut guard).media_queries);
-
-        *mqs.write_with(&mut guard) = new_medialist;
     }
 }
 

--- a/components/script/dom/csssupportsrule.rs
+++ b/components/script/dom/csssupportsrule.rs
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use servo_arc::Arc;
-use style::parser::ParserContext;
 use style::shared_lock::{Locked, ToCssWithGuard};
-use style::stylesheets::supports_rule::SupportsCondition;
-use style::stylesheets::{CssRuleType, Origin, SupportsRule};
-use style_traits::{ParsingMode, ToCss};
+use style::stylesheets::SupportsRule;
+use style_traits::ToCss;
 
-use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
-use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
+use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cssconditionrule::CSSConditionRule;
@@ -61,42 +57,6 @@ impl CSSSupportsRule {
         let guard = self.cssconditionrule.shared_lock().read();
         let rule = self.supportsrule.read_with(&guard);
         rule.condition.to_css_string().into()
-    }
-
-    /// <https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface>
-    pub fn set_condition_text(&self, text: DOMString) {
-        let mut input = ParserInput::new(&text);
-        let mut input = Parser::new(&mut input);
-        let cond = SupportsCondition::parse(&mut input);
-        if let Ok(cond) = cond {
-            let global = self.global();
-            let win = global.as_window();
-            let url = win.Document().url();
-            let quirks_mode = win.Document().quirks_mode();
-            let context = ParserContext::new(
-                Origin::Author,
-                &url,
-                Some(CssRuleType::Supports),
-                ParsingMode::DEFAULT,
-                quirks_mode,
-                None,
-                None,
-            );
-            let enabled = {
-                let namespaces = self
-                    .cssconditionrule
-                    .parent_stylesheet()
-                    .style_stylesheet()
-                    .contents
-                    .namespaces
-                    .read();
-                cond.eval(&context, &namespaces)
-            };
-            let mut guard = self.cssconditionrule.shared_lock().write();
-            let rule = self.supportsrule.write_with(&mut guard);
-            rule.condition = cond;
-            rule.enabled = enabled;
-        }
     }
 }
 

--- a/components/script/dom/webidls/CSSConditionRule.webidl
+++ b/components/script/dom/webidls/CSSConditionRule.webidl
@@ -5,5 +5,5 @@
 // https://drafts.csswg.org/css-conditional/#cssconditionrule
 [Abstract, Exposed=Window]
 interface CSSConditionRule : CSSGroupingRule {
-    attribute DOMString conditionText;
+    readonly attribute DOMString conditionText;
 };

--- a/tests/wpt/meta-legacy-layout/css/css-conditional/idlharness.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-conditional/idlharness.html.ini
@@ -1,6 +1,3 @@
 [idlharness.html]
   [css-conditional IDL tests]
     expected: FAIL
-
-  [CSSConditionRule interface: attribute conditionText]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/idlharness.html.ini
+++ b/tests/wpt/meta/css/css-conditional/idlharness.html.ini
@@ -1,3 +1,0 @@
-[idlharness.html]
-  [CSSConditionRule interface: attribute conditionText]
-    expected: FAIL

--- a/tests/wpt/tests/css/cssom/CSSConditionRule-conditionText.html
+++ b/tests/wpt/tests/css/cssom/CSSConditionRule-conditionText.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>CSSConditionRule.conditionText</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/css-conditional-3/#cssconditionrule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@media not all {
+  :root { color: lime }
+}
+</style>
+<script>
+test(function(t) {
+  let rule = document.styleSheets[0].cssRules[0];
+  assert_true(rule instanceof CSSConditionRule);
+  assert_equals(rule.conditionText, "not all");
+  rule.conditionText = 1;
+  assert_equals(rule.conditionText, "not all");
+  rule.conditionText = "all";
+  assert_equals(rule.conditionText, "not all");
+  assert_not_equals(getComputedStyle(document.documentElement).color, "rgb(0, 255, 0)");
+});
+</script>


### PR DESCRIPTION
As per https://github.com/w3c/csswg-drafts/issues/6819

This will be needed for https://phabricator.services.mozilla.com/D179060

The test was created by Mozilla, but was not correctly synced into WPT.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
