### PR TITLE
Re-enable minification to fix the doc build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compile docs
         run: python3 ./mach doc
         env:
-          RUSTDOCFLAGS: -Z unstable-options --disable-minification --document-private-items
+          RUSTDOCFLAGS: --document-private-items
       - name: Upload docs
         run: |
           cd target/doc


### PR DESCRIPTION
Disable isn't possible for non-nightly versions of Rust, so this is
currently breaking the doc build. In addition, it seems that the
original issue that triggered this change [^1] is now fixed.

[^1]: https://github.com/rust-lang/rust/issues/58849

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this is a fix for the CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
