### PR TITLE
Nix: bump nixpkgs to nixos-23.05 (except gnumake)

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -2,7 +2,7 @@
 # NOTE: This does not work offline or for nix-build
 
 with import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {
@@ -17,6 +17,9 @@ let
       cargo = rustToolchain;
       rustc = rustToolchain;
     };
+    pkgs_gnumake_4_3 = import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz";
+    }) {};
 in
 clangStdenv.mkDerivation rec {
   name = "servo-env";
@@ -38,11 +41,12 @@ clangStdenv.mkDerivation rec {
     # Build utilities
     cmake dbus gcc git pkg-config which llvm perl yasm m4
     (python3.withPackages (ps: with ps; [virtualenv pip dbus]))
+
     # This pins gnumake to 4.3 since 4.4 breaks jobserver
     # functionality in mozjs and causes builds to be extremely
     # slow as it behaves as if -j1 was passed.
     # See https://github.com/servo/mozjs/issues/375
-    gnumake
+    pkgs_gnumake_4_3.gnumake
 
     # crown needs to be in our Cargo workspace so we can test it with `mach test`. This means its
     # dependency tree is listed in the main Cargo.lock, making it awkward to build with Nix because

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -2,7 +2,7 @@
 # NOTE: This does not work offline or for nix-build
 
 with import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/46ae0210ce163b3cba6c7da08840c1d63de9c701.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {
@@ -17,9 +17,6 @@ let
       cargo = rustToolchain;
       rustc = rustToolchain;
     };
-    pkgs_clangStdenv = import (builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
-    }) {};
     pkgs_gnumake_4_3 = import (builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz";
     }) {};
@@ -111,7 +108,7 @@ clangStdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.AppKit
   ]);
 
-  LIBCLANG_PATH = pkgs_clangStdenv.llvmPackages.clang-unwrapped.lib + "/lib/";
+  LIBCLANG_PATH = llvmPackages.clang-unwrapped.lib + "/lib/";
 
   # Allow cargo to download crates
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -2,7 +2,7 @@
 # NOTE: This does not work offline or for nix-build
 
 with import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/46ae0210ce163b3cba6c7da08840c1d63de9c701.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {
@@ -17,6 +17,9 @@ let
       cargo = rustToolchain;
       rustc = rustToolchain;
     };
+    pkgs_clangStdenv = import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
+    }) {};
     pkgs_gnumake_4_3 = import (builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz";
     }) {};
@@ -108,7 +111,7 @@ clangStdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.AppKit
   ]);
 
-  LIBCLANG_PATH = llvmPackages.clang-unwrapped.lib + "/lib/";
+  LIBCLANG_PATH = pkgs_clangStdenv.llvmPackages.clang-unwrapped.lib + "/lib/";
 
   # Allow cargo to download crates
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
This patch bumps nixpkgs to the tip of nixos-23.05, which is the best we can do right now:

- nixos-unstable (<https://github.com/NixOS/nixpkgs/commit/46ae0210ce163b3cba6c7da08840c1d63de9c701>) fails with “Non floating-type complex?”
    - #30587
- nixos-23.11 (<https://github.com/NixOS/nixpkgs/commit/6723fa4e4f1a30d42a633bef5eb01caeb281adc3>) fails with “Non floating-type complex?”
    - #30587
- nixos-23.05 (<https://github.com/NixOS/nixpkgs/commit/70bdadeb94ffc8806c0570eb5c2695ad29f0e421>) works, but we still need to pin gnumake
    - servo/mozjs#375
- nixos-unstable with clangStdenv + LIBCLANG_PATH from nixos-23.05 fails with missing @GLIBC_2.38 symbols

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31053

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the build would fail on NixOS without them