### PR TITLE
Fix libsimpleservo build on Linux and BSD

### DIFF
--- a/ports/libsimpleservo/api/src/gl_glue.rs
+++ b/ports/libsimpleservo/api/src/gl_glue.rs
@@ -116,7 +116,8 @@ pub mod gl {
             include!(concat!(env!("OUT_DIR"), "/glx_bindings.rs"));
         }
 
-        let lib = match Library::new("libGL.so.1").or_else(|_| Library::new("libGL.so")) {
+        let lib = match unsafe { Library::new("libGL.so.1").or_else(|_| Library::new("libGL.so")) }
+        {
             Ok(lib) => lib,
             Err(_) => return Err("Can't find libGL.so, OpenGL isn't configured/installed"),
         };


### PR DESCRIPTION
```
$ cargo build -p simpleservo
[...]
error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> ports/libsimpleservo/api/src/gl_glue.rs:119:25
    |
119 |         let lib = match Library::new("libGL.so.1").or_else(|_| Library::new("libGL.so")) {
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior

error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> ports/libsimpleservo/api/src/gl_glue.rs:119:64
    |
119 |         let lib = match Library::new("libGL.so.1").or_else(|_| Library::new("libGL.so")) {
    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
[...]
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes