### PR TITLE
dependencies: Stop shipping GStreamer binaries on Linux

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -48,25 +48,14 @@ jobs:
         with:
           name: release-binary
           path: release-binary
-      - name: Cache libffi
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ./libffi6_3.2.1-8_amd64.deb
-          key: cache-libffi
-      - name: Download libffi
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
       - name: unPackage binary
         run: tar -xzf release-binary/target.tar.gz
-      - name: Prep test environment
+      - name: Bootstrap dependencies
         run: |
           python3 -m pip install --upgrade pip
           sudo apt update
-          sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libgl1-mesa-dri mesa-vulkan-drivers libegl1-mesa
-          sudo apt install ./libffi6_3.2.1-8_amd64.deb
-          python3 ./mach bootstrap-gstreamer
+          sudo apt install -qy --no-install-recommends mesa-vulkan-drivers
+          python3 ./mach bootstrap
       - name: Sync from upstream WPT
         if: ${{ inputs.wpt-sync-from-upstream }}
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,7 +96,9 @@ jobs:
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies
-        run: sudo apt update && python3 ./mach bootstrap
+        run: |
+          sudo apt update
+          python3 ./mach bootstrap
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all
       - name: Build (${{ inputs.profile }})

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -9,7 +9,6 @@
 
 import os
 import subprocess
-import tempfile
 from typing import Optional, Tuple
 
 import distro
@@ -204,18 +203,6 @@ class Linux(Base):
         if not force and self.is_gstreamer_installed(cross_compilation_target=None):
             return False
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            file_name = os.path.join(temp_dir, GSTREAMER_URL.rsplit('/', maxsplit=1)[-1])
-            util.download_file("Pre-packaged GStreamer binaries", GSTREAMER_URL, file_name)
-
-            print(f"Installing GStreamer packages to {PREPACKAGED_GSTREAMER_ROOT}...")
-            os.makedirs(PREPACKAGED_GSTREAMER_ROOT, exist_ok=True)
-
-            # Extract, but strip one component from the output, because the package includes
-            # a toplevel directory called "./gst/" and we'd like to have the same directory
-            # structure on all platforms.
-            subprocess.check_call(["tar", "xf", file_name, "-C", PREPACKAGED_GSTREAMER_ROOT,
-                                   "--strip-components=2"])
-
-            assert self.is_gstreamer_installed(cross_compilation_target=None)
-            return True
+        raise EnvironmentError(
+            "Bootstrapping GStreamer on Linux is not supported. "
+            + "Please install it using your distribution package manager.")


### PR DESCRIPTION
The binary bundle of GStreamer that we package is not used to compile --
only to run layout tests. It's too old for the APIs that we are using
(as evidenced by needed 1.18 for WebRTC) and nowadays Linux
distributions carry a new version so it's unecessary for our build
machines. No longer using this binary bundle will allow us to upgrade
our GStreamer dependency -- which now has stricter checks that we
are using at least version 1.18.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust the build configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
