### PR TITLE
Unfork and upgrade jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,12 +1887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,12 +2943,21 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.3.2"
+version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
 dependencies = [
  "cc",
- "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
  "libc",
 ]
 
@@ -4471,12 +4474,12 @@ name = "profile"
 version = "0.0.1"
 dependencies = [
  "ipc-channel",
+ "jemalloc-sys",
  "libc",
  "profile_traits",
  "regex",
  "serde",
  "serde_json",
- "servo_allocator",
  "servo_config",
  "task_info",
 ]
@@ -5340,6 +5343,7 @@ name = "servo_allocator"
 version = "0.0.1"
 dependencies = [
  "jemalloc-sys",
+ "jemallocator",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ imsz = "0.2"
 indexmap = { version = "2.1.0", features = ["std"] }
 ipc-channel = "0.18"
 itertools = "0.10"
+jemallocator = "0.5.4"
+jemalloc-sys = "0.5.4"
 keyboard-types = "0.6"
 layout_traits = { path = "components/shared/layout" }
 lazy_static = "1.4"

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -10,7 +10,8 @@ publish = false
 path = "lib.rs"
 
 [target.'cfg(not(windows))'.dependencies]
-jemalloc-sys = { version = "0.3.2" }
+jemallocator = { workspace = true }
+jemalloc-sys = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["heapapi"] }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -7,93 +7,24 @@
 #[global_allocator]
 static ALLOC: Allocator = Allocator;
 
-#[cfg(not(windows))]
-pub use jemalloc_sys;
-
 pub use crate::platform::*;
 
 #[cfg(not(windows))]
 mod platform {
-    use std::alloc::{GlobalAlloc, Layout};
-    use std::os::raw::{c_int, c_void};
+    use std::os::raw::c_void;
 
-    use jemalloc_sys as ffi;
+    use jemallocator;
+
+    pub use self::jemallocator::Jemalloc as Allocator;
 
     /// Get the size of a heap block.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {
-        ffi::malloc_usable_size(ptr as *const _)
+        jemallocator::usable_size(ptr)
     }
 
     /// Memory allocation APIs compatible with libc
     pub mod libc_compat {
-        pub use super::ffi::{free, malloc, realloc};
-    }
-
-    pub struct Allocator;
-
-    // The minimum alignment guaranteed by the architecture. This value is used to
-    // add fast paths for low alignment values.
-    #[cfg(all(any(
-        target_arch = "arm",
-        target_arch = "mips",
-        target_arch = "mipsel",
-        target_arch = "powerpc"
-    )))]
-    const MIN_ALIGN: usize = 8;
-    #[cfg(all(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "powerpc64",
-        target_arch = "powerpc64le",
-        target_arch = "mips64",
-        target_arch = "s390x",
-        target_arch = "sparc64"
-    )))]
-    const MIN_ALIGN: usize = 16;
-
-    fn layout_to_flags(align: usize, size: usize) -> c_int {
-        // If our alignment is less than the minimum alignment they we may not
-        // have to pass special flags asking for a higher alignment. If the
-        // alignment is greater than the size, however, then this hits a sort of odd
-        // case where we still need to ask for a custom alignment. See #25 for more
-        // info.
-        if align <= MIN_ALIGN && align <= size {
-            0
-        } else {
-            // Equivalent to the MALLOCX_ALIGN(a) macro.
-            align.trailing_zeros() as _
-        }
-    }
-
-    unsafe impl GlobalAlloc for Allocator {
-        #[inline]
-        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            let flags = layout_to_flags(layout.align(), layout.size());
-            ffi::mallocx(layout.size(), flags) as *mut u8
-        }
-
-        #[inline]
-        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-            if layout.align() <= MIN_ALIGN && layout.align() <= layout.size() {
-                ffi::calloc(1, layout.size()) as *mut u8
-            } else {
-                let flags = layout_to_flags(layout.align(), layout.size()) | ffi::MALLOCX_ZERO;
-                ffi::mallocx(layout.size(), flags) as *mut u8
-            }
-        }
-
-        #[inline]
-        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            let flags = layout_to_flags(layout.align(), layout.size());
-            ffi::sdallocx(ptr as *mut _, layout.size(), flags)
-        }
-
-        #[inline]
-        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-            let flags = layout_to_flags(layout.align(), new_size);
-            ffi::rallocx(ptr as *mut _, new_size, flags) as *mut u8
-        }
+        pub use jemalloc_sys::{free, malloc, realloc};
     }
 }
 

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -25,4 +25,4 @@ regex = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = { workspace = true }
-servo_allocator = { path = "../allocator" }
+jemalloc-sys = { workspace = true }

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -500,7 +500,7 @@ mod system_reporter {
     }
 
     #[cfg(not(target_os = "windows"))]
-    use servo_allocator::jemalloc_sys::mallctl;
+    use jemalloc_sys::mallctl;
 
     #[cfg(not(target_os = "windows"))]
     fn jemalloc_stat(value_name: &str) -> Option<usize> {


### PR DESCRIPTION
This dependency was forked in ##20641 in order to fix the Android build.
Years have gone by and it's quite likely that many things have changed
in the Android toolchain and these dependencies. We can sort out this
issue when getting the Android build working -- or if all else fails,
disable jemalloc for Android. In the meantime, unfork the dependency and
upgrade it.

Fixes #20645.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20645.
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
