### PR TITLE
Add multiview feature flag in compositing and constellation

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 [features]
 default = []
 gl = ["gleam", "pixels"]
+multiview = []
 
 [dependencies]
 canvas = { path = "../canvas" }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -10,6 +10,10 @@ publish = false
 name = "constellation"
 path = "lib.rs"
 
+[features]
+default = []
+multiview = []
+
 [dependencies]
 background_hang_monitor = { path = "../background_hang_monitor" }
 backtrace = { workspace = true }


### PR DESCRIPTION
This patch adds a Cargo feature for the new multiple webviews work that is disabled by default.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30648

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes