### PR TITLE
Layout: use `Au` in `ContentSizes` 

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -915,7 +915,8 @@ impl FloatBox {
                                 containing_block.inline_size - pbm_sums.inline_sum();
                             non_replaced
                                 .inline_content_sizes(layout_context)
-                                .shrink_to_fit(available_size)
+                                .shrink_to_fit(available_size.into())
+                                .into()
                         });
                         let inline_size = tentative_inline_size
                             .clamp_between_extremums(min_box_size.inline, max_box_size.inline);

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2359,7 +2359,8 @@ impl<'a> ContentSizesComputation<'a> {
                     self.containing_block_writing_mode,
                 );
 
-                self.current_line.min_content += (self.pending_whitespace + outer.min_content.into()).into();
+                self.current_line.min_content +=
+                    (self.pending_whitespace + outer.min_content.into()).into();
                 self.current_line.max_content += outer.max_content;
                 self.pending_whitespace = Length::zero();
                 self.had_non_whitespace_content_yet = true;
@@ -2377,18 +2378,14 @@ impl<'a> ContentSizesComputation<'a> {
     }
 
     fn line_break_opportunity(&mut self) {
-        self.paragraph.min_content = std::cmp::max(
-            self.paragraph.min_content,
-            self.current_line.min_content,
-        );
+        self.paragraph.min_content =
+            std::cmp::max(self.paragraph.min_content, self.current_line.min_content);
     }
 
     fn forced_line_break(&mut self) {
         self.line_break_opportunity();
-        self.paragraph.max_content = std::cmp::max(
-            self.paragraph.max_content,
-            self.current_line.max_content,
-        );
+        self.paragraph.max_content =
+            std::cmp::max(self.paragraph.max_content, self.current_line.max_content);
     }
 
     /// Compute the [`ContentSizes`] of the given [`InlineFormattingContext`].

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2380,12 +2380,14 @@ impl<'a> ContentSizesComputation<'a> {
     fn line_break_opportunity(&mut self) {
         self.paragraph.min_content =
             std::cmp::max(self.paragraph.min_content, self.current_line.min_content);
+        self.current_line.min_content = Au::zero();
     }
 
     fn forced_line_break(&mut self) {
         self.line_break_opportunity();
         self.paragraph.max_content =
             std::cmp::max(self.paragraph.max_content, self.current_line.max_content);
+        self.current_line.max_content = Au::zero();
     }
 
     /// Compute the [`ContentSizes`] of the given [`InlineFormattingContext`].

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -962,7 +962,6 @@ impl NonReplacedFormattingContext {
                         .into()
                 }),
             };
-
             (clearance, (margin_inline_start, margin_inline_end)) =
                 solve_clearance_and_inline_margins_avoiding_floats(
                     &sequential_layout_state,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -962,6 +962,7 @@ impl NonReplacedFormattingContext {
                         .into()
                 }),
             };
+
             (clearance, (margin_inline_start, margin_inline_end)) =
                 solve_clearance_and_inline_margins_avoiding_floats(
                     &sequential_layout_state,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -563,7 +563,8 @@ impl HoistedAbsolutelyPositionedBox {
                             cbis - anchor - pbm.padding_border_sums.inline - margin_sum;
                         non_replaced
                             .inline_content_sizes(layout_context)
-                            .shrink_to_fit(available_size)
+                            .shrink_to_fit(available_size.into())
+                            .into()
                     });
 
                     // If the tentative used inline size is greater than ‘max-inline-size’,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -241,8 +241,8 @@ impl ReplacedContent {
             .inline
             .unwrap_or(Length::zero());
         ContentSizes {
-            min_content: inline,
-            max_content: inline,
+            min_content: inline.into(),
+            max_content: inline.into(),
         }
     }
 

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -120,10 +120,8 @@ pub(crate) fn outer_inline(
         None => get_content_size().map(|content_box_size| {
             match box_sizing {
                 // Clamp to 'min-width' and 'max-width', which are sizing the…
-                BoxSizing::ContentBox => {
-                    (clamp(content_box_size.into()) + pb_lengths.into()).into()
-                },
-                BoxSizing::BorderBox => clamp((content_box_size + pb_lengths.into()).into()).into(),
+                BoxSizing::ContentBox => clamp(content_box_size.into()) + pb_lengths.into(),
+                BoxSizing::BorderBox => clamp(content_box_size + pb_lengths.into()),
             }
         }),
     };

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -95,7 +95,7 @@ impl<'a> TableLayout<'a> {
 
         // https://drafts.csswg.org/css-tables/#used-min-width-of-table
         // > The used min-width of a table is the greater of the resolved min-width, CAPMIN, and GRIDMIN.
-        let used_min_width_of_table = grid_min_inline_size.max(min_content_sizes.inline);
+        let used_min_width_of_table = grid_min_inline_size.max(min_content_sizes.inline.into());
 
         // https://drafts.csswg.org/css-tables/#used-width-of-table
         // > The used width of a table depends on the columns and captions widths as follows:
@@ -105,10 +105,10 @@ impl<'a> TableLayout<'a> {
         // > * If the table-root has 'width: auto', the used width is the greater of min(GRIDMAX,
         // >   the table’s containing block width), the used min-width of the table.
         let used_width_of_table = match content_box_size.inline {
-            LengthPercentage(length_percentage) => length_percentage.max(used_min_width_of_table),
+            LengthPercentage(length_percentage) => length_percentage.max(used_min_width_of_table.into()),
             Auto => grid_max_inline_size
-                .min(containing_block.inline_size)
-                .max(used_min_width_of_table),
+                .min(containing_block.inline_size.into())
+                .max(used_min_width_of_table).into(),
         };
 
         self.assignable_width = used_width_of_table.into();
@@ -186,7 +186,7 @@ impl<'a> TableLayout<'a> {
             ) = match inline_size {
                 LengthPercentage(length_percentage) if length_percentage.has_percentage() => {
                     let percent_guess = min_content_width
-                        .max(length_percentage.resolve(self.assignable_width.into()));
+                        .max(length_percentage.resolve(self.assignable_width.into()).into());
                     (percent_guess, percent_guess, percent_guess)
                 },
                 LengthPercentage(_) => (min_content_width, max_content_width, max_content_width),
@@ -450,7 +450,7 @@ impl Table {
         };
 
         let sizes = cell.inline_content_sizes(layout_context, writing_mode);
-        sizes.map(|size| size / cell.colspan as f32)
+        sizes.map(|size| Au::from_f32_px(Au::to_f32_px(size) / cell.colspan as f32))
     }
 
     pub(crate) fn compute_inline_content_sizes(
@@ -520,8 +520,8 @@ impl TableSlotCell {
             .contents
             .contents
             .inline_content_sizes(layout_context, writing_mode);
-        sizes.min_content += border_padding_sum;
-        sizes.max_content += border_padding_sum;
+        sizes.min_content += border_padding_sum.into();
+        sizes.max_content += border_padding_sum.into();
         sizes
     }
 

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -105,10 +105,13 @@ impl<'a> TableLayout<'a> {
         // > * If the table-root has 'width: auto', the used width is the greater of min(GRIDMAX,
         // >   the table’s containing block width), the used min-width of the table.
         let used_width_of_table = match content_box_size.inline {
-            LengthPercentage(length_percentage) => length_percentage.max(used_min_width_of_table.into()),
+            LengthPercentage(length_percentage) => {
+                length_percentage.max(used_min_width_of_table.into())
+            },
             Auto => grid_max_inline_size
                 .min(containing_block.inline_size.into())
-                .max(used_min_width_of_table).into(),
+                .max(used_min_width_of_table)
+                .into(),
         };
 
         self.assignable_width = used_width_of_table.into();
@@ -185,8 +188,11 @@ impl<'a> TableLayout<'a> {
                 max_content_sizing_guess,
             ) = match inline_size {
                 LengthPercentage(length_percentage) if length_percentage.has_percentage() => {
-                    let percent_guess = min_content_width
-                        .max(length_percentage.resolve(self.assignable_width.into()).into());
+                    let percent_guess = min_content_width.max(
+                        length_percentage
+                            .resolve(self.assignable_width.into())
+                            .into(),
+                    );
                     (percent_guess, percent_guess, percent_guess)
                 },
                 LengthPercentage(_) => (min_content_width, max_content_width, max_content_width),

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -456,7 +456,7 @@ impl Table {
         };
 
         let sizes = cell.inline_content_sizes(layout_context, writing_mode);
-        sizes.map(|size| Au::from_f32_px(Au::to_f32_px(size) / cell.colspan as f32))
+        sizes.map(|size| size.scale_by(1.0 / cell.colspan as f32))
     }
 
     pub(crate) fn compute_inline_content_sizes(

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-141.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-141.xht.ini
@@ -1,2 +1,0 @@
-[floats-141.xht]
-  expected: FAIL


### PR DESCRIPTION

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
