### PR TITLE
ci: do not set LIBCLANG_PATH for nightly build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        if: ${{ !inputs.upload  }} # not needed on ubuntu 20.04 used for nightly
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Install taplo
         uses: baptiste0928/cargo-install@v2


### PR DESCRIPTION
This environment variable was added when we moved to Ubuntu 22.04 and it is not needed for nightly builds which we have now switched to 20.04

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix an issue in CI job

