### PR TITLE
Minibrowser: Add Back and Forward navigation

### DIFF
--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -10,6 +10,7 @@ use egui::{Key, Modifiers, TopBottomPanel};
 use euclid::Length;
 use log::{trace, warn};
 use servo::compositing::windowing::EmbedderEvent;
+use servo::msg::constellation_msg::TraversalDirection;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_surfman::WebrenderSurfman;
 
@@ -33,6 +34,8 @@ pub struct Minibrowser {
 pub enum MinibrowserEvent {
     /// Go button clicked.
     Go,
+    Back,
+    Forward,
 }
 
 impl Minibrowser {
@@ -87,7 +90,12 @@ impl Minibrowser {
                             event_queue.borrow_mut().push(MinibrowserEvent::Go);
                             location_dirty.set(false);
                         }
-
+                        if ui.button("back").clicked() {
+                            event_queue.borrow_mut().push(MinibrowserEvent::Back);
+                        }
+                        if ui.button("forward").clicked() {
+                            event_queue.borrow_mut().push(MinibrowserEvent::Forward);
+                        }
                         let location_field = ui.add_sized(
                             ui.available_size(),
                             egui::TextEdit::singleline(&mut *location.borrow_mut()),
@@ -136,6 +144,14 @@ impl Minibrowser {
                         warn!("failed to parse location");
                         break;
                     }
+                },
+                MinibrowserEvent::Back => {
+                    let browser_id = browser.browser_id().unwrap();
+                    app_event_queue.push(EmbedderEvent::Navigation(browser_id, TraversalDirection::Back(1)));
+                },
+                MinibrowserEvent::Forward => {
+                    let browser_id = browser.browser_id().unwrap();
+                    app_event_queue.push(EmbedderEvent::Navigation(browser_id, TraversalDirection::Forward(1)));
                 },
             }
         }

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -84,22 +84,29 @@ impl Minibrowser {
             TopBottomPanel::top("toolbar").show(ctx, |ui| {
                 ui.allocate_ui_with_layout(
                     ui.available_size(),
-                    egui::Layout::right_to_left(egui::Align::Center),
+                    egui::Layout::left_to_right(egui::Align::Center),
                     |ui| {
-                        if ui.button("go").clicked() {
-                            event_queue.borrow_mut().push(MinibrowserEvent::Go);
-                            location_dirty.set(false);
-                        }
                         if ui.button("back").clicked() {
                             event_queue.borrow_mut().push(MinibrowserEvent::Back);
                         }
                         if ui.button("forward").clicked() {
                             event_queue.borrow_mut().push(MinibrowserEvent::Forward);
                         }
+
+                        // As we are using the `left_to_right` layout, we reserve space for the "Go" button
+                        // at the end by subtracting its estimated width from the available width.
+                        let button_space = 30.0;
+                        let text_edit_width = ui.available_width() - button_space;
+
                         let location_field = ui.add_sized(
-                            ui.available_size(),
+                            [text_edit_width, ui.available_height()],
                             egui::TextEdit::singleline(&mut *location.borrow_mut()),
                         );
+
+                        if ui.button("go").clicked() {
+                            event_queue.borrow_mut().push(MinibrowserEvent::Go);
+                            location_dirty.set(false);
+                        }
                         if location_field.changed() {
                             location_dirty.set(true);
                         }
@@ -147,11 +154,17 @@ impl Minibrowser {
                 },
                 MinibrowserEvent::Back => {
                     let browser_id = browser.browser_id().unwrap();
-                    app_event_queue.push(EmbedderEvent::Navigation(browser_id, TraversalDirection::Back(1)));
+                    app_event_queue.push(EmbedderEvent::Navigation(
+                        browser_id,
+                        TraversalDirection::Back(1),
+                    ));
                 },
                 MinibrowserEvent::Forward => {
                     let browser_id = browser.browser_id().unwrap();
-                    app_event_queue.push(EmbedderEvent::Navigation(browser_id, TraversalDirection::Forward(1)));
+                    app_event_queue.push(EmbedderEvent::Navigation(
+                        browser_id,
+                        TraversalDirection::Forward(1),
+                    ));
                 },
             }
         }


### PR DESCRIPTION
Minibrowser: Add Back and Forward navigation

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30049 (GitHub issue number if applicable)
