### PR TITLE
Fix two more warnings in WebRender

### DIFF
--- a/third_party/webrender/patches/004-Fix-more-WebRender-warnings.diff
+++ b/third_party/webrender/patches/004-Fix-more-WebRender-warnings.diff
@@ -1,0 +1,20 @@
+diff --git a/third_party/webrender/webrender_api/src/display_item_cache.rs b/third_party/webrender/webrender_api/src/display_item_cache.rs
+index 169e54797a..8a28ac4ab2 100644
+--- a/third_party/webrender/webrender_api/src/display_item_cache.rs
++++ b/third_party/webrender/webrender_api/src/display_item_cache.rs
+@@ -58,13 +58,13 @@ pub struct DisplayItemCache {
+ 
+ impl DisplayItemCache {
+     fn add_item(&mut self, key: ItemKey, item: CachedDisplayItem) {
+-        let mut entry = &mut self.entries[key as usize];
++        let entry = &mut self.entries[key as usize];
+         entry.items.push(item);
+         entry.occupied = true;
+     }
+ 
+     fn clear_entry(&mut self, key: ItemKey) {
+-        let mut entry = &mut self.entries[key as usize];
++        let entry = &mut self.entries[key as usize];
+         entry.items.clear();
+         entry.occupied = false;
+     }

--- a/third_party/webrender/patches/series
+++ b/third_party/webrender/patches/series
@@ -1,3 +1,4 @@
 001-Restore-hit-testing-api.diff
 002-Upgrade-version-of-gleam.diff
 003-Fix-WebRender-warnings.diff
+004-Fix-more-WebRender-warnings.diff

--- a/third_party/webrender/webrender_api/src/display_item_cache.rs
+++ b/third_party/webrender/webrender_api/src/display_item_cache.rs
@@ -58,13 +58,13 @@ pub struct DisplayItemCache {
 
 impl DisplayItemCache {
     fn add_item(&mut self, key: ItemKey, item: CachedDisplayItem) {
-        let mut entry = &mut self.entries[key as usize];
+        let entry = &mut self.entries[key as usize];
         entry.items.push(item);
         entry.occupied = true;
     }
 
     fn clear_entry(&mut self, key: ItemKey) {
-        let mut entry = &mut self.entries[key as usize];
+        let entry = &mut self.entries[key as usize];
         entry.items.clear();
         entry.occupied = false;
     }


### PR DESCRIPTION
These appeared after switching to the latest Rust stable release.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30861.
- [x] These changes do not require tests because they fix warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
