### PR TITLE
Use os version in taplo cache-key & setuptools 65 in py3.8

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           crate: taplo-cli
           locked: true
-          hash: ${{ inputs.upload && '20.04' || '22.04' }}
+          cache-key: ${{ inputs.upload && '20.04' || '22.04' }}
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies
@@ -180,4 +180,3 @@ jobs:
       - name: Mark the job as unsuccessful
         run: exit 1
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,8 +5,8 @@ blessings == 1.7
 distro == 1.4
 mozinfo == 1.2.1
 mozlog == 7.1.0
-setuptools == 68.2.2; python_version >= "3.8"
-setuptools == 65.5.1; python_version < "3.8"
+setuptools == 68.2.2; python_version > "3.8"
+setuptools == 65.5.1; python_version <= "3.8"
 toml == 0.9.2
 dataclasses == 0.8; python_version < "3.7"
 


### PR DESCRIPTION
It works: https://github.com/servo/servo/actions/runs/7167362715

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30835 
- [x] There are tests for these changes (test run)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
