### PR TITLE
Nix: bump nixpkgs to nixos-unstable

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -32,7 +32,11 @@ let
       allowedRequisites =
         lib.mapNullable (rs: rs ++ [ bintools ]) (stdenv.allowedRequisites or null);
     };
-    stdenv = mkStdenvWithLibc llvmPackages_11.stdenv glibc;
+
+    # We need clangStdenv with:
+    # - clang < 16 (#30587)
+    # - glibc 2.38 (#31054)
+    stdenv = mkStdenvWithLibc llvmPackages_15.stdenv glibc;
 in
 stdenv.mkDerivation rec {
   name = "servo-env";
@@ -121,7 +125,7 @@ stdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.AppKit
   ]);
 
-  LIBCLANG_PATH = llvmPackages_11.clang-unwrapped.lib + "/lib/";
+  LIBCLANG_PATH = llvmPackages_15.clang-unwrapped.lib + "/lib/";
 
   # Allow cargo to download crates
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -23,8 +23,9 @@ let
 
     # We need clangStdenv with:
     # - clang < 16 (#30587)
+    # - clang < 15 (#31059)
     # - glibc 2.38 (#31054)
-    llvmPackages = llvmPackages_15;
+    llvmPackages = llvmPackages_14;
     stdenv = llvmPackages.stdenv;
 in
 stdenv.mkDerivation rec {

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -17,9 +17,6 @@ let
       cargo = rustToolchain;
       rustc = rustToolchain;
     };
-    pkgs_clang_11 = import (builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/70bdadeb94ffc8806c0570eb5c2695ad29f0e421.tar.gz";
-    }) {};
     pkgs_gnumake_4_3 = import (builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz";
     }) {};
@@ -35,7 +32,7 @@ let
       allowedRequisites =
         lib.mapNullable (rs: rs ++ [ bintools ]) (stdenv.allowedRequisites or null);
     };
-    stdenv = mkStdenvWithLibc pkgs_clang_11.clangStdenv glibc;
+    stdenv = mkStdenvWithLibc llvmPackages_11.stdenv glibc;
 in
 stdenv.mkDerivation rec {
   name = "servo-env";
@@ -124,7 +121,7 @@ stdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.AppKit
   ]);
 
-  LIBCLANG_PATH = pkgs_clang_11.llvmPackages.clang-unwrapped.lib + "/lib/";
+  LIBCLANG_PATH = llvmPackages_11.clang-unwrapped.lib + "/lib/";
 
   # Allow cargo to download crates
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -21,22 +21,11 @@ let
       url = "https://github.com/NixOS/nixpkgs/archive/6adf48f53d819a7b6e15672817fa1e78e5f4e84f.tar.gz";
     }) {};
 
-    mkStdenvWithLibc = stdenv: libc: let
-      bintools = stdenv.cc.bintools.override {
-        inherit libc;
-      };
-    in stdenv.override {
-      cc = stdenv.cc.override {
-        inherit libc bintools;
-      };
-      allowedRequisites =
-        lib.mapNullable (rs: rs ++ [ bintools ]) (stdenv.allowedRequisites or null);
-    };
-
     # We need clangStdenv with:
     # - clang < 16 (#30587)
     # - glibc 2.38 (#31054)
-    stdenv = mkStdenvWithLibc llvmPackages_15.stdenv glibc;
+    llvmPackages = llvmPackages_15;
+    stdenv = llvmPackages.stdenv;
 in
 stdenv.mkDerivation rec {
   name = "servo-env";
@@ -125,7 +114,7 @@ stdenv.mkDerivation rec {
     darwin.apple_sdk.frameworks.AppKit
   ]);
 
-  LIBCLANG_PATH = llvmPackages_15.clang-unwrapped.lib + "/lib/";
+  LIBCLANG_PATH = llvmPackages.clang-unwrapped.lib + "/lib/";
 
   # Allow cargo to download crates
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
This patch bumps nixpkgs to the tip of nixos-unstable (<https://github.com/NixOS/nixpkgs/commit/46ae0210ce163b3cba6c7da08840c1d63de9c701>), except for gnumake, fixing problems that seem to be caused by building servoshell against old versions of libEGL and/or glibc.

We also bump clang to version 14, the last version unaffected by #30587 and #31059.

Tested on:

- [x] NixOS 23.11
- [x] NixOS 23.05
- [x] Ubuntu 23.10 (modulo #31060)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31054

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the build would fail on NixOS without them