### PR TITLE
WebGPU: always send exit message to script before exiting

### DIFF
--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -831,13 +831,10 @@ impl<'a> WGPU<'a> {
                         gfx_select!(texture => global.texture_drop(texture, true));
                     },
                     WebGPURequest::Exit(sender) => {
-                        if let Err(e) = self.script_sender.send(WebGPUMsg::Exit) {
-                            warn!("Failed to send WebGPUMsg::Exit to script ({})", e);
-                        }
                         if let Err(e) = sender.send(()) {
                             warn!("Failed to send response to WebGPURequest::Exit ({})", e)
                         }
-                        return;
+                        break;
                     },
                     WebGPURequest::FreeCommandBuffer(command_buffer_id) => {
                         self.error_command_encoders
@@ -888,7 +885,7 @@ impl<'a> WGPU<'a> {
                                     e
                                 )
                                 }
-                                return;
+                                break;
                             },
                         };
                         let adapter = WebGPUAdapter(adapter_id);
@@ -943,7 +940,7 @@ impl<'a> WGPU<'a> {
                                     w
                                 )
                                 }
-                                return;
+                                break;
                             },
                         };
                         let device = WebGPUDevice(id);
@@ -1248,6 +1245,9 @@ impl<'a> WGPU<'a> {
                     },
                 }
             }
+        }
+        if let Err(e) = self.script_sender.send(WebGPUMsg::Exit) {
+            warn!("Failed to send WebGPUMsg::Exit to script ({})", e);
         }
     }
 

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -1694,7 +1694,31 @@
   expected: CRASH
 
 [cts.https.html?q=webgpu:api,operation,adapter,requestDevice:features,known:*]
-  expected: CRASH
+  expected: TIMEOUT
+  [:feature="bgra8unorm-storage"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="texture-compression-etc2"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="texture-compression-astc"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="timestamp-query"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="indirect-first-instance"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="shader-f16"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="rg11b10ufloat-renderable"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:feature="float32-filterable"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,renderPass,renderBundle:*]
   expected: TIMEOUT
@@ -26363,7 +26387,115 @@
   expected: CRASH
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,limits,maxStorageTexturesPerShaderStage:createBindGroupLayout,at_over:*]
-  expected: CRASH
+  expected: [CRASH, TIMEOUT]
+  [:limitTest="underDefault";testValueName="atLimit";visibility=2;order="forward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=2;order="backward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=2;order="shiftByHalf"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=4;order="forward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=4;order="backward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=4;order="shiftByHalf"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=6;order="forward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=6;order="backward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";visibility=6;order="shiftByHalf"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=2;order="forward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=2;order="backward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=2;order="shiftByHalf"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=4;order="forward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=4;order="backward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=4;order="shiftByHalf"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=6;order="forward"]
+    expected: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=6;order="backward"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="underDefault";testValueName="overLimit";visibility=6;order="shiftByHalf"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=2;order="forward"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=2;order="backward"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=2;order="shiftByHalf"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=4;order="forward"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=4;order="backward"]
+    expected: [FAIL, TIMEOUT, NOTRUN]
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=4;order="shiftByHalf"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=6;order="forward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=6;order="backward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="atLimit";visibility=6;order="shiftByHalf"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=2;order="forward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=2;order="backward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=2;order="shiftByHalf"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=4;order="forward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=4;order="backward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=4;order="shiftByHalf"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=6;order="forward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=6;order="backward"]
+    expected: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";visibility=6;order="shiftByHalf"]
+    expected: NOTRUN
+
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,abs:u32:*]
   expected: CRASH
@@ -31605,7 +31737,103 @@
   expected: CRASH
 
 [cts.https.html?q=webgpu:api,operation,adapter,requestDevice:limit,out_of_range:*]
-  expected: CRASH
+  expected: TIMEOUT
+  [:limit="maxTextureDimension1D"]
+    expected: TIMEOUT
+
+  [:limit="maxTextureDimension2D"]
+    expected: NOTRUN
+
+  [:limit="maxTextureDimension3D"]
+    expected: NOTRUN
+
+  [:limit="maxTextureArrayLayers"]
+    expected: NOTRUN
+
+  [:limit="maxBindGroups"]
+    expected: NOTRUN
+
+  [:limit="maxBindGroupsPlusVertexBuffers"]
+    expected: NOTRUN
+
+  [:limit="maxBindingsPerBindGroup"]
+    expected: NOTRUN
+
+  [:limit="maxDynamicUniformBuffersPerPipelineLayout"]
+    expected: NOTRUN
+
+  [:limit="maxDynamicStorageBuffersPerPipelineLayout"]
+    expected: NOTRUN
+
+  [:limit="maxSampledTexturesPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxSamplersPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxStorageBuffersPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxStorageTexturesPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxUniformBuffersPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxUniformBufferBindingSize"]
+    expected: NOTRUN
+
+  [:limit="maxStorageBufferBindingSize"]
+    expected: NOTRUN
+
+  [:limit="minUniformBufferOffsetAlignment"]
+    expected: NOTRUN
+
+  [:limit="minStorageBufferOffsetAlignment"]
+    expected: NOTRUN
+
+  [:limit="maxVertexBuffers"]
+    expected: NOTRUN
+
+  [:limit="maxBufferSize"]
+    expected: NOTRUN
+
+  [:limit="maxVertexAttributes"]
+    expected: NOTRUN
+
+  [:limit="maxVertexBufferArrayStride"]
+    expected: NOTRUN
+
+  [:limit="maxInterStageShaderComponents"]
+    expected: NOTRUN
+
+  [:limit="maxInterStageShaderVariables"]
+    expected: NOTRUN
+
+  [:limit="maxColorAttachments"]
+    expected: NOTRUN
+
+  [:limit="maxColorAttachmentBytesPerSample"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupStorageSize"]
+    expected: NOTRUN
+
+  [:limit="maxComputeInvocationsPerWorkgroup"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupSizeX"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupSizeY"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupSizeZ"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupsPerDimension"]
+    expected: NOTRUN
+
 
 [cts.https.html?q=webgpu:api,validation,createView:aspect:*]
   [:format="rgb10a2uint";aspect="all"]
@@ -35881,7 +36109,103 @@
 
 
 [cts.https.html?q=webgpu:api,operation,adapter,requestDevice:limit,better_than_supported:*]
-  expected: CRASH
+  expected: TIMEOUT
+  [:limit="maxTextureDimension3D"]
+    expected: NOTRUN
+
+  [:limit="maxTextureArrayLayers"]
+    expected: NOTRUN
+
+  [:limit="maxBindGroups"]
+    expected: NOTRUN
+
+  [:limit="maxBindGroupsPlusVertexBuffers"]
+    expected: NOTRUN
+
+  [:limit="maxBindingsPerBindGroup"]
+    expected: NOTRUN
+
+  [:limit="maxDynamicUniformBuffersPerPipelineLayout"]
+    expected: NOTRUN
+
+  [:limit="maxDynamicStorageBuffersPerPipelineLayout"]
+    expected: NOTRUN
+
+  [:limit="maxSampledTexturesPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxSamplersPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxStorageBuffersPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxStorageTexturesPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxUniformBuffersPerShaderStage"]
+    expected: NOTRUN
+
+  [:limit="maxUniformBufferBindingSize"]
+    expected: NOTRUN
+
+  [:limit="maxStorageBufferBindingSize"]
+    expected: NOTRUN
+
+  [:limit="minUniformBufferOffsetAlignment"]
+    expected: NOTRUN
+
+  [:limit="minStorageBufferOffsetAlignment"]
+    expected: NOTRUN
+
+  [:limit="maxVertexBuffers"]
+    expected: NOTRUN
+
+  [:limit="maxBufferSize"]
+    expected: NOTRUN
+
+  [:limit="maxVertexAttributes"]
+    expected: NOTRUN
+
+  [:limit="maxVertexBufferArrayStride"]
+    expected: NOTRUN
+
+  [:limit="maxInterStageShaderComponents"]
+    expected: NOTRUN
+
+  [:limit="maxInterStageShaderVariables"]
+    expected: NOTRUN
+
+  [:limit="maxColorAttachments"]
+    expected: NOTRUN
+
+  [:limit="maxColorAttachmentBytesPerSample"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupStorageSize"]
+    expected: NOTRUN
+
+  [:limit="maxComputeInvocationsPerWorkgroup"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupSizeX"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupSizeY"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupSizeZ"]
+    expected: NOTRUN
+
+  [:limit="maxComputeWorkgroupsPerDimension"]
+    expected: NOTRUN
+
+  [:limit="maxTextureDimension1D"]
+    expected: [PASS, TIMEOUT, NOTRUN]
+
+  [:limit="maxTextureDimension2D"]
+    expected: [PASS, TIMEOUT, NOTRUN]
+
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:type:*]
   expected: CRASH


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When WebGPU exits, including when it internally encounters an error, always first send the `Exit` message to script before exiting. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://github.com/servo/servo/issues/30915

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
