### PR TITLE
Matrix in CI and `mach try` with presets

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,10 +11,8 @@ on:
       profile:
         required: false
         default: "release"
-        type: string
+        type: choice
         options: ["release", "debug", "production"]
-  push:
-    branches: ["try-android"]
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -1,0 +1,55 @@
+name: Dispatch Workflow
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        required: true
+        type: string
+      profile:
+        required: true
+        type: string
+      wpt-tests-to-run:
+        required: true
+        type: string
+      wpt-layout:
+        required: true
+        type: string
+      unit-tests:
+        required: true
+        type: boolean
+
+jobs:
+  win:
+    if: ${{ inputs.workflow == 'windows' }}
+    uses: ./.github/workflows/windows.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      unit-tests: ${{ inputs.unit-tests }}
+
+  macos:
+    if: ${{ inputs.workflow == 'macos' }}
+    uses: ./.github/workflows/mac.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      wpt-layout: ${{ inputs.wpt-layout }}
+      unit-tests: ${{ inputs.unit-tests }}
+      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+
+  linux:
+    if: ${{ inputs.workflow == 'linux' }}
+    uses: ./.github/workflows/linux.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}
+      wpt-layout: ${{ inputs.wpt-layout }}
+      unit-tests: ${{ inputs.unit-tests }}
+      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+
+  android:
+    if: ${{ inputs.workflow == 'android' }}
+    uses: ./.github/workflows/android.yml
+    secrets: inherit
+    with:
+      profile: ${{ inputs.profile }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,124 +11,36 @@ on:
     branches: ["**"]
   merge_group:
     types: [checks_requested]
-  workflow_call:
-    inputs:
-      configuration:
-        required: true
-        type: string
   workflow_dispatch:
-    inputs:
-      profile:
-        required: false
-        default: "release"
-        type: choice
-        options: ["release", "debug", "production"]
-      wpt-tests-to-run:
-        default: ""
-        required: false
-        type: string
-      platform:
-        required: false
-        type: choice
-        options: ["linux", "windows", "macos", "all"]
-      wpt-layout:
-        required: false
-        type: choice
-        options: ["none", "2013", "2020", "all"]
-      unit-tests:
-        required: false
-        type: boolean
 
 jobs:
-  decision:
-    name: Decision
-    runs-on: ubuntu-20.04
-    outputs:
-      configuration: ${{ steps.configuration.outputs.result }}
-    steps:
-      - name: Configuration
-        id: configuration
-        uses: actions/github-script@v6
-        with:
-          script: |
-            // If this is a workflow call with a configuration object,
-            // then just return it immediately.
-            let configuration = ${{ inputs.configuration || '""' }};
-            if (configuration != "") {
-              console.log("Using configuration: " + JSON.stringify(configuration));
-              return configuration;
-            }
-
-            // We need to pick defaults if the inputs are not provided. Unprovided inputs
-            // are empty strings in this template.
-            let platform = "${{ inputs.platform }}" || "linux";
-            let profile = "${{ inputs.profile }}" || "release";
-            let wpt_layout = "${{ inputs.wpt-layout }}" || "none";
-            let wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
-            let unit_tests = Boolean(${{ inputs.unit-tests }})
-
-            // Merge queue runs and pushes to `main` should always trigger a full build and test.
-            if (["push", "merge_group"].includes(context.eventName)) {
-              platform = "all";
-              wpt_layout = "all";
-              unit_tests = true;
-            }
-
-            let platforms = [];
-            if (platform == "all") {
-              platforms = [ "linux", "windows", "macos", "android" ];
-            } else {
-              platforms = [ platform ];
-            }
-
-            let returnValue = {
-              platforms,
-              wpt_layout,
-              unit_tests,
-              profile,
-              wpt_tests_to_run,
-            };
-
-            console.log("Using configuration: " + JSON.stringify(returnValue));
-            return returnValue;
-
   build-win:
     name: Windows
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'windows') }}
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/windows.yml
     with:
-      profile: ${{ fromJson(needs.decision.outputs.configuration).profile }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+      unit-tests: true
     secrets: inherit
 
   build-mac:
     name: Mac
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'macos') }}
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/mac.yml
     with:
-      wpt-tests-to-run: ${{ fromJson(needs.decision.outputs.configuration).wpt_tests_to_run }}
-      profile: ${{ fromJson(needs.decision.outputs.configuration).profile }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+      unit-tests: true
     secrets: inherit
 
   build-linux:
     name: Linux
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'linux') }}
     uses: ./.github/workflows/linux.yml
     with:
-      wpt-tests-to-run: ${{ fromJson(needs.decision.outputs.configuration).wpt_tests_to_run }}
-      profile: ${{ fromJson(needs.decision.outputs.configuration).profile }}
-      wpt-layout: ${{ fromJson(needs.decision.outputs.configuration).wpt_layout }}
-      unit-tests: ${{ fromJson(needs.decision.outputs.configuration).unit_tests }}
+      unit-tests: true
+      wpt-layout: ${{ github.event_name == 'pull_request' && 'none' || 'all' }}
     secrets: inherit
 
   build-android:
     name: Android
-    needs: ["decision"]
-    if: ${{ contains(fromJson(needs.decision.outputs.configuration).platforms, 'android') }}
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/android.yml
     with:
       profile: "release"
@@ -140,15 +52,11 @@ jobs:
     if: always()
     # needs all build to detect cancellation
     needs:
-      - "decision"
       - "build-win"
       - "build-mac"
       - "build-linux"
       - "build-android"
     steps:
-      - name: Mark skipped jobs as successful
-        if: ${{ fromJson(needs.decision.outputs.configuration).platforms[0] != null }}
-        run: exit 0
       - name: Mark the job as successful
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -29,6 +29,9 @@ jobs:
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
     steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -29,6 +29,17 @@ jobs:
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            python/servo/try_parser.py
+          sparse-checkout-cone-mode: false
+      - name: Generate full
+        id: full
+        run: |
+          out=$(python ./python/servo/try_parser.py)
+          echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
       - name: Configuration
         id: configuration
         uses: actions/github-script@v6
@@ -52,35 +63,7 @@ jobs:
             }
 
             // If we reach here we are likely doing a full run.
-            configuration = {
-              "fail_fast": false,
-              "matrix": [
-                {
-                  "workflow": "linux",
-                  "name": "Linux",
-                  "wpt_layout": "all",
-                  "profile": "release",
-                  "unit_tests": true,
-                  "wpt_tests_to_run": "",
-                },
-                {
-                  "workflow": "windows",
-                  "name": "Windows",
-                  "wpt_layout": "none", // not used
-                  "profile": "release",
-                  "unit_tests": true,
-                  "wpt_tests_to_run": "",
-                },
-                {
-                  "workflow": "mac",
-                  "name": "MacOS",
-                  "wpt_layout": "none",
-                  "profile": "release",
-                  "unit_tests": true,
-                  "wpt_tests_to_run": "",
-                }
-              ],
-            };
+            configuration = ${{ steps.full.outputs.config }};
 
             // Process `workflow_dispatch` provided configuration overrides.
             if (context.eventName == "workflow_dispatch") {

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   decision:
-    name: Decision
+    name: Generate matrix
     runs-on: ubuntu-20.04
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
@@ -78,7 +78,7 @@ jobs:
               let profile = '${{ inputs.profile }}';
               for (const platform of configuration.matrix) {
                 platform.profile = profile;
-                platfrom.unit_tests = unit_tests;
+                platform.unit_tests = unit_tests;
               }
             }
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   decision:
-    name: Generate matrix
+    name: Generate Try Configuration
     runs-on: ubuntu-20.04
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
@@ -38,11 +38,14 @@ jobs:
           sparse-checkout: |
             python/servo/try_parser.py
           sparse-checkout-cone-mode: false
-      - name: Generate full
-        id: full
+      - name: Get Full Configuration
+        id: full_config
         run: |
-          out=$(python ./python/servo/try_parser.py)
-          echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
+          {
+            echo 'config<<EOF'
+            python ./python/servo/try_parser.py
+            echo EOF
+           } >> $GITHUB_OUTPUT
       - name: Configuration
         id: configuration
         uses: actions/github-script@v6
@@ -66,7 +69,7 @@ jobs:
             }
 
             // If we reach here we are likely doing a full run.
-            configuration = ${{ steps.full.outputs.config }};
+            configuration = ${{ steps.full_config.outputs.config }};
 
             // Process `workflow_dispatch` provided configuration overrides.
             if (context.eventName == "workflow_dispatch") {

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -1,203 +1,134 @@
 name: Try
 
 on:
-  pull_request_target:
-    types: [labeled]
   push:
-    branches: ["try", "try-linux", "try-mac", "try-wpt-mac", "try-wpt-mac-2020", "try-wpt", "try-wpt-2020", "try-windows"]
+    branches: ["try"]
+  workflow_dispatch:
+    inputs:
+      profile:
+        required: false
+        default: "release"
+        type: choice
+        options: ["release", "debug", "production"]
+      wpt-tests-to-run:
+        default: ""
+        required: false
+        type: string
+      wpt-layout:
+        required: false
+        type: choice
+        options: ["none", "2013", "2020", "all"]
+      unit-tests:
+        required: false
+        type: boolean
 
 jobs:
-  parse-comment:
-    name: Trigger Try
-    runs-on: ubuntu-latest
-    concurrency:
-      group: try-${{ github.event.number }}
+  decision:
+    name: Decision
+    runs-on: ubuntu-20.04
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
     steps:
-      - uses: actions/github-script@v6
+      - name: Configuration
         id: configuration
+        uses: actions/github-script@v6
         with:
           script: |
-            function makeComment(body) {
-                console.log(body);
+            // When triggered via a push try the `try` branch, search the last commit for a configuration object.
+            if (${{ github.ref_name == 'try' }}) {
+              let commit_msg = context.payload.head_commit.message;
+              try {
+                var config = JSON.parse(commit_msg.split('\n').slice(-1));
 
-                if (context.eventName != 'pull_request_target')
-                  return;
-
-                github.rest.issues.createComment({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body
-                })
-            }
-
-            function combineWPTLayoutOptions(layout, newLayout) {
-                let has2013 = layout == "2013" || layout == "all";
-                let has2020 = layout == "2020" || layout == "all";
-                let adding2013 = newLayout == "2013";
-                let adding2020 = newLayout == "2020";
-
-                if ((adding2020 && has2020) || (adding2013 && has2013)) {
-                  return layout;
+                if (config && typeof config === "object") {
+                  console.log("Using try commit configuration: " + JSON.stringify(config));
+                  return config;
                 }
-                if (adding2020) {
-                  return has2013 ? "all" : "2020";
-                }
-                if (adding2013) {
-                  return has2020 ? "all" : "2013";
-                }
-                return layout;
-            }
-
-            function addPlatformToConfiguration(platform, configuration) {
-              if (!configuration.platforms.includes(platform)) {
-                configuration.platforms.push(platform);
+              }
+              catch (exception) {
+                console.log("Could not parse try configuration from commit message: " + exception);
+                console.log("Triggering full try run.");
               }
             }
 
-            function updateConfigurationFromString(tryString, configuration) {
-                if (tryString.includes("full")) {
-                  configuration.platforms = ["linux", "macos", "windows"];
-                  configuration.unit_tests = true;
-                  configuration.wpt_layout = "all";
-                  return configuration;
+            // If we reach here we are likely doing a full run.
+            configuration = {
+              "fail_fast": false,
+              "matrix": [
+                {
+                  "workflow": "linux",
+                  "name": "Linux",
+                  "wpt_layout": "all",
+                  "profile": "release",
+                  "unit_tests": true,
+                  "wpt_tests_to_run": "",
+                },
+                {
+                  "workflow": "windows",
+                  "name": "Windows",
+                  "wpt_layout": "none", // not used
+                  "profile": "release",
+                  "unit_tests": true,
+                  "wpt_tests_to_run": "",
+                },
+                {
+                  "workflow": "mac",
+                  "name": "MacOS",
+                  "wpt_layout": "none",
+                  "profile": "release",
+                  "unit_tests": true,
+                  "wpt_tests_to_run": "",
                 }
-
-                if (tryString.includes("linux")) {
-                  addPlatformToConfiguration("linux", configuration);
-                  configuration.unit_tests = true;
-                } else if (tryString.includes("mac")) {
-                  addPlatformToConfiguration("macos", configuration);
-                  configuration.unit_tests = true;
-                } else if (tryString.includes("win")) {
-                  addPlatformToConfiguration("windows", configuration);
-                  configuration.unit_tests = true;
-                }
-
-                if (tryString.includes("wpt")) {
-                  addPlatformToConfiguration("linux", configuration);
-                  if (tryString.includes("2020")) {
-                    configuration.wpt_layout = combineWPTLayoutOptions(configuration.wpt_layout, "2020");
-                  } else {
-                    configuration.wpt_layout = combineWPTLayoutOptions(configuration.wpt_layout, "2013");
-                  }
-                }
-            }
-
-            let configuration = {
-              platforms: [],
-              wpt_layout: "none",
-              unit_tests: false,
-              profile: "release",
-              wpt_tests_to_run: "",
+              ],
             };
 
-            if (context.eventName == 'pull_request_target') {
-              for (const label of context.payload.pull_request.labels) {
-                if (!label.name.startsWith("T-")) {
-                  continue;
-                }
+            // Process `workflow_dispatch` provided configuration overrides.
+            if (context.eventName == "workflow_dispatch") {
+              // WPT-related overrides only affect Linux currently, as tests don't run by default on other platforms.
+              configuration.matrix[0].wpt_layout = "${{ inputs.wpt-layout }}" || "none";
+              configuration.matrix[0].wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
 
-                // Try to remove the label. If that fails, it's likely that another
-                // workflow has already processed it or a user has removed it.
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    name: label.name,
-                  });
-                } catch (exception) {
-                  console.log("Assuming '" + label.name + "' is already removed: " + exception);
-                  continue;
-                }
-
-                console.log("Found label: " + label.name);
-                updateConfigurationFromString(label.name, configuration);
-              }
-            } else {
-              let ref_name = "${{ github.ref_name || 'empty' }}";
-              if (ref_name == "try") {
-                updateConfigurationFromString("full", configuration);
-              } else {
-                updateConfigurationFromString(ref_name, configuration);
+              let unit_tests = Boolean(${{ inputs.unit-tests }});
+              let profile = '${{ inputs.profile }}';
+              for (const platform of configuration.matrix) {
+                platform.profile = profile;
+                platfrom.unit_tests = unit_tests;
               }
             }
 
-            console.log(JSON.stringify(configuration));
-
-            if (configuration.platforms.length == 0) {
-                return { platforms: [] };
-            }
-
-            let username = context.payload.sender.login;
-            let result = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username
-            });
-            if (!result.data.user.permissions.push) {
-              makeComment('🔒 User @' + username + ' does not have permission to trigger try jobs.');
-              return { platforms: [] };
-            }
-
-            const url = context.serverUrl +
-              "/" + context.repo.owner +
-              "/" + context.repo.repo +
-              "/actions/runs/" + context.runId;
-            const formattedURL = "[#" + context.runId + "](" + url + ")";
-            let platformsString = configuration.platforms.toString();
-            makeComment("🔨 Triggering try run (" + formattedURL + ") with platforms=" +
-                        platformsString + " and layout=" + configuration.wpt_layout);
+            console.log("Using configuration: " + JSON.stringify(configuration));
             return configuration;
 
-  run-try:
-    name: Run Try
-    needs: ["parse-comment"]
-    if: ${{ fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
-    uses: ./.github/workflows/main.yml
+  build:
+    needs: ["decision"]
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ fromJson(needs.decision.outputs.configuration).fail_fast }}
+      matrix:
+        include: ${{ fromJson(needs.decision.outputs.configuration).matrix }}
+    # We need to use `dipatch-workflow.yml` because workflows do not support using: ${}
+    uses: ./.github/workflows/dispatch-workflow.yml
+    secrets: inherit
     with:
-      configuration: ${{ needs.parse-comment.outputs.configuration }}
+      workflow: ${{ matrix.workflow }}
+      wpt-layout: ${{ matrix.wpt_layout }}
+      profile: ${{ matrix.profile }}
+      unit-tests: ${{ matrix.unit_tests }}
+      wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
 
-  results:
-    name: Results
-    needs: ["parse-comment", "run-try"]
+  build-result:
+    name: Result
     runs-on: ubuntu-latest
-    if: ${{ always() && fromJson(needs.parse-comment.outputs.configuration).platforms[0] != null }}
+    if: always()
+    # `needs: "build"` is necessary to detect cancellation.
+    needs:
+      - "decision"
+      - "build"
+
     steps:
-      - name: Success
-        if: ${{ github.event_name == 'pull_request_target' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-        uses: actions/github-script@v6
-        with:
-          script: |
-              const url = context.serverUrl +
-                "/" + context.repo.owner +
-                "/" + context.repo.repo +
-                "/actions/runs/" + context.runId;
-              const formattedURL = "[#" + context.runId + "](" + url + ")";
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "✨ Try run (" + formattedURL + ") " + "succeeded.",
-              });
-      - name: Failure
-        if: ${{ github.event_name == 'pull_request_target' && contains(needs.*.result, 'failure') }}
-        uses: actions/github-script@v6
-        with:
-          script: |
-              const url = context.serverUrl +
-                "/" + context.repo.owner +
-                "/" + context.repo.repo +
-                "/actions/runs/" + context.runId;
-              const formattedURL = "[#" + context.runId + "](" + url + ")";
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "⚠️ Try run (" + formattedURL + ") " + "failed.",
-              });
-
-
+      - name: Mark the job as successful
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: exit 0
+      - name: Mark the job as unsuccessful
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           out=$(python ./python/servo/try_parser.py ${{ steps.try_string.outputs.result }})
           echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
-      - name: Collect Labels
+      - name: Report triggered run
         if: ${{ steps.try_string.outputs.result }}
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -1,0 +1,176 @@
+name: Try (Label)
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  parse-comment:
+    name: Trigger Try
+    runs-on: ubuntu-latest
+    concurrency:
+      group: try-${{ github.event.number }}
+    outputs:
+      configuration: ${{ steps.configuration.outputs.config }}
+      try_string: ${{ steps.try_string.outputs.result }}
+    steps:
+      - name: Collect Labels
+        uses: actions/github-script@v6
+        id: try_string
+        with:
+          result-encoding: string
+          script: |
+            function makeComment(body) {
+                console.log(body);
+
+                if (context.eventName != 'pull_request_target')
+                  return;
+
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body
+                })
+            }
+
+            let try_string = "${{ inputs.try_string }}" || "";
+
+            if (context.eventName == 'pull_request_target') {
+              for (const label of context.payload.pull_request.labels) {
+                if (!label.name.startsWith("T-")) {
+                  continue;
+                }
+
+                // Try to remove the label. If that fails, it's likely that another
+                // workflow has already processed it or a user has removed it.
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: label.name,
+                  });
+                } catch (exception) {
+                  console.log("Assuming '" + label.name + "' is already removed: " + exception);
+                  continue;
+                }
+
+                console.log("Found label: " + label.name);
+                // Remove the "T-" prefix.
+                label = label.name.slice(2);
+                try_string += " " + label;
+              }
+            }
+
+            console.log(try_string);
+
+            // Exit early if the try string is empty (no try triggered).
+            if (!try_string.trim()) {
+              return "";
+            }
+
+            let username = context.payload.sender.login;
+            let result = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username
+            });
+            if (!result.data.user.permissions.push) {
+              makeComment('🔒 User @' + username + ' does not have permission to trigger try jobs.');
+              return "";
+            }
+
+            const url = context.serverUrl +
+              "/" + context.repo.owner +
+              "/" + context.repo.repo +
+              "/actions/runs/" + context.runId;
+            const formattedURL = "[#" + context.runId + "](" + url + ")";
+            makeComment("🔨 Triggering try run (" + formattedURL + ")");
+
+            return try_string;
+      - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            python/try_parser.py
+          sparse-checkout-cone-mode: false
+      # This is necessary to checkout the pull request if this run was triggered
+      # via an `issue_comment` action on a pull request.
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: refs/pull/${{ github.event.number }}/head
+          fetch-depth: 1
+          sparse-checkout: |
+            python/try_parser.py
+          sparse-checkout-cone-mode: false
+      - name: Parse Try string
+        if: ${{ steps.try_string.outputs.result }}
+        id: configuration
+        run: |
+          out=$(python ./python/try_parser.py ${{ steps.try_string.outputs.result }})
+          echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
+      - name: Check output var
+        run: echo ${{ steps.configuration.outputs.config }}
+
+
+  run-try:
+    if: ${{ needs.parse-comment.outputs.try_string }}
+    needs: ["parse-comment"]
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ fromJson(needs.parse-comment.outputs.configuration).fail_fast }}
+      matrix:
+        include: ${{ fromJson(needs.parse-comment.outputs.configuration).matrix }}
+    # We need to use `dipatch-workflow.yml` because workflows do not support using: ${}.
+    uses: ./.github/workflows/dispatch-workflow.yml
+    secrets: inherit
+    with:
+      workflow: ${{ matrix.workflow }}
+      wpt-layout: ${{ matrix.wpt_layout }}
+      profile: ${{ matrix.profile }}
+      unit-tests: ${{ matrix.unit_tests }}
+      wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
+
+  results:
+    name: Results
+    needs: ["parse-comment", "run-try"]
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.parse-comment.outputs.try_string }}
+    steps:
+      - name: Success
+        if: ${{ github.event_name == 'pull_request_target' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+              const url = context.serverUrl +
+                "/" + context.repo.owner +
+                "/" + context.repo.repo +
+                "/actions/runs/" + context.runId;
+              const formattedURL = "[#" + context.runId + "](" + url + ")";
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "✨ Try run (" + formattedURL + ") " + "succeeded.",
+              });
+      - name: Failure
+        if: ${{ github.event_name == 'pull_request_target' && contains(needs.*.result, 'failure') }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+              const url = context.serverUrl +
+                "/" + context.repo.owner +
+                "/" + context.repo.repo +
+                "/actions/runs/" + context.runId;
+              const formattedURL = "[#" + context.runId + "](" + url + ")";
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "⚠️ Try run (" + formattedURL + ") " + "failed.",
+              });
+
+

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           fetch-depth: 1
           sparse-checkout: |
-            python/try_parser.py
+            python/servo/try_parser.py
           sparse-checkout-cone-mode: false
       # This is necessary to checkout the pull request if this run was triggered
       # via an `issue_comment` action on a pull request.
@@ -97,13 +97,13 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 1
           sparse-checkout: |
-            python/try_parser.py
+            python/servo/try_parser.py
           sparse-checkout-cone-mode: false
       - name: Parse Try string
         if: ${{ steps.try_string.outputs.result }}
         id: configuration
         run: |
-          out=$(python ./python/try_parser.py ${{ steps.try_string.outputs.result }})
+          out=$(python ./python/servo/try_parser.py ${{ steps.try_string.outputs.result }})
           echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
       - name: Collect Labels
         if: ${{ steps.try_string.outputs.result }}

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -37,7 +37,7 @@ jobs:
             let try_string = "${{ inputs.try_string }}" || "";
 
             if (context.eventName == 'pull_request_target') {
-              for (const label of context.payload.pull_request.labels) {
+              for (let label of context.payload.pull_request.labels) {
                 if (!label.name.startsWith("T-")) {
                   continue;
                 }

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -81,13 +81,6 @@ jobs:
               return "";
             }
 
-            const url = context.serverUrl +
-              "/" + context.repo.owner +
-              "/" + context.repo.repo +
-              "/actions/runs/" + context.runId;
-            const formattedURL = "[#" + context.runId + "](" + url + ")";
-            makeComment("🔨 Triggering try run (" + formattedURL + ")");
-
             return try_string;
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -112,8 +105,34 @@ jobs:
         run: |
           out=$(python ./python/try_parser.py ${{ steps.try_string.outputs.result }})
           echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
-      - name: Check output var
-        run: echo ${{ steps.configuration.outputs.config }}
+      - name: Collect Labels
+        if: ${{ steps.try_string.outputs.result }}
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            let config = ${{ steps.configuration.outputs.config }};
+            function makeComment(body) {
+                console.log(body);
+
+                if (context.eventName != 'pull_request_target')
+                  return;
+
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body
+                })
+            }
+
+            const url = context.serverUrl +
+              "/" + context.repo.owner +
+              "/" + context.repo.repo +
+              "/actions/runs/" + context.runId;
+            const formattedURL = "[#" + context.runId + "](" + url + ")";
+            makeComment("🔨 Triggering try run (" + formattedURL + ") for "
+             + config.matrix.map(m => m.name).join(", "));
 
 
   run-try:

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -82,6 +82,9 @@ jobs:
             }
 
             return try_string;
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
         with:

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -23,9 +23,6 @@ jobs:
             function makeComment(body) {
                 console.log(body);
 
-                if (context.eventName != 'pull_request_target')
-                  return;
-
                 github.rest.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
@@ -34,33 +31,31 @@ jobs:
                 })
             }
 
-            let try_string = "${{ inputs.try_string }}" || "";
+            let try_string = "";
 
-            if (context.eventName == 'pull_request_target') {
-              for (let label of context.payload.pull_request.labels) {
-                if (!label.name.startsWith("T-")) {
-                  continue;
-                }
-
-                // Try to remove the label. If that fails, it's likely that another
-                // workflow has already processed it or a user has removed it.
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.issue.number,
-                    name: label.name,
-                  });
-                } catch (exception) {
-                  console.log("Assuming '" + label.name + "' is already removed: " + exception);
-                  continue;
-                }
-
-                console.log("Found label: " + label.name);
-                // Remove the "T-" prefix.
-                label = label.name.slice(2);
-                try_string += " " + label;
+            for (let label of context.payload.pull_request.labels) {
+              if (!label.name.startsWith("T-")) {
+                continue;
               }
+
+              // Try to remove the label. If that fails, it's likely that another
+              // workflow has already processed it or a user has removed it.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name,
+                });
+              } catch (exception) {
+                console.log("Assuming '" + label.name + "' is already removed: " + exception);
+                continue;
+              }
+
+              console.log("Found label: " + label.name);
+              // Remove the "T-" prefix.
+              label = label.name.slice(2);
+              try_string += " " + label;
             }
 
             console.log(try_string);
@@ -86,29 +81,24 @@ jobs:
         with:
           python-version: '3.10'
       - uses: actions/checkout@v3
-        if: github.event_name != 'pull_request_target'
         with:
-          fetch-depth: 1
-          sparse-checkout: |
-            python/servo/try_parser.py
-          sparse-checkout-cone-mode: false
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
-      - uses: actions/checkout@v3
-        if: github.event_name == 'pull_request_target'
-        with:
+          # This is necessary to checkout the pull request if this run was triggered
+          # via an `label` action on a pull request.
           ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 1
           sparse-checkout: |
             python/servo/try_parser.py
           sparse-checkout-cone-mode: false
-      - name: Parse Try string
+      - name: Parse Labels
         if: ${{ steps.try_string.outputs.result }}
         id: configuration
         run: |
-          out=$(python ./python/servo/try_parser.py ${{ steps.try_string.outputs.result }})
-          echo "config<<EOF"$'\n'"$out"$'\n'EOF >> $GITHUB_OUTPUT
-      - name: Report triggered run
+          {
+            echo 'config<<EOF'
+            python ./python/servo/try_parser.py ${{ steps.try_string.outputs.result }}
+            echo EOF
+           } >> $GITHUB_OUTPUT
+      - name: Comment Run Start
         if: ${{ steps.try_string.outputs.result }}
         uses: actions/github-script@v6
         with:
@@ -117,9 +107,6 @@ jobs:
             let config = ${{ steps.configuration.outputs.config }};
             function makeComment(body) {
                 console.log(body);
-
-                if (context.eventName != 'pull_request_target')
-                  return;
 
                 github.rest.issues.createComment({
                   issue_number: context.issue.number,
@@ -136,7 +123,6 @@ jobs:
             const formattedURL = "[#" + context.runId + "](" + url + ")";
             makeComment("🔨 Triggering try run (" + formattedURL + ") for "
              + config.matrix.map(m => m.name).join(", "));
-
 
   run-try:
     if: ${{ needs.parse-comment.outputs.try_string }}
@@ -163,7 +149,7 @@ jobs:
     if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
       - name: Success
-        if: ${{ github.event_name == 'pull_request_target' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: actions/github-script@v6
         with:
           script: |
@@ -179,7 +165,7 @@ jobs:
                 body: "✨ Try run (" + formattedURL + ") " + "succeeded.",
               });
       - name: Failure
-        if: ${{ github.event_name == 'pull_request_target' && contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
     inputs:
       profile:
-        required: true
+        required: false
+        default: "release"
         type: string
       unit-tests:
         required: false

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -288,7 +288,7 @@ class MachCommands(CommandBase):
         else:
             try_string = " ".join(try_string)
         conf = Config(try_string)
-        result = call(["git", "commit", "--allow-empty", "-m", f"{try_string}\n\n{conf.toJSON()}"])
+        result = call(["git", "commit", "--allow-empty", "-m", f"{try_string}\n\n{conf.to_json()}"])
         if result != 0:
             return result
 

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -303,6 +303,6 @@ class MachCommands(CommandBase):
         git_remote = git_remote.replace(".git", "/actions")
         print(f"You can find triggered workflow here: {git_remote}")
 
-        # we need to delete last commit
+        # Remove the last commit which only contains the try configuration.
         result += call(["git", "reset", "--soft", "HEAD~1"])
         return result

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -288,7 +288,7 @@ class MachCommands(CommandBase):
         else:
             try_string = " ".join(try_string)
         conf = Config(try_string)
-        result = call(["git", "commit", "--allow-empty", "-m", f"{try_string}\n\n{conf.to_json()}"])
+        result = call(["git", "commit", "--allow-empty", "-m", try_string, "-m", f"{conf.to_json()}"])
         if result != 0:
             return result
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -244,6 +244,10 @@ class MachCommands(CommandBase):
         print("Running tidy tests...")
         passed = tidy.run_tests() and passed
 
+        import python.servo.try_parser as try_parser
+        print("Running try_parser tests...")
+        passed = try_parser.run_tests() and passed
+
         print("Running WPT tests...")
         passed = wpt.run_tests() and passed
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -11,6 +11,9 @@
 
 import json
 import sys
+from typing import Optional
+import unittest
+import logging
 
 from dataclasses import dataclass
 from enum import Enum, Flag, auto
@@ -53,7 +56,7 @@ class JobConfig(object):
     wpt_tests_to_run: str = ""
 
 
-def handle_preset(s: str) -> JobConfig | None:
+def handle_preset(s: str) -> Optional[JobConfig]:
     s = s.lower()
 
     if s == "linux":
@@ -96,7 +99,7 @@ class Encoder(json.JSONEncoder):
 
 
 class Config(object):
-    def __init__(self, s: str | None = None):
+    def __init__(self, s: Optional[str] = None):
         self.fail_fast: bool = False
         self.matrix: list[JobConfig] = list()
         if s is not None:
@@ -136,10 +139,6 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-
-import unittest # noqa
-import logging # noqa
 
 
 class TestParser(unittest.TestCase):

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -63,7 +63,7 @@ def handle_preset(s: str) -> JobConfig | None:
     elif s in ["win", "windows"]:
         return JobConfig("Windows", Workflow.WINDOWS, unit_tests=True)
     elif s in ["wpt", "linux-wpt"]:
-        return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.all())
+        return JobConfig("Linux WPT", Workflow.LINUX, unit_tests=True, wpt_layout=Layout.all())
     elif s in ["wpt-2013", "linux-wpt-2013"]:
         return JobConfig("Linux WPT legacy-layout", Workflow.LINUX, wpt_layout=Layout.layout2013)
     elif s in ["wpt-2020", "linux-wpt-2020"]:
@@ -116,7 +116,7 @@ class Config(object):
                 self.fail_fast = True
                 continue  # skip over keyword
             if word == "full":
-                words.extend(["linux", "macos", "windows", "android"])
+                words.extend(["linux-wpt", "macos", "windows", "android"])
                 continue  # skip over keyword
 
             preset = handle_preset(word)
@@ -152,7 +152,7 @@ class TestParser(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(Config("").to_json(),
                          '{"fail_fast": false, "matrix": [\
-{"name": "Linux", "workflow": "linux", "wpt_layout": "none", "profile": "release", \
+{"name": "Linux WPT", "workflow": "linux", "wpt_layout": "all", "profile": "release", \
 "unit_tests": true, "wpt_tests_to_run": ""}, \
 {"name": "MacOS", "workflow": "macos", "wpt_layout": "none", "profile": "release", \
 "unit_tests": true, "wpt_tests_to_run": ""}, \
@@ -162,7 +162,7 @@ class TestParser(unittest.TestCase):
 "unit_tests": false, "wpt_tests_to_run": ""}]}')
 
     def test_full(self):
-        self.assertEqual(Config("linux macos windows android").to_json(), Config("").to_json())
+        self.assertEqual(Config("linux-wpt macos windows android").to_json(), Config("").to_json())
 
 
 def run_tests():

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -10,9 +10,10 @@
 # except according to those terms.
 
 import json
-from enum import Enum, Flag, auto
 import sys
+
 from dataclasses import dataclass
+from enum import Enum, Flag, auto
 
 
 class Layout(Flag):
@@ -124,13 +125,13 @@ class Config(object):
             else:
                 self.matrix.append(preset)
 
-    def toJSON(self) -> str:
+    def to_json(self) -> str:
         return json.dumps(self, cls=Encoder)
 
 
 def main():
     conf = Config(" ".join(sys.argv[1:]))
-    print(conf.toJSON())
+    print(conf.to_json())
 
 
 if __name__ == "__main__":
@@ -143,13 +144,13 @@ import logging # noqa
 
 class TestParser(unittest.TestCase):
     def test_string(self):
-        self.assertEqual(Config("linux fail-fast").toJSON(),
+        self.assertEqual(Config("linux fail-fast").to_json(),
                          '{"fail_fast": true, "matrix": [\
 {"name": "Linux", "workflow": "linux", "wpt_layout": "none", "profile": "release", \
 "unit_tests": true, "wpt_tests_to_run": ""}]}')
 
     def test_empty(self):
-        self.assertEqual(Config("").toJSON(),
+        self.assertEqual(Config("").to_json(),
                          '{"fail_fast": false, "matrix": [\
 {"name": "Linux", "workflow": "linux", "wpt_layout": "none", "profile": "release", \
 "unit_tests": true, "wpt_tests_to_run": ""}, \
@@ -161,7 +162,7 @@ class TestParser(unittest.TestCase):
 "unit_tests": true, "wpt_tests_to_run": ""}]}')
 
     def test_full(self):
-        self.assertEqual(Config("linux macos windows android").toJSON(), Config("").toJSON())
+        self.assertEqual(Config("linux macos windows android").to_json(), Config("").to_json())
 
 
 def run_tests():

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+import json
+from enum import Enum, Flag, auto
+import sys
+from dataclasses import dataclass
+
+
+class Layout(Flag):
+    none = 0
+    layout2013 = auto()
+    layout2020 = auto()
+
+    @staticmethod
+    def all():
+        return Layout.layout2013 | Layout.layout2020
+
+    def to_string(self):
+        if Layout.all() in self:
+            return "all"
+        elif Layout.layout2020 in self:
+            return "2020"
+        elif Layout.layout2013 in self:
+            return "2013"
+        else:
+            return "none"
+
+
+class Workflow(str, Enum):
+    LINUX = 'linux'
+    MACOS = 'macos'
+    WINDOWS = 'windows'
+    ANDROID = 'android'
+
+
+@dataclass
+class JobConfig(object):
+    name: str
+    workflow: Workflow = Workflow.LINUX
+    wpt_layout: Layout = Layout.none
+    profile: str = "release"
+    unit_tests: bool = True
+    wpt_tests_to_run: str = ""
+
+
+def handle_preset(s: str) -> JobConfig | None:
+    s = s.lower()
+
+    if s == "linux":
+        return JobConfig("Linux", Workflow.LINUX)
+    elif s in ["mac", "macos"]:
+        return JobConfig("MacOS", Workflow.MACOS)
+    elif s in ["win", "windows"]:
+        return JobConfig("Windows", Workflow.WINDOWS)
+    elif s in ["wpt", "linux-wpt"]:
+        return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.all())
+    elif s in ["wpt-2013", "linux-wpt-2013"]:
+        return JobConfig("Linux WPT legacy-layout", Workflow.LINUX, wpt_layout=Layout.layout2013)
+    elif s in ["wpt-2020", "linux-wpt-2020"]:
+        return JobConfig("Linux WPT layout-2020", Workflow.LINUX, wpt_layout=Layout.layout2020)
+    elif s in ["mac-wpt", "wpt-mac"]:
+        return JobConfig("MacOS WPT", Workflow.MACOS, wpt_layout=Layout.all())
+    elif s == "mac-wpt-2013":
+        return JobConfig("MacOS WPT legacy-layout", Workflow.MACOS, wpt_layout=Layout.layout2013)
+    elif s == "mac-wpt-2020":
+        return JobConfig("MacOS WPT layout-2020", Workflow.MACOS, wpt_layout=Layout.layout2020)
+    elif s == "android":
+        return JobConfig("Android", Workflow.ANDROID)
+    elif s == "webgpu":
+        return JobConfig("WebGPU CTS", Workflow.LINUX,
+                         wpt_layout=Layout.layout2020,  # reftests are mode for new layout
+                         wpt_tests_to_run="_webgpu",  # run only webgpu cts
+                         profile="production",  # WebGPU works to slow with debug assert
+                         unit_tests=False)  # production profile does not work with unit-tests
+    else:
+        return None
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, (Config, JobConfig)):
+            return o.__dict__
+        if isinstance(o, Layout):
+            return o.to_string()
+        return json.JSONEncoder.default(self, o)
+
+
+class Config(object):
+    def __init__(self, s: str | None = None):
+        self.fail_fast: bool = False
+        self.matrix: list[JobConfig] = list()
+        if s is not None:
+            self.parse(s)
+
+    def parse(self, input: str):
+        input = input.lower().strip()
+
+        if not input:
+            input = "full"
+
+        words: list[str] = input.split(" ")
+
+        for word in words:
+            # Handle keywords.
+            if word in ["fail-fast", "failfast", "fail_fast"]:
+                self.fail_fast = True
+                continue  # skip over keyword
+            if word == "full":
+                words.extend(["linux", "macos", "windows", "android"])
+                continue  # skip over keyword
+
+            preset = handle_preset(word)
+            if preset is None:
+                print(f"Ignoring unknown preset {word}")
+            else:
+                self.matrix.append(preset)
+
+    def toJSON(self) -> str:
+        return json.dumps(self, cls=Encoder)
+
+
+def main():
+    conf = Config(" ".join(sys.argv[1:]))
+    print(conf.toJSON())
+
+
+if __name__ == "__main__":
+    main()
+
+
+import unittest # noqa
+import logging # noqa
+
+
+class TestParser(unittest.TestCase):
+    def test_string(self):
+        self.assertEqual(Config("linux fail-fast").toJSON(),
+                         '{"fail_fast": true, "matrix": [\
+{"name": "Linux", "workflow": "linux", "wpt_layout": "none", "profile": "release", \
+"unit_tests": true, "wpt_tests_to_run": ""}]}')
+
+    def test_empty(self):
+        self.assertEqual(Config("").toJSON(),
+                         '{"fail_fast": false, "matrix": [\
+{"name": "Linux", "workflow": "linux", "wpt_layout": "none", "profile": "release", \
+"unit_tests": true, "wpt_tests_to_run": ""}, \
+{"name": "MacOS", "workflow": "macos", "wpt_layout": "none", "profile": "release", \
+"unit_tests": true, "wpt_tests_to_run": ""}, \
+{"name": "Windows", "workflow": "windows", "wpt_layout": "none", "profile": "release", \
+"unit_tests": true, "wpt_tests_to_run": ""}, \
+{"name": "Android", "workflow": "android", "wpt_layout": "none", "profile": "release", \
+"unit_tests": true, "wpt_tests_to_run": ""}]}')
+
+    def test_full(self):
+        self.assertEqual(Config("linux macos windows android").toJSON(), Config("").toJSON())
+
+
+def run_tests():
+    verbosity = 1 if logging.getLogger().level >= logging.WARN else 2
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestParser)
+    return unittest.TextTestRunner(verbosity=verbosity).run(suite).wasSuccessful()

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -49,7 +49,7 @@ class JobConfig(object):
     workflow: Workflow = Workflow.LINUX
     wpt_layout: Layout = Layout.none
     profile: str = "release"
-    unit_tests: bool = True
+    unit_tests: bool = False
     wpt_tests_to_run: str = ""
 
 
@@ -57,11 +57,11 @@ def handle_preset(s: str) -> JobConfig | None:
     s = s.lower()
 
     if s == "linux":
-        return JobConfig("Linux", Workflow.LINUX)
+        return JobConfig("Linux", Workflow.LINUX, unit_tests=True)
     elif s in ["mac", "macos"]:
-        return JobConfig("MacOS", Workflow.MACOS)
+        return JobConfig("MacOS", Workflow.MACOS, unit_tests=True)
     elif s in ["win", "windows"]:
-        return JobConfig("Windows", Workflow.WINDOWS)
+        return JobConfig("Windows", Workflow.WINDOWS, unit_tests=True)
     elif s in ["wpt", "linux-wpt"]:
         return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.all())
     elif s in ["wpt-2013", "linux-wpt-2013"]:
@@ -159,7 +159,7 @@ class TestParser(unittest.TestCase):
 {"name": "Windows", "workflow": "windows", "wpt_layout": "none", "profile": "release", \
 "unit_tests": true, "wpt_tests_to_run": ""}, \
 {"name": "Android", "workflow": "android", "wpt_layout": "none", "profile": "release", \
-"unit_tests": true, "wpt_tests_to_run": ""}]}')
+"unit_tests": false, "wpt_tests_to_run": ""}]}')
 
     def test_full(self):
         self.assertEqual(Config("linux macos windows android").to_json(), Config("").to_json())

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -143,25 +143,58 @@ if __name__ == "__main__":
 
 class TestParser(unittest.TestCase):
     def test_string(self):
-        self.assertEqual(Config("linux fail-fast").to_json(),
-                         '{"fail_fast": true, "matrix": [\
-{"name": "Linux", "workflow": "linux", "wpt_layout": "none", "profile": "release", \
-"unit_tests": true, "wpt_tests_to_run": ""}]}')
+        self.assertDictEqual(json.loads(Config("linux fail-fast").to_json()),
+                             {'fail_fast': True,
+                              'matrix': [{
+                                  'name': 'Linux',
+                                  'profile': 'release',
+                                  'unit_tests': True,
+                                  'workflow': 'linux',
+                                  'wpt_layout': 'none',
+                                  'wpt_tests_to_run': ''
+                              }]
+                              })
 
     def test_empty(self):
-        self.assertEqual(Config("").to_json(),
-                         '{"fail_fast": false, "matrix": [\
-{"name": "Linux WPT", "workflow": "linux", "wpt_layout": "all", "profile": "release", \
-"unit_tests": true, "wpt_tests_to_run": ""}, \
-{"name": "MacOS", "workflow": "macos", "wpt_layout": "none", "profile": "release", \
-"unit_tests": true, "wpt_tests_to_run": ""}, \
-{"name": "Windows", "workflow": "windows", "wpt_layout": "none", "profile": "release", \
-"unit_tests": true, "wpt_tests_to_run": ""}, \
-{"name": "Android", "workflow": "android", "wpt_layout": "none", "profile": "release", \
-"unit_tests": false, "wpt_tests_to_run": ""}]}')
+        self.assertDictEqual(json.loads(Config("").to_json()),
+                             {"fail_fast": False, "matrix": [
+                              {
+                                  "name": "Linux WPT",
+                                  "workflow": "linux",
+                                  "wpt_layout": "all",
+                                  "profile": "release",
+                                  "unit_tests": True,
+                                  "wpt_tests_to_run": ""
+                              },
+                              {
+                                  "name": "MacOS",
+                                  "workflow": "macos",
+                                  "wpt_layout": "none",
+                                  "profile": "release",
+                                  "unit_tests": True,
+                                  "wpt_tests_to_run": ""
+                              },
+                              {
+                                  "name": "Windows",
+                                  "workflow": "windows",
+                                  "wpt_layout": "none",
+                                  "profile": "release",
+                                  "unit_tests": True,
+                                  "wpt_tests_to_run": ""
+                              },
+                              {
+                                  "name": "Android",
+                                  "workflow": "android",
+                                  "wpt_layout": "none",
+                                  "profile": "release",
+                                  "unit_tests": False,
+                                  "wpt_tests_to_run": ""
+                              }
+                              ]})
 
     def test_full(self):
-        self.assertEqual(Config("linux-wpt macos windows android").to_json(), Config("").to_json())
+        self.assertDictEqual(json.loads(Config("linux-wpt macos windows android").to_json()),
+                             json.loads(Config("").to_json()))
 
 
 def run_tests():


### PR DESCRIPTION
Splitted from https://github.com/servo/servo/pull/30920

This PR replaces try branches with single `try` branch that accepts configuration (that is encoded in last line of commit in JSON). `try_parser.py` is there just to have preset -> JSON in one place (try label = preset).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
