### PR TITLE
Fix the WPT exporter

### DIFF
--- a/python/wpt/exporter/__init__.py
+++ b/python/wpt/exporter/__init__.py
@@ -19,6 +19,7 @@ import dataclasses
 import json
 import logging
 import re
+import shutil
 import subprocess
 
 from typing import Callable, Optional
@@ -50,8 +51,12 @@ class LocalGitRepo:
         self.path = path
         self.sync = sync
 
+        # We pass env to subprocess, which may clobber PATH, so we need to find
+        # git in advance and run the subprocess by its absolute path.
+        self.git_path = shutil.which("git")
+
     def run_without_encoding(self, *args, env: dict = {}):
-        command_line = ["git"] + list(args)
+        command_line = [self.git_path] + list(args)
         logging.info("  → Execution (cwd='%s'): %s",
                      self.path, " ".join(command_line))
 

--- a/python/wpt/exporter/__init__.py
+++ b/python/wpt/exporter/__init__.py
@@ -142,9 +142,9 @@ class WPTSync:
     suppress_force_push: bool = False
 
     def __post_init__(self):
-        self.servo = GithubRepository(self, self.servo_repo)
-        self.wpt = GithubRepository(self, self.wpt_repo)
-        self.downstream_wpt = GithubRepository(self, self.downstream_wpt_repo)
+        self.servo = GithubRepository(self, self.servo_repo, "main")
+        self.wpt = GithubRepository(self, self.wpt_repo, "master")
+        self.downstream_wpt = GithubRepository(self, self.downstream_wpt_repo, "master")
         self.local_servo_repo = LocalGitRepo(self.servo_path, self)
         self.local_wpt_repo = LocalGitRepo(self.wpt_path, self)
 

--- a/python/wpt/exporter/github.py
+++ b/python/wpt/exporter/github.py
@@ -55,10 +55,10 @@ class GithubRepository:
     This class allows interacting with a single GitHub repository.
     """
 
-    def __init__(self, sync: WPTSync, repo: str, main_branch_name: str):
+    def __init__(self, sync: WPTSync, repo: str, default_branch: str):
         self.sync = sync
         self.repo = repo
-        self.main_branch_name = main_branch_name
+        self.default_branch = default_branch
         self.org = repo.split("/")[0]
         self.pulls_url = f"repos/{self.repo}/pulls"
 
@@ -106,7 +106,7 @@ class GithubRepository:
         data = {
             "title": title,
             "head": branch.get_pr_head_reference_for_repo(self),
-            "base": self.main_branch_name,
+            "base": self.default_branch,
             "body": body,
             "maintainer_can_modify": False,
         }

--- a/python/wpt/exporter/github.py
+++ b/python/wpt/exporter/github.py
@@ -55,9 +55,10 @@ class GithubRepository:
     This class allows interacting with a single GitHub repository.
     """
 
-    def __init__(self, sync: WPTSync, repo: str):
+    def __init__(self, sync: WPTSync, repo: str, main_branch_name: str):
         self.sync = sync
         self.repo = repo
+        self.main_branch_name = main_branch_name
         self.org = repo.split("/")[0]
         self.pulls_url = f"repos/{self.repo}/pulls"
 
@@ -74,7 +75,7 @@ class GithubRepository:
         self, branch: GithubBranch
     ) -> Optional[PullRequest]:
         """If this repository has an open pull request with the
-        given source head reference targeting the master branch,
+        given source head reference targeting the main branch,
         return the first matching pull request, otherwise return None."""
 
         params = "+".join([
@@ -105,7 +106,7 @@ class GithubRepository:
         data = {
             "title": title,
             "head": branch.get_pr_head_reference_for_repo(self),
-            "base": "master",
+            "base": self.main_branch_name,
             "body": body,
             "maintainer_can_modify": False,
         }

--- a/python/wpt/exporter/github.py
+++ b/python/wpt/exporter/github.py
@@ -74,7 +74,7 @@ class GithubRepository:
         self, branch: GithubBranch
     ) -> Optional[PullRequest]:
         """If this repository has an open pull request with the
-        given source head reference targeting the main branch,
+        given source head reference targeting the master branch,
         return the first matching pull request, otherwise return None."""
 
         params = "+".join([
@@ -105,7 +105,7 @@ class GithubRepository:
         data = {
             "title": title,
             "head": branch.get_pr_head_reference_for_repo(self),
-            "base": "main",
+            "base": "master",
             "body": body,
             "maintainer_can_modify": False,
         }

--- a/python/wpt/exporter/step.py
+++ b/python/wpt/exporter/step.py
@@ -190,7 +190,7 @@ class CreateOrUpdateBranchForPRStep(Step):
             return branch_name
         finally:
             try:
-                run.sync.local_wpt_repo.run("checkout", "main")
+                run.sync.local_wpt_repo.run("checkout", "master")
                 run.sync.local_wpt_repo.run("branch", "-D", branch_name)
             except Exception:
                 pass

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -644,17 +644,17 @@ def setUpModule():
         suppress_force_push=True,
     )
 
-    def setup_mock_repo(repo_name, local_repo):
+    def setup_mock_repo(repo_name, local_repo, main_branch_name: str):
         subprocess.check_output(
             ["cp", "-R", "-p", os.path.join(TESTS_DIR, repo_name), local_repo.path])
-        local_repo.run("init", "-b", "main")
+        local_repo.run("init", "-b", main_branch_name)
         local_repo.run("add", ".")
         local_repo.run("commit", "-a", "-m", "Initial commit")
 
     logging.info("=" * 80)
     logging.info("Setting up mock repositories")
-    setup_mock_repo("servo-mock", SYNC.local_servo_repo)
-    setup_mock_repo("wpt-mock", SYNC.local_wpt_repo)
+    setup_mock_repo("servo-mock", SYNC.local_servo_repo, "main")
+    setup_mock_repo("wpt-mock", SYNC.local_wpt_repo, "master")
     logging.info("=" * 80)
 
 

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -644,10 +644,10 @@ def setUpModule():
         suppress_force_push=True,
     )
 
-    def setup_mock_repo(repo_name, local_repo, main_branch_name: str):
+    def setup_mock_repo(repo_name, local_repo, default_branch: str):
         subprocess.check_output(
             ["cp", "-R", "-p", os.path.join(TESTS_DIR, repo_name), local_repo.path])
-        local_repo.run("init", "-b", main_branch_name)
+        local_repo.run("init", "-b", default_branch)
         local_repo.run("add", ".")
         local_repo.run("commit", "-a", "-m", "Initial commit")
 


### PR DESCRIPTION
#30788 updates branch references from “master” to “main”, but [web-platform-tests/wpt](https://github.com/web-platform-tests/wpt) and [servo-wpt-sync/web-platform-tests](https://github.com/servo-wpt-sync/web-platform-tests) still use “master”, so the WPT exporter now fails to check out and open pull requests against “main”.

This patch makes the default branch name in GithubRepository configurable, set to main in Servo and master in WPT. We also fix the tests so they can now run on NixOS.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30869 (GitHub issue number if applicable)