### PR TITLE
Fix trivial typo in variable name

### DIFF
--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -51,9 +51,9 @@ class Configuration:
         # Mark the descriptors for which only a single nativeType implements
         # an interface.
         for descriptor in self.descriptors:
-            intefaceName = descriptor.interface.identifier.name
+            interfaceName = descriptor.interface.identifier.name
             otherDescriptors = [d for d in self.descriptors
-                                if d.interface.identifier.name == intefaceName]
+                                if d.interface.identifier.name == interfaceName]
             descriptor.uniqueImplementation = len(otherDescriptors) == 1
 
         self.enums = [e for e in parseData if e.isEnum()]


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors : it does report one unrelated error, introduced in a8b34e88ca9ab4d0707fdf7ff3e30a508c8f54fe
- [X] These changes do not require tests because this is a trivial typo fix