### PR TITLE
ci: Install Ubuntu dependencies for fake audio output

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -51,6 +51,10 @@ jobs:
           path: release-binary
       - name: unPackage binary
         run: tar -xzf release-binary/target.tar.gz
+      # These dependencies are necessary to get dummy audio output on the
+      # GitHub Actions runner.
+      - name: Install audio dependencies
+        run: sudo apt-get install pulseaudio jackd2 alsa-utils dbus-x11
       - name: Bootstrap dependencies
         run: |
           python3 -m pip install --upgrade pip


### PR DESCRIPTION
Before running tests, try to install some dependencies in order to allow
fake audio output on the GitHub runner. This is a speculative fix for
flaky webaudio tests.

Fix found here: https://github.com/actions/runner-images/issues/1114

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #___ (GitHub issue number if applicable)
- [x] These changes do not require tests because this is a CI change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
