### PR TITLE
Extend character-based soft wrap prevention to before atomics

### DIFF
--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-003.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-003.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-006.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-006.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-013.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-013.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-014.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-014.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-016.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-016.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-018.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-018.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-018.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-020.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-020.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-020.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-022.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-022.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-022.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-024.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-024.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-024.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-026.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-026.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-026.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-002.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-002.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-replaced-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-003.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-replaced-003.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-replaced-003.html]
-  expected: FAIL


### PR DESCRIPTION
The changes in #30740, fixed an issue where certain characters should
prevent line break opportunity after atomics. This change extends that
to also apply to before atomics, which is what the specification says
should happen.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
