### PR TITLE
Integrate hyper_serde into Servo source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,9 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "hyper_serde"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4193ebe2b9ecb7d04dd1a777c25f3294e10310fe5583e1006a3f47779d6c6a01"
+version = "0.13.2"
 dependencies = [
  "cookie 0.12.0",
  "headers",
@@ -2796,6 +2794,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_bytes",
+ "serde_test",
  "time 0.1.45",
 ]
 
@@ -5101,6 +5100,15 @@ checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ html5ever = "0.26"
 http = "0.2"
 hyper = "0.14"
 hyper-rustls = { version = "0.24", default-features = false, features = ["acceptor", "http1", "http2", "logging", "tls12", "webpki-tokio"] }
-hyper_serde = "0.13"
+hyper_serde = { path = "components/hyper_serde" }
 image = "0.24"
 imsz = "0.2"
 indexmap = { version = "1.0.2", features = ["std"] }

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "hyper_serde"
+version = "0.13.2"
+edition = "2018"
+authors = ["The Servo Project Developers"]
+description = "Serde support for hyper types."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/servo/servo"
+documentation = "https://docs.rs/hyper_serde"
+categories = ["encoding", "web-programming"]
+keywords = ["serde", "serialization", "hyper", "cookie", "mime"]
+
+[lib]
+path = "lib.rs"
+doctest = false
+test = false
+
+[dependencies]
+cookie = { workspace = true }
+headers = { workspace = true }
+http = { workspace = true }
+hyper = { workspace = true }
+mime = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+time = { workspace = true }
+
+[dev-dependencies]
+serde_test = "1.0"

--- a/components/hyper_serde/LICENSE-APACHE
+++ b/components/hyper_serde/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/components/hyper_serde/LICENSE-MIT
+++ b/components/hyper_serde/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2016 Anthony Ramine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/components/hyper_serde/README.md
+++ b/components/hyper_serde/README.md
@@ -1,0 +1,41 @@
+Serde support for Hyper types
+=============================
+
+This crate provides wrappers and convenience functions to support [Serde] for
+some types defined in [cookie], [Hyper], [mime] and [time].
+
+[cookie]: https://github.com/SergioBenitez/cookie-rs
+[Hyper]: https://github.com/hyperium/hyper
+[mime]: https://github.com/hyperium/mime
+[Serde]: https://github.com/serde-rs/serde
+[time]: https://github.com/time-rs/time
+
+The supported types are:
+
+* `cookie::Cookie`
+* `hyper::header::ContentType`
+* `hyper::header::Headers`
+* `hyper::http::RawStatus`
+* `hyper::method::Method`
+* `hyper::Uri`
+* `mime::Mime`
+* `time::Tm`
+
+For more details, see the crate documentation.
+
+## License
+
+hyper_serde is licensed under the following licenses.
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in hyper_serde by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -1,0 +1,682 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This crate provides wrappers and convenience functions to make Hyper and
+//! Serde work hand in hand.
+//!
+//! The supported types are:
+//!
+//! * `cookie::Cookie`
+//! * `headers_ext::ContentType`
+//! * `hyper::header::Headers`
+//! * `hyper::StatusCode`
+//! * `hyper::Method`
+//! * `hyper::Uri`
+//! * `mime::Mime`
+//! * `time::Tm`
+//!
+//! # How do I use a data type with a `HeaderMap` member with Serde?
+//!
+//! Use the serde attributes `deserialize_with` and `serialize_with`.
+//!
+//! ```
+//! struct MyStruct {
+//! #[serde(deserialize_with = "hyper_serde::deserialize",
+//! serialize_with = "hyper_serde::serialize")]
+//! headers: HeaderMap,
+//! }
+//! ```
+//!
+//! # How do I encode a `HeaderMap` value with `serde_json::to_string`?
+//!
+//! Use the `Ser` wrapper.
+//!
+//! ```
+//! serde_json::to_string(&Ser::new(&headers))
+//! ```
+//!
+//! # How do I decode a `Method` value with `serde_json::parse`?
+//!
+//! Use the `De` wrapper.
+//!
+//! ```
+//! serde_json::parse::<De<Method>>("\"PUT\"").map(De::into_inner)
+//! ```
+//!
+//! # How do I send `Cookie` values as part of an IPC channel?
+//!
+//! Use the `Serde` wrapper. It implements `Deref` and `DerefMut` for
+//! convenience.
+//!
+//! ```
+//! ipc::channel::<Serde<Cookie>>()
+//! ```
+//!
+//!
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
+use std::ops::{Deref, DerefMut};
+use std::str::FromStr;
+use std::{cmp, fmt, str};
+
+use cookie::Cookie;
+use headers::ContentType;
+use http::HeaderMap;
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::{Method, StatusCode, Uri};
+use mime::Mime;
+use serde::de::{self, Error, MapAccess, SeqAccess, Visitor};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_bytes::{ByteBuf, Bytes};
+use time::{strptime, Tm};
+
+/// Deserialises a `T` value with a given deserializer.
+///
+/// This is useful to deserialize Hyper types used in structure fields or
+/// tuple members with `#[serde(deserialize_with = "hyper_serde::deserialize")]`.
+#[inline(always)]
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    De<T>: Deserialize<'de>,
+{
+    De::deserialize(deserializer).map(De::into_inner)
+}
+
+/// Serialises `value` with a given serializer.
+///
+/// This is useful to serialize Hyper types used in structure fields or
+/// tuple members with `#[serde(serialize_with = "hyper_serde::serialize")]`.
+#[inline(always)]
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    Ser::new(value).serialize(serializer)
+}
+
+/// Serialises `value` with a given serializer in a pretty way.
+///
+/// This does the same job as `serialize` but with a prettier format
+/// for some combinations of types and serialisers.
+///
+/// For now, the only change from `serialize` is when serialising `Headers`,
+/// where the items in the header values get serialised as strings instead
+/// of sequences of bytes, if they represent UTF-8 text.
+#[inline(always)]
+pub fn serialize_pretty<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    Ser::new_pretty(value).serialize(serializer)
+}
+
+/// A wrapper to deserialize Hyper types.
+///
+/// This is useful with functions such as `serde_json::from_str`.
+///
+/// Values of this type can only be obtained through
+/// the `serde::Deserialize` trait.
+#[derive(Debug, PartialEq)]
+pub struct De<T> {
+    v: T,
+}
+
+impl<T> De<T> {
+    /// Returns a new `De` wrapper
+    #[inline(always)]
+    pub fn new(v: T) -> Self {
+        De { v: v }
+    }
+}
+
+impl<'de, T> De<T>
+where
+    De<T>: Deserialize<'de>,
+{
+    /// Consumes this wrapper, returning the deserialized value.
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.v
+    }
+}
+
+/// A wrapper to serialize Hyper types.
+///
+/// This is useful with functions such as `serde_json::to_string`.
+///
+/// Values of this type can only be passed to the `serde::Serialize` trait.
+#[derive(Debug)]
+pub struct Ser<'a, T: 'a> {
+    v: &'a T,
+    pretty: bool,
+}
+
+impl<'a, T> Ser<'a, T>
+where
+    Ser<'a, T>: serde::Serialize,
+{
+    /// Returns a new `Ser` wrapper.
+    #[inline(always)]
+    pub fn new(value: &'a T) -> Self {
+        Ser {
+            v: value,
+            pretty: false,
+        }
+    }
+
+    /// Returns a new `Ser` wrapper, in pretty mode.
+    ///
+    /// See `serialize_pretty`.
+    #[inline(always)]
+    pub fn new_pretty(value: &'a T) -> Self {
+        Ser {
+            v: value,
+            pretty: true,
+        }
+    }
+}
+
+/// A convenience wrapper to be used as a type parameter, for example when
+/// a `Vec<T>` need to be passed to serde.
+#[derive(Clone, PartialEq)]
+pub struct Serde<T>(pub T)
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize;
+
+impl<T> Serde<T>
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    /// Consumes this wrapper, returning the inner value.
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> fmt::Debug for Serde<T>
+where
+    T: fmt::Debug,
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.0.fmt(formatter)
+    }
+}
+
+impl<T> Deref for Serde<T>
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Serde<T>
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T: PartialEq> PartialEq<T> for Serde<T>
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<'b, T> Deserialize<'b> for Serde<T>
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'b>,
+    {
+        De::deserialize(deserializer).map(De::into_inner).map(Serde)
+    }
+}
+
+impl<T> Serialize for Serde<T>
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Ser::new(&self.0).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for De<ContentType> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize(deserializer)
+            .map(|v: mime::Mime| ContentType::from(v))
+            .map(De::new)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, ContentType> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize(&mime::Mime::from(self.v.clone()), serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Cookie<'static>> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CookieVisitor;
+
+        impl<'de> Visitor<'de> for CookieVisitor {
+            type Value = De<Cookie<'static>>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an HTTP cookie header value")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Cookie::parse(v)
+                    .map(Cookie::into_owned)
+                    .map(De::new)
+                    .map_err(|e| E::custom(format!("{:?}", e)))
+            }
+        }
+
+        deserializer.deserialize_string(CookieVisitor)
+    }
+}
+
+impl<'a, 'cookie> Serialize for Ser<'a, Cookie<'cookie>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.v.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for De<HeaderMap> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct HeadersVisitor;
+
+        impl<'de> Visitor<'de> for HeadersVisitor {
+            type Value = De<HeaderMap>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a map from header names to header values")
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(De::new(HeaderMap::new()))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut headers = HeaderMap::new();
+                while let Some((k, values)) = visitor.next_entry::<String, Value>()? {
+                    for v in values.0.iter() {
+                        headers.append(
+                            HeaderName::from_str(&k).map_err(V::Error::custom)?,
+                            HeaderValue::from_bytes(&v).map_err(V::Error::custom)?,
+                        );
+                    }
+                }
+                Ok(De::new(headers))
+            }
+        }
+
+        struct Value(Vec<Vec<u8>>);
+
+        impl<'de> Deserialize<'de> for Value {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserializer.deserialize_seq(ValueVisitor)
+            }
+        }
+
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an array of strings and sequences of bytes")
+            }
+
+            fn visit_unit<E>(self) -> Result<Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Value(vec![]))
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                // Clamp to not OOM on rogue values.
+                let capacity = cmp::min(visitor.size_hint().unwrap_or(0), 64);
+                let mut values = Vec::with_capacity(capacity);
+                while let Some(v) = visitor.next_element::<ByteBuf>()? {
+                    values.push(v.into_vec());
+                }
+                Ok(Value(values))
+            }
+        }
+
+        deserializer.deserialize_map(HeadersVisitor)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, HeaderMap> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        struct Value<'headers>(&'headers [Vec<u8>], bool);
+
+        impl<'headers> Serialize for Value<'headers> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let mut serializer = serializer.serialize_seq(Some(self.0.len()))?;
+                for v in self.0 {
+                    if self.1 {
+                        if let Ok(v) = str::from_utf8(v) {
+                            serializer.serialize_element(v)?;
+                            continue;
+                        }
+                    }
+                    serializer.serialize_element(&Bytes::new(v))?;
+                }
+                serializer.end()
+            }
+        }
+
+        let mut serializer = serializer.serialize_map(Some(self.v.keys_len()))?;
+        for name in self.v.keys() {
+            let values = self.v.get_all(name);
+            serializer.serialize_entry(
+                name.as_str(),
+                &Value(
+                    &values
+                        .iter()
+                        .map(|v| v.as_bytes().iter().cloned().collect())
+                        .collect::<Vec<Vec<u8>>>(),
+                    self.pretty,
+                ),
+            )?;
+        }
+        serializer.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Method> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MethodVisitor;
+
+        impl<'de> Visitor<'de> for MethodVisitor {
+            type Value = De<Method>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an HTTP method")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                v.parse::<Method>().map(De::new).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_string(MethodVisitor)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, Method> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Serialize::serialize(self.v.as_ref(), serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Mime> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MimeVisitor;
+
+        impl<'de> Visitor<'de> for MimeVisitor {
+            type Value = De<Mime>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a mime type")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                v.parse::<Mime>()
+                    .map(De::new)
+                    .map_err(|_| E::custom("could not parse mime type"))
+            }
+        }
+
+        deserializer.deserialize_string(MimeVisitor)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, Mime> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.v.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for De<StatusCode> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let code = Deserialize::deserialize(deserializer)?;
+        Ok(De::new(
+            StatusCode::from_u16(code).map_err(D::Error::custom)?,
+        ))
+    }
+}
+
+impl<'a> Serialize for Ser<'a, StatusCode> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.v.as_u16().serialize(serializer)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, (StatusCode, String)> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serializer = serializer.serialize_seq(Some(2))?;
+        serializer.serialize_element(&Ser::new(&self.v.0))?;
+        serializer.serialize_element(&self.v.1)?;
+        serializer.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for De<(StatusCode, String)> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(De::new(deserializer.deserialize_seq(StatusVisitor)?))
+    }
+}
+
+struct StatusVisitor;
+
+impl<'de> Visitor<'de> for StatusVisitor {
+    type Value = (StatusCode, String);
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "an array containing a status code and a reason string"
+        )
+    }
+
+    fn visit_seq<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: SeqAccess<'de>,
+    {
+        let code = visitor
+            .next_element::<u16>()?
+            .ok_or_else(|| V::Error::custom("Can't find the status code"))?;
+        let code = StatusCode::from_u16(code).map_err(V::Error::custom)?;
+        let reason = visitor
+            .next_element::<String>()?
+            .ok_or_else(|| V::Error::custom("Can't find the reason string"))?;
+        Ok((code, reason))
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Tm> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TmVisitor;
+
+        impl<'de> Visitor<'de> for TmVisitor {
+            type Value = De<Tm>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a date and time according to RFC 3339")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                strptime(v, "%Y-%m-%dT%H:%M:%SZ")
+                    .map(De::new)
+                    .map_err(|e| E::custom(e.to_string()))
+            }
+        }
+
+        deserializer.deserialize_string(TmVisitor)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, Tm> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.v.rfc3339().to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for De<Uri> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct UriVisitor;
+
+        impl<'de> Visitor<'de> for UriVisitor {
+            type Value = De<Uri>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "an HTTP Uri value")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Uri::from_str(v)
+                    .map(De::new)
+                    .map_err(|e| E::custom(format!("{}", e)))
+            }
+        }
+
+        deserializer.deserialize_string(UriVisitor)
+    }
+}
+
+impl<'a> Serialize for Ser<'a, Uri> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // As of hyper 0.12, hyper::Uri (re-exported http::Uri)
+        // does not implement as_ref due to underlying implementation
+        // so we must construct a string to serialize it
+        serializer.serialize_str(&self.v.to_string())
+    }
+}

--- a/components/hyper_serde/tests/supported.rs
+++ b/components/hyper_serde/tests/supported.rs
@@ -1,0 +1,38 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use cookie::Cookie;
+use headers::ContentType;
+use http::header::HeaderMap;
+use hyper::{Method, StatusCode, Uri};
+use hyper_serde::{De, Ser, Serde};
+use mime::Mime;
+use serde::{Deserialize, Serialize};
+use time::Tm;
+
+fn is_supported<T>()
+where
+    for<'de> De<T>: Deserialize<'de>,
+    for<'a> Ser<'a, T>: Serialize,
+    for<'de> Serde<T>: Deserialize<'de> + Serialize,
+{
+}
+
+#[test]
+fn supported() {
+    is_supported::<Cookie>();
+    is_supported::<ContentType>();
+    is_supported::<HeaderMap>();
+    is_supported::<Method>();
+    is_supported::<Mime>();
+    is_supported::<StatusCode>();
+    is_supported::<Tm>();
+    is_supported::<Uri>();
+}

--- a/components/hyper_serde/tests/tokens.rs
+++ b/components/hyper_serde/tests/tokens.rs
@@ -1,0 +1,136 @@
+// Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use cookie::Cookie;
+use headers::ContentType;
+use http::header::{self, HeaderMap, HeaderValue};
+use http::StatusCode;
+use hyper::{Method, Uri};
+use hyper_serde::{De, Ser};
+use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
+use time::Duration;
+
+#[test]
+fn test_content_type() {
+    let content_type = ContentType::from("Application/Json".parse::<mime::Mime>().unwrap());
+    let tokens = &[Token::Str("application/json")];
+
+    assert_ser_tokens(&Ser::new(&content_type), tokens);
+    assert_de_tokens(&De::new(content_type), tokens);
+}
+
+#[test]
+fn test_cookie() {
+    // Unfortunately we have to do the to_string().parse() dance here to avoid the object being a
+    // string with a bunch of indices in it which apparently is different from the exact same
+    // cookie but parsed as a bunch of strings.
+    let cookie: Cookie = Cookie::build("Hello", "World!")
+        .max_age(Duration::seconds(42))
+        .domain("servo.org")
+        .path("/")
+        .secure(true)
+        .http_only(false)
+        .finish()
+        .to_string()
+        .parse()
+        .unwrap();
+
+    let tokens = &[Token::Str(
+        "Hello=World!; Secure; Path=/; Domain=servo.org; Max-Age=42",
+    )];
+
+    assert_ser_tokens(&Ser::new(&cookie), tokens);
+    assert_de_tokens(&De::new(cookie), tokens);
+}
+
+#[test]
+fn test_headers_empty() {
+    let headers = HeaderMap::new();
+
+    let tokens = &[Token::Map { len: Some(0) }, Token::MapEnd];
+
+    assert_ser_tokens(&Ser::new(&headers), tokens);
+    assert_de_tokens(&De::new(headers), tokens);
+}
+
+#[test]
+fn test_headers_not_empty() {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::HOST, HeaderValue::from_static("baguette"));
+
+    // In http, HeaderMap is internally a HashMap and thus testing this
+    // with multiple headers is non-deterministic.
+
+    let tokens = &[
+        Token::Map { len: Some(1) },
+        Token::Str("host"),
+        Token::Seq { len: Some(1) },
+        Token::Bytes(b"baguette"),
+        Token::SeqEnd,
+        Token::MapEnd,
+    ];
+
+    assert_ser_tokens(&Ser::new(&headers), tokens);
+    assert_de_tokens(&De::new(headers.clone()), tokens);
+
+    let pretty = &[
+        Token::Map { len: Some(1) },
+        Token::Str("host"),
+        Token::Seq { len: Some(1) },
+        Token::Str("baguette"),
+        Token::SeqEnd,
+        Token::MapEnd,
+    ];
+
+    assert_ser_tokens(&Ser::new_pretty(&headers), pretty);
+    assert_de_tokens(&De::new(headers), pretty);
+}
+
+#[test]
+fn test_method() {
+    let method = Method::PUT;
+    let tokens = &[Token::Str("PUT")];
+
+    assert_ser_tokens(&Ser::new(&method), tokens);
+    assert_de_tokens(&De::new(method), tokens);
+}
+
+#[test]
+fn test_raw_status() {
+    let raw_status = StatusCode::from_u16(200).unwrap();
+    let tokens = &[Token::U16(200)];
+
+    assert_ser_tokens(&Ser::new(&raw_status), tokens);
+    assert_de_tokens(&De::new(raw_status), tokens);
+}
+
+#[test]
+fn test_tm() {
+    use time::strptime;
+
+    let time = strptime("2017-02-22T12:03:31Z", "%Y-%m-%dT%H:%M:%SZ").unwrap();
+    let tokens = &[Token::Str("2017-02-22T12:03:31Z")];
+
+    assert_ser_tokens(&Ser::new(&time), tokens);
+    assert_de_tokens(&De::new(time), tokens);
+}
+
+#[test]
+fn test_uri() {
+    use std::str::FromStr;
+
+    // Note that fragment is not serialized / deserialized
+    let uri_string = "abc://username:password@example.com:123/path/data?key=value&key2=value2";
+    let uri = Uri::from_str(uri_string).unwrap();
+    let tokens = &[Token::Str(uri_string)];
+
+    assert_ser_tokens(&Ser::new(&uri), tokens);
+    assert_de_tokens(&De::new(uri), tokens);
+}

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -209,6 +209,7 @@ class MachCommands(CommandBase):
             "servoshell",
             "background_hang_monitor",
             "gfx",
+            "hyper_serde",
             "layout_2013",
             "layout_2020",
             "msg",


### PR DESCRIPTION
hyper_serde changes very infrequently and typically only in order to
upgrade Servo dependencies. crates.io lists hyper_serde as having no
dependents, and its integration will not prevent releasing new versions.
Integrating it will both reduce the number of repositories we have to
maintain as well as making it easier to upgrade Servo dependencies.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
