### PR TITLE
Fix wpt-sync-from-upstream boolean

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -10,6 +10,7 @@ on:
         required: false
         type: string
       wpt-sync-from-upstream:
+        default: false
         required: false
         type: boolean
       wpt-layout:
@@ -67,11 +68,11 @@ jobs:
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
           python3 ./mach bootstrap-gstreamer
       - name: Sync from upstream WPT
-        if: ${{ inputs.wpt-sync-from-upstream == 'true' }}
+        if: ${{ inputs.wpt-sync-from-upstream }}
         run: |
           ./mach update-wpt --sync --patch
       - name: Run tests
-        if: ${{ inputs.wpt-sync-from-upstream != 'true' }}
+        if: ${{ !inputs.wpt-sync-from-upstream }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${{ inputs.wpt-tests-to-run }} \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
@@ -83,7 +84,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
       - name: Run tests (sync)
-        if: ${{ inputs.wpt-sync-from-upstream == 'true' }}
+        if: ${{ inputs.wpt-sync-from-upstream }}
         run: |
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
@@ -92,7 +93,7 @@ jobs:
             --always-succeed
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
-        if: ${{ always() && inputs.wpt-sync-from-upstream != 'true' }}
+        if: ${{ always() && !inputs.wpt-sync-from-upstream }}
         with:
           name: wpt-filtered-results-linux-${{ inputs.wpt-layout }}
           path: |
@@ -100,14 +101,14 @@ jobs:
             unexpected-test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ failure() && inputs.wpt-sync-from-upstream != 'true' }}
+        if: ${{ failure() && !inputs.wpt-sync-from-upstream }}
         with:
           name: wpt-logs-linux-${{ inputs.wpt-layout }}
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ inputs.wpt-sync-from-upstream == 'true' }}
+        if: ${{ inputs.wpt-sync-from-upstream }}
         with:
           name: wpt-logs-linux-${{ inputs.wpt-layout }}
           path: |
@@ -117,7 +118,7 @@ jobs:
   report-test-results:
     name: Report WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && inputs.wpt-sync-from-upstream != 'true' }}
+    if: ${{ always() && !cancelled() && !inputs.wpt-sync-from-upstream }}
     needs:
       - "linux-wpt"
     steps:


### PR DESCRIPTION
WPT imports were failing because of it.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
