### PR TITLE
Fix the build on Ubuntu 20.04

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -58,7 +58,6 @@ class MachCommands(CommandBase):
     def build(self, build_type: BuildType, jobs=None, params=None, no_package=False,
               verbose=False, very_verbose=False, libsimpleservo=False, **kwargs):
         opts = params or []
-        has_media_stack = "media-gstreamer" in self.features
 
         if build_type.is_release():
             opts += ["--release"]
@@ -74,7 +73,7 @@ class MachCommands(CommandBase):
         if very_verbose:
             opts += ["-vv"]
 
-        env = self.build_env(is_build=True)
+        env = self.build_env()
         self.ensure_bootstrapped()
         self.ensure_clobbered()
 
@@ -173,7 +172,7 @@ class MachCommands(CommandBase):
                     status = 1
 
                 # copy needed gstreamer DLLs in to servo.exe dir
-                if has_media_stack:
+                if self.enable_media:
                     print("Packaging gstreamer DLLs")
                     if not package_gstreamer_dlls(env, servo_exe_dir, target_triple):
                         status = 1
@@ -189,7 +188,7 @@ class MachCommands(CommandBase):
                 servo_bin_dir = os.path.dirname(servo_path)
                 assert os.path.exists(servo_bin_dir)
 
-                if has_media_stack:
+                if self.enable_media:
                     print("Packaging gstreamer dylibs")
                     if not package_gstreamer_dylibs(self.cross_compile_target, servo_path):
                         return 1

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -26,11 +26,6 @@ class Base:
     def set_gstreamer_environment_variables_if_necessary(
         self, env: Dict[str, str], cross_compilation_target: Optional[str], check_installation=True
     ):
-        # Environment variables are not needed when cross-compiling on any platform other
-        # than Windows. GStreamer for Android is handled elsewhere.
-        if cross_compilation_target and (not self.is_windows or "android" in cross_compilation_target):
-            return
-
         # We may not need to update environment variables if GStreamer is installed
         # for the system on Linux.
         gstreamer_root = self.gstreamer_root(cross_compilation_target)
@@ -51,14 +46,6 @@ class Base:
                 f"gst-plugin-scanner{self.executable_suffix()}",
             )
             env["GST_PLUGIN_SYSTEM_PATH"] = os.path.join(gstreamer_root, "lib", "gstreamer-1.0")
-
-        # If we are not cross-compiling GStreamer must be installed for the system. In
-        # the cross-compilation case, we might be picking it up from another directory.
-        if check_installation and not self.is_gstreamer_installed(cross_compilation_target):
-            raise FileNotFoundError(
-                "GStreamer libraries not found (>= version 1.18)."
-                "Please see installation instructions in README.md"
-            )
 
     def gstreamer_root(self, _cross_compilation_target: Optional[str]) -> Optional[str]:
         raise NotImplementedError("Do not know how to get GStreamer path for platform.")

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -12,7 +12,6 @@ import subprocess
 from typing import Optional, Tuple
 
 import distro
-from .. import util
 from .base import Base
 
 # Please keep these in sync with the packages on the wiki, using the instructions below
@@ -75,8 +74,6 @@ XBPS_PKGS = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
 
 GSTREAMER_URL = \
     "https://github.com/servo/servo-build-deps/releases/download/linux/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz"
-PREPACKAGED_GSTREAMER_ROOT = \
-    os.path.join(util.get_target_dir(), "dependencies", "gstreamer")
 
 
 class Linux(Base):
@@ -154,7 +151,6 @@ class Linux(Base):
                                       f"{self.distro}, please file a bug")
 
         installed_something = self.install_non_gstreamer_dependencies(force)
-        installed_something |= self._platform_bootstrap_gstreamer(force)
         return installed_something
 
     def install_non_gstreamer_dependencies(self, force: bool) -> bool:
@@ -199,18 +195,9 @@ class Linux(Base):
         return True
 
     def gstreamer_root(self, cross_compilation_target: Optional[str]) -> Optional[str]:
-        if cross_compilation_target:
-            return None
-        if os.path.exists(PREPACKAGED_GSTREAMER_ROOT):
-            return PREPACKAGED_GSTREAMER_ROOT
-        # GStreamer might be installed system-wide, but we do not return a root in this
-        # case because we don't have to update environment variables.
         return None
 
-    def _platform_bootstrap_gstreamer(self, force: bool) -> bool:
-        if not force and self.is_gstreamer_installed(cross_compilation_target=None):
-            return False
-
+    def _platform_bootstrap_gstreamer(self, _force: bool) -> bool:
         raise EnvironmentError(
             "Bootstrapping GStreamer on Linux is not supported. "
             + "Please install it using your distribution package manager.")

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -266,7 +266,7 @@ class PostBuildCommands(CommandBase):
                     else:
                         copy2(full_name, destination)
 
-        env = self.build_env(is_build=True)
+        env = self.build_env()
         returncode = self.run_cargo_build_like_command("doc", params, env=env, **kwargs)
         if returncode:
             return returncode

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -258,9 +258,7 @@ class MachCommands(CommandBase):
         if nocapture:
             args += ["--", "--nocapture"]
 
-        # We are setting is_build here to true, because running `cargo test` can trigger builds.
-        env = self.build_env(is_build=True)
-
+        env = self.build_env()
         return self.run_cargo_build_like_command(
             "bench" if bench else "test",
             args,


### PR DESCRIPTION
Ubuntu 20.04 doesn't have a new enough version of GStreamer, so
automatically disable media when running on that platform.

This also cleans up the media detection a bit, putting the result in a
`enable-media` variable and moving some of the logic into the build
scripts themselves rather than the platform module.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust the build configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
