### PR TITLE
Generalize LengthPercentageOrAuto impl to Generic Type

### DIFF
--- a/components/style/values/generics/length.rs
+++ b/components/style/values/generics/length.rs
@@ -68,13 +68,13 @@ impl<LengthPercentage> LengthPercentageOrAuto<LengthPercentage> {
     }
 }
 
-impl<U> LengthPercentageOrAuto<U>
+impl<T> LengthPercentageOrAuto<T>
 where
-    U: Clone,
+    T: Clone,
 {
     /// Resolves `auto` values by calling `f`.
     #[inline]
-    pub fn auto_is(&self, f: impl FnOnce() -> U) -> U {
+    pub fn auto_is(&self, f: impl FnOnce() -> T) -> T {
         match self {
             LengthPercentageOrAuto::LengthPercentage(length) => length.clone(),
             LengthPercentageOrAuto::Auto => f(),
@@ -83,7 +83,7 @@ where
 
     /// Returns the non-`auto` value, if any.
     #[inline]
-    pub fn non_auto(&self) -> Option<U> {
+    pub fn non_auto(&self) -> Option<T> {
         match self {
             LengthPercentageOrAuto::LengthPercentage(length) => Some(length.clone()),
             LengthPercentageOrAuto::Auto => None,
@@ -91,7 +91,7 @@ where
     }
 
     /// Maps the length of this value.
-    pub fn map<T>(&self, f: impl FnOnce(U) -> T) -> LengthPercentageOrAuto<T> {
+    pub fn map<U>(&self, f: impl FnOnce(T) -> U) -> LengthPercentageOrAuto<U> {
         match self {
             LengthPercentageOrAuto::LengthPercentage(l) => {
                 LengthPercentageOrAuto::LengthPercentage(f(l.clone()))

--- a/components/style/values/generics/length.rs
+++ b/components/style/values/generics/length.rs
@@ -68,13 +68,13 @@ impl<LengthPercentage> LengthPercentageOrAuto<LengthPercentage> {
     }
 }
 
-impl<LengthPercentage> LengthPercentageOrAuto<LengthPercentage>
+impl<U> LengthPercentageOrAuto<U>
 where
-    LengthPercentage: Clone,
+    U: Clone,
 {
     /// Resolves `auto` values by calling `f`.
     #[inline]
-    pub fn auto_is(&self, f: impl FnOnce() -> LengthPercentage) -> LengthPercentage {
+    pub fn auto_is(&self, f: impl FnOnce() -> U) -> U {
         match self {
             LengthPercentageOrAuto::LengthPercentage(length) => length.clone(),
             LengthPercentageOrAuto::Auto => f(),
@@ -83,7 +83,7 @@ where
 
     /// Returns the non-`auto` value, if any.
     #[inline]
-    pub fn non_auto(&self) -> Option<LengthPercentage> {
+    pub fn non_auto(&self) -> Option<U> {
         match self {
             LengthPercentageOrAuto::LengthPercentage(length) => Some(length.clone()),
             LengthPercentageOrAuto::Auto => None,
@@ -91,7 +91,7 @@ where
     }
 
     /// Maps the length of this value.
-    pub fn map<T>(&self, f: impl FnOnce(LengthPercentage) -> T) -> LengthPercentageOrAuto<T> {
+    pub fn map<T>(&self, f: impl FnOnce(U) -> T) -> LengthPercentageOrAuto<T> {
         match self {
             LengthPercentageOrAuto::LengthPercentage(l) => {
                 LengthPercentageOrAuto::LengthPercentage(f(l.clone()))


### PR DESCRIPTION
This PR uses generic type in LengthPercentageOrAuto Implementation. While diverging `components/style` is not very ideal, it is smallish change and is useful in Au conversion, specifically when using auto_is()

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of adapting `app_units`
