### PR TITLE
Fix build script error when you using Python version > 3.9.

### DIFF
--- a/python/mach/mach/main.py
+++ b/python/mach/mach/main.py
@@ -11,6 +11,9 @@ import argparse
 import codecs
 import errno
 import importlib
+from sys import version_info
+#if version_info.major == 3 and version_info.minor > 9 :
+#    import importlib.util
 import logging
 import os
 import sys


### PR DESCRIPTION
Fix build script error when you using Python version > 3.9.
because starting with Python 3.9, the util module was moved from importlib to a separate top-level module called importlib.util. Therefore, if you are using Python 3.9 or later and you receive an AttributeError stating that module 'importlib' has no attribute 'util', it is likely due to a compatibility issue with your code. You can fix this issue by updating your code to import importlib.util directly

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X ] `./mach build -d` does not report any errors
- [ X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
