### PR TITLE
Script: ensure child JS runtimes are dropped before parent

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -443,6 +443,7 @@ impl DedicatedWorkerGlobalScope {
                                 TaskSourceName::DOMManipulation,
                             ))
                             .unwrap();
+                        scope.clear_js_runtime(context_for_interrupt);
                         return;
                     },
                     Ok((metadata, bytes)) => (metadata, bytes),

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -457,6 +457,7 @@ impl DedicatedWorkerGlobalScope {
                 }
 
                 if scope.is_closing() {
+                    scope.clear_js_runtime(context_for_interrupt);
                     return;
                 }
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -464,6 +464,7 @@ impl DedicatedWorkerGlobalScope {
 
                 {
                     let _ar = AutoWorkerReset::new(&global, worker.clone());
+                    let _ac = enter_realm(&*scope);
                     scope.execute_script(DOMString::from(source));
                 }
 

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -348,9 +348,8 @@ impl ServiceWorkerGlobalScope {
                     control_receiver,
                     closing,
                 );
-                
+
                 let scope = global.upcast::<WorkerGlobalScope>();
-                let _ac = enter_realm(&*scope);
 
                 let referrer = referrer_url
                     .map(|url| Referrer::ReferrerUrl(url))
@@ -383,7 +382,11 @@ impl ServiceWorkerGlobalScope {
                     JS_AddInterruptCallback(*scope.get_cx(), Some(interrupt_callback));
                 }
 
-                scope.execute_script(DOMString::from(source));
+                {
+                    // TODO: use AutoWorkerReset as in dedicated worker?
+                    let _ac = enter_realm(&*scope);
+                    scope.execute_script(DOMString::from(source));
+                }
 
                 global.dispatch_activate();
                 let reporter_name = format!("service-worker-reporter-{}", random::<u64>());

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -348,6 +348,9 @@ impl ServiceWorkerGlobalScope {
                     control_receiver,
                     closing,
                 );
+                
+                let scope = global.upcast::<WorkerGlobalScope>();
+                let _ac = enter_realm(&*scope);
 
                 let referrer = referrer_url
                     .map(|url| Referrer::ReferrerUrl(url))
@@ -367,15 +370,13 @@ impl ServiceWorkerGlobalScope {
                     {
                         Err(_) => {
                             println!("error loading script {}", serialized_worker_url);
+                            scope.clear_js_runtime(context_for_interrupt);
                             return;
                         },
                         Ok((metadata, bytes)) => {
                             (metadata.final_url, String::from_utf8(bytes).unwrap())
                         },
                     };
-
-                let scope = global.upcast::<WorkerGlobalScope>();
-                let _ac = enter_realm(&*scope);
 
                 unsafe {
                     // Handle interrupt requests

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -393,6 +393,8 @@ impl Window {
 
     #[allow(unsafe_code)]
     pub fn clear_js_runtime_for_script_deallocation(&self) {
+        self.upcast::<GlobalScope>()
+            .remove_web_messaging_and_dedicated_workers_infra();
         unsafe {
             *self.js_runtime.borrow_for_script_deallocation() = None;
             self.window_proxy.set(None);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove the annoying `This runtime still has live children.` that keeps showing up. 

Many issues that contain that backtrace as opposed to the actual underlying problem: 

FIX https://github.com/servo/servo/issues/30124 
FIX https://github.com/servo/servo/issues/24168 
FIX https://github.com/servo/servo/issues/25729 
FIX https://github.com/servo/servo/issues/28357 
FIX https://github.com/servo/servo/issues/26778

Marking them as fixed, because it appears to me that the original panic is already filed in other issues(i've pointed it out in each issue). 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
