### PR TITLE
ci: use ubuntu 20.04 for nightly builds on linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,10 @@ env:
 jobs:
   build:
     name: Linux Build
-    runs-on: ubuntu-22.04
+    # Ubuntu 22.04 has glibc 2.34 so the binaries produced
+    # won't run on systems with older glibc e.g wpt.fyi
+    # runners which still use 20.04.
+    runs-on: ubuntu-${{ inputs.upload && '20.04' || '22.04' }}
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'


### PR DESCRIPTION
Ubuntu 22.04 has a newer glibc (2.34) which means builds from there won't run on systems with older glibc, most notably the wpt.fyi taskcluster runners which use 20.04 as the docker base image.

This is a temporary workaround until wpt upgrades to 22.04

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only impact nighty CI job>
