### PR TITLE
build: Simplify GStreamer shared object copying

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -35,8 +35,7 @@ from servo.command_base import (
     is_macosx,
     is_windows,
 )
-from servo.build_commands import copy_dependencies
-from servo.gstreamer import macos_gst_root
+from servo.build_commands import copy_gstreamer_dylibs
 from servo.util import delete, get_target_dir
 
 # Note: mako cannot be imported at the top level because it breaks mach bootstrap
@@ -207,9 +206,7 @@ class PackageCommands(CommandBase):
             change_prefs(dir_to_resources, "macosx")
 
             print("Finding dylibs and relinking")
-            dmg_binary = path.join(content_dir, "servo")
-            dir_to_gst_lib = path.join(macos_gst_root(), 'lib', '')
-            copy_dependencies(dmg_binary, lib_dir, dir_to_gst_lib)
+            copy_gstreamer_dylibs(path.join(content_dir, "servo"))
 
             print("Adding version to Credits.rtf")
             version_command = [binary_path, '--version']

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -56,6 +56,9 @@ class Base:
     def executable_suffix(self) -> str:
         return ""
 
+    def shared_library_name(self, name: str) -> str:
+        raise NotImplementedError("Platform does not have shared object suffix implementation.")
+
     def _platform_bootstrap(self, _force: bool) -> bool:
         raise NotImplementedError("Bootstrap installation detection not yet available.")
 

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -85,6 +85,9 @@ class Linux(Base):
     def library_path_variable_name(self):
         return "LD_LIBRARY_PATH"
 
+    def shared_library_name(self, name: str):
+        return f"lib{name}.so"
+
     @staticmethod
     def get_distro_and_version() -> Tuple[str, str]:
         distrib = distro.name()

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -29,6 +29,9 @@ class MacOS(Base):
     def library_path_variable_name(self):
         return "DYLD_LIBRARY_PATH"
 
+    def shared_library_name(self, name: str) -> str:
+        return f"lib{name}.dylib"
+
     def gstreamer_root(self, cross_compilation_target: Optional[str]) -> Optional[str]:
         # We do not support building with gstreamer while cross-compiling on MacOS.
         if cross_compilation_target or not os.path.exists(GSTREAMER_ROOT):

--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -41,6 +41,9 @@ class Windows(Base):
     def executable_suffix(self):
         return ".exe"
 
+    def shared_library_name(self, name: str) -> str:
+        return f"{name}.dll"
+
     def library_path_variable_name(self):
         return "LIB"
 

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -10,8 +10,8 @@
 import json
 import os
 import os.path as path
+import shutil
 import subprocess
-from shutil import copytree, rmtree, copy2
 from typing import List
 
 import mozdebug
@@ -261,10 +261,10 @@ class PostBuildCommands(CommandBase):
                     destination = path.join(docs, name)
                     if path.isdir(full_name):
                         if path.exists(destination):
-                            rmtree(destination)
-                        copytree(full_name, destination)
+                            shutil.rmtree(destination)
+                        shutil.copytree(full_name, destination)
                     else:
-                        copy2(full_name, destination)
+                        shutil.copy2(full_name, destination)
 
         env = self.build_env()
         returncode = self.run_cargo_build_like_command("doc", params, env=env, **kwargs)
@@ -273,4 +273,4 @@ class PostBuildCommands(CommandBase):
 
         static = path.join(self.context.topdir, "etc", "doc.servo.org")
         for name in os.listdir(static):
-            copy2(path.join(static, name), path.join(docs, name))
+            shutil.copy2(path.join(static, name), path.join(docs, name))


### PR DESCRIPTION
Add a new mach command to run only the post-build steps of copying
GStreamer shared objects. This allows more easily making improvements to
this step.

In addition make a few platform-specific changes:
 1. Simplify the way that dylib dependencies are chased and remove the rpath
    adjustment code. It was unused with recent GStreamer.
 2. Use exactly the same code when packaging dylibs for `./mach package`
    as for the post build action.
 3. For Windows only call vcvarsall before copying dependencies. This
    isn't necessary for the build.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this shouldn't change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
