### PR TITLE
bootstrap: Print more output when installing dependencies

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -5,11 +5,8 @@
 import os
 import platform
 import site
-import shutil
+import subprocess
 import sys
-
-from subprocess import Popen
-from tempfile import TemporaryFile
 
 SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
 TOP_DIR = os.path.abspath(os.path.join(SCRIPT_PATH, ".."))
@@ -103,31 +100,12 @@ def _get_virtualenv_lib_dir():
 
 
 def _process_exec(args):
-    with TemporaryFile() as out:
-        with TemporaryFile() as err:
-            process = Popen(args, stdout=out, stderr=err)
-            process.wait()
-            if process.returncode:
-                print('"%s" failed with error code %d:' % ('" "'.join(args), process.returncode))
-
-                if sys.version_info >= (3, 0):
-                    stdout = sys.stdout.buffer
-                else:
-                    stdout = sys.stdout
-
-                print('Output:')
-                out.seek(0)
-                stdout.flush()
-                shutil.copyfileobj(out, stdout)
-                stdout.flush()
-
-                print('Error:')
-                err.seek(0)
-                stdout.flush()
-                shutil.copyfileobj(err, stdout)
-                stdout.flush()
-
-                sys.exit(1)
+    try:
+        subprocess.check_output(args, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as exception:
+        print(exception.output.decode(sys.stdout.encoding))
+        print(f"Process failed with return code: {exception.returncode}")
+        sys.exit(1)
 
 
 def _activate_virtualenv(topdir):
@@ -137,6 +115,7 @@ def _activate_virtualenv(topdir):
     if os.environ.get("VIRTUAL_ENV") != virtualenv_path:
         venv_script_path = os.path.join(virtualenv_path, _get_virtualenv_script_dir())
         if not os.path.exists(virtualenv_path):
+            print(" * Setting up virtual environment...")
             _process_exec([python, "-m", "venv", "--system-site-packages", virtualenv_path])
 
         # This general approach is taken from virtualenv's `activate_this.py`.
@@ -178,6 +157,7 @@ def _activate_virtualenv(topdir):
         except OSError:
             pass
 
+        print(f" * Installing Python requirements from {req_path}...")
         _process_exec([python, "-m", "pip", "install", "-I", "-r", req_path])
 
         open(marker_path, 'w').close()

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -102,8 +102,8 @@ class Base:
         if not force and shutil.which("taplo") is not None:
             return False
 
-        if subprocess.call(["cargo", "install", "taplo-cli", "--locked"],
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
+        print(" * Installing taplo...")
+        if subprocess.call(["cargo", "install", "taplo-cli", "--locked"]) != 0:
             raise EnvironmentError("Installation of taplo failed.")
 
         return True
@@ -114,8 +114,8 @@ class Base:
         env = dict(os.environ)
         env["CARGO_BUILD_RUSTC"] = "rustc"
 
-        if subprocess.call(["cargo", "install", "--path", "support/crown"],
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env) != 0:
+        print(" * Installing crown (the Servo linter)...")
+        if subprocess.call(["cargo", "install", "--path", "support/crown"], env=env) != 0:
             raise EnvironmentError("Installation of crown failed.")
 
         return True


### PR DESCRIPTION
It's often the case (especially with the taplo installation and on
Windows) that bootstrap is doing lots of stuff in the background for a
long amount of time. Without output it's hard to tell what exactly is
going on. This change adds more output to this process as well as
removing some Python 2.x era code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just modifies bootstrap.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
