### PR TITLE
Use app units in replaced elements

### DIFF
--- a/components/layout_2020/display_list/background.rs
+++ b/components/layout_2020/display_list/background.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use euclid::{Size2D, Vector2D};
 use style::computed_values::background_clip::single_value::T as Clip;
 use style::computed_values::background_origin::single_value::T as Origin;
@@ -130,8 +131,8 @@ pub(super) fn layout_layer(
             if width.is_none() && height.is_none() {
                 // Both computed values are 'auto':
                 // use intrinsic sizes, treating missing width or height as 'auto'
-                width = intrinsic.width;
-                height = intrinsic.height;
+                width = intrinsic.width.map(|v| v.into());
+                height = intrinsic.height.map(|v| v.into());
             }
 
             match (width, height) {
@@ -140,10 +141,10 @@ pub(super) fn layout_layer(
                     let h = if let Some(intrinsic_ratio) = intrinsic.ratio {
                         w / intrinsic_ratio
                     } else if let Some(intrinsic_height) = intrinsic.height {
-                        intrinsic_height
+                        intrinsic_height.into()
                     } else {
                         // Treated as 100%
-                        Length::new(positioning_area.size.height)
+                        Au::from_f32_px(positioning_area.size.height).into()
                     };
                     units::LayoutSize::new(w.px(), h.px())
                 },
@@ -151,10 +152,10 @@ pub(super) fn layout_layer(
                     let w = if let Some(intrinsic_ratio) = intrinsic.ratio {
                         h * intrinsic_ratio
                     } else if let Some(intrinsic_width) = intrinsic.width {
-                        intrinsic_width
+                        intrinsic_width.into()
                     } else {
                         // Treated as 100%
-                        Length::new(positioning_area.size.width)
+                        Au::from_f32_px(positioning_area.size.width).into()
                     };
                     units::LayoutSize::new(w.px(), h.px())
                 },

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -70,7 +70,7 @@ impl IntrinsicSizes {
 
         Self {
             width: Some(Length::new(width).into()),
-            height: Some(Length::new(width).into()),
+            height: Some(Length::new(height).into()),
             ratio,
         }
     }

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -212,7 +212,10 @@ impl ReplacedContent {
     }
 
     fn flow_relative_intrinsic_size(&self, style: &ComputedValues) -> LogicalVec2<Option<Length>> {
-        let intrinsic_size = PhysicalSize::new(self.intrinsic.width.map(|v| v.into()), self.intrinsic.height.map(|v| v.into()));
+        let intrinsic_size = PhysicalSize::new(
+            self.intrinsic.width.map(|v| v.into()),
+            self.intrinsic.height.map(|v| v.into()),
+        );
         LogicalVec2::from_physical_size(&intrinsic_size, style.writing_mode)
     }
 

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -69,8 +69,8 @@ impl IntrinsicSizes {
         };
 
         Self {
-            width: Some(Au::from_f32_px(width)),
-            height: Some(Au::from_f32_px(width)),
+            width: Some(Length::new(width).into()),
+            height: Some(Length::new(width).into()),
             ratio,
         }
     }

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -5,6 +5,7 @@
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
+use app_units::Au;
 use canvas_traits::canvas::{CanvasId, CanvasMsg, FromLayoutMsg};
 use ipc_channel::ipc::{self, IpcSender};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
@@ -51,8 +52,8 @@ pub(crate) struct ReplacedContent {
 ///   to https://drafts.csswg.org/css-images/#intrinsic-dimensions.
 #[derive(Debug, Serialize)]
 pub(crate) struct IntrinsicSizes {
-    pub width: Option<Length>,
-    pub height: Option<Length>,
+    pub width: Option<Au>,
+    pub height: Option<Au>,
     pub ratio: Option<CSSFloat>,
 }
 
@@ -68,8 +69,8 @@ impl IntrinsicSizes {
         };
 
         Self {
-            width: Some(Length::new(width)),
-            height: Some(Length::new(height)),
+            width: Some(Au::from_f32_px(width)),
+            height: Some(Au::from_f32_px(width)),
             ratio,
         }
     }
@@ -211,7 +212,7 @@ impl ReplacedContent {
     }
 
     fn flow_relative_intrinsic_size(&self, style: &ComputedValues) -> LogicalVec2<Option<Length>> {
-        let intrinsic_size = PhysicalSize::new(self.intrinsic.width, self.intrinsic.height);
+        let intrinsic_size = PhysicalSize::new(self.intrinsic.width.map(|v| v.into()), self.intrinsic.height.map(|v| v.into()));
         LogicalVec2::from_physical_size(&intrinsic_size, style.writing_mode)
     }
 
@@ -277,8 +278,8 @@ impl ReplacedContent {
                 })]
             },
             ReplacedContentKind::Canvas(canvas_info) => {
-                if self.intrinsic.width == Some(Length::zero()) ||
-                    self.intrinsic.height == Some(Length::zero())
+                if self.intrinsic.width == Some(Au::zero()) ||
+                    self.intrinsic.height == Some(Au::zero())
                 {
                     return vec![];
                 }


### PR DESCRIPTION
Use app units in replaced elements


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #29819