### PR TITLE
constellation: notify embedder when events are hit-tested to browsers

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2913,17 +2913,7 @@ where
             },
             Some(pipeline) => pipeline,
         };
-        let event_variant = match event {
-            CompositorEvent::ResizeEvent(..) => CompositorEventVariant::ResizeEvent,
-            MouseButtonEvent(..) => CompositorEventVariant::MouseButtonEvent,
-            MouseMoveEvent(..) => CompositorEventVariant::MouseMoveEvent,
-            CompositorEvent::TouchEvent(..) => CompositorEventVariant::TouchEvent,
-            CompositorEvent::WheelEvent(..) => CompositorEventVariant::WheelEvent,
-            CompositorEvent::KeyboardEvent(..) => CompositorEventVariant::KeyboardEvent,
-            CompositorEvent::CompositionEvent(..) => CompositorEventVariant::CompositionEvent,
-            CompositorEvent::IMEDismissedEvent => CompositorEventVariant::IMEDismissedEvent,
-        };
-        let msg = EmbedderMsg::EventDelivered(event_variant);
+        let msg = EmbedderMsg::EventDelivered((&event).into());
         self.embedder_proxy
             .send((Some(pipeline.top_level_browsing_context_id), msg));
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -113,8 +113,7 @@ use devtools_traits::{
     ScriptToDevtoolsControlMsg,
 };
 use embedder_traits::{
-    CompositorEventVariant, Cursor, EmbedderMsg, EmbedderProxy, MediaSessionEvent,
-    MediaSessionPlaybackState,
+    Cursor, EmbedderMsg, EmbedderProxy, MediaSessionEvent, MediaSessionPlaybackState,
 };
 use euclid::default::Size2D as UntypedSize2D;
 use euclid::Size2D;
@@ -2913,12 +2912,16 @@ where
             },
             Some(pipeline) => pipeline,
         };
-        let msg = EmbedderMsg::EventDelivered((&event).into());
-        self.embedder_proxy
-            .send((Some(pipeline.top_level_browsing_context_id), msg));
 
-        let msg = ConstellationControlMsg::SendEvent(destination_pipeline_id, event);
-        if let Err(e) = pipeline.event_loop.send(msg) {
+        self.embedder_proxy.send((
+            Some(pipeline.top_level_browsing_context_id),
+            EmbedderMsg::EventDelivered((&event).into()),
+        ));
+
+        if let Err(e) = pipeline.event_loop.send(ConstellationControlMsg::SendEvent(
+            destination_pipeline_id,
+            event,
+        )) {
             self.handle_send_error(destination_pipeline_id, e);
         }
     }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -208,6 +208,21 @@ pub enum EmbedderMsg {
     OnDevtoolsStarted(Result<u16, ()>, String),
     /// Compositing done, but external code needs to present.
     ReadyToPresent,
+    /// The given event was delivered to a pipeline in the given browser.
+    EventDelivered(CompositorEventVariant),
+}
+
+/// The variant of CompositorEvent that was delivered to a pipeline.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum CompositorEventVariant {
+    ResizeEvent,
+    MouseButtonEvent,
+    MouseMoveEvent,
+    TouchEvent,
+    WheelEvent,
+    KeyboardEvent,
+    CompositionEvent,
+    IMEDismissedEvent,
 }
 
 impl Debug for EmbedderMsg {
@@ -245,6 +260,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::OnDevtoolsStarted(..) => write!(f, "OnDevtoolsStarted"),
             EmbedderMsg::ShowContextMenu(..) => write!(f, "ShowContextMenu"),
             EmbedderMsg::ReadyToPresent => write!(f, "ReadyToPresent"),
+            EmbedderMsg::EventDelivered(..) => write!(f, "HitTestedEvent"),
         }
     }
 }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -27,7 +27,7 @@ use canvas_traits::webgl::WebGLPipeline;
 use compositor::ScrollTreeNodeId;
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
-use embedder_traits::Cursor;
+use embedder_traits::{CompositorEventVariant, Cursor};
 use euclid::default::Point2D;
 use euclid::{Length, Rect, Scale, Size2D, UnknownUnit, Vector2D};
 use gfx_traits::Epoch;
@@ -569,6 +569,21 @@ pub enum CompositorEvent {
     CompositionEvent(CompositionEvent),
     /// Virtual keyboard was dismissed
     IMEDismissedEvent,
+}
+
+impl From<&CompositorEvent> for CompositorEventVariant {
+    fn from(value: &CompositorEvent) -> Self {
+        match value {
+            CompositorEvent::ResizeEvent(..) => CompositorEventVariant::ResizeEvent,
+            CompositorEvent::MouseButtonEvent(..) => CompositorEventVariant::MouseButtonEvent,
+            CompositorEvent::MouseMoveEvent(..) => CompositorEventVariant::MouseMoveEvent,
+            CompositorEvent::TouchEvent(..) => CompositorEventVariant::TouchEvent,
+            CompositorEvent::WheelEvent(..) => CompositorEventVariant::WheelEvent,
+            CompositorEvent::KeyboardEvent(..) => CompositorEventVariant::KeyboardEvent,
+            CompositorEvent::CompositionEvent(..) => CompositorEventVariant::CompositionEvent,
+            CompositorEvent::IMEDismissedEvent => CompositorEventVariant::IMEDismissedEvent,
+        }
+    }
 }
 
 /// Requests a TimerEvent-Message be sent after the given duration.

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -799,7 +799,8 @@ impl ServoGlue {
                 EmbedderMsg::HeadParsed |
                 EmbedderMsg::SetFullscreenState(..) |
                 EmbedderMsg::ReadyToPresent |
-                EmbedderMsg::ReportProfile(..) => {},
+                EmbedderMsg::ReportProfile(..) |
+                EmbedderMsg::EventDelivered(..) => {},
             }
         }
         Ok(())

--- a/ports/servoshell/browser.rs
+++ b/ports/servoshell/browser.rs
@@ -14,8 +14,8 @@ use keyboard_types::{Key, KeyboardEvent, Modifiers, ShortcutMatcher};
 use log::{debug, error, info, trace, warn};
 use servo::compositing::windowing::{EmbedderEvent, WebRenderDebugOption};
 use servo::embedder_traits::{
-    ContextMenuResult, EmbedderMsg, FilterPattern, PermissionPrompt, PermissionRequest,
-    PromptDefinition, PromptOrigin, PromptResult,
+    CompositorEventVariant, ContextMenuResult, EmbedderMsg, FilterPattern, PermissionPrompt,
+    PermissionRequest, PromptDefinition, PromptOrigin, PromptResult,
 };
 use servo::msg::constellation_msg::{TopLevelBrowsingContextId as BrowserId, TraversalDirection};
 use servo::script_traits::TouchEventType;
@@ -544,6 +544,23 @@ where
                 },
                 EmbedderMsg::ReadyToPresent => {
                     need_present = true;
+                },
+                EmbedderMsg::EventDelivered(event) => match (browser_id, event) {
+                    (None, _) => {},
+                    (
+                        _,
+                        CompositorEventVariant::ResizeEvent |
+                        CompositorEventVariant::MouseMoveEvent |
+                        CompositorEventVariant::TouchEvent |
+                        CompositorEventVariant::WheelEvent |
+                        CompositorEventVariant::KeyboardEvent |
+                        CompositorEventVariant::CompositionEvent |
+                        CompositorEventVariant::IMEDismissedEvent,
+                    ) => {},
+                    (Some(browser_id), CompositorEventVariant::MouseButtonEvent) => {
+                        // TODO Focus browser and/or raise to top if needed.
+                        trace!("{}: Got a mouse button event", browser_id);
+                    },
                 },
             }
         }

--- a/ports/servoshell/browser.rs
+++ b/ports/servoshell/browser.rs
@@ -546,21 +546,11 @@ where
                     need_present = true;
                 },
                 EmbedderMsg::EventDelivered(event) => match (browser_id, event) {
-                    (None, _) => {},
-                    (
-                        _,
-                        CompositorEventVariant::ResizeEvent |
-                        CompositorEventVariant::MouseMoveEvent |
-                        CompositorEventVariant::TouchEvent |
-                        CompositorEventVariant::WheelEvent |
-                        CompositorEventVariant::KeyboardEvent |
-                        CompositorEventVariant::CompositionEvent |
-                        CompositorEventVariant::IMEDismissedEvent,
-                    ) => {},
                     (Some(browser_id), CompositorEventVariant::MouseButtonEvent) => {
                         // TODO Focus browser and/or raise to top if needed.
                         trace!("{}: Got a mouse button event", browser_id);
                     },
+                    (_, _) => {},
                 },
             }
         }


### PR DESCRIPTION
This patch adds a new EventDelivered event (embedder ← constellation) that notifies the embedder when a mouse or touch event was hit-tested and delivered to a pipeline in some top-level browsing context.

This will allow the embedder to, for example, focus and raise a browser when clicked.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30648

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the behaviour changes are straightforward