### PR TITLE
build: Use `--keep-going` in `./mach doc`

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -266,6 +266,11 @@ class PostBuildCommands(CommandBase):
                     else:
                         copy2(full_name, destination)
 
+        # Documentation build errors shouldn't cause the entire build to fail. This
+        # prevents issues with dependencies from breaking our documentation build,
+        # with the downside that it hides documentation issues.
+        params.insert(0, "--keep-going")
+
         env = self.build_env()
         returncode = self.run_cargo_build_like_command("doc", params, env=env, **kwargs)
         if returncode:


### PR DESCRIPTION
The documentation build for `gstreamer-gl-x11` depends on nightly Rust
for some reason, which breaks our doc build. Use `--keep-going` to
prevent breakage in dependencies from breaking our doc build. This
unfortunately hides issues in our own documentation build.

NB: It isn't possible to exclude dependencies with `--exclude` unless
you are using `--workspace`. We would probably like to do that, but we
have crates with the same name, preventing using `--workspace`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31109.
- [x] These changes do not require tests because they are a build fix.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
