### PR TITLE
build: Only set PATH for GStreamer

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -498,9 +498,13 @@ class CommandBase(object):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
 
+        # If we are installing on MacOS and Windows, we need to make sure that GStreamer's
+        # `pkg-config` is on the path and takes precedence over other `pkg-config`s.
         if self.enable_media and not self.is_android_build:
-            servo.platform.get().set_gstreamer_environment_variables_if_necessary(
-                env, cross_compilation_target=self.cross_compile_target)
+            platform = servo.platform.get()
+            gstreamer_root = platform.gstreamer_root(cross_compilation_target=self.cross_compile_target)
+            if gstreamer_root:
+                util.prepend_paths_to_env(env, "PATH", os.path.join(gstreamer_root, "bin"))
 
         effective_target = self.cross_compile_target or servo.platform.host_triple()
         if "msvc" in effective_target:

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -23,30 +23,6 @@ class Base:
         self.is_linux = False
         self.is_macos = False
 
-    def set_gstreamer_environment_variables_if_necessary(
-        self, env: Dict[str, str], cross_compilation_target: Optional[str], check_installation=True
-    ):
-        # We may not need to update environment variables if GStreamer is installed
-        # for the system on Linux.
-        gstreamer_root = self.gstreamer_root(cross_compilation_target)
-        if gstreamer_root:
-            util.prepend_paths_to_env(env, "PATH", os.path.join(gstreamer_root, "bin"))
-            util.prepend_paths_to_env(
-                env, "PKG_CONFIG_PATH", os.path.join(gstreamer_root, "lib", "pkgconfig")
-            )
-            util.prepend_paths_to_env(
-                env,
-                self.library_path_variable_name(),
-                os.path.join(gstreamer_root, "lib"),
-            )
-            env["GST_PLUGIN_SCANNER"] = os.path.join(
-                gstreamer_root,
-                "libexec",
-                "gstreamer-1.0",
-                f"gst-plugin-scanner{self.executable_suffix()}",
-            )
-            env["GST_PLUGIN_SYSTEM_PATH"] = os.path.join(gstreamer_root, "lib", "gstreamer-1.0")
-
     def gstreamer_root(self, _cross_compilation_target: Optional[str]) -> Optional[str]:
         raise NotImplementedError("Do not know how to get GStreamer path for platform.")
 
@@ -65,18 +41,23 @@ class Base:
         )
 
     def is_gstreamer_installed(self, cross_compilation_target: Optional[str]) -> bool:
-        env = os.environ.copy()
-        self.set_gstreamer_environment_variables_if_necessary(
-            env, cross_compilation_target, check_installation=False)
-        return (
-            subprocess.call(
-                ["pkg-config", "--atleast-version=1.18", "gstreamer-1.0"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
+        gstreamer_root = self.gstreamer_root(cross_compilation_target)
+        if gstreamer_root:
+            pkg_config = os.path.join(gstreamer_root, "bin", "pkg-config")
+        else:
+            pkg_config = "pkg-config"
+
+        try:
+            return (
+                subprocess.call(
+                    [pkg_config, "--atleast-version=1.18", "gstreamer-1.0"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                == 0
             )
-            == 0
-        )
+        except FileNotFoundError:
+            return False
 
     def bootstrap(self, force: bool):
         installed_something = self._platform_bootstrap(force)

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -36,23 +36,9 @@ class MacOS(Base):
         return GSTREAMER_ROOT
 
     def is_gstreamer_installed(self, cross_compilation_target: Optional[str]) -> bool:
-        if not super().is_gstreamer_installed(cross_compilation_target):
-            return False
-
         # Servo only supports the official GStreamer distribution on MacOS.
-        env = os.environ.copy()
-        self.set_gstreamer_environment_variables_if_necessary(
-            env, cross_compilation_target, check_installation=False
-        )
-        gst_lib_dir = subprocess.check_output(
-            ["pkg-config", "--variable=libdir", "gstreamer-1.0"], env=env
-        )
-        if not gst_lib_dir.startswith(bytes(GSTREAMER_ROOT, "utf-8")):
-            print("GStreamer is installed, but not the official packages.\n"
-                  "Run `./mach bootstrap-gtstreamer` or install packages from "
-                  "https://gstreamer.freedesktop.org/")
-            return False
-        return True
+        # Make sure we use the right `pkg-config`.
+        return not cross_compilation_target and os.path.exists(GSTREAMER_ROOT)
 
     def _platform_bootstrap(self, _force: bool) -> bool:
         installed_something = False


### PR DESCRIPTION
The documentation [^1][^2] claims that this is the only environment variable that
needs to be set before build.

[^1]: https://docs.rs/gstreamer/latest/gstreamer/#gstreamer-binaries-1
[^2]:  https://docs.rs/gstreamer/latest/gstreamer/#gstreamer-binaries

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this shouldn't change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
