### PR TITLE
Re-use the TextMetrics data structure in the Layout 2020 fragment tree

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -281,7 +281,7 @@ impl Fragment {
             .to_physical(fragment.parent_style.writing_mode, containing_block)
             .translate(containing_block.origin.to_vector());
         let mut baseline_origin = rect.origin.clone();
-        baseline_origin.y += fragment.font_metrics.ascent;
+        baseline_origin.y += Length::from(fragment.font_metrics.ascent);
         let glyphs = glyphs(&fragment.glyphs, baseline_origin);
         if glyphs.is_empty() {
             return;
@@ -306,10 +306,6 @@ impl Fragment {
         let color = fragment.parent_style.clone_color();
         let font_metrics = &fragment.font_metrics;
         let dppx = builder.context.style_context.device_pixel_ratio().get();
-        let round_to_nearest_device_pixel = |value: Length| -> Length {
-            // Round to the nearest integer device pixel, ensuring at least one device pixel.
-            Length::new((value.px() * dppx).round().max(1.0) / dppx)
-        };
 
         // Underline.
         if fragment
@@ -317,8 +313,9 @@ impl Fragment {
             .contains(TextDecorationLine::UNDERLINE)
         {
             let mut rect = rect;
-            rect.origin.y = rect.origin.y + font_metrics.ascent - font_metrics.underline_offset;
-            rect.size.height = round_to_nearest_device_pixel(font_metrics.underline_size);
+            rect.origin.y =
+                rect.origin.y + Length::from(font_metrics.ascent - font_metrics.underline_offset);
+            rect.size.height = Length::new(font_metrics.underline_size.to_nearest_pixel(dppx));
             self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
         }
 
@@ -328,7 +325,7 @@ impl Fragment {
             .contains(TextDecorationLine::OVERLINE)
         {
             let mut rect = rect;
-            rect.size.height = round_to_nearest_device_pixel(font_metrics.underline_size);
+            rect.size.height = Length::new(font_metrics.underline_size.to_nearest_pixel(dppx));
             self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
         }
 
@@ -349,9 +346,10 @@ impl Fragment {
             .contains(TextDecorationLine::LINE_THROUGH)
         {
             let mut rect = rect;
-            rect.origin.y = rect.origin.y + font_metrics.ascent - font_metrics.strikeout_offset;
+            rect.origin.y =
+                rect.origin.y + Length::from(font_metrics.ascent - font_metrics.strikeout_offset);
             // XXX(ferjm) This does not work on MacOS #942
-            rect.size.height = round_to_nearest_device_pixel(font_metrics.strikeout_size);
+            rect.size.height = Length::new(font_metrics.strikeout_size.to_nearest_pixel(dppx));
             self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
         }
     }

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use gfx::font::FontMetrics as GfxFontMetrics;
+use gfx::font::FontMetrics;
 use gfx::text::glyph::GlyphStore;
 use gfx_traits::print_tree::PrintTree;
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
@@ -73,29 +73,6 @@ pub(crate) struct AnonymousFragment {
 
     /// The scrollable overflow of this anonymous fragment's children.
     pub scrollable_overflow: PhysicalRect<Length>,
-}
-
-#[derive(Clone, Copy, Serialize)]
-pub(crate) struct FontMetrics {
-    pub ascent: Length,
-    pub line_gap: Length,
-    pub underline_offset: Length,
-    pub underline_size: Length,
-    pub strikeout_offset: Length,
-    pub strikeout_size: Length,
-}
-
-impl From<&GfxFontMetrics> for FontMetrics {
-    fn from(metrics: &GfxFontMetrics) -> FontMetrics {
-        FontMetrics {
-            ascent: metrics.ascent.into(),
-            line_gap: metrics.line_gap.into(),
-            underline_offset: metrics.underline_offset.into(),
-            underline_size: metrics.underline_size.into(),
-            strikeout_offset: metrics.strikeout_offset.into(),
-            strikeout_size: metrics.strikeout_size.into(),
-        }
-    }
 }
 
 #[derive(Serialize)]

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-thickness-from-zero-sized-font.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-thickness-from-zero-sized-font.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-thickness-from-zero-sized-font.html]
-  expected: FAIL


### PR DESCRIPTION
This data structure has all of the metrics needed to render a font and
is in `Au`. We'll need more of these metrics for implementing
`vertical-align` and its use doesn't increase the size of the Fragment
tree (as the BoxFragment is still larger). In addition, this will be
helpful when switching layout to `Au`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
