### PR TITLE
build: Don't add the `neon` feature for arm and aarch64

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -527,12 +527,6 @@ class CommandBase(object):
         if not (self.config["build"]["ccache"] == ""):
             env['CCACHE'] = self.config["build"]["ccache"]
 
-        # Ensure Rust uses hard floats and SIMD on ARM devices
-        if self.cross_compile_target and (
-            self.cross_compile_target.startswith('arm')
-                or self.cross_compile_target.startswith('aarch64')):
-            env['RUSTFLAGS'] += " -C target-feature=+neon"
-
         env["CARGO_TARGET_DIR"] = servo.util.get_target_dir()
 
         # Work around https://github.com/servo/servo/issues/24446


### PR DESCRIPTION
This was enabled to allow using the simd / std::simd / packed-simd crate
in the glyph cache [1][2]. Support for simd in the gfx crate was removed
though [3], so this flag is not really doing anything -- and the Android
build is currently broken. Plus, it's unclear what target features we
can enable using stable Rust. We can explore adding neon support when
Android is working again.

This is part of a long-term effort to remove build complication and make
it so that `cargo build` is equivalent to `./mach build`.

1. https://github.com/servo/servo/pull/10916
2. https://github.com/servo/servo/pull/10900
3. https://github.com/servo/servo/pull/24304

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
