### PR TITLE
mach: Don't print anything when deps are up-to-date

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -141,8 +141,6 @@ def install_virtual_env_requirements(project_path: str, python: str, virtualenv_
                        "-r", requirements_paths[2]])
         with open(marker_path, "w") as marker_file:
             marker_file.write(requirements_hash)
-    else:
-        print(" * Python requirements up to date.")
 
 
 def _activate_virtualenv(topdir):


### PR DESCRIPTION
I added this print statement, but after using `mach` for a while with
it, I think it is far too chatty. This change just removes the line.
Information is only printed when dependencies are installed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
