### PR TITLE
layout: Make all word separators justification opportunities

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -3036,7 +3036,7 @@ fn convert_text_run_to_glyphs(
 
     for slice in text_run.natural_word_slices_in_visual_order(&range) {
         for glyph in slice.glyphs.iter_glyphs_for_byte_range(&slice.range) {
-            let glyph_advance = if glyph.char_is_space() {
+            let glyph_advance = if glyph.char_is_word_separator() {
                 glyph.advance() + text_run.extra_word_spacing
             } else {
                 glyph.advance()

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1156,7 +1156,7 @@ impl InlineFlow {
                 .run
                 .character_slices_in_range(&fragment_range)
             {
-                expansion_opportunities += slice.glyphs.space_count_in_range(&slice.range)
+                expansion_opportunities += slice.glyphs.word_separator_count_in_range(&slice.range)
             }
         }
 

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -783,7 +783,9 @@ fn glyphs(
                     point,
                 };
                 glyphs.push(glyph);
-            } else {
+            }
+
+            if glyph.char_is_word_separator() {
                 origin.x += justification_adjustment;
             }
             origin.x += Length::from(glyph.advance());

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -963,10 +963,8 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
         if is_non_preserved_whitespace {
             self.current_line_segment.trailing_whitespace_size = inline_advance;
         }
-
-        if glyph_store.is_whitespace() {
-            self.current_line_segment.justification_opportunities += 1;
-        }
+        self.current_line_segment.justification_opportunities +=
+            glyph_store.total_word_separators() as usize;
 
         match self.current_line_segment.line_items.last_mut() {
             Some(LineItem::TextRun(text_run)) => {
@@ -2111,9 +2109,7 @@ impl TextRunLineItem {
             .text
             .iter()
             .map(|glyph_store| {
-                if glyph_store.is_whitespace() {
-                    number_of_justification_opportunities += 1
-                }
+                number_of_justification_opportunities += glyph_store.total_word_separators();
                 Length::from(glyph_store.total_advance())
             })
             .sum();

--- a/tests/wpt/tests/css/css-text/text-justify/text-justify-word-separators-ref.html
+++ b/tests/wpt/tests/css/css-text/text-justify/text-justify-word-separators-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text/#word-separator">
+    <meta name="assert" content="text-justify:inter-word should adjust spacing at all word separators.">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <style>
+        .justified {
+            font: 10px/1 Ahem;
+            text-align: justify;
+            text-justify: inter-word;
+            width: 120px;
+            border: solid 1px black;
+        }
+    </style>
+</head>
+<body>
+    <div class="justified">XXXX XXXX XXXX</div>
+    <div class="justified">XXXX XXXX XXXX</div>
+    <div class="justified">XXXX XXXX XXXX</div>
+    <div class="justified">XXXX XXXX XXXX</div>
+    <div class="justified">XXXX XXXX XXXX</div>
+    <div class="justified">XXXX XXXX XXXX</div>
+    <div class="justified">XXXX XXXX XXXX</div>
+</body>
+</html>

--- a/tests/wpt/tests/css/css-text/text-justify/text-justify-word-separators.html
+++ b/tests/wpt/tests/css/css-text/text-justify/text-justify-word-separators.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Text 6.4. Justification Method: text-justify: inter-word</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="help" href="https://drafts.csswg.org/css-text/#word-separator">
+    <link rel='match' href='text-justify-word-separators-ref.html'>
+    <meta name="assert" content="text-justify:inter-word should adjust spacing at all word separators.">
+    <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+    <style>
+        .justified {
+            font: 10px/1 Ahem;
+            text-align: justify;
+            text-justify: inter-word;
+            width: 120px;
+            border: solid 1px black;
+        }
+        /* Hide the word separators, in case the system doesn't
+           have an appropriate font installed and shows tofu.
+           Justification should still work in this case. */
+        .hidden {
+            color: transparent;
+        }
+    </style>
+</head>
+<body>
+    <!-- A normal space -->
+    <div class="justified">XXXX XXXX XXXX</div>
+
+    <!-- Non-breaking space -->
+    <div class="justified">XXXX<span class="hidden">&nbsp;</span>XXXX XXXX</div>
+
+    <!-- Ethiopic word space -->
+    <div class="justified">XXXX<span class="hidden">&#x1361;</span>XXXX XXXX</div>
+
+    <!-- Aegean word separators -->
+    <div class="justified">XXXX<span class="hidden">&#x10100;</span>XXXX XXXX</div>
+    <div class="justified">XXXX<span class="hidden">&#x10101;</span>XXXX XXXX</div>
+
+    <!-- Ugaritic word divider -->
+    <div class="justified">XXXX<span class="hidden">&#x1039F;</span>XXXX XXXX</div>
+
+    <!-- Phoenician word separator -->
+    <div class="justified">XXXX<span class="hidden">&#x1091F;</span>XXXX XXXX</div>
+</body>
+</html>


### PR DESCRIPTION
This change adapts both layout and legacy layout to the specification
which gives a list of word separators to use as justification
opportunities.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
