### PR TITLE
Compile Servo with the latest version of rust stable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -39,6 +39,7 @@ linker = "lld-link.exe"
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "10.10"
+RUSTC_BOOTSTRAP = "crown,script,style_tests"
 
 [build]
 rustdocflags = ["--document-private-items"]

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -586,10 +586,15 @@ impl StackingContext {
             return;
         };
 
-        let StackingContextContent::Fragment { fragment, scroll_node_id, containing_block, .. }
-            = first_stacking_context_fragment else {
-                debug_panic!("Expected a fragment, not a stacking container");
-            };
+        let StackingContextContent::Fragment {
+            fragment,
+            scroll_node_id,
+            containing_block,
+            ..
+        } = first_stacking_context_fragment
+        else {
+            debug_panic!("Expected a fragment, not a stacking container");
+        };
         let fragment = fragment.borrow();
         let box_fragment = match &*fragment {
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => box_fragment,

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![feature(once_cell)]
 
 mod cell;
 pub mod context;

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1241,7 +1241,7 @@ impl LayoutThread {
         );
 
         // Flush shadow roots stylesheets if dirty.
-        document.flush_shadow_roots_stylesheets(&mut self.stylist, guards.author.clone());
+        document.flush_shadow_roots_stylesheets(&mut self.stylist, guards.author);
 
         let restyles = std::mem::take(&mut data.pending_restyles);
         debug!("Draining restyles: {}", restyles.len());

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -913,7 +913,7 @@ impl LayoutThread {
         }
 
         // Flush shadow roots stylesheets if dirty.
-        document.flush_shadow_roots_stylesheets(&mut self.stylist, guards.author.clone());
+        document.flush_shadow_roots_stylesheets(&mut self.stylist, guards.author);
 
         let restyles = std::mem::take(&mut data.pending_restyles);
         debug!("Draining restyles: {}", restyles.len());

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -218,7 +218,7 @@ impl GPUDevice {
 
     fn handle_error(&self, scope: ErrorScopeId, error: GPUError) {
         let mut context = self.scope_context.borrow_mut();
-        if let Some(mut err_scope) = context.error_scopes.get_mut(&scope) {
+        if let Some(err_scope) = context.error_scopes.get_mut(&scope) {
             if err_scope.error.is_none() {
                 err_scope.error = Some(error);
             }
@@ -229,7 +229,7 @@ impl GPUDevice {
 
     fn try_remove_scope(&self, scope: ErrorScopeId) {
         let mut context = self.scope_context.borrow_mut();
-        let remove = if let Some(mut err_scope) = context.error_scopes.get_mut(&scope) {
+        let remove = if let Some(err_scope) = context.error_scopes.get_mut(&scope) {
             err_scope.op_count -= 1;
             if let Some(ref promise) = err_scope.promise {
                 if !promise.is_fulfilled() {
@@ -272,7 +272,7 @@ impl GPUDevice {
             .find(|meta| !meta.popped.get())
             .map(|meta| meta.id);
         scope_id.and_then(|s_id| {
-            context.error_scopes.get_mut(&s_id).map(|mut scope| {
+            context.error_scopes.get_mut(&s_id).map(|scope| {
                 scope.op_count += 1;
                 s_id
             })
@@ -1107,7 +1107,7 @@ impl GPUDeviceMethods for GPUDevice {
                 promise.reject_error(Error::Operation);
                 return promise;
             };
-        let remove = if let Some(mut err_scope) = context.error_scopes.get_mut(&scope_id) {
+        let remove = if let Some(err_scope) = context.error_scopes.get_mut(&scope_id) {
             if let Some(ref e) = err_scope.error {
                 promise.resolve_native(e);
             } else if err_scope.op_count == 0 {

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -5,7 +5,6 @@
 // check-tidy: no specs after this line
 
 use std::borrow::ToOwned;
-use std::ptr;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
@@ -1043,11 +1042,7 @@ impl TestBindingMethods for TestBinding {
 
     #[allow(unsafe_code)]
     fn CrashHard(&self) {
-        static READ_ONLY_VALUE: i32 = 0;
-        unsafe {
-            let p: *mut u32 = &READ_ONLY_VALUE as *const _ as *mut _;
-            ptr::write_volatile(p, 0xbaadc0de);
-        }
+        unsafe { std::ptr::null_mut::<i32>().write(42) }
     }
 
     fn AdvanceClock(&self, ms: i32) {

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![feature(once_cell)]
-#![feature(plugin)]
 #![feature(register_tool)]
 #![deny(unsafe_code)]
 #![doc = "The script crate contains all matters DOM."]

--- a/components/shared/script/compositor.rs
+++ b/components/shared/script/compositor.rs
@@ -97,7 +97,7 @@ impl ScrollTreeNode {
         &mut self,
         scroll_location: ScrollLocation,
     ) -> Option<(ExternalScrollId, LayoutVector2D)> {
-        let mut info = match self.scroll_info {
+        let info = match self.scroll_info {
             Some(ref mut data) => data,
             None => return None,
         };

--- a/components/shared/script/tests/compositor.rs
+++ b/components/shared/script/tests/compositor.rs
@@ -155,7 +155,7 @@ fn test_scroll_tree_chain_through_overflow_hidden() {
         .get_node_mut(&overflow_hidden_id)
         .scroll_info
         .as_mut()
-        .map(|mut info| {
+        .map(|info| {
             info.scroll_sensitivity = ScrollSensitivity::Script;
         });
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -524,12 +524,6 @@ class CommandBase(object):
         if self.config["build"]["rustflags"]:
             env['RUSTFLAGS'] += " " + self.config["build"]["rustflags"]
 
-        # Turn on rust's version of lld if we are on x86 Linux.
-        # TODO(mrobinson): Gradually turn this on for more platforms, when support stabilizes.
-        # See https://github.com/rust-lang/rust/issues/39915
-        if not self.cross_compile_target and effective_target == "x86_64-unknown-linux-gnu":
-            env['RUSTFLAGS'] += " " + servo.platform.get().linker_flag()
-
         if not (self.config["build"]["ccache"] == ""):
             env['CCACHE'] = self.config["build"]["ccache"]
 

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -66,9 +66,6 @@ class Base:
     def library_path_variable_name(self):
         raise NotImplementedError("Do not know how to set library path for platform.")
 
-    def linker_flag(self) -> str:
-        return ""
-
     def executable_suffix(self) -> str:
         return ""
 

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -150,17 +150,6 @@ class Linux(Base):
         installed_something |= self._platform_bootstrap_gstreamer(force)
         return installed_something
 
-    def linker_flag(self) -> str:
-        # the rust-lld binary downloaded by rustup
-        # doesn't respect NIX_LDFLAGS and also needs
-        # other patches to work correctly. Use system
-        # version of lld for now. See
-        # https://github.com/NixOS/nixpkgs/issues/220717
-        if self.distro.lower() == 'nixos':
-            return '-C link-arg=-fuse-ld=lld'
-        else:
-            return '-Zgcc-ld=lld'
-
     def install_non_gstreamer_dependencies(self, force: bool) -> bool:
         install = False
         pkgs = []

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -292,7 +292,10 @@ class MachCommands(CommandBase):
         else:
             manifest_dirty = wpt.manifestupdate.update(check_clean=True)
         tidy_failed = tidy.scan(not all_files, not no_progress, stylo=stylo, no_wpt=no_wpt)
-        rustfmt_failed = call(["cargo", "fmt", "--", "--check"])
+
+        call(["rustup", "install", "nightly-2023-03-18"])
+        call(["rustup", "component", "add", "rustfmt", "--toolchain", "nightly-2023-03-18"])
+        rustfmt_failed = call(["cargo", "+nightly-2023-03-18", "fmt", "--", "--check"])
 
         if rustfmt_failed:
             print("Run `./mach fmt` to fix the formatting")
@@ -396,7 +399,10 @@ class MachCommands(CommandBase):
         result = format_toml_files_with_taplo(check_only=False)
         if result != 0:
             return result
-        return call(["cargo", "fmt"])
+
+        call(["rustup", "install", "nightly-2023-03-18"])
+        call(["rustup", "component", "add", "rustfmt", "--toolchain", "nightly-2023-03-18"])
+        return call(["cargo", "+nightly-2023-03-18", "fmt"])
 
     @Command('update-wpt',
              description='Update the web platform tests',

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-03-18"
+channel = "1.74"
 components = [
     # For support/crown
     "llvm-tools",

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -70,32 +70,32 @@ Stuff copied from clippy:
 */
 
 fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<Item = DefId> + 'tcx {
-    use rustc_middle::ty::fast_reject::SimplifiedType::*;
+    use rustc_middle::ty::fast_reject::SimplifiedType;
     let ty = match name {
-        "bool" => BoolSimplifiedType,
-        "char" => CharSimplifiedType,
-        "str" => StrSimplifiedType,
-        "array" => ArraySimplifiedType,
-        "slice" => SliceSimplifiedType,
+        "bool" => SimplifiedType::Bool,
+        "char" => SimplifiedType::Char,
+        "str" => SimplifiedType::Str,
+        "array" => SimplifiedType::Array,
+        "slice" => SimplifiedType::Slice,
         // FIXME: rustdoc documents these two using just `pointer`.
         //
         // Maybe this is something we should do here too.
-        "const_ptr" => PtrSimplifiedType(Mutability::Not),
-        "mut_ptr" => PtrSimplifiedType(Mutability::Mut),
-        "isize" => IntSimplifiedType(IntTy::Isize),
-        "i8" => IntSimplifiedType(IntTy::I8),
-        "i16" => IntSimplifiedType(IntTy::I16),
-        "i32" => IntSimplifiedType(IntTy::I32),
-        "i64" => IntSimplifiedType(IntTy::I64),
-        "i128" => IntSimplifiedType(IntTy::I128),
-        "usize" => UintSimplifiedType(UintTy::Usize),
-        "u8" => UintSimplifiedType(UintTy::U8),
-        "u16" => UintSimplifiedType(UintTy::U16),
-        "u32" => UintSimplifiedType(UintTy::U32),
-        "u64" => UintSimplifiedType(UintTy::U64),
-        "u128" => UintSimplifiedType(UintTy::U128),
-        "f32" => FloatSimplifiedType(FloatTy::F32),
-        "f64" => FloatSimplifiedType(FloatTy::F64),
+        "const_ptr" => SimplifiedType::Ptr(Mutability::Not),
+        "mut_ptr" => SimplifiedType::Ptr(Mutability::Mut),
+        "isize" => SimplifiedType::Int(IntTy::Isize),
+        "i8" => SimplifiedType::Int(IntTy::I8),
+        "i16" => SimplifiedType::Int(IntTy::I16),
+        "i32" => SimplifiedType::Int(IntTy::I32),
+        "i64" => SimplifiedType::Int(IntTy::I64),
+        "i128" => SimplifiedType::Int(IntTy::I128),
+        "usize" => SimplifiedType::Uint(UintTy::Usize),
+        "u8" => SimplifiedType::Uint(UintTy::U8),
+        "u16" => SimplifiedType::Uint(UintTy::U16),
+        "u32" => SimplifiedType::Uint(UintTy::U32),
+        "u64" => SimplifiedType::Uint(UintTy::U64),
+        "u128" => SimplifiedType::Uint(UintTy::U128),
+        "f32" => SimplifiedType::Float(FloatTy::F32),
+        "f64" => SimplifiedType::Float(FloatTy::F64),
         _ => return [].iter().copied(),
     };
 
@@ -329,7 +329,7 @@ pub fn implements_trait_with_env<'tcx>(
         kind: TypeVariableOriginKind::MiscVariable,
         span: DUMMY_SP,
     };
-    let ty_params = tcx.mk_substs_from_iter(
+    let ty_params = tcx.mk_args_from_iter(
         ty_params
             .into_iter()
             .map(|arg| arg.unwrap_or_else(|| infcx.next_ty_var(orig).into())),

--- a/support/crown/src/main.rs
+++ b/support/crown/src/main.rs
@@ -42,7 +42,8 @@ impl Callbacks for MyCallbacks {
         config.register_lints = Some(Box::new(move |sess, lint_store| {
             // Skip checks for proc-macro crates.
             if sess
-                .crate_types()
+                .opts
+                .crate_types
                 .contains(&rustc_session::config::CrateType::ProcMacro)
             {
                 return;
@@ -58,7 +59,9 @@ impl Callbacks for MyCallbacks {
 }
 
 fn main() -> ExitCode {
-    rustc_driver::init_env_logger("CROWN_LOG");
+    let handler =
+        rustc_session::EarlyErrorHandler::new(rustc_session::config::ErrorOutputType::default());
+    rustc_driver::init_env_logger(&handler, "CROWN_LOG");
     let args: Vec<_> = std::env::args().collect();
 
     match rustc_driver::RunCompiler::new(&args, &mut MyCallbacks).run() {

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -118,7 +118,7 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
     let mut walker = ty.walk();
     while let Some(generic_arg) = walker.next() {
         let t = match generic_arg.unpack() {
-            rustc_middle::ty::subst::GenericArgKind::Type(t) => t,
+            rustc_middle::ty::GenericArgKind::Type(t) => t,
             _ => {
                 walker.skip_current_subtree();
                 continue;
@@ -171,7 +171,7 @@ impl<'tcx> LateLintPass<'tcx> for NotracePass {
         if let hir::ItemKind::Struct(def, ..) = &item.kind {
             for ref field in def.fields() {
                 let field_type = cx.tcx.type_of(field.def_id);
-                incorrect_no_trace(&self.symbols, cx, field_type.0, field.span);
+                incorrect_no_trace(&self.symbols, cx, field_type.skip_binder(), field.span);
             }
         }
     }
@@ -181,7 +181,7 @@ impl<'tcx> LateLintPass<'tcx> for NotracePass {
             hir::VariantData::Tuple(fields, ..) => {
                 for field in fields {
                     let field_type = cx.tcx.type_of(field.def_id);
-                    incorrect_no_trace(&self.symbols, cx, field_type.0, field.ty.span);
+                    incorrect_no_trace(&self.symbols, cx, field_type.skip_binder(), field.ty.span);
                 }
             },
             _ => (), // Struct variants already caught by check_struct_def

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -77,7 +77,7 @@ fn is_unrooted_ty<'tcx>(
     let mut walker = ty.walk();
     while let Some(generic_arg) = walker.next() {
         let t = match generic_arg.unpack() {
-            rustc_middle::ty::subst::GenericArgKind::Type(t) => t,
+            rustc_middle::ty::GenericArgKind::Type(t) => t,
             _ => {
                 walker.skip_current_subtree();
                 continue;
@@ -191,7 +191,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
         if let hir::ItemKind::Struct(def, ..) = &item.kind {
             for ref field in def.fields() {
                 let field_type = cx.tcx.type_of(field.def_id);
-                if is_unrooted_ty(&self.symbols, cx, field_type.0, false) {
+                if is_unrooted_ty(&self.symbols, cx, field_type.skip_binder(), false) {
                     cx.lint(
                         UNROOTED_MUST_ROOT,
                         "Type must be rooted, use #[crown::unrooted_must_root_lint::must_root] \
@@ -214,7 +214,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                 hir::VariantData::Tuple(fields, ..) => {
                     for field in fields {
                         let field_type = cx.tcx.type_of(field.def_id);
-                        if is_unrooted_ty(&self.symbols, cx, field_type.0, false) {
+                        if is_unrooted_ty(&self.symbols, cx, field_type.skip_binder(), false) {
                             cx.lint(
                                 UNROOTED_MUST_ROOT,
                                 "Type must be rooted, \
@@ -247,7 +247,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
         };
 
         if !in_derive_expn(span) {
-            let sig = cx.tcx.type_of(def_id).0.fn_sig(cx.tcx);
+            let sig = cx.tcx.type_of(def_id).skip_binder().fn_sig(cx.tcx);
 
             for (arg, ty) in decl.inputs.iter().zip(sig.inputs().skip_binder().iter()) {
                 if is_unrooted_ty(&self.symbols, cx, *ty, false) {

--- a/support/crown/tests/compile-fail/trace_in_no_trace_composable_works.rs
+++ b/support/crown/tests/compile-fail/trace_in_no_trace_composable_works.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 // compile-flags: --error-format=human
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
 /// Mock `JSTraceable`
 pub trait JSTraceable {}
 

--- a/support/crown/tests/compile-fail/trace_in_no_trace_works.rs
+++ b/support/crown/tests/compile-fail/trace_in_no_trace_works.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 /// Mock `JSTraceable`
 pub trait JSTraceable {}

--- a/support/crown/tests/compile-fail/unrooted_must_root_parameter.rs
+++ b/support/crown/tests/compile-fail/unrooted_must_root_parameter.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 #[crown::unrooted_must_root_lint::must_root]
 struct Foo(i32);

--- a/support/crown/tests/compile-fail/unrooted_must_root_return_type.rs
+++ b/support/crown/tests/compile-fail/unrooted_must_root_return_type.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 #[crown::unrooted_must_root_lint::must_root]
 struct Foo(i32);

--- a/support/crown/tests/compile-fail/unrooted_must_root_struct_field.rs
+++ b/support/crown/tests/compile-fail/unrooted_must_root_struct_field.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 #[crown::unrooted_must_root_lint::must_root]
 struct Foo(i32);

--- a/support/crown/tests/run-pass/trace_in_no_trace_composable.rs
+++ b/support/crown/tests/run-pass/trace_in_no_trace_composable.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 /// Mock `JSTraceable`
 pub trait JSTraceable {}

--- a/support/crown/tests/run-pass/trace_in_no_trace_ok.rs
+++ b/support/crown/tests/run-pass/trace_in_no_trace_ok.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 /// Mock `JSTraceable`
 pub trait JSTraceable {}

--- a/support/crown/tests/run-pass/unrooted_must_root_ok.rs
+++ b/support/crown/tests/run-pass/unrooted_must_root_ok.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 // compile-flags: --error-format=human
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
 #[crown::unrooted_must_root_lint::must_root]
 struct Foo(i32);
 #[crown::unrooted_must_root_lint::must_root]

--- a/support/crown/tests/ui/trace_in_no_trace_primitive.rs
+++ b/support/crown/tests/ui/trace_in_no_trace_primitive.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
 
 /// Mock `JSTraceable`
 pub trait JSTraceable {}

--- a/support/crown/tests/ui/trace_in_no_trace_primitive.stderr
+++ b/support/crown/tests/ui/trace_in_no_trace_primitive.stderr
@@ -1,7 +1,7 @@
 warning: must_not_have_traceable marked wrapper is not needed for types that implements empty Traceable (like primitive types). Consider removing the wrapper.
-  --> $DIR/trace_in_no_trace_primitive.rs:15:12
+  --> $DIR/trace_in_no_trace_primitive.rs:16:12
    |
-15 | struct Foo(NoTrace<i32>);
+16 | struct Foo(NoTrace<i32>);
    |            ^^^^^^^^^^^^
    |
    = note: `#[warn(crown::empty_trace_in_no_trace)]` on by default


### PR DESCRIPTION
Compile Servo with the latest version of rust stable

This completes the transition to compiling Servo with rust stable. Some
nightly-only features are still used when compiling the `script` and
`crown` crates, as well as for some style unit tests. These will likely
break with newer compiler versions, but `crown` can be disabled for them
conditionally. This is just the first step.

This has some caveats:

1. We need to disable setting up the special linker on Linux. The -Z
   option isn't supported with stable rust so using this is out --
   meanwhile we can't be sure that lld is installed on most systems.
2. `cargo fmt` still uses some unstable options, so we need to rely on
   the unstable toolchain just for running `fmt`. The idea is to fix this
   gradually.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
