### PR TITLE
fix conditional logic that enables native bluetooth

### DIFF
--- a/components/bluetooth/adapter.rs
+++ b/components/bluetooth/adapter.rs
@@ -5,17 +5,17 @@
 use std::error::Error;
 use std::sync::Arc;
 
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_adapter::Adapter as BluetoothAdapterAndroid;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_device::Device as BluetoothDeviceAndroid;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_discovery_session::DiscoverySession as BluetoothDiscoverySessionAndroid;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothAdapter as BluetoothAdapterMac;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothDevice as BluetoothDeviceMac;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothDiscoverySession as BluetoothDiscoverySessionMac;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_adapter::FakeBluetoothAdapter;
@@ -23,30 +23,30 @@ use blurmock::fake_adapter::FakeBluetoothAdapter;
 use blurmock::fake_device::FakeBluetoothDevice;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_adapter::BluetoothAdapter as BluetoothAdapterBluez;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as BluetoothDiscoverySessionBluez;
 
 use super::bluetooth::{BluetoothDevice, BluetoothDiscoverySession};
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothDevice as BluetoothDeviceEmpty;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::EmptyAdapter as BluetoothAdapterEmpty;
 use super::macros::get_inner_and_call;
@@ -55,16 +55,16 @@ use super::macros::get_inner_and_call_test_func;
 
 #[derive(Clone, Debug)]
 pub enum BluetoothAdapter {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     Bluez(Arc<BluetoothAdapterBluez>),
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     Android(Arc<BluetoothAdapterAndroid>),
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     Mac(Arc<BluetoothAdapterMac>),
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     Empty(Arc<BluetoothAdapterEmpty>),
     #[cfg(feature = "bluetooth-test")]
@@ -72,28 +72,28 @@ pub enum BluetoothAdapter {
 }
 
 impl BluetoothAdapter {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
         let bluez_adapter = BluetoothAdapterBluez::init()?;
         Ok(Self::Bluez(Arc::new(bluez_adapter)))
     }
 
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
         let blurdroid_adapter = BluetoothAdapterAndroid::get_adapter()?;
         Ok(Self::Android(Arc::new(blurdroid_adapter)))
     }
 
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
         let mac_adapter = BluetoothAdapterMac::init()?;
         Ok(Self::Mac(Arc::new(mac_adapter)))
     }
 
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     pub fn new() -> Result<BluetoothAdapter, Box<dyn Error>> {
         let adapter = BluetoothAdapterEmpty::init()?;
@@ -111,20 +111,15 @@ impl BluetoothAdapter {
 
     pub fn get_devices(&self) -> Result<Vec<BluetoothDevice>, Box<dyn Error>> {
         match self {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             BluetoothAdapter::Bluez(inner) => {
                 let device_list = inner.get_device_list()?;
                 Ok(device_list
                     .into_iter()
-                    .map(|device| {
-                        BluetoothDevice::Bluez(BluetoothDeviceBluez::new_empty(
-                            self.0.clone(),
-                            device,
-                        ))
-                    })
+                    .map(|device| BluetoothDevice::Bluez(BluetoothDeviceBluez::new(device).into()))
                     .collect())
             },
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             BluetoothAdapter::Android(inner) => {
                 let device_list = inner.get_device_list()?;
                 Ok(device_list
@@ -137,7 +132,7 @@ impl BluetoothAdapter {
                     })
                     .collect())
             },
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             BluetoothAdapter::Mac(inner) => {
                 let device_list = inner.get_device_list()?;
                 Ok(device_list
@@ -151,9 +146,9 @@ impl BluetoothAdapter {
                     .collect())
             },
             #[cfg(not(any(
-                all(target_os = "linux", feature = "bluetooth"),
-                all(target_os = "android", feature = "bluetooth"),
-                all(target_os = "macos", feature = "bluetooth")
+                all(target_os = "linux", feature = "native-bluetooth"),
+                all(target_os = "android", feature = "native-bluetooth"),
+                all(target_os = "macos", feature = "native-bluetooth")
             )))]
             BluetoothAdapter::Empty(inner) => {
                 let device_list = inner.get_device_list()?;
@@ -201,24 +196,22 @@ impl BluetoothAdapter {
 
     pub fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<dyn Error>> {
         let discovery_session = match self {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
-            BluetoothAdapter::Bluez(inner) => {
-                BluetoothDiscoverySession::Bluez(Arc::new(
-                    BluetoothDiscoverySessionBluez::create_session(inner.get_id())?,
-                ));
-            },
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
+            BluetoothAdapter::Bluez(inner) => BluetoothDiscoverySession::Bluez(Arc::new(
+                BluetoothDiscoverySessionBluez::create_session(inner.get_id())?,
+            )),
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             BluetoothAdapter::Android(inner) => BluetoothDiscoverySession::Android(Arc::new(
                 BluetoothDiscoverySessionAndroid::create_session(inner.clone())?,
             )),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             BluetoothAdapter::Mac(_) => {
                 BluetoothDiscoverySession::Mac(Arc::new(BluetoothDiscoverySessionMac {}))
             },
             #[cfg(not(any(
-                all(target_os = "linux", feature = "bluetooth"),
-                all(target_os = "android", feature = "bluetooth"),
-                all(target_os = "macos", feature = "bluetooth")
+                all(target_os = "linux", feature = "native-bluetooth"),
+                all(target_os = "android", feature = "native-bluetooth"),
+                all(target_os = "macos", feature = "native-bluetooth")
             )))]
             BluetoothAdapter::Empty(_) => {
                 BluetoothDiscoverySession::Empty(Arc::new(BluetoothDiscoverySessionEmpty {}))

--- a/components/bluetooth/bluetooth.rs
+++ b/components/bluetooth/bluetooth.rs
@@ -6,25 +6,25 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
 
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_device::Device as BluetoothDeviceAndroid;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_discovery_session::DiscoverySession as BluetoothDiscoverySessionAndroid;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_gatt_characteristic::Characteristic as BluetoothGATTCharacteristicAndroid;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_gatt_descriptor::Descriptor as BluetoothGATTDescriptorAndroid;
-#[cfg(all(target_os = "android", feature = "bluetooth"))]
+#[cfg(all(target_os = "android", feature = "native-bluetooth"))]
 use blurdroid::bluetooth_gatt_service::Service as BluetoothGATTServiceAndroid;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothDevice as BluetoothDeviceMac;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothDiscoverySession as BluetoothDiscoverySessionMac;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicMac;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothGATTDescriptor as BluetoothGATTDescriptorMac;
-#[cfg(all(target_os = "macos", feature = "bluetooth"))]
+#[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
 use blurmac::BluetoothGATTService as BluetoothGATTServiceMac;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_characteristic::FakeBluetoothGATTCharacteristic;
@@ -36,46 +36,46 @@ use blurmock::fake_device::FakeBluetoothDevice;
 use blurmock::fake_discovery_session::FakeBluetoothDiscoverySession;
 #[cfg(feature = "bluetooth-test")]
 use blurmock::fake_service::FakeBluetoothGATTService;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_device::BluetoothDevice as BluetoothDeviceBluez;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_discovery_session::BluetoothDiscoverySession as BluetoothDiscoverySessionBluez;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_gatt_characteristic::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicBluez;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_gatt_descriptor::BluetoothGATTDescriptor as BluetoothGATTDescriptorBluez;
-#[cfg(all(target_os = "linux", feature = "bluetooth"))]
+#[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
 use blurz::bluetooth_gatt_service::BluetoothGATTService as BluetoothGATTServiceBluez;
 
 pub use super::adapter::BluetoothAdapter;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothDevice as BluetoothDeviceEmpty;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothDiscoverySession as BluetoothDiscoverySessionEmpty;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothGATTCharacteristic as BluetoothGATTCharacteristicEmpty;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothGATTDescriptor as BluetoothGATTDescriptorEmpty;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 use super::empty::BluetoothGATTService as BluetoothGATTServiceEmpty;
 use super::macros::get_inner_and_call;
@@ -88,16 +88,16 @@ const NOT_SUPPORTED_ON_MOCK_ERROR: &'static str =
 
 #[derive(Debug)]
 pub enum BluetoothDiscoverySession {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     Bluez(Arc<BluetoothDiscoverySessionBluez>),
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     Android(Arc<BluetoothDiscoverySessionAndroid>),
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     Mac(Arc<BluetoothDiscoverySessionMac>),
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     Empty(Arc<BluetoothDiscoverySessionEmpty>),
     #[cfg(feature = "bluetooth-test")]
@@ -106,16 +106,16 @@ pub enum BluetoothDiscoverySession {
 
 #[derive(Clone, Debug)]
 pub enum BluetoothDevice {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     Bluez(Arc<BluetoothDeviceBluez>),
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     Android(Arc<BluetoothDeviceAndroid>),
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     Mac(Arc<BluetoothDeviceMac>),
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     Empty(Arc<BluetoothDeviceEmpty>),
     #[cfg(feature = "bluetooth-test")]
@@ -124,16 +124,16 @@ pub enum BluetoothDevice {
 
 #[derive(Clone, Debug)]
 pub enum BluetoothGATTService {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     Bluez(Arc<BluetoothGATTServiceBluez>),
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     Android(Arc<BluetoothGATTServiceAndroid>),
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     Mac(Arc<BluetoothGATTServiceMac>),
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     Empty(Arc<BluetoothGATTServiceEmpty>),
     #[cfg(feature = "bluetooth-test")]
@@ -142,16 +142,16 @@ pub enum BluetoothGATTService {
 
 #[derive(Clone, Debug)]
 pub enum BluetoothGATTCharacteristic {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     Bluez(Arc<BluetoothGATTCharacteristicBluez>),
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     Android(Arc<BluetoothGATTCharacteristicAndroid>),
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     Mac(Arc<BluetoothGATTCharacteristicMac>),
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     Empty(Arc<BluetoothGATTCharacteristicEmpty>),
     #[cfg(feature = "bluetooth-test")]
@@ -160,16 +160,16 @@ pub enum BluetoothGATTCharacteristic {
 
 #[derive(Clone, Debug)]
 pub enum BluetoothGATTDescriptor {
-    #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+    #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
     Bluez(Arc<BluetoothGATTDescriptorBluez>),
-    #[cfg(all(target_os = "android", feature = "bluetooth"))]
+    #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
     Android(Arc<BluetoothGATTDescriptorAndroid>),
-    #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+    #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
     Mac(Arc<BluetoothGATTDescriptorMac>),
     #[cfg(not(any(
-        all(target_os = "linux", feature = "bluetooth"),
-        all(target_os = "android", feature = "bluetooth"),
-        all(target_os = "macos", feature = "bluetooth")
+        all(target_os = "linux", feature = "native-bluetooth"),
+        all(target_os = "android", feature = "native-bluetooth"),
+        all(target_os = "macos", feature = "native-bluetooth")
     )))]
     Empty(Arc<BluetoothGATTDescriptorEmpty>),
     #[cfg(feature = "bluetooth-test")]
@@ -425,22 +425,22 @@ impl BluetoothDevice {
 impl BluetoothGATTService {
     fn create_service(device: BluetoothDevice, service: String) -> BluetoothGATTService {
         match device {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             BluetoothDevice::Bluez(_bluez_device) => {
                 BluetoothGATTService::Bluez(Arc::new(BluetoothGATTServiceBluez::new(service)))
             },
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             BluetoothDevice::Android(android_device) => BluetoothGATTService::Android(Arc::new(
                 BluetoothGATTServiceAndroid::new(android_device, service),
             )),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             BluetoothDevice::Mac(mac_device) => BluetoothGATTService::Mac(Arc::new(
                 BluetoothGATTServiceMac::new(mac_device, service),
             )),
             #[cfg(not(any(
-                all(target_os = "linux", feature = "bluetooth"),
-                all(target_os = "android", feature = "bluetooth"),
-                all(target_os = "macos", feature = "bluetooth")
+                all(target_os = "linux", feature = "native-bluetooth"),
+                all(target_os = "android", feature = "native-bluetooth"),
+                all(target_os = "macos", feature = "native-bluetooth")
             )))]
             BluetoothDevice::Empty(_device) => {
                 BluetoothGATTService::Empty(Arc::new(BluetoothGATTServiceEmpty::new(service)))
@@ -528,24 +528,24 @@ impl BluetoothGATTCharacteristic {
         characteristic: String,
     ) -> BluetoothGATTCharacteristic {
         match service {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             BluetoothGATTService::Bluez(_bluez_service) => BluetoothGATTCharacteristic::Bluez(
                 Arc::new(BluetoothGATTCharacteristicBluez::new(characteristic)),
             ),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             BluetoothGATTService::Android(android_service) => {
                 BluetoothGATTCharacteristic::Android(Arc::new(
                     BluetoothGATTCharacteristicAndroid::new(android_service, characteristic),
                 ))
             },
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             BluetoothGATTService::Mac(mac_service) => BluetoothGATTCharacteristic::Mac(Arc::new(
                 BluetoothGATTCharacteristicMac::new(mac_service, characteristic),
             )),
             #[cfg(not(any(
-                all(target_os = "linux", feature = "bluetooth"),
-                all(target_os = "android", feature = "bluetooth"),
-                all(target_os = "macos", feature = "bluetooth")
+                all(target_os = "linux", feature = "native-bluetooth"),
+                all(target_os = "android", feature = "native-bluetooth"),
+                all(target_os = "macos", feature = "native-bluetooth")
             )))]
             BluetoothGATTService::Empty(_service) => BluetoothGATTCharacteristic::Empty(Arc::new(
                 BluetoothGATTCharacteristicEmpty::new(characteristic),
@@ -654,27 +654,27 @@ impl BluetoothGATTDescriptor {
         descriptor: String,
     ) -> BluetoothGATTDescriptor {
         match characteristic {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             BluetoothGATTCharacteristic::Bluez(_bluez_characteristic) => {
                 BluetoothGATTDescriptor::Bluez(Arc::new(BluetoothGATTDescriptorBluez::new(
                     descriptor,
                 )))
             },
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             BluetoothGATTCharacteristic::Android(android_characteristic) => {
                 BluetoothGATTDescriptor::Android(Arc::new(BluetoothGATTDescriptorAndroid::new(
                     android_characteristic,
                     descriptor,
                 )))
             },
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             BluetoothGATTCharacteristic::Mac(_mac_characteristic) => {
                 BluetoothGATTDescriptor::Mac(Arc::new(BluetoothGATTDescriptorMac::new(descriptor)))
             },
             #[cfg(not(any(
-                all(target_os = "linux", feature = "bluetooth"),
-                all(target_os = "android", feature = "bluetooth"),
-                all(target_os = "macos", feature = "bluetooth")
+                all(target_os = "linux", feature = "native-bluetooth"),
+                all(target_os = "android", feature = "native-bluetooth"),
+                all(target_os = "macos", feature = "native-bluetooth")
             )))]
             BluetoothGATTCharacteristic::Empty(_characteristic) => BluetoothGATTDescriptor::Empty(
                 Arc::new(BluetoothGATTDescriptorEmpty::new(descriptor)),

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -5,9 +5,9 @@
 pub mod adapter;
 pub mod bluetooth;
 #[cfg(not(any(
-    all(target_os = "linux", feature = "bluetooth"),
-    all(target_os = "android", feature = "bluetooth"),
-    all(target_os = "macos", feature = "bluetooth")
+    all(target_os = "linux", feature = "native-bluetooth"),
+    all(target_os = "android", feature = "native-bluetooth"),
+    all(target_os = "macos", feature = "native-bluetooth")
 )))]
 mod empty;
 mod macros;

--- a/components/bluetooth/macros.rs
+++ b/components/bluetooth/macros.rs
@@ -5,15 +5,15 @@
 macro_rules! get_inner_and_call(
     ($enum_value: expr, $enum_type: ident, $function_name: ident) => {
         match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             &$enum_type::Bluez(ref bluez) => bluez.$function_name(),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             &$enum_type::Android(ref android) => android.$function_name(),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             &$enum_type::Mac(ref mac) => mac.$function_name(),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
+            #[cfg(not(any(all(target_os = "linux", feature = "native-bluetooth"),
+                          all(target_os = "android", feature = "native-bluetooth"),
+                          all(target_os = "macos", feature = "native-bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name(),
             #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name(),
@@ -22,15 +22,15 @@ macro_rules! get_inner_and_call(
 
     (@with_bluez_offset, $enum_value: expr, $enum_type: ident, $function_name: ident) => {
         match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             &$enum_type::Bluez(ref bluez) => bluez.$function_name(None),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             &$enum_type::Android(ref android) => android.$function_name(),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             &$enum_type::Mac(ref mac) => mac.$function_name(),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
+            #[cfg(not(any(all(target_os = "linux", feature = "native-bluetooth"),
+                          all(target_os = "android", feature = "native-bluetooth"),
+                          all(target_os = "macos", feature = "native-bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name(),
             #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name(),
@@ -39,15 +39,15 @@ macro_rules! get_inner_and_call(
 
     ($enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
         match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             &$enum_type::Bluez(ref bluez) => bluez.$function_name($value),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             &$enum_type::Android(ref android) => android.$function_name($value),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             &$enum_type::Mac(ref mac) => mac.$function_name($value),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
+            #[cfg(not(any(all(target_os = "linux", feature = "native-bluetooth"),
+                          all(target_os = "android", feature = "native-bluetooth"),
+                          all(target_os = "macos", feature = "native-bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name($value),
             #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name($value),
@@ -56,15 +56,15 @@ macro_rules! get_inner_and_call(
 
     (@with_bluez_offset, $enum_value: expr, $enum_type: ident, $function_name: ident, $value: expr) => {
         match $enum_value {
-            #[cfg(all(target_os = "linux", feature = "bluetooth"))]
+            #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
             &$enum_type::Bluez(ref bluez) => bluez.$function_name($value, None),
-            #[cfg(all(target_os = "android", feature = "bluetooth"))]
+            #[cfg(all(target_os = "android", feature = "native-bluetooth"))]
             &$enum_type::Android(ref android) => android.$function_name($value),
-            #[cfg(all(target_os = "macos", feature = "bluetooth"))]
+            #[cfg(all(target_os = "macos", feature = "native-bluetooth"))]
             &$enum_type::Mac(ref mac) => mac.$function_name($value),
-            #[cfg(not(any(all(target_os = "linux", feature = "bluetooth"),
-                          all(target_os = "android", feature = "bluetooth"),
-                          all(target_os = "macos", feature = "bluetooth"))))]
+            #[cfg(not(any(all(target_os = "linux", feature = "native-bluetooth"),
+                          all(target_os = "android", feature = "native-bluetooth"),
+                          all(target_os = "macos", feature = "native-bluetooth"))))]
             &$enum_type::Empty(ref empty) => empty.$function_name($value),
             #[cfg(feature = "bluetooth-test")]
             &$enum_type::Mock(ref fake) => fake.$function_name($value),


### PR DESCRIPTION
PR #30974 integrated `servo/devices` repo into servo codebase. `servo/devices` exposed the `bluetooth`
feature to conditionally compile native bluetooth support for the target platform. In servo, this feature is indirectly enabled via the `native-bluetooth` feature exposed by `components/bluetooth`. When `servo/devices` was integrated to servo, the conditional code was not updated to use the `native-bluetooth` feature directly.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they re-enable code that used to be compiled before #30974. Existing tests should hopefully catch integration issues missed by #30974 which upgrades the dependencies.