### PR TITLE
Try to kill XProtect before running Mac CI

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -56,6 +56,13 @@ jobs:
     name: Mac Build
     runs-on: macos-13
     steps:
+      # XProtect can cause random failures if it decides that the DMG we create
+      # during the packaging phase is malware.
+      # TODO(mrobinson): Is there a way we can do things in a less suspicious way so
+      # we don't have to kill this service?
+      - name: Kill XProtectBehaviorService
+        run: |
+          echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
         with:


### PR DESCRIPTION
This is an attempt to fix errors on the Mac CI when running `hdiutil`
that look like this:

```
Run python3 ./mach package --release
hdiutil: create failed - Resource busy
Creating Servo.app
Copying files
Swapping prefs
Finding dylibs and relinking
Adding version to Credits.rtf
Creating dmg
Packaging MacOS dmg exited with return value 1
Error: Process completed with exit code 1.
```

This approach was taken from
https://github.com/actions/runner-images/issues/7522.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they update the CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
