### PR TITLE
Fix Intermittent CRASH in AudioBuffer

### DIFF
--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -262,7 +262,7 @@ impl AudioBufferMethods for AudioBuffer {
         let cx = GlobalScope::get_cx();
         let channel_number = channel_number as usize;
         let offset = start_in_channel as usize;
-        let mut dest = Vec::with_capacity(destination.len());
+        let mut dest = vec![0.0_f32; bytes_to_copy];
 
         // We either copy form js_channels or shared_channels.
         let js_channel = &self.js_channels.borrow()[channel_number];


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

FIX https://github.com/servo/servo/issues/31065

These changes fix a regression introduced by https://github.com/servo/servo/pull/30990. The previous code was using `extend_from_slice` on the vec, while the new code using the typed array is using `copy_from_slice` on the underlying slice, hence the crash caused by the empty vec.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #31065 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
