### PR TITLE
Remove thinlto servobuild.config option

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -302,7 +302,6 @@ class CommandBase(object):
         self.config["build"].setdefault("ccache", "")
         self.config["build"].setdefault("rustflags", "")
         self.config["build"].setdefault("incremental", None)
-        self.config["build"].setdefault("thinlto", False)
         self.config["build"].setdefault("webgl-backtrace", False)
         self.config["build"].setdefault("dom-backtrace", False)
 
@@ -541,9 +540,6 @@ class CommandBase(object):
             env['RUSTFLAGS'] += " -C target-feature=+neon"
 
         env["CARGO_TARGET_DIR"] = servo.util.get_target_dir()
-
-        if self.config["build"]["thinlto"]:
-            env['RUSTFLAGS'] += " -Z thinlto"
 
         # Work around https://github.com/servo/servo/issues/24446
         # Argument-less str.split normalizes leading, trailing, and double spaces

--- a/servobuild.example
+++ b/servobuild.example
@@ -54,9 +54,6 @@ media-stack = "auto"
 #incremental = false
 #incremental = true
 
-# Whether to use ThinLTO or not
-#thinlto = false
-
 # Android information
 [android]
 # Defaults to the value of $ANDROID_SDK, $ANDROID_NDK, $ANDROID_TOOLCHAIN, $ANDROID_PLATFORM respectively


### PR DESCRIPTION
Rust uses a version of ThinLTO (thin Local LTO) by default now [^1]. 
This can be tweaked by adjusting rust compiler flags, which is
probably a better way of controlling this than a custom servo
configuration considering:

1. We want to remove the custom servo configuration eventually.
2. The -Z option that this configuration currently uses is unsupported
   by stable rust.

[^1]: https://blog.rust-lang.org/inside-rust/2020/06/29/lto-improvements.html

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove a configuration option.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
