### PR TITLE
script: Allow moving back to non-quirks mode

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -823,12 +823,12 @@ impl Document {
         self.quirks_mode.get()
     }
 
-    pub fn set_quirks_mode(&self, mode: QuirksMode) {
-        self.quirks_mode.set(mode);
+    pub fn set_quirks_mode(&self, new_mode: QuirksMode) {
+        let old_mode = self.quirks_mode.replace(new_mode);
 
-        if mode == QuirksMode::Quirks {
+        if old_mode != new_mode {
             match self.window.layout_chan() {
-                Some(chan) => chan.send(Msg::SetQuirksMode(mode)).unwrap(),
+                Some(chan) => chan.send(Msg::SetQuirksMode(new_mode)).unwrap(),
                 None => warn!("Layout channel unavailable"),
             }
         }


### PR DESCRIPTION
The code in script is written so that the document itself can move from
quirks to non-quirks mode, but this is never communicated to layout --
meaning quirky layout keeps happening. This is an issue when rewriting
the entire document with `document.write()` which is what some WPT tests
do to test quirks mode behavior.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no layout changes are currently observable with this change, but it will prevent test failures for #30902, because that PR exercises the proper update to style quirks mode settings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
