### PR TITLE
ci: Set LLVM_PATH when building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           python3 ./mach bootstrap
+      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Compile docs
         run: python3 ./mach doc
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           python3 ./mach bootstrap
-      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+      - name: Set LIBCLANG_PATH # This is needed for bindgen in mozangle.
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Compile docs
         run: python3 ./mach doc


### PR DESCRIPTION
This is needed on 22.04 runners (that we started using in https://github.com/servo/servo/pull/31088).

Fixes docs building.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
