### PR TITLE
dependencies: Update to latest version of `unwind-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6445,8 +6445,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unwind-sys"
-version = "0.1.3"
-source = "git+https://github.com/sfackler/rstack?rev=bd0f3ec#bd0f3eceb9f086a93c1e4c5fbccf1f886effe627"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a81ba64bc45243d442e9bb2a362f303df152b5078c56ce4a0dc7d813c8df91"
 dependencies = [
  "libc",
  "pkg-config",

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -29,6 +29,4 @@ mach = "0.3"
 
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64"))))'.dependencies]
 nix = "0.25"
-# There's a bug in 0.1.3 that prevent proper compilation against rc revisions
-# of libunwind. Depend on the git repository version until 0.1.4 is released.
-unwind-sys = { git = "https://github.com/sfackler/rstack", rev = "bd0f3ec" }
+unwind-sys = "0.1.4"


### PR DESCRIPTION
This allows us to remove the dependency on the git version of
`unwind-sys` necessary for allowing compilation on Fedora 39.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just updates a dependency.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
