### PR TITLE
Remove `clean_rmeta()` call from crown test

### DIFF
--- a/support/crown/tests/compile_test.rs
+++ b/support/crown/tests/compile_test.rs
@@ -34,7 +34,6 @@ fn run_mode(mode: &'static str, bless: bool) {
     ));
     // Does not work reliably: https://github.com/servo/servo/pull/30508#issuecomment-1834542203
     //config.link_deps();
-    config.clean_rmeta();
     config.strict_headers = true;
 
     compiletest::run_tests(&config);


### PR DESCRIPTION
it causes rebuilds in unit tests


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30821
- [x] These changes do not have test but works for me

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
