### PR TITLE
Fail gracefully when DMG smoketest fails

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -111,7 +111,7 @@ jobs:
           command: python3 ./mach test-unit --${{ inputs.profile }}
       - name: Build mach package
         run: python3 ./mach package --${{ inputs.profile }}
-      - name: Run smoketest for mach package
+      - name: Run DMG smoketest
         uses: nick-fields/retry@v2
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5

--- a/etc/ci/macos_package_smoketest.sh
+++ b/etc/ci/macos_package_smoketest.sh
@@ -24,4 +24,7 @@ grep 'success' /tmp/out
 
 # Clean up.
 popd
-hdiutil detach /Volumes/Servo
+
+hdiutil detach /Volumes/Servo || \
+    echo "WARNING: Could not detach /Volumes/Servo. " \
+         "Please detach with hdiutil manually."


### PR DESCRIPTION
It seems that timing issues (related to MacOS or the GitHub MacOS)
runners can sometimes cause `hdiutil detach` to fail. Instead of having
this cause the entire build to fail, fail gracefully. This is
essentially a non-issue as the CI environment is always cleaned up when
using GitHub Actions.

Fixes #30757.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this fixes a CI issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
