### PR TITLE
Update mozjs to 01d777e14e17b4a7994f5f8b7ca262e56bb6faf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,7 +3703,7 @@ checksum = "903970ae2f248d7275214cf8f387f8ba0c4ea7e3d87a320e85493db60ce28616"
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#f452fb2e642e158893a094b62956b5f40e015c3e"
+source = "git+https://github.com/servo/mozjs#01d777e14e17b4a7994f5f8b7ca262e56bb6faf8"
 dependencies = [
  "bindgen 0.68.1",
  "cc",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.68.2"
-source = "git+https://github.com/servo/mozjs#f452fb2e642e158893a094b62956b5f40e015c3e"
+source = "git+https://github.com/servo/mozjs#01d777e14e17b4a7994f5f8b7ca262e56bb6faf8"
 dependencies = [
  "bindgen 0.68.1",
  "cc",


### PR DESCRIPTION
Update mozjs to latest.

Most notably it contains fix for macos linkers: https://github.com/servo/mozjs/commit/655655ed1920eb03dc673c2b84b17de7e6a1be78


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they update a dependency.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
