### PR TITLE
Fix installation instructions for Python on Debian-like distributions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ manually, try the [manual build setup][manual-build].
 
 - Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - Install Python
-    - **Debian-like:** Run `sudo apt install python3-pip`
+    - **Debian-like:** Run `sudo apt install python3-pip python3-venv`
     - **Fedora:** Run `sudo dnf install python3 python3-pip python3-devel`
     - **Arch:** Run `sudo pacman -S --needed python python-pip`
     - **Gentoo:** Run `sudo emerge dev-python/pip`


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR fixes the installation of Python on Debian-like distributions. Specifically, it appears that the installation of python3-env is missing, so I have added it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they adjust build instructions

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
