### PR TITLE
Fix bootstrap for python 3.8

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,8 +5,8 @@ blessings == 1.7
 distro == 1.4
 mozinfo == 1.2.1
 mozlog == 7.1.0
-setuptools == 68.2.2; python_version > "3.8"
-setuptools == 65.5.1; python_version <= "3.8"
+setuptools == 68.2.2; python_version >= "3.8"
+setuptools == 65.5.1; python_version < "3.8"
 toml == 0.9.2
 dataclasses == 0.8; python_version < "3.7"
 


### PR DESCRIPTION
It's crazy, but partial revert of https://github.com/servo/servo/pull/30848 makes nightly builds work again.

If same error would be thrown again in the future and the fix would be to reapply patch we should simply update python and end this pain.

Try CI run: https://github.com/servo/servo/actions/runs/7327178383

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
