### PR TITLE
layout: Convert layout internal display to inline for replaced elements

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -172,6 +172,7 @@ fn traverse_element<'dom, Node>(
         },
         Display::GeneratingBox(display) => {
             let contents = replaced.map_or(Contents::OfElement, Contents::Replaced);
+            let display = display.used_value_for_contents(&contents);
             let box_slot = element.element_box_slot();
             let info = NodeAndStyleInfo::new(element, style);
             handler.handle_element(&info, display, contents, box_slot);

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -679,7 +679,7 @@ where
                             )
                         },
                         Err(_replaced) => {
-                            panic!("We don't handle this yet.");
+                            unreachable!("Replaced should not have a LayoutInternal display type.");
                         },
                     };
 

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-211.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-211.xht.ini
@@ -1,2 +1,2 @@
 [table-anonymous-objects-211.xht]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
@@ -1,85 +1,9 @@
 [table-model-fixup-2.html]
-  expected: CRASH
-  [Replaced elements inside a table cannot be table-row and are considered inline -- input elements (top)]
-    expected: FAIL
-
-  [Replaced elements inside a table cannot be table-row and are considered inline -- img elements (top)]
-    expected: FAIL
-
   [Replaced elements inside a table cannot be table-column and are considered inline -- input elements (width)]
-    expected: FAIL
-
-  [Replaced elements inside a table cannot be table-column and are considered inline -- input elements (top)]
-    expected: FAIL
-
-  [Replaced elements inside a table cannot be table-column and are considered inline -- img elements (top)]
     expected: FAIL
 
   [Replaced elements inside a table cannot be table-cell and are considered inline -- input elements (width)]
     expected: FAIL
 
-  [Replaced elements inside a table cannot be table-cell and are considered inline -- input elements (top)]
-    expected: FAIL
-
-  [Replaced elements inside a table cannot be table-cell and are considered inline -- img elements (top)]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row and are considered inline -- input=text elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row and are considered inline -- input=button elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row and are considered inline -- input=file elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row and are considered inline -- img elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row-group and are considered inline -- input=text elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row-group and are considered inline -- input=button elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row-group and are considered inline -- input=file elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row-group and are considered inline -- img elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-column and are considered inline inline -- input=text elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-column and are considered inline -- input=button elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-column and are considered inline -- input=file elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-column and are considered inline -- img elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-cell and are considered inline -- input=text elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-cell and are considered inline -- input=button elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-cell and are considered inline -- input=file elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-cell and are considered inline -- img elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-caption and are considered inline -- input=text elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-caption and are considered inline -- input=button elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-caption and are considered inline -- input=file elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-caption and are considered inline -- img elements]
+  [Replaced elements inside a table cannot be table-row and are considered inline -- input elements (width)]
     expected: FAIL


### PR DESCRIPTION
Replaced elements should never be able to have a layout internal
display, according to the specification. This change makes it so that
the used value of replaced element's display is always inline, as the
specification says.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
