### PR TITLE
Fix underflow in PerformanceResourceTiming API

### DIFF
--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -113,7 +113,7 @@ impl PerformanceResourceTiming {
                 DOMString::from(url.into_string()),
                 DOMString::from("resource"),
                 resource_timing.start_time as f64,
-                (resource_timing.response_end - resource_timing.start_time) as f64,
+                resource_timing.response_end as f64 - resource_timing.start_time as f64,
             ),
             initiator_type: initiator_type,
             next_hop: next_hop,


### PR DESCRIPTION
[servo.org](https://servo.org/) crashes in debug builds after #31020, because we take the difference of two u64 values before converting that to f64. This patch fixes that by converting the values to f64 before subtracting.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31062

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes require tests, but our CI does not support testing debug builds yet