### PR TITLE
Fix the try build when pushing to branches

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -113,7 +113,7 @@ jobs:
   report-test-results:
     name: Report WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && (github.ref_name == 'try-wpt' || github.ref_name == 'try-wpt-2020' || inputs.wpt == 'test') }}
+    if: ${{ always() && !cancelled() && inputs.wpt == 'test' }}
     needs:
       - "linux-wpt"
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,8 +47,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["try-linux", "try-wpt", "try-wpt-2020"]
 
 env:
   RUST_BACKTRACE: 1
@@ -96,11 +94,11 @@ jobs:
       - name: Build (${{ inputs.profile }})
         run: python3 ./mach build --${{ inputs.profile }}
       - name: Smoketest
-        run: xvfb-run python3 ./mach smoketest --${{ inputs.profile }}
+        run: xvfb-run python3 ./mach smoketest --${{ inputs.profile  }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
-        if: ${{ inputs.unit-tests || github.ref_name == 'try-linux' }}
+        if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 20
@@ -142,7 +140,7 @@ jobs:
           path: target.tar.gz
 
   wpt-2020:
-    if: ${{ github.ref_name == 'try-wpt-2020' || inputs.layout == '2020' || inputs.layout == 'all' }}
+    if: ${{ inputs.layout == '2020' || inputs.layout == 'all' }}
     name: Linux WPT Tests 2020
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
@@ -153,7 +151,7 @@ jobs:
     secrets: inherit
 
   wpt-2013:
-    if: ${{ github.ref_name == 'try-wpt' || inputs.layout == '2013' || inputs.layout == 'all' }}
+    if: ${{ inputs.layout == '2013' || inputs.layout == 'all' }}
     name: Linux WPT Tests 2013
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -40,8 +40,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["try-mac", "try-wpt-mac", "try-wpt-mac-2020"]
 
 env:
   RUST_BACKTRACE: 1
@@ -97,7 +95,7 @@ jobs:
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
-        if: ${{ inputs.unit-tests || github.ref_name == 'try-mac' }}
+        if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 20 # https://github.com/servo/servo/issues/30275
@@ -143,7 +141,7 @@ jobs:
           path: target.tar.gz
 
   wpt-2020:
-    if: ${{ github.ref_name == 'try-wpt-mac-2020' || inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
+    if: ${{ inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
     name: Mac WPT Tests 2020
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
@@ -153,7 +151,7 @@ jobs:
     secrets: inherit
 
   wpt-2013:
-    if: ${{ github.ref_name == 'try-wpt-mac' || inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
+    if: ${{ inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
     name: Mac WPT Tests 2013
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     # Run the entire pipeline for 'main' even though the merge queue already runs checks
     # for every change. This just offers an extra layer of testing and covers the case of
     # random force pushes.
-    branches: ["main", "try"]
+    branches: ["main"]
   pull_request:
     types: ['opened', 'synchronize']
     branches: ["**"]

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -3,6 +3,8 @@ name: Try
 on:
   pull_request_target:
     types: [labeled]
+  push:
+    branches: ["try", "try-linux", "try-mac", "try-wpt-mac", "try-wpt-mac-2020", "try-wpt", "try-wpt-2020", "try-windows"]
 
 jobs:
   parse-comment:
@@ -19,6 +21,10 @@ jobs:
           script: |
             function makeComment(body) {
                 console.log(body);
+
+                if (github.event_name != 'pull_request_target')
+                  return;
+
                 github.rest.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
@@ -62,7 +68,7 @@ jobs:
                 if (tryString.includes("linux")) {
                   addPlatformToConfiguration("linux", configuration);
                   configuration.unit_tests = true;
-                } else if (tryString.includes("macos")) {
+                } else if (tryString.includes("mac")) {
                   addPlatformToConfiguration("macos", configuration);
                   configuration.unit_tests = true;
                 } else if (tryString.includes("win")) {
@@ -86,28 +92,36 @@ jobs:
               unit_tests: false,
             };
 
-            let try_labels = [];
-            for (const label of context.payload.pull_request.labels) {
-              if (!label.name.startsWith("T-")) {
-                continue;
-              }
+            if (github.event_name == 'pull_request_target') {
+              for (const label of context.payload.pull_request.labels) {
+                if (!label.name.startsWith("T-")) {
+                  continue;
+                }
 
-              // Try to remove the label. If that fails, it's likely that another
-              // workflow has already processed it or a user has removed it.
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  name: label.name,
-                });
-              } catch (exception) {
-                console.log("Assuming '" + label.name + "' is already removed: " + exception);
-                continue;
-              }
+                // Try to remove the label. If that fails, it's likely that another
+                // workflow has already processed it or a user has removed it.
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: label.name,
+                  });
+                } catch (exception) {
+                  console.log("Assuming '" + label.name + "' is already removed: " + exception);
+                  continue;
+                }
 
-              console.log("Found label: " + label.name);
-              updateConfigurationFromString(label.name, configuration);
+                console.log("Found label: " + label.name);
+                updateConfigurationFromString(label.name, configuration);
+              }
+            } else {
+              let ref_name = "${{ github.ref_name || 'empty' }}";
+              if (ref_name == "try") {
+                updateConfigurationFromString("full", configuration);
+              } else {
+                updateConfigurationFromString(ref_name, configuration);
+              }
             }
 
             console.log(JSON.stringify(configuration));
@@ -152,7 +166,7 @@ jobs:
     if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
     steps:
       - name: Success
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        if: ${{ github.event_name == 'pull_request_target' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: actions/github-script@v6
         with:
           script: |
@@ -168,7 +182,7 @@ jobs:
                 body: "✨ Try run (" + formattedURL + ") " + "succeeded.",
               });
       - name: Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ github.event_name == 'pull_request_target' && contains(needs.*.result, 'failure') }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,8 +32,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["try-windows"]
 
 env:
   RUST_BACKTRACE: 1
@@ -89,7 +87,7 @@ jobs:
       - name: Smoketest
         run: python mach smoketest --angle --${{ inputs.profile }}
       - name: Unit tests
-        if: ${{ inputs.unit-tests || github.ref_name == 'try-windows' }}
+        if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30


### PR DESCRIPTION
Make it so that all try builds go through try.yml and pass
workflow_call arguments as expected to subsequent workflows.

<!-- Please describe your changes on the following line: -->

Co-authored-by: Samson <16504129+sagudev@users.noreply.github.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix a CI issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
