### PR TITLE
bootstrap: Improve pip dependency resolution

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,8 +3,8 @@
 
 blessings == 1.7
 distro == 1.4
-mozinfo == 1.2.1
-mozlog == 7.1.0
+mozinfo == 1.2.3
+mozlog == 8.0.0
 setuptools == 68.2.2; python_version >= "3.8"
 setuptools == 65.5.1; python_version < "3.8"
 toml == 0.9.2
@@ -27,7 +27,7 @@ pyOpenSSL == 23.0.0
 PyGithub == 1.58.1
 
 # For Python3 compatibility
-six == 1.15
+six == 1.16
 
 # For sending build notifications.
 notify-py == 0.3.42


### PR DESCRIPTION
We can now use the "new" pip resolver which should prevent the
installation of conflicting packages. Also, take this opportunity to
make bootstrap more resilient. Hash all dependencies to detect
situations where a newer marker file has been installed, but for an
older branch. This should ensure that dependencies are up to date even
when switching back and forth between older and new branches.

This also updates some dependencies to be the same as the ones used for
WPT tests, which is an issue caught be the resolver.

Fixes #10611.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #10611.
- [x] These changes do not require tests because they fix an issue with bootstrap.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
