### PR TITLE
crown: Add a cargo config.toml file

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,10 +71,6 @@ jobs:
           choco install wixtoolset
           echo "C:\\Program Files (x86)\\WiX Toolset v3.11\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Bootstrap
-        env:
-          # We need to override the rustc set in cargo/config.toml, because at
-          # this point crown is not installed yet.
-          RUSTC: "rustc"
         run: |
           python -m pip install --upgrade pip
           python mach fetch

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -96,13 +96,8 @@ class Base:
         return True
 
     def install_crown(self, force: bool) -> bool:
-        # We need to override the rustc set in cargo/config.toml because crown
-        # may not be installed yet.
-        env = dict(os.environ)
-        env["CARGO_BUILD_RUSTC"] = "rustc"
-
         print(" * Installing crown (the Servo linter)...")
-        if subprocess.call(["cargo", "install", "--path", "support/crown"], env=env) != 0:
+        if subprocess.call(["cargo", "install", "--path", "support/crown"]) != 0:
             raise EnvironmentError("Installation of crown failed.")
 
         return True

--- a/support/crown/.cargo/config.toml
+++ b/support/crown/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc = "rustc"


### PR DESCRIPTION
This makes it more foolproof to install crown from inside the Servo
directory, because the root Servo config.toml overrides the rustc to use
crown (an obvious circular dependency).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
