### PR TITLE
bootstrap: Don't try to install Windows Python with `./mach bootstrap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ manually, try the [manual build setup][manual-build].
 
  - Download and run [`rustup-init.exe`](https://win.rustup.rs/) then follow the onscreen instructions.
  - Install [chocolatey](https://chocolatey.org/)
+ - Install [Python 3.11](https://apps.microsoft.com/detail/9NRWMJP3717K?hl=en-US&gl=US)
  - Run `mach bootstrap`
-  - *This will install CMake, Git, Ninja, Python and the Visual Studio 2019 Build Tools
+  - *This will install CMake, Git, Ninja, and the Visual Studio 2019 Build Tools
      via choco in an Administrator console. It can take quite a while.*
   - *If you already have Visual Studio 2019 installed, this may not install all necessary components.
      Please follow the Visual Studio 2019 installation instructions in the [manual setup][manual-build].*

--- a/support/windows/chocolatey.config
+++ b/support/windows/chocolatey.config
@@ -5,7 +5,5 @@
   <package id="llvm"/>
   <package id="wixtoolset" version="3.11.2"/>
   <package id="ninja"/>
-  <package id="python"/>
-  <package id="python3-virtualenv"/>
   <package id="visualstudio2019buildtools" packageParameters="--add Microsoft.VisualStudio.Component.Roslyn.Compiler --add Microsoft.Component.MSBuild --add Microsoft.VisualStudio.Component.CoreBuildTools --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Component.Windows10SDK  --add Microsoft.VisualStudio.Component.Windows10SDK.20348 --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.Redist.14.Latest --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATLMFC --add Microsoft.VisualStudio.Component.TextTemplating --add Microsoft.VisualStudio.Component.VC.CoreIde --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core --add Microsoft.VisualStudio.Workload.VCTools" />
 </packages>


### PR DESCRIPTION
It doesn't make sense to try to install Python using `./mach bootstrap`
since it needs Python to run. Instead separate out Python installation
into its own step in the README.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they adjust build instructions.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
