### PR TITLE
More powerful try strings & matrix in workflows

### DIFF
--- a/.github/workflows/dispatch-os.yml
+++ b/.github/workflows/dispatch-os.yml
@@ -1,0 +1,48 @@
+name: Dispatch OS
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      profile:
+        required: true
+        type: string
+      wpt-tests-to-run:
+        required: true
+        type: string
+      wpt-layout:
+        required: true
+        type: string
+      unit-tests:
+        required: true
+        type: boolean
+
+jobs:
+  win:
+    if: ${{ inputs.os == 'windows' }}
+    uses: ./.github/workflows/windows.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      unit-tests: ${{ inputs.unit-tests }}
+
+  mac:
+    if: ${{ inputs.os == 'mac' }}
+    uses: ./.github/workflows/mac.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      wpt-layout: ${{ inputs.wpt-layout }}
+      unit-tests: ${{ inputs.unit-tests }}
+      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+
+  linux:
+    if: ${{ inputs.os == 'linux' }}
+    uses: ./.github/workflows/linux.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      wpt-layout: ${{ inputs.wpt-layout }}
+      unit-tests: ${{ inputs.unit-tests }}
+      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,13 @@ name: Main
 
 on:
   push:
-    # Run the entire pipeline for 'main' even though the merge queue already runs checks
-    # for every change. This just offers an extra layer of testing and covers the case of
-    # random force pushes.
-    branches: ["main"]
+    branches:
+      # Run the entire pipeline for 'main' even though the merge queue already runs checks
+      # for every change. This just offers an extra layer of testing and covers the case of
+      # random force pushes.
+      - "main"
+      # For try runs
+      - "try"
   pull_request:
     types: ['opened', 'synchronize']
     branches: ["**"]
@@ -59,71 +62,105 @@ jobs:
               return configuration;
             }
 
-            // We need to pick defaults if the inputs are not provided. Unprovided inputs
-            // are empty strings in this template.
-            let platform = "${{ inputs.platform }}" || "linux";
-            let profile = "${{ inputs.profile }}" || "release";
-            let wpt_layout = "${{ inputs.wpt-layout }}" || "none";
-            let wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
-            let unit_tests = Boolean(${{ inputs.unit-tests }})
-
-            // Merge queue runs and pushes to `main` should always trigger a full build and test.
-            if (["push", "merge_group"].includes(context.eventName)) {
-              platform = "all";
-              wpt_layout = "all";
-              unit_tests = true;
+            if (context.eventName == "pull_request") {
+              return {
+                "fail_fast": false,
+                "matrix": [
+                  {
+                    "os": "linux",
+                    "name": "Linux",
+                    "wpt_layout": "none",
+                    "profile": "release",
+                    "unit_tests": true,
+                    "wpt_tests_to_run": "",
+                  },
+                ],
+              };
             }
 
-            let platforms = [];
-            if (platform == "all") {
-              platforms = [ "linux", "windows", "macos" ];
-            } else {
-              platforms = [ platform ];
+            // try runs can have config in last commit msg
+            if (${{ github.ref_name == 'try' }}) {
+              let commit_msg = context.payload.head_commit.message;
+              try {
+                var o = JSON.parse(commit_msg.split('\n').slice(-1));
+
+                if (o && typeof o === "object") {
+                  console.log("Using try commit configuration: " + JSON.stringify(o));
+                  return o;
+                }
+              }
+              catch (e) { } // try with bad commit msg will do full run
             }
 
-            let returnValue = {
-              platforms,
-              wpt_layout,
-              unit_tests,
-              profile,
-              wpt_tests_to_run,
+            // If we reach here we are likely doing full run
+            configuration = {
+              "fail_fast": false,
+              "matrix": [
+                {
+                  "os": "linux",
+                  "name": "Linux",
+                  "wpt_layout": "all",
+                  "profile": "release",
+                  "unit_tests": true,
+                  "wpt_tests_to_run": "",
+                },
+                {
+                  "os": "windows",
+                  "name": "Windows",
+                  "wpt_layout": "none", // not used
+                  "profile": "release",
+                  "unit_tests": true,
+                  "wpt_tests_to_run": "",
+                },
+                {
+                  "os": "mac",
+                  "name": "MacOS",
+                  "wpt_layout": "none",
+                  "profile": "release",
+                  "unit_tests": true,
+                  "wpt_tests_to_run": "",
+                }
+              ],
             };
 
-            console.log("Using configuration: " + JSON.stringify(returnValue));
-            return returnValue;
+            // Make merge queue fast
+            if (context.eventName == "merge_group") {
+              configuration.fail_fast = true;
+            }
 
-  build-win:
-    name: Windows
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'windows') }}
-    uses: ./.github/workflows/windows.yml
-    with:
-      profile: ${{ fromJson(needs.decision.outputs.configuration).profile }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
-    secrets: inherit
+            // user provided overrides of full run
+            if (context.eventName == "workflow_dispatch") {
+              // only linux-wpt
+              configuration.matrix.linux.wpt_layout = "${{ inputs.wpt-layout }}" || "none";
+              configuration.matrix.linux.wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
 
-  build-mac:
-    name: Mac
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'macos') }}
-    uses: ./.github/workflows/mac.yml
-    with:
-      wpt-tests-to-run: ${{ fromJson(needs.decision.outputs.configuration).wpt_tests_to_run }}
-      profile: ${{ fromJson(needs.decision.outputs.configuration).profile }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
-    secrets: inherit
+              let unit_tests = Boolean(${{ inputs.unit-tests }});
+              let profile = '${{ inputs.profile }}';
+              for (const platform of configuration.matrix) {
+                platform.profile = profile;
+                platfrom.unit_tests = unit_tests;
+              }
+            }
 
-  build-linux:
-    name: Linux
+            console.log("Using configuration: " + JSON.stringify(configuration));
+            return configuration;
+
+  build:
     needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'linux') }}
-    uses: ./.github/workflows/linux.yml
-    with:
-      wpt-tests-to-run: ${{ fromJson(needs.decision.outputs.configuration).wpt_tests_to_run }}
-      profile: ${{ fromJson(needs.decision.outputs.configuration).profile }}
-      wpt-layout: ${{ fromJson(needs.decision.outputs.configuration).wpt_layout }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ fromJson(needs.decision.outputs.configuration).fail_fast }}
+      matrix:
+        include: ${{ fromJson(needs.decision.outputs.configuration).matrix }}
+    # we need dipatch os because workflows do not support uses: ${}
+    uses: ./.github/workflows/dispatch-os.yml
     secrets: inherit
+    with:
+      os: ${{ matrix.os }}
+      wpt-layout: ${{ matrix.wpt_layout }}
+      profile: ${{ matrix.profile }}
+      unit-tests: ${{ matrix.unit_tests }}
+      wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
 
   build-result:
     name: Result
@@ -132,14 +169,9 @@ jobs:
     # needs all build to detect cancellation
     needs:
       - "decision"
-      - "build-win"
-      - "build-mac"
-      - "build-linux"
+      - "build"
 
     steps:
-      - name: Mark skipped jobs as successful
-        if: ${{ fromJson(needs.decision.outputs.configuration).platforms[0] != null }}
-        run: exit 0
       - name: Mark the job as successful
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,8 +131,8 @@ jobs:
             // user provided overrides of full run
             if (context.eventName == "workflow_dispatch") {
               // only linux-wpt
-              configuration.matrix.linux.wpt_layout = "${{ inputs.wpt-layout }}" || "none";
-              configuration.matrix.linux.wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
+              configuration.matrix[0].wpt_layout = "${{ inputs.wpt-layout }}" || "none";
+              configuration.matrix[0].wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
 
               let unit_tests = Boolean(${{ inputs.unit-tests }});
               let profile = '${{ inputs.profile }}';

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -3,8 +3,11 @@ name: Try
 on:
   pull_request_target:
     types: [labeled]
-  push:
-    branches: ["try", "try-linux", "try-mac", "try-wpt-mac", "try-wpt-mac-2020", "try-wpt", "try-wpt-2020", "try-windows"]
+  workflow_dispatch:
+    inputs:
+      try_string:
+        type: string
+        required: true
 
 jobs:
   parse-comment:
@@ -14,9 +17,11 @@ jobs:
       group: try-${{ github.event.number }}
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
+      try_string: ${{ steps.try_string.outputs.result }}
     steps:
-      - uses: actions/github-script@v6
-        id: configuration
+      - name: Get Try string
+        uses: actions/github-script@v6
+        id: try_string
         with:
           script: |
             function makeComment(body) {
@@ -33,66 +38,7 @@ jobs:
                 })
             }
 
-            function combineWPTLayoutOptions(layout, newLayout) {
-                let has2013 = layout == "2013" || layout == "all";
-                let has2020 = layout == "2020" || layout == "all";
-                let adding2013 = newLayout == "2013";
-                let adding2020 = newLayout == "2020";
-
-                if ((adding2020 && has2020) || (adding2013 && has2013)) {
-                  return layout;
-                }
-                if (adding2020) {
-                  return has2013 ? "all" : "2020";
-                }
-                if (adding2013) {
-                  return has2020 ? "all" : "2013";
-                }
-                return layout;
-            }
-
-            function addPlatformToConfiguration(platform, configuration) {
-              if (!configuration.platforms.includes(platform)) {
-                configuration.platforms.push(platform);
-              }
-            }
-
-            function updateConfigurationFromString(tryString, configuration) {
-                if (tryString.includes("full")) {
-                  configuration.platforms = ["linux", "macos", "windows"];
-                  configuration.unit_tests = true;
-                  configuration.wpt_layout = "all";
-                  return configuration;
-                }
-
-                if (tryString.includes("linux")) {
-                  addPlatformToConfiguration("linux", configuration);
-                  configuration.unit_tests = true;
-                } else if (tryString.includes("mac")) {
-                  addPlatformToConfiguration("macos", configuration);
-                  configuration.unit_tests = true;
-                } else if (tryString.includes("win")) {
-                  addPlatformToConfiguration("windows", configuration);
-                  configuration.unit_tests = true;
-                }
-
-                if (tryString.includes("wpt")) {
-                  addPlatformToConfiguration("linux", configuration);
-                  if (tryString.includes("2020")) {
-                    configuration.wpt_layout = combineWPTLayoutOptions(configuration.wpt_layout, "2020");
-                  } else {
-                    configuration.wpt_layout = combineWPTLayoutOptions(configuration.wpt_layout, "2013");
-                  }
-                }
-            }
-
-            let configuration = {
-              platforms: [],
-              wpt_layout: "none",
-              unit_tests: false,
-              profile: "release",
-              wpt_tests_to_run: "",
-            };
+            let try_string = "${{ inputs.try_string }}" || "";
 
             if (context.eventName == 'pull_request_target') {
               for (const label of context.payload.pull_request.labels) {
@@ -115,21 +61,15 @@ jobs:
                 }
 
                 console.log("Found label: " + label.name);
-                updateConfigurationFromString(label.name, configuration);
-              }
-            } else {
-              let ref_name = "${{ github.ref_name || 'empty' }}";
-              if (ref_name == "try") {
-                updateConfigurationFromString("full", configuration);
-              } else {
-                updateConfigurationFromString(ref_name, configuration);
+                try_string += " " + label.name.slice(2); // "T-" removed
               }
             }
 
-            console.log(JSON.stringify(configuration));
+            console.log(try_string);
 
-            if (configuration.platforms.length == 0) {
-                return { platforms: [] };
+            // empty try string
+            if (!try_string) {
+              return "";
             }
 
             let username = context.payload.sender.login;
@@ -140,7 +80,7 @@ jobs:
             });
             if (!result.data.user.permissions.push) {
               makeComment('🔒 User @' + username + ' does not have permission to trigger try jobs.');
-              return { platforms: [] };
+              return "";
             }
 
             const url = context.serverUrl +
@@ -148,24 +88,58 @@ jobs:
               "/" + context.repo.repo +
               "/actions/runs/" + context.runId;
             const formattedURL = "[#" + context.runId + "](" + url + ")";
-            let platformsString = configuration.platforms.toString();
-            makeComment("🔨 Triggering try run (" + formattedURL + ") with platforms=" +
-                        platformsString + " and layout=" + configuration.wpt_layout);
-            return configuration;
+            makeComment("🔨 Triggering try run (" + formattedURL + ")");
+
+            return try_string;
+      - uses: actions/checkout@v3
+        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 2
+          sparse-checkout: |
+            etc/try_parser.py
+            third_party/ply
+          sparse-checkout-cone-mode: false
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        with:
+          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          fetch-depth: 2
+          sparse-checkout: |
+            etc/try_parser.py
+            third_party/ply
+          sparse-checkout-cone-mode: false
+      - name: Parse Try string
+        if: ${{ steps.try_string.outputs.result }}
+        id: configuration
+        run: |
+          out=$(python ./etc/try_parser.py ${{ steps.try_string.outputs.result }})
+          echo "result=${out}" >> $GITHUB_OUTPUT
 
   run-try:
-    name: Run Try
+    if: ${{ needs.parse-comment.outputs.try_string }}
     needs: ["parse-comment"]
-    if: ${{ fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
-    uses: ./.github/workflows/main.yml
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ fromJson(needs.parse-comment.outputs.configuration).fail_fast }}
+      matrix:
+        include: ${{ fromJson(needs.parse-comment.outputs.configuration).matrix }}
+    # we need dipatch os because workflows do not support uses: ${}
+    uses: ./.github/workflows/dispatch-os.yml
+    secrets: inherit
     with:
-      configuration: ${{ needs.parse-comment.outputs.configuration }}
+      os: ${{ matrix.os }}
+      wpt-layout: ${{ matrix.wpt_layout }}
+      profile: ${{ matrix.profile }}
+      unit-tests: ${{ matrix.unit_tests }}
+      wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
 
   results:
     name: Results
     needs: ["parse-comment", "run-try"]
     runs-on: ubuntu-latest
-    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
+    if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
       - name: Success
         if: ${{ github.event_name == 'pull_request_target' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -384,6 +384,12 @@ If you need to create a new test file, it should be located in `tests/wpt/mozill
 ./mach test-wpt --manifest-update
 ```
 
+### Running tests via GitHub Actions
+
+Running whole WPT suite is resource intensive and tedious task. Instead of using your computer resources, you can enable Workflows in personal fork and then send your patches to try branch. To make things easier you can use `./mach try` that will automatically send git `HEAD` (patches that are committed in current checkout) to try branch and run full CI build, using same config as it's used for landing things in servo/servo.
+
+For advance try runs see: [try guide](./try.md)
+
 ### Debugging a test
 
 See the [debugging guide](./debugging.md) to get started in how to debug Servo.

--- a/docs/try.md
+++ b/docs/try.md
@@ -1,16 +1,14 @@
-# Try builds
+# Try Guide
 
-Instead of using your computer resources, you can enable Workflows in personal fork and then use try builds to test patches before sanding PR to servo.
+Try runs allows to build and test changes on GitHub CI without requiring code to be reviewed and landed.
 
 ## Triggering try runs
 
 You can trigger try runs via:
 
 - adding `T-` labels on PR (servo organization members only)
-- dispatching workflows from personal fork
-- running `mach try $try_string` command
-
-`mach try` will send git `HEAD` (patches that are committed in current checkout) to try branch.
+- dispatching workflows from GitHub UI on personal fork
+- running `mach try $try_string` command that will send git `HEAD` (patches that are committed in current checkout) to try branch on personal fork.
 
 ## Try strings
 
@@ -23,7 +21,8 @@ Try string can contain:
 ### Options
 
 - `os` (possible values: `linux` (default), `windows` or `mac`)
-- `layout` (selects layout for wpt tests; possible values: `all`, `2020`, `2013`, `none`)
+- `layout` (selects layout for wpt tests; possible values: `all`/`both`, `2020`, `2013`, `none`)
+- `wpt` (additional arguments to be passed to `mach test-wpt` in CI; usually used for limiting testing scope)
 - `unit-tests` (default: `true`)
 - `profile` (`release` (default), `debug`, `production`)
 
@@ -31,12 +30,12 @@ Try string can contain:
 
 - `linux` (does not run any wpt tests)
 - `mac`
-- `win` or `windows`
-- `wpt` or `linux-wpt` (runs wpt tests for `both` layouts on linux)
-- `webgpu` (runs WebGPU CTS on linux with layout2020 and production profile)
+- `win`/`windows`
+- `wpt`/`linux-wpt` (runs wpt tests for `both` layouts on linux)
+- `webgpu` (runs WebGPU CTS on linux)
 - `wpt-2013` or `linux-wpt-2013` (runs wpt tests on `2013` layout)
 - `wpt-2020` or `linux-wpt-2020` (runs wpt tests on `2020` layout)
-- `mac-wpt`
+- `mac-wpt` (runs wpt tests for `both` layouts on mac)
 - `mac-wpt-2013`
 - `mac-wpt-2020`
 

--- a/docs/try.md
+++ b/docs/try.md
@@ -8,17 +8,17 @@ You can trigger try runs via:
 
 - adding `T-` labels on PR (servo organization members only)
 - dispatching workflows from personal fork
-- running `mach try [try string]` command
+- running `mach try $try_string` command
 
-`mach try` will  send git `HEAD` (patches that are committed in current checkout) to try branch.
+`mach try` will send git `HEAD` (patches that are committed in current checkout) to try branch.
 
 ## Try strings
 
 Try string can contain:
 
 - `full`/`try` keyword that will be expanded to `linux mac windows`
-- `fail-fast` as marker keyword that will set [matrix fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to true
-- config tuples: `name(option=value, option2=value)` (`name` is also valid if `name` is preset)
+- `fail-fast` marker keyword that will set [matrix fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to true
+- config tuples: `name[option=value, option2=value]` (`name` is also valid if `name` is preset)
 
 ### Options
 

--- a/docs/try.md
+++ b/docs/try.md
@@ -1,0 +1,43 @@
+# Try builds
+
+Instead of using your computer resources, you can enable Workflows in personal fork and then use try builds to test patches before sanding PR to servo.
+
+## Triggering try runs
+
+You can trigger try runs via:
+
+- adding `T-` labels on PR (servo organization members only)
+- dispatching workflows from personal fork
+- running `mach try [try string]` command
+
+`mach try` will  send git `HEAD` (patches that are committed in current checkout) to try branch.
+
+## Try strings
+
+Try string can contain:
+
+- `full`/`try` keyword that will be expanded to `linux mac windows`
+- `fail-fast` as marker keyword that will set [matrix fail-fast](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) to true
+- config tuples: `name(option=value, option2=value)` (`name` is also valid if `name` is preset)
+
+### Options
+
+- `os` (possible values: `linux` (default), `windows` or `mac`)
+- `layout` (selects layout for wpt tests; possible values: `all`, `2020`, `2013`, `none`)
+- `unit-tests` (default: `true`)
+- `profile` (`release` (default), `debug`, `production`)
+
+### Presets
+
+- `linux` (does not run any wpt tests)
+- `mac`
+- `win` or `windows`
+- `wpt` or `linux-wpt` (runs wpt tests for `both` layouts on linux)
+- `webgpu` (runs WebGPU CTS on linux with layout2020 and production profile)
+- `wpt-2013` or `linux-wpt-2013` (runs wpt tests on `2013` layout)
+- `wpt-2020` or `linux-wpt-2020` (runs wpt tests on `2020` layout)
+- `mac-wpt`
+- `mac-wpt-2013`
+- `mac-wpt-2020`
+
+Using tuple config with presets you can override presets options.

--- a/etc/try_parser.py
+++ b/etc/try_parser.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import json
+from enum import Enum
+from typing import Any, Tuple
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "third_party", "ply"))
+from ply.lex import lex  # noqa: E402
+from ply.yacc import yacc  # noqa: E402
+
+
+tokens = ("STRING",)
+
+literals = ["(", ")", "=", ","]
+
+t_ignore = " \t\r"
+
+
+def t_STRING(t):
+    # r"""('.*'|".*"|[a-zA-Z_0-9\-]+)"""
+    r"""\"([^\\"]+|\\"|\\\\)"|'([^\\']+|\\'|\\\\)'|[a-zA-Z_0-9\-]+"""
+    if t.value[0] in "\"'":
+        t.value = t.value[1:-1].encode().decode("unicode_escape")
+    return t
+
+
+def t_ignore_newline(t):
+    r"\n+"
+    t.lexer.lineno += t.value.count("\n")
+
+
+def t_error(t):
+    print(f"Illegal character {t.value!r} at line {t.lineno}")
+    t.lexer.skip(1)
+
+
+# --------------- Parser ---------------
+
+
+def p_dists(p):
+    """
+    dists : dist
+          | dist ',' dists
+          | dist dists
+    """
+    if len(p) == 4:
+        p[0] = [p[1]] + p[3]
+    elif len(p) == 3:
+        p[0] = [p[1]] + p[2]
+    else:
+        p[0] = [p[1]]
+
+
+def p_dist(p):
+    """
+    dist : STRING
+         | STRING '(' key_value_pairs ')'
+    """
+    # load dict into job config
+    # handle full and try
+    if len(p) == 2:
+        if p[1] in ["full", "try"]:
+            p[0] = [
+                JobConfig("Linux", OS.linux),
+                JobConfig("MacOS", OS.mac),
+                JobConfig("Windows", OS.win)
+            ]
+        elif p[1] in ["fail_fast", "fail-fast"]:
+            p[0] = []
+        else:
+            p[0] = [JobConfig.parse(p[1])]
+    else:
+        p[0] = [JobConfig.parse(p[1], p[3])]
+
+
+def p_key_value_pairs(p):
+    """
+    key_value_pairs : pair
+                    | pair ',' key_value_pairs
+    """
+    # join all pairs into dist
+    p[0] = [p[1]] + p[3] if len(p) == 4 else [p[1]]
+
+
+def p_pair(p):
+    "pair : STRING '=' STRING"
+    p[0] = parse_option(p[1], p[3])
+
+
+def p_error(p):
+    print(f"Syntax error at {p.value!r} at line {p.lineno}")
+
+
+lexer = lex()
+parser = yacc(write_tables=False, debug=False)
+
+# ---------------- Real Stuff -----------------
+
+
+class Layout(str, Enum):
+    none = 'none'
+    layout2013 = '2013'
+    layout2020 = '2020'
+    all = 'all'
+
+    @staticmethod
+    def parse(s: str):
+        s = s.lower()
+        if s == 'none':
+            return Layout.none
+        elif s == 'all' or s == 'both':
+            return Layout.all
+        elif "legacy" in s or "2013" in s:
+            return Layout.layout2013
+        elif "2020" in s:
+            return Layout.layout2020
+        else:
+            return None
+
+
+class OS(str, Enum, ):
+    linux = 'linux'
+    mac = 'mac'
+    win = 'windows'
+
+    @staticmethod
+    def parse(s: str):
+        s = s.lower()
+        if s == 'linux':
+            return OS.linux
+        elif "mac" in s:
+            return OS.mac
+        elif "win" in s:
+            return OS.win
+        else:
+            return None
+
+
+def parse_option(k: str, v: str) -> Tuple[str, Any]:
+    kk = k.lower()
+    if kk == "os":
+        val = OS.parse(v)
+    elif kk in ["layout", "wpt-layout"]:
+        kk = "wpt_layout"
+        val = Layout.parse(v)
+    elif kk in ["unit-tests", "unit-test"]:
+        kk = "unit_tests"
+        val = (v.lower() == "true")
+    elif kk in ["wpt", "wpt_tests_to_run", "wpt-tests-to-run"]:
+        kk = "wpt_tests_to_run"
+        val = v
+    elif kk in ["profile"]:
+        val = v
+    else:
+        raise RuntimeError(f"`{k}` is unknown option.")
+
+    if val is None:
+        raise RuntimeError(f"`{v}` is wrong value for `{k}`.")
+
+    return (kk, val)
+
+
+class JobConfig(object):
+    """
+    Represents one config tuple
+
+    name(os=_, layout=_, ...)
+    """
+
+    def __init__(self, name: str, os: OS, layout: Layout = Layout.none,
+                 profile: str = "release", unit_test: bool = True, wpt: str = ""):
+        self.os: OS = os
+        self.name: str = name
+        self.wpt_layout: Layout = layout
+        self.profile: str = profile
+        self.unit_tests: bool = unit_test
+        self.wpt_tests_to_run: str = wpt
+
+    @staticmethod
+    def parse(name: str, overrides: list[Tuple[str, str]] = []):
+        job = preset(name)
+        if job is None:
+            job = JobConfig(name, OS.linux)
+        for (k, v) in overrides:
+            job.__dict__[k] = v
+        return job
+
+
+# preset from name
+def preset(s: str) -> JobConfig | None:
+    s = s.lower()
+
+    if s == "linux":
+        return JobConfig("Linux", OS.linux)
+    elif s == "mac":
+        return JobConfig("MacOS", OS.mac)
+    elif s in ["win", "windows"]:
+        return JobConfig("Windows", OS.win)
+    elif s in ["wpt", "linux-wpt"]:
+        return JobConfig("Linux WPT", OS.linux, layout=Layout.all)
+    elif s in ["wpt-2013", "linux-wpt-2013"]:
+        return JobConfig("Linux WPT legacy-layout", OS.linux, layout=Layout.layout2013)
+    elif s in ["wpt-2020", "linux-wpt-2020"]:
+        return JobConfig("Linux WPT layout-2020", OS.linux, layout=Layout.layout2020)
+    elif s in ["mac-wpt", "wpt-mac"]:
+        return JobConfig("MacOS WPT", OS.mac, layout=Layout.all)
+    elif s == "mac-wpt-2013":
+        return JobConfig("MacOS WPT legacy-layout", OS.mac, layout=Layout.layout2013)
+    elif s == "mac-wpt-2020":
+        return JobConfig("MacOS WPT layout-2020", OS.mac, layout=Layout.layout2020)
+    elif s == "webgpu":
+        return JobConfig("WebGPU CTS", OS.linux, layout=Layout.layout2020, wpt="_webgpu",
+                         profile="production",  # WebGPU works to slow with debug assert
+                         unit_test=False)  # production profile does not work with unit-tests
+    else:
+        return None
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, (Config, JobConfig)):
+            return o.__dict__
+        return json.JSONEncoder.default(self, o)
+
+
+class Config(object):
+    def __init__(self, s: str | None = None):
+        self.fail_fast: bool = False
+        self.matrix: list[JobConfig] = list()
+        if s:
+            self.parse(s)
+
+    def parse(self, s: str):
+        s = s.strip()
+        if "fail_fast" in s or "fail-fast" in s:
+            self.fail_fast = True
+        # if no input provided default to full build
+        if not s:
+            s = "full"
+        ast = parser.parse(
+            s
+        )
+        # flatten
+        self.matrix = [item for row in ast for item in row]
+
+    def toJSON(self) -> str:
+        return json.dumps(self, cls=Encoder)
+
+
+def main():
+    conf = Config()
+    conf.parse(" ".join(sys.argv[1:]))
+    print(conf.toJSON())
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/try_parser.py
+++ b/etc/try_parser.py
@@ -21,7 +21,7 @@ from ply.yacc import yacc  # noqa: E402
 
 tokens = ("STRING",)
 
-literals = ["(", ")", "=", ","]
+literals = ["[", "]", "=", ","]
 
 t_ignore = " \t\r"
 
@@ -64,9 +64,8 @@ def p_dists(p):
 def p_dist(p):
     """
     dist : STRING
-         | STRING '(' key_value_pairs ')'
+         | STRING '[' key_value_pairs ']'
     """
-    # load dict into job config
     # handle full and try
     if len(p) == 2:
         if p[1] in ["full", "try"]:
@@ -174,7 +173,7 @@ class JobConfig(object):
     """
     Represents one config tuple
 
-    name(os=_, layout=_, ...)
+    name[os=_, layout=_, ...]
     """
 
     def __init__(self, name: str, os: OS, layout: Layout = Layout.none,

--- a/etc/try_parser.py
+++ b/etc/try_parser.py
@@ -27,8 +27,7 @@ t_ignore = " \t\r"
 
 
 def t_STRING(t):
-    # r"""('.*'|".*"|[a-zA-Z_0-9\-]+)"""
-    r"""\"([^\\"]+|\\"|\\\\)"|'([^\\']+|\\'|\\\\)'|[a-zA-Z_0-9\-]+"""
+    r"""\"([^\\"]+|\\"|\\\\)"|'([^\\']+|\\'|\\\\)'|[a-zA-Z_0-9/\-]+"""
     if t.value[0] in "\"'":
         t.value = t.value[1:-1].encode().decode("unicode_escape")
     return t

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -20,11 +20,11 @@ class TestParser(unittest.TestCase):
  "name": "Linux", "wpt_layout": "none", "profile": "release", "unit_tests": true, "wpt_tests_to_run": ""}]}')
 
     def test_tuple1(self):
-        conf = Config("linux(profile='debug')")
+        conf = Config("linux[profile='debug']")
         self.assertEqual(conf.matrix[0].profile, "debug")
 
     def test_tuple2(self):
-        conf = Config("linux(profile=debug, unit-tests=false)")
+        conf = Config("linux[profile=debug, unit-tests=false]")
         self.assertEqual(conf.matrix[0].profile, 'debug')
         self.assertEqual(conf.matrix[0].unit_tests, False)
 

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -10,7 +10,7 @@
 # except according to those terms.
 
 import unittest
-from try_parser import Config
+from try_parser import Config, Layout
 
 
 class TestParser(unittest.TestCase):
@@ -23,10 +23,13 @@ class TestParser(unittest.TestCase):
         conf = Config("linux[profile='debug']")
         self.assertEqual(conf.matrix[0].profile, "debug")
 
-    def test_tuple2(self):
-        conf = Config("linux[profile=debug, unit-tests=false]")
+    def test_tuple5(self):
+        conf = Config("linux[name=linux2020, profile=debug, unit-tests=false,layout=2020, wpt=\"some/wpt/test\"]")
+        self.assertEqual(conf.matrix[0].name, 'linux2020')
         self.assertEqual(conf.matrix[0].profile, 'debug')
         self.assertEqual(conf.matrix[0].unit_tests, False)
+        self.assertEqual(conf.matrix[0].wpt_layout, Layout.layout2020)
+        self.assertEqual(conf.matrix[0].wpt_tests_to_run, "some/wpt/test")
 
     def test_special(self):
         conf = Config("fail-fast try")

--- a/etc/try_parser_test.py
+++ b/etc/try_parser_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import unittest
+from try_parser import Config
+
+
+class TestParser(unittest.TestCase):
+    def test_string(self):
+        self.assertEqual(Config("linux").toJSON(),
+                         '{"fail_fast": false, "matrix": [{"os": "linux",\
+ "name": "Linux", "wpt_layout": "none", "profile": "release", "unit_tests": true, "wpt_tests_to_run": ""}]}')
+
+    def test_tuple1(self):
+        conf = Config("linux(profile='debug')")
+        self.assertEqual(conf.matrix[0].profile, "debug")
+
+    def test_tuple2(self):
+        conf = Config("linux(profile=debug, unit-tests=false)")
+        self.assertEqual(conf.matrix[0].profile, 'debug')
+        self.assertEqual(conf.matrix[0].unit_tests, False)
+
+    def test_special(self):
+        conf = Config("fail-fast try")
+        self.assertEqual(conf.fail_fast, True)
+        self.assertEqual(len(conf.matrix), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -307,5 +307,5 @@ class MachCommands(CommandBase):
         res = call(["git", "push", remote, "--force", "HEAD:try"], env=self.build_env())
         # if we got jobs we need to delete last commit
         if jobs:
-            res += call(["git", "reset", "--hard", "HEAD~1"], env=self.build_env())
+            res += call(["git", "reset", "--soft", "HEAD~1"], env=self.build_env())
         return res

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -325,6 +325,16 @@ class MachCommands(CommandBase):
         print("Running tidy tests...")
         passed = tidy.run_tests() and passed
 
+        def test_try_parser():
+            import unittest
+            verbosity = 1 if logging.getLogger().level >= logging.WARN else 2
+            sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "etc"))
+            import try_parser_test
+            suite = unittest.TestLoader().loadTestsFromModule(try_parser_test)
+            return unittest.TextTestRunner(verbosity=verbosity).run(suite).wasSuccessful()
+        print("Running try_parser tests...")
+        passed = test_try_parser() and passed
+
         print("Running WPT tests...")
         passed = wpt.run_tests() and passed
 


### PR DESCRIPTION
Rebased version of https://github.com/servo/servo/pull/30694.

This PR removes try branches and instead provides unified entry point for all try runs (one single `try` branch). This is achieved using empty commits on try branch that have configuration encoded within commit message. This allows creating more complex try runs. Labels are still operational and are calling presets in try_parser.

Another important addition is usage of matrix which allows us to limit number of concurrent runs and fails-fast option.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://github.com/servo/servo/issues/30667
- [x] There are tests for try_parser

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
