### PR TITLE
rustdoc: Fix many rustdoc errors

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -2499,7 +2499,7 @@ impl WebGLImpl {
 
 /// ANGLE adds a `_u` prefix to variable names:
 ///
-/// https://chromium.googlesource.com/angle/angle/+/855d964bd0d05f6b2cb303f625506cf53d37e94f
+/// <https://chromium.googlesource.com/angle/angle/+/855d964bd0d05f6b2cb303f625506cf53d37e94f>
 ///
 /// To avoid hard-coding this we would need to use the `sh::GetAttributes` and `sh::GetUniforms`
 /// API to look up the `x.name` and `x.mappedName` members.

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -120,7 +120,7 @@ pub struct Opts {
 
     /// Whether or not to completely ignore SSL certificate validation errors.
     /// TODO: We should see if we can eliminate the need for this by fixing
-    /// https://github.com/servo/servo/issues/30080.
+    /// <https://github.com/servo/servo/issues/30080>.
     pub ignore_certificate_errors: bool,
 
     /// Unminify Javascript.

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -87,7 +87,7 @@
 //!
 //! * Anything (other than a routing thread) can block on a routing thread
 //!
-//! See https://github.com/servo/servo/issues/14704
+//! See <https://github.com/servo/servo/issues/14704>
 
 use std::borrow::{Cow, ToOwned};
 use std::collections::hash_map::Entry;
@@ -237,7 +237,7 @@ struct Browser {
 
 /// A browsing context group.
 ///
-/// https://html.spec.whatwg.org/multipage/#browsing-context-group
+/// <https://html.spec.whatwg.org/multipage/#browsing-context-group>
 #[derive(Clone, Default)]
 struct BrowsingContextGroup {
     /// A browsing context group holds a set of top-level browsing contexts.
@@ -421,7 +421,7 @@ pub struct Constellation<Message, LTF, STF, SWF> {
 
     /// A user agent holds a a set of browsing context groups.
     ///
-    /// https://html.spec.whatwg.org/multipage/#browsing-context-group-set
+    /// <https://html.spec.whatwg.org/multipage/#browsing-context-group-set>
     browsing_context_group_set: HashMap<BrowsingContextGroupId, BrowsingContextGroup>,
 
     /// The Id counter for BrowsingContextGroup.
@@ -1854,7 +1854,7 @@ where
 
     /// Check the origin of a message against that of the pipeline it came from.
     /// Note: this is still limited as a security check,
-    /// see https://github.com/servo/servo/issues/11722
+    /// see <https://github.com/servo/servo/issues/11722>
     fn check_origin_against_pipeline(
         &self,
         pipeline_id: &PipelineId,

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -17,7 +17,7 @@ use style_traits::CSSPixel;
 use crate::browsingcontext::NewBrowsingContextInfo;
 
 /// Represents the joint session history
-/// https://html.spec.whatwg.org/multipage/#joint-session-history
+/// <https://html.spec.whatwg.org/multipage/#joint-session-history>
 #[derive(Debug)]
 pub struct JointSessionHistory {
     /// Diffs used to traverse to past entries. Oldest entries are at the back,

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Liberally derived from the [Firefox JS implementation]
-//! (http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webbrowser.js).
+//! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webbrowser.js).
 //! Connection point for remote devtools that wish to investigate a particular Browsing Context's contents.
 //! Supports dynamic attaching and detaching which control notifications of navigation, etc.
 

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Liberally derived from the [Firefox JS implementation]
-//! (http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js).
+//! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js).
 //! Mediates interaction between the remote web console and equivalent functionality (object
 //! inspection, JS evaluation, autocompletion) in Servo.
 

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Liberally derived from the [Firefox JS implementation]
-//! (http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/inspector.js).
+//! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/inspector.js).
 
 use std::cell::RefCell;
 use std::net::TcpStream;

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Liberally derived from the [Firefox JS implementation]
-//! (http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js).
+//! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js).
 //! Handles interaction with the remote web console on network events (HTTP requests, responses) in Servo.
 
 use std::net::TcpStream;

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -101,7 +101,7 @@ struct FramerateEmitterReply {
 /// HighResolutionStamp is struct that contains duration in milliseconds
 /// with accuracy to microsecond that shows how much time has passed since
 /// actor registry inited
-/// analog https://w3c.github.io/hr-time/#sec-DOMHighResTimeStamp
+/// analog <https://w3c.github.io/hr-time/#sec-DOMHighResTimeStamp>
 pub struct HighResolutionStamp(f64);
 
 impl HighResolutionStamp {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -48,7 +48,7 @@ use crate::actors::worker::{WorkerActor, WorkerType};
 use crate::protocol::JsonPacketStream;
 
 mod actor;
-/// Corresponds to http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/
+/// Corresponds to <http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/>
 mod actors {
     pub mod browsing_context;
     pub mod console;

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Low-level wire protocol implementation. Currently only supports
-//! [JSON packets]
-//! (https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport#JSON_Packets).
+//! [JSON packets](https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport#JSON_Packets).
 
 use std::error::Error;
 use std::io::{Read, Write};

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -59,7 +59,7 @@ impl FontTableMethods for FontTable {
 }
 
 /// Data from the OS/2 table of an OpenType font.
-/// See https://www.microsoft.com/typography/otspec/os2.htm
+/// See <https://www.microsoft.com/typography/otspec/os2.htm>
 #[derive(Debug)]
 struct OS2Table {
     us_weight_class: u16,

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -117,7 +117,7 @@ impl GlyphEntry {
     /// non-exhaustively listed in the specification. Other characters may map to the same
     /// glyphs, but this function does not take mapping into account.
     ///
-    /// See https://drafts.csswg.org/css-text/#word-separator.
+    /// See <https://drafts.csswg.org/css-text/#word-separator>.
     fn char_is_word_separator(&self) -> bool {
         self.has_flag(FLAG_CHAR_IS_WORD_SEPARATOR)
     }
@@ -433,7 +433,7 @@ pub struct GlyphStore {
     total_advance: Au,
 
     /// A cache of the number of word separators in the entire glyph store.
-    /// See https://drafts.csswg.org/css-text/#word-separator.
+    /// See <https://drafts.csswg.org/css-text/#word-separator>.
     total_word_separators: i32,
 
     /// Used to check if fast path should be used in glyph iteration.

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -13,17 +13,17 @@
 //! "CSS 2.1" or "CSS 2.2" refers to the editor's draft of the W3C "Cascading Style Sheets Level 2
 //! Revision 2 (CSS 2.2) Specification" available here:
 //!
-//!   http://dev.w3.org/csswg/css2/
+//!   <http://dev.w3.org/csswg/css2/>
 //!
 //! "INTRINSIC" refers to L. David Baron's "More Precise Definitions of Inline Layout and Table
 //! Layout" available here:
 //!
-//!   http://dbaron.org/css/intrinsic/
+//!   <http://dbaron.org/css/intrinsic/>
 //!
 //! "CSS-SIZING" refers to the W3C "CSS Intrinsic & Extrinsic Sizing Module Level 3" document
 //! available here:
 //!
-//!   http://dev.w3.org/csswg/css-sizing/
+//!   <http://dev.w3.org/csswg/css-sizing/>
 
 use std::cmp::{max, min};
 use std::fmt;

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -40,7 +40,7 @@ pub struct BackgroundPlacement {
 /// Obviously it does not work with empty arrays.
 ///
 /// This is used for multiple layered background images.
-/// See: https://drafts.csswg.org/css-backgrounds-3/#layering
+/// See: <https://drafts.csswg.org/css-backgrounds-3/#layering>
 pub fn get_cyclic<T>(arr: &[T], index: usize) -> &T {
     &arr[index % arr.len()]
 }

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -103,7 +103,7 @@ impl<'a> ClipScrollState<'a> {
 }
 
 /// Contentful paint, for the purpose of
-/// https://w3c.github.io/paint-timing/#first-contentful-paint
+/// <https://w3c.github.io/paint-timing/#first-contentful-paint>
 /// (i.e. the display list contains items of type text,
 /// image, non-white canvas or SVG). Used by metrics.
 pub struct IsContentful(pub bool);

--- a/components/layout/flow_ref.rs
+++ b/components/layout/flow_ref.rs
@@ -5,8 +5,8 @@
 //! Reference-counted pointers to flows.
 //!
 //! Eventually, with dynamically sized types in Rust, much of this code will
-//! be superfluous. This design is largely duplicating logic of Arc<T> and
-//! Weak<T>; please see comments there for details.
+//! be superfluous. This design is largely duplicating logic of `Arc<T>` and
+//! `Weak<T>`; please see comments there for details.
 
 use std::ops::Deref;
 use std::sync::{Arc, Weak};
@@ -25,7 +25,7 @@ impl Deref for FlowRef {
 
 impl FlowRef {
     /// `FlowRef`s can only be made available to the traversal code.
-    /// See https://github.com/servo/servo/issues/14014 for more details.
+    /// See <https://github.com/servo/servo/issues/14014> for more details.
     pub fn new(mut r: Arc<dyn Flow>) -> Self {
         // This assertion checks that this `FlowRef` does not alias normal `Arc`s.
         // If that happens, we're in trouble.
@@ -46,7 +46,7 @@ impl FlowRef {
     }
     /// WARNING: This should only be used when there is no aliasing:
     /// when the traversal ensures that no other threads accesses the same flow at the same time.
-    /// See https://github.com/servo/servo/issues/6503
+    /// See <https://github.com/servo/servo/issues/6503>.
     /// Use Arc::get_mut instead when possible (e.g. on an Arc that was just created).
     #[allow(unsafe_code)]
     pub fn deref_mut(this: &mut FlowRef) -> &mut dyn Flow {

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! CSS Multi-column layout http://dev.w3.org/csswg/css-multicol/
+//! CSS Multi-column layout <http://dev.w3.org/csswg/css-multicol/>
 
 use std::cmp::{max, min};
 use std::fmt;

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -726,7 +726,7 @@ pub fn process_node_scroll_id_request<'dom>(
     layout_node.generate_scroll_id(id)
 }
 
-/// https://drafts.csswg.org/cssom-view/#scrolling-area
+/// <https://drafts.csswg.org/cssom-view/#scrolling-area>
 pub fn process_scrolling_area_request(
     requested_node: Option<OpaqueNode>,
     layout_root: &mut dyn Flow,

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -1167,7 +1167,7 @@ impl<'a> Iterator for TableRowIterator<'a> {
 /// for each cell
 ///
 /// Used for correctly handling table layers from
-/// https://drafts.csswg.org/css2/tables.html#table-layers
+/// <https://drafts.csswg.org/css2/tables.html#table-layers>
 struct TableCellStyleIterator<'table> {
     column_styles: Vec<ColumnStyle<'table>>,
     row_iterator: TableRowAndGroupIterator<'table>,

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -7,7 +7,7 @@
 //! This follows the "More Precise Definitions of Inline Layout and Table Layout" proposal written
 //! by L. David Baron (Mozilla) here:
 //!
-//!   http://dbaron.org/css/intrinsic/
+//!   <http://dbaron.org/css/intrinsic/>
 //!
 //! Hereafter this document is referred to as INTRINSIC.
 

--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -55,7 +55,7 @@ pub(super) fn build(
     }
 }
 
-/// https://drafts.csswg.org/css-images-3/#linear-gradients
+/// <https://drafts.csswg.org/css-images-3/#linear-gradients>
 pub(super) fn build_linear(
     style: &ComputedValues,
     items: &[GradientItem<Color, LengthPercentage>],
@@ -155,7 +155,7 @@ pub(super) fn build_linear(
     )
 }
 
-/// https://drafts.csswg.org/css-images-3/#radial-gradients
+/// <https://drafts.csswg.org/css-images-3/#radial-gradients>
 pub(super) fn build_radial(
     style: &ComputedValues,
     items: &[GradientItem<Color, LengthPercentage>],
@@ -255,7 +255,7 @@ pub(super) fn build_radial(
     )
 }
 
-/// https://drafts.csswg.org/css-images-4/#color-stop-fixup
+/// <https://drafts.csswg.org/css-images-4/#color-stop-fixup>
 fn fixup_stops(
     style: &ComputedValues,
     items: &[GradientItem<Color, LengthPercentage>],

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -118,7 +118,7 @@ pub(crate) struct DisplayListBuilder<'a> {
 
     /// Contentful paint i.e. whether the display list contains items of type
     /// text, image, non-white canvas or SVG). Used by metrics.
-    /// See https://w3c.github.io/paint-timing/#first-contentful-paint.
+    /// See <https://w3c.github.io/paint-timing/#first-contentful-paint>.
     is_contentful: bool,
 }
 

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -511,7 +511,7 @@ impl StackingContext {
         true
     }
 
-    /// https://drafts.csswg.org/css-backgrounds/#special-backgrounds
+    /// <https://drafts.csswg.org/css-backgrounds/#special-backgrounds>
     ///
     /// This is only called for the root `StackingContext`
     pub(crate) fn build_canvas_background_display_list(

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -327,7 +327,7 @@ where
     })
 }
 
-/// https://www.w3.org/TR/CSS2/generate.html#propdef-content
+/// <https://www.w3.org/TR/CSS2/generate.html#propdef-content>
 fn generate_pseudo_element_content<'dom, Node>(
     pseudo_element_style: &ComputedValues,
     element: Node,

--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -38,7 +38,7 @@ impl FlexContainer {
     }
 }
 
-/// https://drafts.csswg.org/css-flexbox/#flex-items
+/// <https://drafts.csswg.org/css-flexbox/#flex-items>
 struct FlexContainerBuilder<'a, 'dom, Node> {
     context: &'a LayoutContext<'a>,
     info: &'a NodeAndStyleInfo<Node>,
@@ -98,7 +98,7 @@ where
     }
 }
 
-/// https://drafts.csswg.org/css-text/#white-space
+/// <https://drafts.csswg.org/css-text/#white-space>
 fn is_only_document_white_space<Node>(run: &TextRun<'_, Node>) -> bool {
     // FIXME: is this the right definition? See
     // https://github.com/w3c/csswg-drafts/issues/5146

--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! https://drafts.csswg.org/css-flexbox/#box-model
+//! <https://drafts.csswg.org/css-flexbox/#box-model>
 
 use style::properties::longhands::flex_direction::computed_value::T as FlexDirection;
 
@@ -87,7 +87,7 @@ pub(super) enum FlexAxis {
 }
 
 /// Which flow-relative sides map to the main-start and cross-start sides, respectively.
-/// See https://drafts.csswg.org/css-flexbox/#box-model
+/// See <https://drafts.csswg.org/css-flexbox/#box-model>
 #[derive(Clone, Copy)]
 pub(super) enum MainStartCrossStart {
     InlineStartBlockStart,

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -69,10 +69,10 @@ struct FlexItem<'a> {
     /// This is the difference between an outer and inner size.
     pbm_auto_is_zero: FlexRelativeVec2<Length>,
 
-    /// https://drafts.csswg.org/css-flexbox/#algo-main-item
+    /// <https://drafts.csswg.org/css-flexbox/#algo-main-item>
     flex_base_size: Length,
 
-    /// https://drafts.csswg.org/css-flexbox/#algo-main-item
+    /// <https://drafts.csswg.org/css-flexbox/#algo-main-item>
     hypothetical_main_size: Length,
     /// This is `align-self`, defaulting to `align-items` if `auto`
     align_self: AlignItems,
@@ -153,7 +153,7 @@ impl FlexContainer {
         ContentSizes::zero() // Return an incorrect result rather than panic
     }
 
-    /// https://drafts.csswg.org/css-flexbox/#layout-algorithm
+    /// <https://drafts.csswg.org/css-flexbox/#layout-algorithm>
     pub(crate) fn layout(
         &self,
         layout_context: &LayoutContext,
@@ -552,7 +552,7 @@ impl<'a> FlexItem<'a> {
     }
 }
 
-/// https://drafts.csswg.org/css-flexbox/#algo-main-item
+/// <https://drafts.csswg.org/css-flexbox/#algo-main-item>
 fn flex_base_size(
     flex_context: &FlexContext,
     flex_item: &mut IndependentFormattingContext,
@@ -872,7 +872,7 @@ impl FlexLine<'_> {
     }
 
     /// Return the *main size* of each item, and the line’s remainaing free space
-    /// https://drafts.csswg.org/css-flexbox/#resolve-flexible-lengths
+    /// <https://drafts.csswg.org/css-flexbox/#resolve-flexible-lengths>
     fn resolve_flexible_lengths(&self, container_main_size: Length) -> (Vec<Length>, Length) {
         let mut frozen = vec![false; self.items.len()];
         let mut target_main_sizes_vec = self
@@ -1135,7 +1135,7 @@ impl<'a> FlexItem<'a> {
 }
 
 impl<'items> FlexLine<'items> {
-    /// https://drafts.csswg.org/css-flexbox/#algo-cross-line
+    /// <https://drafts.csswg.org/css-flexbox/#algo-cross-line>
     fn cross_size(
         &self,
         item_layout_results: &[FlexItemLayoutResult],
@@ -1238,7 +1238,7 @@ impl<'items> FlexLine<'items> {
 
 impl FlexItem<'_> {
     /// Return the cross-start and cross-end margin, with `auto` values resolved.
-    /// https://drafts.csswg.org/css-flexbox/#algo-cross-margins
+    /// <https://drafts.csswg.org/css-flexbox/#algo-cross-margins>
     fn resolve_auto_cross_margins(
         &self,
         flex_context: &FlexContext,

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -4,7 +4,7 @@
 
 //! Float layout.
 //!
-//! See CSS 2.1 § 9.5.1: https://www.w3.org/TR/CSS2/visuren.html#float-position
+//! See CSS 2.1 § 9.5.1: <https://www.w3.org/TR/CSS2/visuren.html#float-position>
 
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
@@ -506,7 +506,7 @@ pub struct PlacementInfo {
 
 /// Whether the float is left or right.
 ///
-/// See CSS 2.1 § 9.5.1: https://www.w3.org/TR/CSS2/visuren.html#float-position
+/// See CSS 2.1 § 9.5.1: <https://www.w3.org/TR/CSS2/visuren.html#float-position>
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FloatSide {
     Left,
@@ -600,8 +600,8 @@ impl FloatBand {
 ///
 /// AA trees were chosen for simplicity.
 ///
-/// See: https://en.wikipedia.org/wiki/AA_tree
-///      https://arxiv.org/pdf/1412.4882.pdf
+/// See: <https://en.wikipedia.org/wiki/AA_tree>
+///      <https://arxiv.org/pdf/1412.4882.pdf>
 #[derive(Clone, Debug)]
 pub struct FloatBandTree {
     pub root: FloatBandLink,
@@ -787,12 +787,13 @@ impl FloatBandLink {
     }
 
     /// Corrects tree balance:
-    ///
+    ///```text
     ///         T          L
     ///        / \        / \
     ///       L   R  →   A   T      if level(T) = level(L)
     ///      / \            / \
     ///     A   B          B   R
+    /// ```
     fn skew(&self) -> FloatBandLink {
         if let Some(ref this) = self.0 {
             if let Some(ref left) = this.left.0 {
@@ -816,12 +817,13 @@ impl FloatBandLink {
     }
 
     /// Corrects tree balance:
-    ///
+    ///```text
     ///         T            R
     ///        / \          / \
     ///       A   R   →    T   X    if level(T) = level(X)
     ///          / \      / \
     ///         B   X    A   B
+    /// ```
     fn split(&self) -> FloatBandLink {
         if let Some(ref this) = self.0 {
             if let Some(ref right) = this.right.0 {

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -93,7 +93,7 @@ pub(crate) struct InlineBox {
     pub children: Vec<ArcRefCell<InlineLevelBox>>,
 }
 
-/// https://www.w3.org/TR/css-display-3/#css-text-run
+/// <https://www.w3.org/TR/css-display-3/#css-text-run>
 #[derive(Debug, Serialize)]
 pub(crate) struct TextRun {
     pub base_fragment_info: BaseFragmentInfo,
@@ -296,7 +296,7 @@ impl LineBlockSizes {
             .adjust_for_nested_baseline_offset(baseline_offset);
     }
 
-    /// From https://drafts.csswg.org/css2/visudet.html#line-height:
+    /// From <https://drafts.csswg.org/css2/visudet.html#line-height>:
     ///  > The inline-level boxes are aligned vertically according to their 'vertical-align'
     ///  > property. In case they are aligned 'top' or 'bottom', they must be aligned so as
     ///  > to minimize the line box height. If such boxes are tall enough, there are multiple
@@ -475,7 +475,7 @@ struct InlineContainerState {
     has_content: bool,
 
     /// Indicates whether this nesting level have text decorations in effect.
-    /// From https://drafts.csswg.org/css-text-decor/#line-decoration
+    /// From <https://drafts.csswg.org/css-text-decor/#line-decoration>
     // "When specified on or propagated to a block container that establishes
     //  an IFC..."
     text_decoration_line: TextDecorationLine,
@@ -483,7 +483,7 @@ struct InlineContainerState {
     /// The block size contribution of this container's default font ie the size of the
     /// "strut." Whether this is integrated into the [`Self::nested_strut_block_sizes`]
     /// depends on the line-height quirk described in
-    /// https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk.
+    /// <https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk>.
     strut_block_sizes: LineBlockSizes,
 
     /// The strut block size of this inline container maxed with the strut block
@@ -527,7 +527,7 @@ struct InlineFormattingContextState<'a, 'b> {
 
     /// The [`InlineContainerState`] for the container formed by the root of the
     /// [`InlineFormattingContext`]. This is effectively the "root inline box" described
-    /// by https://drafts.csswg.org/css-inline/#model:
+    /// by <https://drafts.csswg.org/css-inline/#model>:
     ///
     /// > The block container also generates a root inline box, which is an anonymous
     /// > inline box that holds all of its inline-level contents. (Thus, all text in an
@@ -546,10 +546,10 @@ struct InlineFormattingContextState<'a, 'b> {
     /// are currently laid out at the top-level of each [`InlineFormattingContext`].
     fragments: Vec<Fragment>,
 
-    /// Information about the line currently being laid out into [`LineItems`]s.
+    /// Information about the line currently being laid out into [`LineItem`]s.
     current_line: LineUnderConstruction,
 
-    /// Information about the unbreakable line segment currently being laid out into [`LineItems`]s.
+    /// Information about the unbreakable line segment currently being laid out into [`LineItem`]s.
     current_line_segment: UnbreakableSegmentUnderConstruction,
 
     /// The line breaking state for this inline formatting context.
@@ -2183,7 +2183,7 @@ fn font_metrics_from_style(layout_context: &LayoutContext, style: &ComputedValue
 
 /// comes before or after an atomic inline element.
 ///
-/// From https://www.w3.org/TR/css-text-3/#line-break-details:
+/// From <https://www.w3.org/TR/css-text-3/#line-break-details>:
 ///
 /// > For Web-compatibility there is a soft wrap opportunity before and after each
 /// > replaced element or other atomic inline, even when adjacent to a character that
@@ -2213,7 +2213,7 @@ fn is_baseline_relative(vertical_align: GenericVerticalAlign<LengthPercentage>) 
 /// all inline containers get struts. In quirks mode this isn't always the case
 /// though.
 ///
-/// From https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk
+/// From <https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk>
 ///
 /// > ### § 3.3. The line height calculation quirk
 /// > In quirks mode and limited-quirks mode, an inline box that matches the following
@@ -2405,6 +2405,7 @@ impl<'a> ContentSizesComputation<'a> {
             had_non_whitespace_content_yet: false,
             linebreaker: None,
             ending_inline_pbm_stack: Vec::new(),
-        }.traverse(inline_formatting_context)
+        }
+        .traverse(inline_formatting_context)
     }
 }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -622,8 +622,8 @@ impl BlockLevelBox {
 /// Lay out a normal flow non-replaced block that does not establish a new formatting
 /// context.
 ///
-/// - https://drafts.csswg.org/css2/visudet.html#blockwidth
-/// - https://drafts.csswg.org/css2/visudet.html#normal-block
+/// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
+/// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
 fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
@@ -826,8 +826,8 @@ impl NonReplacedFormattingContext {
     /// Lay out a normal in flow non-replaced block that establishes an independent
     /// formatting context in its containing formatting context.
     ///
-    /// - https://drafts.csswg.org/css2/visudet.html#blockwidth
-    /// - https://drafts.csswg.org/css2/visudet.html#normal-block
+    /// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
+    /// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
     fn layout_in_flow_block_level(
         &self,
         layout_context: &LayoutContext,
@@ -1119,9 +1119,9 @@ impl NonReplacedFormattingContext {
     }
 }
 
-/// https://drafts.csswg.org/css2/visudet.html#block-replaced-width
-/// https://drafts.csswg.org/css2/visudet.html#inline-replaced-width
-/// https://drafts.csswg.org/css2/visudet.html#inline-replaced-height
+/// <https://drafts.csswg.org/css2/visudet.html#block-replaced-width>
+/// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-width>
+/// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-height>
 fn layout_in_flow_replaced_block_level<'a>(
     containing_block: &ContainingBlock,
     base_fragment_info: BaseFragmentInfo,

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -34,7 +34,7 @@ pub struct BoxTree {
     /// There may be zero if that element has `display: none`.
     root: BlockFormattingContext,
 
-    /// https://drafts.csswg.org/css-backgrounds/#special-backgrounds
+    /// <https://drafts.csswg.org/css-backgrounds/#special-backgrounds>
     canvas_background: CanvasBackground,
 }
 
@@ -338,7 +338,7 @@ impl BoxTree {
     }
 }
 
-/// https://drafts.csswg.org/css-backgrounds/#root-background
+/// <https://drafts.csswg.org/css-backgrounds/#root-background>
 #[derive(Clone, Serialize)]
 pub struct CanvasBackground {
     /// DOM node for the root element
@@ -346,7 +346,7 @@ pub struct CanvasBackground {
 
     /// The element whose style the canvas takes background properties from (see next field).
     /// This can be the root element (same as the previous field), or the HTML `<body>` element.
-    /// See https://drafts.csswg.org/css-backgrounds/#body-background
+    /// See <https://drafts.csswg.org/css-backgrounds/#body-background>
     pub from_element: OpaqueNode,
 
     /// The computed styles to take background properties from.

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -24,7 +24,7 @@ use crate::style_ext::DisplayInside;
 use crate::table::Table;
 use crate::ContainingBlock;
 
-/// https://drafts.csswg.org/css-display/#independent-formatting-context
+/// <https://drafts.csswg.org/css-display/#independent-formatting-context>
 #[derive(Debug, Serialize)]
 pub(crate) enum IndependentFormattingContext {
     NonReplaced(NonReplacedFormattingContext),
@@ -62,7 +62,7 @@ pub(crate) enum NonReplacedFormattingContextContents {
 pub(crate) struct IndependentLayout {
     pub fragments: Vec<Fragment>,
 
-    /// https://drafts.csswg.org/css2/visudet.html#root-height
+    /// <https://drafts.csswg.org/css2/visudet.html#root-height>
     pub content_block_size: Au,
 
     /// The offset of the last inflow baseline of this layout in the content area, if

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -29,7 +29,7 @@ pub(crate) struct BoxFragment {
 
     /// From the containing block’s start corner…?
     /// This might be broken when the containing block is in a different writing mode:
-    /// https://drafts.csswg.org/css-writing-modes/#orthogonal-flows
+    /// <https://drafts.csswg.org/css-writing-modes/#orthogonal-flows>
     pub content_rect: LogicalRect<Length>,
 
     pub padding: LogicalSides<Length>,
@@ -41,7 +41,7 @@ pub(crate) struct BoxFragment {
     /// so that the element doesn't overlap earlier floats in the same BFC.
     /// The presence of clearance prevents the top margin from collapsing with
     /// earlier margins or with the bottom margin of the parent block.
-    /// https://drafts.csswg.org/css2/#clearance
+    /// <https://drafts.csswg.org/css2/#clearance>
     pub clearance: Option<Length>,
 
     /// When this box contains an inline formatting context, this tracks the baseline

--- a/components/layout_2020/fragment_tree/containing_block.rs
+++ b/components/layout_2020/fragment_tree/containing_block.rs
@@ -15,7 +15,7 @@ pub(crate) struct ContainingBlockManager<'a, T> {
     /// position is 'relative' or 'static', the containing block is formed by the
     /// content edge of the nearest block container ancestor box." This is also
     /// the case for 'position: sticky' elements.
-    /// https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
+    /// <https://www.w3.org/TR/CSS2/visudet.html#containing-block-details>
     pub for_non_absolute_descendants: &'a T,
 
     /// The containing block for absolute descendants. "If the element has
@@ -29,7 +29,7 @@ pub(crate) struct ContainingBlockManager<'a, T> {
     ///      undefined.
     ///   2. Otherwise, the containing block is formed by the padding edge of the
     ///      ancestor."
-    /// https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
+    /// <https://www.w3.org/TR/CSS2/visudet.html#containing-block-details>
     /// If the ancestor forms a containing block for all descendants (see below),
     /// this value will be None and absolute descendants will use the containing
     /// block for fixed descendants.
@@ -41,7 +41,7 @@ pub(crate) struct ContainingBlockManager<'a, T> {
     /// establish a containing block for all descendants. Its padding box will be
     /// used to layout for all of its absolute-position descendants,
     /// fixed-position descendants, and descendant fixed background attachments."
-    /// https://w3c.github.io/csswg-drafts/css-transforms-1/#containing-block-for-all-descendants
+    /// <https://w3c.github.io/csswg-drafts/css-transforms-1/#containing-block-for-all-descendants>
     /// See `ComputedValues::establishes_containing_block_for_all_descendants`
     /// for a list of conditions where an element forms a containing block for
     /// all descendants.

--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -31,13 +31,13 @@ pub struct FragmentTree {
     pub(crate) root_fragments: Vec<ArcRefCell<Fragment>>,
 
     /// The scrollable overflow rectangle for the entire tree
-    /// https://drafts.csswg.org/css-overflow/#scrollable
+    /// <https://drafts.csswg.org/css-overflow/#scrollable>
     pub(crate) scrollable_overflow: PhysicalRect<Length>,
 
     /// The containing block used in the layout of this fragment tree.
     pub(crate) initial_containing_block: PhysicalRect<Length>,
 
-    /// https://drafts.csswg.org/css-backgrounds/#special-backgrounds
+    /// <https://drafts.csswg.org/css-backgrounds/#special-backgrounds>
     #[serde(skip)]
     pub(crate) canvas_background: CanvasBackground,
 }

--- a/components/layout_2020/lists.rs
+++ b/components/layout_2020/lists.rs
@@ -11,7 +11,7 @@ use crate::dom::NodeExt;
 use crate::dom_traversal::{NodeAndStyleInfo, PseudoElementContentItem};
 use crate::replaced::ReplacedContent;
 
-/// https://drafts.csswg.org/css-lists/#content-property
+/// <https://drafts.csswg.org/css-lists/#content-property>
 pub(crate) fn make_marker<'dom, Node>(
     context: &LayoutContext,
     info: &NodeAndStyleInfo<Node>,
@@ -44,7 +44,7 @@ where
     })
 }
 
-/// https://drafts.csswg.org/css-lists/#marker-string
+/// <https://drafts.csswg.org/css-lists/#marker-string>
 fn marker_string(style: &style_structs::List) -> Option<&'static str> {
     match style.list_style_type {
         ListStyleType::None => None,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -755,13 +755,13 @@ struct AbsoluteAxisSolver<'a> {
 impl<'a> AbsoluteAxisSolver<'a> {
     /// This unifies some of the parts in common in:
     ///
-    /// * https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width
-    /// * https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-height
+    /// * <https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width>
+    /// * <https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-height>
     ///
     /// … and:
     ///
-    /// * https://drafts.csswg.org/css2/visudet.html#abs-replaced-width
-    /// * https://drafts.csswg.org/css2/visudet.html#abs-replaced-height
+    /// * <https://drafts.csswg.org/css2/visudet.html#abs-replaced-width>
+    /// * <https://drafts.csswg.org/css2/visudet.html#abs-replaced-height>
     ///
     /// In the replaced case, `size` is never `Auto`.
     fn solve_for_size(&self, computed_size: LengthOrAuto) -> AxisResult {
@@ -859,7 +859,7 @@ fn vec_append_owned<T>(a: &mut Vec<T>, mut b: Vec<T>) {
     }
 }
 
-/// https://drafts.csswg.org/css2/visuren.html#relative-positioning
+/// <https://drafts.csswg.org/css2/visuren.html#relative-positioning>
 pub(crate) fn relative_adjustement(
     style: &ComputedValues,
     containing_block: &ContainingBlock,

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -199,7 +199,7 @@ pub fn process_node_scroll_id_request<'dom>(
     layout_node.generate_scroll_id(id)
 }
 
-/// https://drafts.csswg.org/cssom-view/#scrolling-area
+/// <https://drafts.csswg.org/cssom-view/#scrolling-area>
 pub fn process_node_scroll_area_request(
     requested_node: Option<OpaqueNode>,
     fragment_tree: Option<Arc<FragmentTree>>,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -38,18 +38,18 @@ pub(crate) struct ReplacedContent {
 
 /// * Raster images always have an intrinsic width and height, with 1 image pixel = 1px.
 ///   The intrinsic ratio should be based on dividing those.
-///   See https://github.com/w3c/csswg-drafts/issues/4572 for the case where either is zero.
+///   See <https://github.com/w3c/csswg-drafts/issues/4572> for the case where either is zero.
 ///   PNG specifically disallows this but I (SimonSapin) am not sure about other formats.
 ///
 /// * Form controls have both intrinsic width and height **but no intrinsic ratio**.
-///   See https://github.com/w3c/csswg-drafts/issues/1044 and
-///   https://drafts.csswg.org/css-images/#intrinsic-dimensions “In general, […]”
+///   See <https://github.com/w3c/csswg-drafts/issues/1044> and
+///   <https://drafts.csswg.org/css-images/#intrinsic-dimensions> “In general, […]”
 ///
-/// * For SVG, see https://svgwg.org/svg2-draft/coords.html#SizingSVGInCSS
-///   and again https://github.com/w3c/csswg-drafts/issues/4572.
+/// * For SVG, see <https://svgwg.org/svg2-draft/coords.html#SizingSVGInCSS>
+///   and again <https://github.com/w3c/csswg-drafts/issues/4572>.
 ///
 /// * IFrames do not have intrinsic width and height or intrinsic ratio according
-///   to https://drafts.csswg.org/css-images/#intrinsic-dimensions.
+///   to <https://drafts.csswg.org/css-images/#intrinsic-dimensions>.
 #[derive(Debug, Serialize)]
 pub(crate) struct IntrinsicSizes {
     pub width: Option<Au>,
@@ -318,11 +318,11 @@ impl ReplacedContent {
         }
     }
 
-    /// https://drafts.csswg.org/css2/visudet.html#inline-replaced-width
-    /// https://drafts.csswg.org/css2/visudet.html#inline-replaced-height
+    /// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-width>
+    /// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-height>
     ///
     /// Also used in other cases, for example
-    /// https://drafts.csswg.org/css2/visudet.html#block-replaced-width
+    /// <https://drafts.csswg.org/css2/visudet.html#block-replaced-width>
     pub fn used_size_as_if_inline_element(
         &self,
         containing_block: &ContainingBlock,

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! https://drafts.csswg.org/css-sizing/
+//! <https://drafts.csswg.org/css-sizing/>
 
 use serde::Serialize;
 use style::logical_geometry::WritingMode;
@@ -19,7 +19,7 @@ pub(crate) struct ContentSizes {
     pub max_content: Length,
 }
 
-/// https://drafts.csswg.org/css-sizing/#intrinsic-sizes
+/// <https://drafts.csswg.org/css-sizing/#intrinsic-sizes>
 impl ContentSizes {
     pub fn zero() -> Self {
         Self {
@@ -51,7 +51,7 @@ impl ContentSizes {
 }
 
 impl ContentSizes {
-    /// https://drafts.csswg.org/css2/visudet.html#shrink-to-fit-float
+    /// <https://drafts.csswg.org/css2/visudet.html#shrink-to-fit-float>
     pub fn shrink_to_fit(&self, available_size: Length) -> Length {
         available_size.max(self.min_content).min(self.max_content)
     }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -39,7 +39,7 @@ pub(crate) enum DisplayGeneratingBox {
         outside: DisplayOutside,
         inside: DisplayInside,
     },
-    // https://drafts.csswg.org/css-display-3/#layout-specific-display
+    /// <https://drafts.csswg.org/css-display-3/#layout-specific-display>
     LayoutInternal(DisplayLayoutInternal),
 }
 
@@ -63,7 +63,7 @@ pub(crate) enum DisplayOutside {
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(crate) enum DisplayInside {
     // “list-items are limited to the Flow Layout display types”
-    // https://drafts.csswg.org/css-display/#list-items
+    // <https://drafts.csswg.org/css-display/#list-items>
     Flow { is_list_item: bool },
     FlowRoot { is_list_item: bool },
     Flex,
@@ -71,7 +71,7 @@ pub(crate) enum DisplayInside {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-/// https://drafts.csswg.org/css-display-3/#layout-specific-display
+/// <https://drafts.csswg.org/css-display-3/#layout-specific-display>
 pub(crate) enum DisplayLayoutInternal {
     TableCaption,
     TableCell,
@@ -84,7 +84,7 @@ pub(crate) enum DisplayLayoutInternal {
 }
 
 impl DisplayLayoutInternal {
-    /// https://drafts.csswg.org/css-display-3/#layout-specific-displa
+    /// <https://drafts.csswg.org/css-display-3/#layout-specific-displa>
     pub(crate) fn display_inside(&self) -> DisplayInside {
         // When we add ruby, the display_inside of ruby must be Flow.
         // TODO: this should be unreachable for everything but
@@ -407,7 +407,7 @@ impl ComputedValuesExt for ComputedValues {
     }
 
     /// Get the effective z-index of this fragment. Z-indices only apply to positioned elements
-    /// per CSS 2 9.9.1 (http://www.w3.org/TR/CSS2/visuren.html#z-index), so this value may differ
+    /// per CSS 2 9.9.1 (<http://www.w3.org/TR/CSS2/visuren.html#z-index>), so this value may differ
     /// from the value specified in the style.
     fn effective_z_index(&self) -> i32 {
         match self.get_box().position {

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -303,7 +303,7 @@ impl TableBuilder {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows
+    /// <https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows>
     /// Push a single cell onto the slot map, handling any colspans it may have, and
     /// setting up the outgoing rowspans.
     pub fn add_cell(&mut self, cell: TableSlotCell) {
@@ -468,7 +468,7 @@ where
             .push(AnonymousTableContent::Text(info.clone(), text));
     }
 
-    /// https://html.spec.whatwg.org/multipage/#forming-a-table
+    /// <https://html.spec.whatwg.org/multipage/#forming-a-table>
     fn handle_element(
         &mut self,
         info: &NodeAndStyleInfo<Node>,
@@ -646,7 +646,7 @@ where
             .push(AnonymousTableContent::Text(info.clone(), text));
     }
 
-    /// https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows
+    /// <https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows>
     fn handle_element(
         &mut self,
         info: &NodeAndStyleInfo<Node>,

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -139,7 +139,7 @@ pub enum TableSlot {
     ///
     /// If there is more than one cell that spans a slot, this is a table model error, but
     /// we still keep track of it. See
-    /// https://html.spec.whatwg.org/multipage/#table-model-error
+    /// <https://html.spec.whatwg.org/multipage/#table-model-error>
     Spanned(Vec<TableSlotOffset>),
 
     /// An empty spot in the table. This can happen when there is a gap in columns between

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -137,7 +137,7 @@ pub enum CACertificates {
 ///
 /// FIXME: The `ignore_certificate_errors` argument ignores all certificate errors. This
 /// is used when running the WPT tests, because rustls currently rejects the WPT certificiate.
-/// See https://github.com/servo/servo/issues/30080
+/// See <https://github.com/servo/servo/issues/30080>
 pub fn create_tls_config(
     ca_certificates: CACertificates,
     ignore_certificate_errors: bool,

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Implementation of cookie creation and matching as specified by
-//! http://tools.ietf.org/html/rfc6265
+//! <http://tools.ietf.org/html/rfc6265>
 
 use std::borrow::ToOwned;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Implementation of cookie storage as specified in
-//! http://tools.ietf.org/html/rfc6265
+//! <http://tools.ietf.org/html/rfc6265>
 
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -164,7 +164,7 @@ pub async fn fetch_with_cors_cache(
     main_fetch(request, cache, false, false, target, &mut None, &context).await;
 }
 
-/// https://www.w3.org/TR/CSP/#should-block-request
+/// <https://www.w3.org/TR/CSP/#should-block-request>
 pub fn should_request_be_blocked_by_csp(request: &Request) -> csp::CheckResult {
     let origin = match &request.origin {
         Origin::Client => return csp::CheckResult::Allowed,

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -144,7 +144,7 @@ impl HstsList {
         }
     }
 
-    /// Step 2.9 of https://fetch.spec.whatwg.org/#concept-main-fetch.
+    /// Step 2.9 of <https://fetch.spec.whatwg.org/#concept-main-fetch>.
     pub fn apply_hsts_rules(&self, url: &mut ServoUrl) {
         if url.scheme() != "http" && url.scheme() != "ws" {
             return;

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -223,7 +223,7 @@ fn strict_origin_when_cross_origin(
     strip_url_for_use_as_referrer(referrer_url, true)
 }
 
-/// https://html.spec.whatwg.org/multipage/#schemelessly-same-site
+/// <https://html.spec.whatwg.org/multipage/#schemelessly-same-site>
 fn is_schemelessy_same_site(site_a: &ImmutableOrigin, site_b: &ImmutableOrigin) -> bool {
     // Step 1
     if !site_a.is_tuple() && !site_b.is_tuple() && site_a == site_b {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -94,7 +94,7 @@ fn set_webrender_image_key(webrender_api: &WebrenderIpcSender, image: &mut Image
 // Aux structs and enums.
 // ======================================================================
 
-/// https://html.spec.whatwg.org/multipage/#list-of-available-images
+/// <https://html.spec.whatwg.org/multipage/#list-of-available-images>
 type ImageKey = (ServoUrl, ImmutableOrigin, Option<CorsSettings>);
 
 // Represents all the currently pending loads/decodings. For

--- a/components/remutex/lib.rs
+++ b/components/remutex/lib.rs
@@ -7,7 +7,7 @@
 //! Re-entrant mutexes are like mutexes, but where it is expected
 //! that a single thread may own a lock more than once.
 
-//! It provides the same interface as https://github.com/rust-lang/rust/blob/5edaa7eefd76d4996dcf85dfc1c1a3f737087257/src/libstd/sys_common/remutex.rs
+//! It provides the same interface as <https://github.com/rust-lang/rust/blob/5edaa7eefd76d4996dcf85dfc1c1a3f737087257/src/libstd/sys_common/remutex.rs>
 //! so if those types are ever exported, we should be able to replace this implemtation.
 
 use std::cell::{Cell, UnsafeCell};
@@ -148,7 +148,7 @@ unsafe impl Send for HandOverHandMutex {}
 
 /// A type for re-entrant mutexes.
 ///
-/// It provides the same interface as https://github.com/rust-lang/rust/blob/5edaa7eefd76d4996dcf85dfc1c1a3f737087257/src/libstd/sys_common/remutex.rs
+/// It provides the same interface as <https://github.com/rust-lang/rust/blob/5edaa7eefd76d4996dcf85dfc1c1a3f737087257/src/libstd/sys_common/remutex.rs>
 
 pub struct ReentrantMutex<T> {
     mutex: HandOverHandMutex,

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -342,7 +342,7 @@ impl Callback for TransmitBodyPromiseRejectionHandler {
     }
 }
 
-/// The result of https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+/// The result of <https://fetch.spec.whatwg.org/#concept-bodyinit-extract>
 pub struct ExtractedBody {
     pub stream: DomRoot<ReadableStream>,
     pub source: BodySource,
@@ -353,12 +353,12 @@ pub struct ExtractedBody {
 impl ExtractedBody {
     /// Build a request body from the extracted body,
     /// to be sent over IPC to net to use with `concept-request-transmit-body`,
-    /// see https://fetch.spec.whatwg.org/#concept-request-transmit-body.
+    /// see <https://fetch.spec.whatwg.org/#concept-request-transmit-body>.
     ///
     /// Also returning the corresponding readable stream,
     /// to be stored on the request in script,
     /// and potentially used as part of `consume_body`,
-    /// see https://fetch.spec.whatwg.org/#concept-body-consume-body
+    /// see <https://fetch.spec.whatwg.org/#concept-body-consume-body>
     ///
     /// Transmitting a body over fetch, and consuming it in script,
     /// are mutually exclusive operations, since each will lock the stream to a reader.

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -150,7 +150,7 @@ pub(crate) struct CanvasState {
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
     /// The base URL for resolving CSS image URL values.
-    /// Needed because of https://github.com/servo/servo/issues/17625
+    /// Needed because of <https://github.com/servo/servo/issues/17625>
     #[no_trace]
     base_url: ServoUrl,
     #[no_trace]

--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -129,7 +129,7 @@ impl AnalyserNode {
         Ok(object)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-analysernode
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-analysernode>
     #[allow(non_snake_case)]
     pub fn Constructor(
         window: &Window,
@@ -147,7 +147,7 @@ impl AnalyserNode {
 
 impl AnalyserNodeMethods for AnalyserNode {
     #[allow(unsafe_code)]
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloatfrequencydata
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloatfrequencydata>
     fn GetFloatFrequencyData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
@@ -156,7 +156,7 @@ impl AnalyserNodeMethods for AnalyserNode {
     }
 
     #[allow(unsafe_code)]
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytefrequencydata
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytefrequencydata>
     fn GetByteFrequencyData(&self, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
@@ -165,7 +165,7 @@ impl AnalyserNodeMethods for AnalyserNode {
     }
 
     #[allow(unsafe_code)]
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloattimedomaindata
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloattimedomaindata>
     fn GetFloatTimeDomainData(&self, mut array: CustomAutoRooterGuard<Float32Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
@@ -174,7 +174,7 @@ impl AnalyserNodeMethods for AnalyserNode {
     }
 
     #[allow(unsafe_code)]
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytetimedomaindata
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-getbytetimedomaindata>
     fn GetByteTimeDomainData(&self, mut array: CustomAutoRooterGuard<Uint8Array>) {
         // Invariant to maintain: No JS code that may touch the array should
         // run whilst we're writing to it
@@ -182,7 +182,7 @@ impl AnalyserNodeMethods for AnalyserNode {
         self.engine.borrow().fill_byte_time_domain_data(dest);
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-fftsize
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-fftsize>
     fn SetFftSize(&self, value: u32) -> Fallible<()> {
         if value > 32768 || value < 32 || (value & (value - 1) != 0) {
             return Err(Error::IndexSize);
@@ -191,22 +191,22 @@ impl AnalyserNodeMethods for AnalyserNode {
         Ok(())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-fftsize
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-fftsize>
     fn FftSize(&self) -> u32 {
         self.engine.borrow().get_fft_size() as u32
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-frequencybincount
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-frequencybincount>
     fn FrequencyBinCount(&self) -> u32 {
         self.FftSize() / 2
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-mindecibels
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-mindecibels>
     fn MinDecibels(&self) -> Finite<f64> {
         Finite::wrap(self.engine.borrow().get_min_decibels())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-mindecibels
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-mindecibels>
     fn SetMinDecibels(&self, value: Finite<f64>) -> Fallible<()> {
         if *value >= self.engine.borrow().get_max_decibels() {
             return Err(Error::IndexSize);
@@ -215,12 +215,12 @@ impl AnalyserNodeMethods for AnalyserNode {
         Ok(())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-maxdecibels
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-maxdecibels>
     fn MaxDecibels(&self) -> Finite<f64> {
         Finite::wrap(self.engine.borrow().get_max_decibels())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-maxdecibels
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-maxdecibels>
     fn SetMaxDecibels(&self, value: Finite<f64>) -> Fallible<()> {
         if *value <= self.engine.borrow().get_min_decibels() {
             return Err(Error::IndexSize);
@@ -229,12 +229,12 @@ impl AnalyserNodeMethods for AnalyserNode {
         Ok(())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-smoothingtimeconstant
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-smoothingtimeconstant>
     fn SmoothingTimeConstant(&self) -> Finite<f64> {
         Finite::wrap(self.engine.borrow().get_smoothing_constant())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-analysernode-smoothingtimeconstant
+    /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-smoothingtimeconstant>
     fn SetSmoothingTimeConstant(&self, value: Finite<f64>) -> Fallible<()> {
         if *value < 0. || *value > 1. {
             return Err(Error::IndexSize);

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -34,7 +34,7 @@ pub const MAX_SAMPLE_RATE: f32 = 192000.;
 ///
 /// js_channels buffers are (re)attached right before calling GetChannelData
 /// and remain attached until its contents are needed by some other API
-/// implementation. Follow https://webaudio.github.io/web-audio-api/#acquire-the-content
+/// implementation. Follow <https://webaudio.github.io/web-audio-api/#acquire-the-content>
 /// to know in which situations js_channels buffers must be detached.
 ///
 #[dom_struct]
@@ -48,13 +48,13 @@ pub struct AudioBuffer {
     #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
     shared_channels: DomRefCell<Option<ServoMediaAudioBuffer>>,
-    /// https://webaudio.github.io/web-audio-api/#dom-audiobuffer-samplerate
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-samplerate>
     sample_rate: f32,
-    /// https://webaudio.github.io/web-audio-api/#dom-audiobuffer-length
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-length>
     length: u32,
-    /// https://webaudio.github.io/web-audio-api/#dom-audiobuffer-duration
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-duration>
     duration: f64,
-    /// https://webaudio.github.io/web-audio-api/#dom-audiobuffer-numberofchannels
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-numberofchannels>
     number_of_channels: u32,
 }
 

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -39,9 +39,9 @@ use crate::task_source::TaskSource;
 pub struct AudioContext {
     context: BaseAudioContext,
     latency_hint: AudioContextLatencyCategory,
-    /// https://webaudio.github.io/web-audio-api/#dom-audiocontext-baselatency
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-baselatency>
     base_latency: f64,
-    /// https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency>
     output_latency: f64,
 }
 
@@ -256,7 +256,7 @@ impl AudioContextMethods for AudioContext {
         promise
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediaelementsource
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediaelementsource>
     fn CreateMediaElementSource(
         &self,
         media_element: &HTMLMediaElement,
@@ -266,7 +266,7 @@ impl AudioContextMethods for AudioContext {
         MediaElementAudioSourceNode::new(window, self, media_element)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamsource
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamsource>
     fn CreateMediaStreamSource(
         &self,
         stream: &MediaStream,
@@ -276,7 +276,7 @@ impl AudioContextMethods for AudioContext {
         MediaStreamAudioSourceNode::new(window, self, stream)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamtracksource
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamtracksource>
     fn CreateMediaStreamTrackSource(
         &self,
         track: &MediaStreamTrack,
@@ -286,7 +286,7 @@ impl AudioContextMethods for AudioContext {
         MediaStreamTrackAudioSourceNode::new(window, self, track)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamdestination>
     fn CreateMediaStreamDestination(&self) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let global = self.global();
         let window = global.as_window();

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -86,20 +86,20 @@ pub struct BaseAudioContext {
     #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
     audio_context_impl: Arc<Mutex<AudioContext>>,
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-destination
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-destination>
     destination: MutNullableDom<AudioDestinationNode>,
     listener: MutNullableDom<AudioListener>,
     /// Resume promises which are soon to be fulfilled by a queued task.
     #[ignore_malloc_size_of = "promises are hard"]
     in_flight_resume_promises_queue: DomRefCell<VecDeque<(Box<[Rc<Promise>]>, ErrorResult)>>,
-    /// https://webaudio.github.io/web-audio-api/#pendingresumepromises
+    /// <https://webaudio.github.io/web-audio-api/#pendingresumepromises>
     #[ignore_malloc_size_of = "promises are hard"]
     pending_resume_promises: DomRefCell<Vec<Rc<Promise>>>,
     #[ignore_malloc_size_of = "promises are hard"]
     decode_resolvers: DomRefCell<HashMap<String, DecodeResolver>>,
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-samplerate
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-samplerate>
     sample_rate: f32,
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-state
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-state>
     /// Although servo-media already keeps track of the control thread state,
     /// we keep a state flag here as well. This is so that we can synchronously
     /// throw when trying to do things on the context when the context has just
@@ -268,23 +268,23 @@ impl BaseAudioContext {
 }
 
 impl BaseAudioContextMethods for BaseAudioContext {
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-samplerate
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-samplerate>
     fn SampleRate(&self) -> Finite<f32> {
         Finite::wrap(self.sample_rate)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-currenttime
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-currenttime>
     fn CurrentTime(&self) -> Finite<f64> {
         let current_time = self.audio_context_impl.lock().unwrap().current_time();
         Finite::wrap(current_time)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-state
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-state>
     fn State(&self) -> AudioContextState {
         self.state.get()
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-resume
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-resume>
     fn Resume(&self, comp: InRealm) -> Rc<Promise> {
         // Step 1.
         let promise = Promise::new_in_current_realm(comp);
@@ -315,7 +315,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         promise
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-destination
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-destination>
     fn Destination(&self) -> DomRoot<AudioDestinationNode> {
         let global = self.global();
         self.destination.or_init(|| {
@@ -327,7 +327,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         })
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-listener
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-listener>
     fn Listener(&self) -> DomRoot<AudioListener> {
         let global = self.global();
         let window = global.as_window();
@@ -337,7 +337,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
     // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange
     event_handler!(statechange, GetOnstatechange, SetOnstatechange);
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createoscillator
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createoscillator>
     fn CreateOscillator(&self) -> Fallible<DomRoot<OscillatorNode>> {
         OscillatorNode::new(
             &self.global().as_window(),
@@ -346,22 +346,22 @@ impl BaseAudioContextMethods for BaseAudioContext {
         )
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-creategain
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-creategain>
     fn CreateGain(&self) -> Fallible<DomRoot<GainNode>> {
         GainNode::new(&self.global().as_window(), &self, &GainOptions::empty())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createpanner
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createpanner>
     fn CreatePanner(&self) -> Fallible<DomRoot<PannerNode>> {
         PannerNode::new(&self.global().as_window(), &self, &PannerOptions::empty())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createanalyser
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createanalyser>
     fn CreateAnalyser(&self) -> Fallible<DomRoot<AnalyserNode>> {
         AnalyserNode::new(&self.global().as_window(), &self, &AnalyserOptions::empty())
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbiquadfilter
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbiquadfilter>
     fn CreateBiquadFilter(&self) -> Fallible<DomRoot<BiquadFilterNode>> {
         BiquadFilterNode::new(
             &self.global().as_window(),
@@ -370,7 +370,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         )
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createstereopanner
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createstereopanner>
     fn CreateStereoPanner(&self) -> Fallible<DomRoot<StereoPannerNode>> {
         StereoPannerNode::new(
             &self.global().as_window(),
@@ -379,7 +379,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         )
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createconstantsource
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createconstantsource>
     fn CreateConstantSource(&self) -> Fallible<DomRoot<ConstantSourceNode>> {
         ConstantSourceNode::new(
             &self.global().as_window(),
@@ -388,21 +388,21 @@ impl BaseAudioContextMethods for BaseAudioContext {
         )
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelmerger
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelmerger>
     fn CreateChannelMerger(&self, count: u32) -> Fallible<DomRoot<ChannelMergerNode>> {
         let mut opts = ChannelMergerOptions::empty();
         opts.numberOfInputs = count;
         ChannelMergerNode::new(&self.global().as_window(), &self, &opts)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelsplitter
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelsplitter>
     fn CreateChannelSplitter(&self, count: u32) -> Fallible<DomRoot<ChannelSplitterNode>> {
         let mut opts = ChannelSplitterOptions::empty();
         opts.numberOfOutputs = count;
         ChannelSplitterNode::new(&self.global().as_window(), &self, &opts)
     }
 
-    /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer
+    /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer>
     fn CreateBuffer(
         &self,
         number_of_channels: u32,

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -224,8 +224,9 @@ where
 /// A rooting mechanism for reflectors on the stack.
 /// LIFO is not required.
 ///
-/// See also [*Exact Stack Rooting - Storing a GCPointer on the CStack*]
-/// (https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/GC/Exact_Stack_Rooting).
+/// See also [*Exact Stack Rooting - Storing a GCPointer on the CStack*][cstack].
+///
+/// [cstack]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/GC/Exact_Stack_Rooting
 pub struct RootCollection {
     roots: UnsafeCell<Vec<*const dyn JSTraceable>>,
 }
@@ -340,7 +341,7 @@ impl<T> Dom<T> {
 }
 
 impl<T: DomObject> Dom<T> {
-    /// Create a Dom<T> from a &T
+    /// Create a `Dom<T>` from a `&T`
     #[allow(crown::unrooted_must_root)]
     pub fn from_ref(obj: &T) -> Dom<T> {
         assert_in_script();
@@ -758,7 +759,7 @@ where
         self.value
     }
 
-    /// Transforms a slice of Dom<T> into a slice of LayoutDom<T>.
+    /// Transforms a slice of `Dom<T>` into a slice of `LayoutDom<T>`.
     // FIXME(nox): This should probably be done through a ToLayout trait.
     pub unsafe fn to_layout_slice(slice: &'dom [Dom<T>]) -> &'dom [LayoutDom<'dom, T>] {
         // This doesn't compile if Dom and LayoutDom don't have the same

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! Trait representing the concept of [serializable objects]
-//! (https://html.spec.whatwg.org/multipage/#serializable-objects).
+//! (<https://html.spec.whatwg.org/multipage/#serializable-objects>).
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::structuredclone::StructuredDataHolder;

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -316,12 +316,12 @@ impl DOMString {
 
     /// A valid date string should be "YYYY-MM-DD"
     /// YYYY must be four or more digits, MM and DD both must be two digits
-    /// https://html.spec.whatwg.org/multipage/#valid-date-string
+    /// <https://html.spec.whatwg.org/multipage/#valid-date-string>
     pub fn is_valid_date_string(&self) -> bool {
         self.parse_date_string().is_ok()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#parse-a-date-string
+    /// <https://html.spec.whatwg.org/multipage/#parse-a-date-string>
     pub fn parse_date_string(&self) -> Result<(i32, u32, u32), ()> {
         let value = &self.0;
         // Step 1, 2, 3
@@ -336,7 +336,7 @@ impl DOMString {
         Ok((year_int, month_int, day_int))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#parse-a-time-string
+    /// <https://html.spec.whatwg.org/multipage/#parse-a-time-string>
     pub fn parse_time_string(&self) -> Result<(u32, u32, f64), ()> {
         let value = &self.0;
         // Step 1, 2, 3
@@ -353,12 +353,12 @@ impl DOMString {
 
     /// A valid month string should be "YYYY-MM"
     /// YYYY must be four or more digits, MM both must be two digits
-    /// https://html.spec.whatwg.org/multipage/#valid-month-string
+    /// <https://html.spec.whatwg.org/multipage/#valid-month-string>
     pub fn is_valid_month_string(&self) -> bool {
         self.parse_month_string().is_ok()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#parse-a-month-string
+    /// <https://html.spec.whatwg.org/multipage/#parse-a-month-string>
     pub fn parse_month_string(&self) -> Result<(i32, u32), ()> {
         let value = &self;
         // Step 1, 2, 3
@@ -374,12 +374,12 @@ impl DOMString {
 
     /// A valid week string should be like {YYYY}-W{WW}, such as "2017-W52"
     /// YYYY must be four or more digits, WW both must be two digits
-    /// https://html.spec.whatwg.org/multipage/#valid-week-string
+    /// <https://html.spec.whatwg.org/multipage/#valid-week-string>
     pub fn is_valid_week_string(&self) -> bool {
         self.parse_week_string().is_ok()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#parse-a-week-string
+    /// <https://html.spec.whatwg.org/multipage/#parse-a-week-string>
     pub fn parse_week_string(&self) -> Result<(i32, u32), ()> {
         let value = &self.0;
         // Step 1, 2, 3
@@ -422,7 +422,7 @@ impl DOMString {
         Ok((year_int, week_int))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#valid-floating-point-number
+    /// <https://html.spec.whatwg.org/multipage/#valid-floating-point-number>
     pub fn is_valid_floating_point_number_string(&self) -> bool {
         lazy_static! {
             static ref RE: Regex =
@@ -431,7 +431,7 @@ impl DOMString {
         RE.is_match(&self.0) && self.parse_floating_point_number().is_ok()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#rules-for-parsing-floating-point-number-values
+    /// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-floating-point-number-values>
     pub fn parse_floating_point_number(&self) -> Result<f64, ()> {
         // Steps 15-16 are telling us things about IEEE rounding modes
         // for floating-point significands; this code assumes the Rust
@@ -456,7 +456,7 @@ impl DOMString {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number
+    /// <https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number>
     pub fn set_best_representation_of_the_floating_point_number(&mut self) {
         if let Ok(val) = self.parse_floating_point_number() {
             self.0 = val.to_string();
@@ -465,7 +465,7 @@ impl DOMString {
 
     /// A valid normalized local date and time string should be "{date}T{time}"
     /// where date and time are both valid, and the time string must be as short as possible
-    /// https://html.spec.whatwg.org/multipage/#valid-normalised-local-date-and-time-string
+    /// <https://html.spec.whatwg.org/multipage/#valid-normalised-local-date-and-time-string>
     pub fn convert_valid_normalized_local_date_and_time_string(&mut self) -> Result<(), ()> {
         let ((year, month, day), (hour, minute, second)) =
             self.parse_local_date_and_time_string()?;
@@ -491,7 +491,7 @@ impl DOMString {
         Ok(())
     }
 
-    /// https://html.spec.whatwg.org/multipage/#parse-a-local-date-and-time-string
+    /// <https://html.spec.whatwg.org/multipage/#parse-a-local-date-and-time-string>
     pub fn parse_local_date_and_time_string(
         &self,
     ) -> Result<((i32, u32, u32), (u32, u32, f64)), ()> {
@@ -520,7 +520,7 @@ impl DOMString {
         Ok((date_tuple, time_tuple))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#valid-e-mail-address
+    /// <https://html.spec.whatwg.org/multipage/#valid-e-mail-address>
     pub fn is_valid_email_address_string(&self) -> bool {
         lazy_static! {
             static ref RE: Regex = Regex::new(concat!(
@@ -532,7 +532,7 @@ impl DOMString {
         RE.is_match(&self.0)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#valid-simple-colour
+    /// <https://html.spec.whatwg.org/multipage/#valid-simple-colour>
     pub fn is_valid_simple_color_string(&self) -> bool {
         let mut chars = self.0.chars();
         if self.0.len() == 7 && chars.next() == Some('#') {
@@ -669,7 +669,7 @@ impl Extend<char> for DOMString {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#parse-a-month-component
+/// <https://html.spec.whatwg.org/multipage/#parse-a-month-component>
 fn parse_month_component(value: &str) -> Result<(i32, u32), ()> {
     // Step 3
     let mut iterator = value.split('-');
@@ -692,7 +692,7 @@ fn parse_month_component(value: &str) -> Result<(i32, u32), ()> {
     Ok((year_int, month_int))
 }
 
-/// https://html.spec.whatwg.org/multipage/#parse-a-date-component
+/// <https://html.spec.whatwg.org/multipage/#parse-a-date-component>
 fn parse_date_component(value: &str) -> Result<(i32, u32, u32), ()> {
     // Step 1
     let (year_int, month_int) = parse_month_component(value)?;
@@ -714,7 +714,7 @@ fn parse_date_component(value: &str) -> Result<(i32, u32, u32), ()> {
     Ok((year_int, month_int, day_int))
 }
 
-/// https://html.spec.whatwg.org/multipage/#parse-a-time-component
+/// <https://html.spec.whatwg.org/multipage/#parse-a-time-component>
 fn parse_time_component(value: &str) -> Result<(u32, u32, f64), ()> {
     // Step 1
     let mut iterator = value.split(':');
@@ -781,7 +781,7 @@ fn max_day_in_month(year_num: i32, month_num: u32) -> Result<u32, ()> {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#week-number-of-the-last-day
+/// <https://html.spec.whatwg.org/multipage/#week-number-of-the-last-day>
 fn max_week_in_year(year: i32) -> u32 {
     Utc.with_ymd_and_hms(year as i32, 1, 1, 0, 0, 0)
         .earliest()

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! This module implements structured cloning, as defined by [HTML]
-//! (https://html.spec.whatwg.org/multipage/#safe-passing-of-structured-data).
+//! This module implements structured cloning, as defined by [HTML](https://html.spec.whatwg.org/multipage/#safe-passing-of-structured-data).
 
 use std::collections::HashMap;
 use std::os::raw;
@@ -253,7 +252,7 @@ static STRUCTURED_CLONE_CALLBACKS: JSStructuredCloneCallbacks = JSStructuredClon
 };
 
 /// A data holder for results from, and inputs to, structured-data read/write operations.
-/// https://html.spec.whatwg.org/multipage/#safe-passing-of-structured-data
+/// <https://html.spec.whatwg.org/multipage/#safe-passing-of-structured-data>
 pub enum StructuredDataHolder {
     Read {
         /// A map of deserialized blobs, stored temporarily here to keep them rooted.

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -579,7 +579,7 @@ impl<'a, T: 'static + JSTraceable> RootedVec<'a, T> {
 }
 
 impl<'a, T: 'static + JSTraceable + DomObject> RootedVec<'a, Dom<T>> {
-    /// Create a vector of items of type Dom<T> that is rooted for
+    /// Create a vector of items of type `Dom<T>` that is rooted for
     /// the lifetime of this struct
     pub fn from_iter<I>(root: &'a mut RootableVec<Dom<T>>, iter: I) -> Self
     where

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! Trait representing the concept of [transferable objects]
-//! (https://html.spec.whatwg.org/multipage/#transferable-objects).
+//! (<https://html.spec.whatwg.org/multipage/#transferable-objects>).
 
 use js::jsapi::MutableHandleObject;
 

--- a/components/script/dom/bindings/xmlname.rs
+++ b/components/script/dom/bindings/xmlname.rs
@@ -9,7 +9,7 @@ use html5ever::{namespace_url, ns, LocalName, Namespace, Prefix};
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::str::DOMString;
 
-/// Validate a qualified name. See https://dom.spec.whatwg.org/#validate for details.
+/// Validate a qualified name. See <https://dom.spec.whatwg.org/#validate> for details.
 pub fn validate_qualified_name(qualified_name: &str) -> ErrorResult {
     // Step 2.
     match xml_name_type(qualified_name) {
@@ -20,7 +20,7 @@ pub fn validate_qualified_name(qualified_name: &str) -> ErrorResult {
 }
 
 /// Validate a namespace and qualified name and extract their parts.
-/// See https://dom.spec.whatwg.org/#validate-and-extract for details.
+/// See <https://dom.spec.whatwg.org/#validate-and-extract> for details.
 pub fn validate_and_extract(
     namespace: Option<DOMString>,
     qualified_name: &str,
@@ -86,7 +86,7 @@ pub enum XMLName {
     InvalidXMLName,
 }
 
-/// Check if an element name is valid. See http://www.w3.org/TR/xml/#NT-Name
+/// Check if an element name is valid. See <http://www.w3.org/TR/xml/#NT-Name>
 /// for details.
 pub fn xml_name_type(name: &str) -> XMLName {
     fn is_valid_start(c: char) -> bool {

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -307,7 +307,7 @@ impl BlobMethods for Blob {
 /// <https://w3c.github.io/FileAPI/#dfn-type>
 /// XXX: We will relax the restriction here,
 /// since the spec has some problem over this part.
-/// see https://github.com/w3c/FileAPI/issues/43
+/// see <https://github.com/w3c/FileAPI/issues/43>
 pub fn normalize_type_string(s: &str) -> String {
     if is_ascii_printable(s) {
         let s_lower = s.to_ascii_lowercase();
@@ -322,6 +322,6 @@ pub fn normalize_type_string(s: &str) -> String {
 
 fn is_ascii_printable(string: &str) -> bool {
     // Step 5.1 in Sec 5.1 of File API spec
-    // https://w3c.github.io/FileAPI/#constructorBlob
+    // <https://w3c.github.io/FileAPI/#constructorBlob>
     string.chars().all(|c| c >= '\x20' && c <= '\x7E')
 }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -464,7 +464,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         // Step 6
         promise
     }
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-upgrade
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-upgrade>
     fn Upgrade(&self, node: &Node) {
         // Spec says to make a list first and then iterate the list, but
         // try-to-upgrade only queues upgrade reactions and doesn't itself
@@ -540,7 +540,7 @@ impl CustomElementDefinition {
         self.name == self.local_name
     }
 
-    /// https://dom.spec.whatwg.org/#concept-create-element Step 6.1
+    /// <https://dom.spec.whatwg.org/#concept-create-element> Step 6.1
     #[allow(unsafe_code)]
     pub fn create_element(
         &self,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -649,7 +649,7 @@ unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
 }
 
 impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
-    /// https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage>
     fn PostMessage(
         &self,
         cx: SafeJSContext,
@@ -659,7 +659,7 @@ impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
         self.post_message_impl(cx, message, transfer)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage>
     fn PostMessage_(
         &self,
         cx: SafeJSContext,

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -135,7 +135,7 @@ impl DissimilarOriginWindowMethods for DissimilarOriginWindow {
         false
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-postmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-postmessage>
     fn PostMessage(
         &self,
         cx: JSContext,
@@ -146,7 +146,7 @@ impl DissimilarOriginWindowMethods for DissimilarOriginWindow {
         self.post_message_impl(&target_origin, cx, message, transfer)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-postmessage-options
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-postmessage-options>
     fn PostMessage_(
         &self,
         cx: JSContext,
@@ -195,7 +195,7 @@ impl DissimilarOriginWindowMethods for DissimilarOriginWindow {
 }
 
 impl DissimilarOriginWindow {
-    /// https://html.spec.whatwg.org/multipage/#window-post-message-steps
+    /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>
     fn post_message_impl(
         &self,
         target_origin: &USVString,
@@ -209,7 +209,7 @@ impl DissimilarOriginWindow {
         self.post_message(target_origin, data)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#window-post-message-steps
+    /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>
     pub fn post_message(
         &self,
         target_origin: &USVString,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -289,7 +289,7 @@ pub struct Document {
     pending_parsing_blocking_script: DomRefCell<Option<PendingScript>>,
     /// Number of stylesheets that block executing the next parser-inserted script
     script_blocking_stylesheets_count: Cell<u32>,
-    /// https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing
+    /// <https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing>
     deferred_scripts: PendingInOrderScriptVec,
     /// <https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible>
     asap_in_order_scripts_list: PendingInOrderScriptVec,
@@ -346,7 +346,7 @@ pub struct Document {
     /// The document's origin.
     #[no_trace]
     origin: MutableOrigin,
-    ///  https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-states
+    ///  <https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-states>
     #[no_trace]
     referrer_policy: Cell<Option<ReferrerPolicy>>,
     /// <https://html.spec.whatwg.org/multipage/#dom-document-referrer>
@@ -370,7 +370,7 @@ pub struct Document {
     /// This is sent to the layout thread every time a reflow is done;
     /// layout uses this to determine if the gains from parallel layout will be worth the overhead.
     ///
-    /// See also: https://github.com/servo/servo/issues/10110
+    /// See also: <https://github.com/servo/servo/issues/10110>
     dom_count: Cell<u32>,
     /// Entry node for fullscreen.
     fullscreen_element: MutNullableDom<Element>,
@@ -378,7 +378,7 @@ pub struct Document {
     /// their 'form' content attribute. Used to reset form controls
     /// whenever any element with the same ID as the form attribute
     /// is inserted or removed from the document.
-    /// See https://html.spec.whatwg.org/multipage/#form-owner
+    /// See <https://html.spec.whatwg.org/multipage/#form-owner>
     form_id_listener_map: DomRefCell<HashMapTracedValues<Atom, HashSet<Dom<Element>>>>,
     #[no_trace]
     interactive_time: DomRefCell<InteractiveMetrics>,
@@ -386,9 +386,9 @@ pub struct Document {
     tti_window: DomRefCell<InteractiveWindow>,
     /// RAII canceller for Fetch
     canceller: FetchCanceller,
-    /// https://html.spec.whatwg.org/multipage/#throw-on-dynamic-markup-insertion-counter
+    /// <https://html.spec.whatwg.org/multipage/#throw-on-dynamic-markup-insertion-counter>
     throw_on_dynamic_markup_insertion_counter: Cell<u64>,
-    /// https://html.spec.whatwg.org/multipage/#page-showing
+    /// <https://html.spec.whatwg.org/multipage/#page-showing>
     page_showing: Cell<bool>,
     /// Whether the document is salvageable.
     salvageable: Cell<bool>,
@@ -405,7 +405,7 @@ pub struct Document {
     /// List of tasks to execute as soon as last script/layout blocker is removed.
     #[ignore_malloc_size_of = "Measuring trait objects is hard"]
     delayed_tasks: DomRefCell<Vec<Box<dyn TaskBox>>>,
-    /// https://html.spec.whatwg.org/multipage/#completely-loaded
+    /// <https://html.spec.whatwg.org/multipage/#completely-loaded>
     completely_loaded: Cell<bool>,
     /// Set of shadow roots connected to the document tree.
     shadow_roots: DomRefCell<HashSet<Dom<ShadowRoot>>>,
@@ -422,14 +422,14 @@ pub struct Document {
         DomRefCell<HashMapTracedValues<WebGLContextId, Dom<WebGLRenderingContext>>>,
     /// List of all WebGPU context IDs that need flushing.
     dirty_webgpu_contexts: DomRefCell<HashMap<WebGPUContextId, Dom<GPUCanvasContext>>>,
-    /// https://html.spec.whatwg.org/multipage/#concept-document-csp-list
+    /// <https://html.spec.whatwg.org/multipage/#concept-document-csp-list>
     #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
     #[no_trace]
     csp_list: DomRefCell<Option<CspList>>,
-    /// https://w3c.github.io/slection-api/#dfn-selection
+    /// <https://w3c.github.io/slection-api/#dfn-selection>
     selection: MutNullableDom<Selection>,
     /// A timeline for animations which is used for synchronizing animations.
-    /// https://drafts.csswg.org/web-animations/#timeline
+    /// <https://drafts.csswg.org/web-animations/#timeline>
     animation_timeline: DomRefCell<AnimationTimeline>,
     /// Animations for this Document
     animations: DomRefCell<Animations>,
@@ -2426,7 +2426,7 @@ impl Document {
         self.pending_parsing_blocking_script.borrow().is_some()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#prepare-a-script step 22.d.
+    /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step 22.d.
     pub fn pending_parsing_blocking_script_loaded(
         &self,
         element: &HTMLScriptElement,
@@ -2465,8 +2465,8 @@ impl Document {
             .push(Dom::from_ref(script));
     }
 
-    /// https://html.spec.whatwg.org/multipage/#the-end step 5.
-    /// https://html.spec.whatwg.org/multipage/#prepare-a-script step 22.d.
+    /// <https://html.spec.whatwg.org/multipage/#the-end> step 5.
+    /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step 22.d.
     pub fn asap_script_loaded(&self, element: &HTMLScriptElement, result: ScriptResult) {
         {
             let mut scripts = self.asap_scripts_set.borrow_mut();
@@ -2484,8 +2484,8 @@ impl Document {
         self.asap_in_order_scripts_list.push(script);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#the-end step 5.
-    /// https://html.spec.whatwg.org/multipage/#prepare-a-script step 22.c.
+    /// <https://html.spec.whatwg.org/multipage/#the-end> step 5.
+    /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step> 22.c.
     pub fn asap_in_order_script_loaded(&self, element: &HTMLScriptElement, result: ScriptResult) {
         self.asap_in_order_scripts_list.loaded(element, result);
         while let Some((element, result)) = self
@@ -2501,14 +2501,14 @@ impl Document {
         self.deferred_scripts.push(script);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#the-end step 3.
-    /// https://html.spec.whatwg.org/multipage/#prepare-a-script step 22.d.
+    /// <https://html.spec.whatwg.org/multipage/#the-end> step 3.
+    /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step 22.d.
     pub fn deferred_script_loaded(&self, element: &HTMLScriptElement, result: ScriptResult) {
         self.deferred_scripts.loaded(element, result);
         self.process_deferred_scripts();
     }
 
-    /// https://html.spec.whatwg.org/multipage/#the-end step 3.
+    /// <https://html.spec.whatwg.org/multipage/#the-end> step 3.
     fn process_deferred_scripts(&self) {
         if self.ready_state.get() != DocumentReadyState::Interactive {
             return;
@@ -3207,7 +3207,7 @@ impl Document {
         ref_filter_map(self.csp_list.borrow(), Option::as_ref)
     }
 
-    /// https://www.w3.org/TR/CSP/#should-block-inline
+    /// <https://www.w3.org/TR/CSP/#should-block-inline>
     pub fn should_elements_inline_type_behavior_be_blocked(
         &self,
         el: &Element,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -491,7 +491,7 @@ impl Element {
         self.shadow_root().is_some()
     }
 
-    /// https://dom.spec.whatwg.org/#dom-element-attachshadow
+    /// <https://dom.spec.whatwg.org/#dom-element-attachshadow>
     /// XXX This is not exposed to web content yet. It is meant to be used
     ///     for UA widgets only.
     pub fn attach_shadow(&self, is_ua_widget: IsUserAgentWidget) -> Fallible<DomRoot<ShadowRoot>> {

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -29,16 +29,16 @@ use crate::script_runtime::JSContext;
 #[dom_struct]
 #[allow(non_snake_case)]
 pub struct ExtendableMessageEvent {
-    /// https://w3c.github.io/ServiceWorker/#extendableevent
+    /// <https://w3c.github.io/ServiceWorker/#extendableevent>
     event: ExtendableEvent,
-    /// https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-data
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-data>
     #[ignore_malloc_size_of = "mozjs"]
     data: Heap<JSVal>,
     /// <https://w3c.github.io/ServiceWorker/#extendablemessage-event-origin>
     origin: DOMString,
-    /// https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-lasteventid
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-lasteventid>
     lastEventId: DOMString,
-    /// https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-ports
+    /// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-ports>
     ports: Vec<Dom<MessagePort>>,
     #[ignore_malloc_size_of = "mozjs"]
     frozen_ports: DomRefCell<Option<Heap<JSVal>>>,
@@ -193,7 +193,7 @@ impl ExtendableMessageEventMethods for ExtendableMessageEvent {
         self.event.IsTrusted()
     }
 
-    /// https://w3c.github.io/ServiceWorker/#extendablemessage-event-ports
+    /// <https://w3c.github.io/ServiceWorker/#extendablemessage-event-ports>
     fn Ports(&self, cx: JSContext) -> JSVal {
         if let Some(ports) = &*self.frozen_ports.borrow() {
             return ports.get();

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -184,7 +184,7 @@ impl From<FakeXRRegionType> for EntityType {
 }
 
 impl FakeXRDeviceMethods for FakeXRDevice {
-    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     fn SetViews(&self, views: Vec<FakeXRViewInit>) -> Fallible<()> {
         let _ = self
             .sender
@@ -192,7 +192,7 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-setviewerorigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-setviewerorigin>
     fn SetViewerOrigin(
         &self,
         origin: &FakeXRRigidTransformInit,
@@ -204,17 +204,17 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-clearviewerorigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-clearviewerorigin>
     fn ClearViewerOrigin(&self) {
         let _ = self.sender.send(MockDeviceMsg::SetViewerOrigin(None));
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-clearfloororigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-clearfloororigin>
     fn ClearFloorOrigin(&self) {
         let _ = self.sender.send(MockDeviceMsg::SetFloorOrigin(None));
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-setfloororigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-setfloororigin>
     fn SetFloorOrigin(&self, origin: &FakeXRRigidTransformInit) -> Fallible<()> {
         let _ = self
             .sender
@@ -222,18 +222,18 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-clearworld
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-clearworld>
     fn ClearWorld(&self) {
         let _ = self.sender.send(MockDeviceMsg::ClearWorld);
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-setworld
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-setworld>
     fn SetWorld(&self, world: &FakeXRWorldInit) -> Fallible<()> {
         let _ = self.sender.send(MockDeviceMsg::SetWorld(get_world(world)?));
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-simulatevisibilitychange
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-simulatevisibilitychange>
     fn SimulateVisibilityChange(&self, v: XRVisibilityState) {
         let v = match v {
             XRVisibilityState::Visible => Visibility::Visible,
@@ -243,7 +243,7 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         let _ = self.sender.send(MockDeviceMsg::VisibilityChange(v));
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-simulateinputsourceconnection
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-simulateinputsourceconnection>
     fn SimulateInputSourceConnection(
         &self,
         init: &FakeXRInputSourceInit,
@@ -289,7 +289,7 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         Ok(controller)
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-disconnect
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-disconnect>
     fn Disconnect(&self) -> Rc<Promise> {
         let global = self.global();
         let p = Promise::new(&global);

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -59,34 +59,34 @@ impl FakeXRInputController {
 }
 
 impl FakeXRInputControllerMethods for FakeXRInputController {
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setpointerorigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setpointerorigin>
     fn SetPointerOrigin(&self, origin: &FakeXRRigidTransformInit, _emulated: bool) -> Fallible<()> {
         self.send_message(MockInputMsg::SetPointerOrigin(Some(get_origin(origin)?)));
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setgriporigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setgriporigin>
     fn SetGripOrigin(&self, origin: &FakeXRRigidTransformInit, _emulated: bool) -> Fallible<()> {
         self.send_message(MockInputMsg::SetGripOrigin(Some(get_origin(origin)?)));
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-cleargriporigin
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-cleargriporigin>
     fn ClearGripOrigin(&self) {
         self.send_message(MockInputMsg::SetGripOrigin(None))
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-disconnect
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-disconnect>
     fn Disconnect(&self) {
         self.send_message(MockInputMsg::Disconnect)
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-reconnect
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-reconnect>
     fn Reconnect(&self) {
         self.send_message(MockInputMsg::Reconnect)
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-startselection
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-startselection>
     fn StartSelection(&self) {
         self.send_message(MockInputMsg::TriggerSelect(
             SelectKind::Select,
@@ -94,7 +94,7 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
         ))
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-endselection
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-endselection>
     fn EndSelection(&self) {
         self.send_message(MockInputMsg::TriggerSelect(
             SelectKind::Select,
@@ -102,7 +102,7 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
         ))
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-simulateselect
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-simulateselect>
     fn SimulateSelect(&self) {
         self.send_message(MockInputMsg::TriggerSelect(
             SelectKind::Select,
@@ -110,7 +110,7 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
         ))
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-sethandedness
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-sethandedness>
     fn SetHandedness(&self, handedness: XRHandedness) {
         let h = match handedness {
             XRHandedness::None => Handedness::None,
@@ -120,7 +120,7 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
         let _ = self.send_message(MockInputMsg::SetHandedness(h));
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-settargetraymode
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-settargetraymode>
     fn SetTargetRayMode(&self, target_ray_mode: XRTargetRayMode) {
         let t = match target_ray_mode {
             XRTargetRayMode::Gaze => TargetRayMode::Gaze,
@@ -130,7 +130,7 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
         let _ = self.send_message(MockInputMsg::SetTargetRayMode(t));
     }
 
-    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setprofiles
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setprofiles>
     fn SetProfiles(&self, profiles: Vec<DOMString>) {
         let t = profiles.into_iter().map(String::from).collect();
         let _ = self.send_message(MockInputMsg::SetProfiles(t));

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -131,7 +131,7 @@ use crate::timers::{
 
 #[derive(JSTraceable)]
 pub struct AutoCloseWorker {
-    /// https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-closing
+    /// <https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-closing>
     closing: Arc<AtomicBool>,
     /// A handle to join on the worker thread.
     join_handle: Option<JoinHandle<()>>,
@@ -207,7 +207,7 @@ pub struct GlobalScope {
     console_timers: DomRefCell<HashMap<DOMString, Instant>>,
 
     /// module map is used when importing JavaScript modules
-    /// https://html.spec.whatwg.org/multipage/#concept-settings-object-module-map
+    /// <https://html.spec.whatwg.org/multipage/#concept-settings-object-module-map>
     #[ignore_malloc_size_of = "mozjs"]
     module_map: DomRefCell<HashMapTracedValues<ServoUrl, Rc<ModuleTree>>>,
 
@@ -257,7 +257,7 @@ pub struct GlobalScope {
     #[no_trace]
     origin: MutableOrigin,
 
-    /// https://html.spec.whatwg.org/multipage/#concept-environment-creation-url
+    /// <https://html.spec.whatwg.org/multipage/#concept-environment-creation-url>
     #[no_trace]
     creation_url: Option<ServoUrl>,
 
@@ -442,7 +442,7 @@ pub struct ManagedMessagePort {
 pub enum BroadcastChannelState {
     /// The broadcast-channel router id for this global, and a queue of managed channels.
     /// Step 9, "sort destinations"
-    /// of https://html.spec.whatwg.org/multipage/#dom-broadcastchannel-postmessage
+    /// of <https://html.spec.whatwg.org/multipage/#dom-broadcastchannel-postmessage>
     /// requires keeping track of creation order, hence the queue.
     Managed(
         #[no_trace] BroadcastChannelRouterId,
@@ -1339,7 +1339,7 @@ impl GlobalScope {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#ports-and-garbage-collection
+    /// <https://html.spec.whatwg.org/multipage/#ports-and-garbage-collection>
     pub fn perform_a_message_port_garbage_collection_checkpoint(&self) {
         let is_empty = if let MessagePortState::Managed(_id, message_ports) =
             &mut *self.message_port_state.borrow_mut()
@@ -1373,7 +1373,7 @@ impl GlobalScope {
 
     /// Remove broadcast-channels that are closed.
     /// TODO: Also remove them if they do not have an event-listener.
-    /// see https://github.com/servo/servo/issues/25772
+    /// see <https://github.com/servo/servo/issues/25772>
     pub fn perform_a_broadcast_channel_garbage_collection_checkpoint(&self) {
         let is_empty = if let BroadcastChannelState::Managed(router_id, ref mut channels) =
             &mut *self.broadcast_channel_state.borrow_mut()
@@ -1791,7 +1791,7 @@ impl GlobalScope {
         }
     }
 
-    /// https://w3c.github.io/FileAPI/#dfn-size
+    /// <https://w3c.github.io/FileAPI/#dfn-size>
     pub fn get_blob_size(&self, blob_id: &BlobId) -> u64 {
         let blob_state = self.blob_state.borrow();
         if let BlobState::Managed(blobs_map) = &*blob_state {
@@ -3055,7 +3055,7 @@ impl GlobalScope {
         false
     }
 
-    /// https://www.w3.org/TR/CSP/#get-csp-of-object
+    /// <https://www.w3.org/TR/CSP/#get-csp-of-object>
     pub fn get_csp_list(&self) -> Option<CspList> {
         if let Some(window) = self.downcast::<Window>() {
             return window.Document().get_csp_list().map(|c| c.clone());

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -86,7 +86,7 @@ impl GPUAdapter {
 }
 
 impl GPUAdapterMethods for GPUAdapter {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice>
     fn RequestDevice(&self, descriptor: &GPUDeviceDescriptor, comp: InRealm) -> Rc<Promise> {
         // Step 2
         let promise = Promise::new_in_current_realm(comp);
@@ -205,13 +205,13 @@ impl GPUAdapterMethods for GPUAdapter {
         promise
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapter-isfallbackadapter
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-isfallbackadapter>
     fn IsFallbackAdapter(&self) -> bool {
         //TODO
         false
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestadapterinfo
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestadapterinfo>
     fn RequestAdapterInfo(&self, unmask_hints: Vec<DOMString>, comp: InRealm) -> Rc<Promise> {
         // XXX: Adapter info should be generated here ...
         // Step 1
@@ -225,12 +225,12 @@ impl GPUAdapterMethods for GPUAdapter {
         promise
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapter-features
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-features>
     fn Features(&self) -> DomRoot<GPUSupportedFeatures> {
         DomRoot::from_ref(&self.features)
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapter-limits
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-limits>
     fn Limits(&self) -> DomRoot<GPUSupportedLimits> {
         DomRoot::from_ref(&self.limits)
     }

--- a/components/script/dom/gpuadapterinfo.rs
+++ b/components/script/dom/gpuadapterinfo.rs
@@ -35,22 +35,22 @@ impl GPUAdapterInfo {
 
 // TODO: wgpu does not expose right fields right now
 impl GPUAdapterInfoMethods for GPUAdapterInfo {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-vendor
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-vendor>
     fn Vendor(&self) -> DOMString {
         DOMString::new()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-architecture
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-architecture>
     fn Architecture(&self) -> DOMString {
         DOMString::new()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-device
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-device>
     fn Device(&self) -> DOMString {
         DOMString::new()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-description
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-description>
     fn Description(&self) -> DOMString {
         DOMString::from_string(self.info.driver_info.clone())
     }

--- a/components/script/dom/gpubindgroup.rs
+++ b/components/script/dom/gpubindgroup.rs
@@ -63,12 +63,12 @@ impl GPUBindGroup {
 }
 
 impl GPUBindGroupMethods for GPUBindGroup {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpubindgrouplayout.rs
+++ b/components/script/dom/gpubindgrouplayout.rs
@@ -48,12 +48,12 @@ impl GPUBindGroupLayout {
 }
 
 impl GPUBindGroupLayoutMethods for GPUBindGroupLayout {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -135,7 +135,7 @@ impl Drop for GPUBuffer {
 
 impl GPUBufferMethods for GPUBuffer {
     #[allow(unsafe_code)]
-    /// https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap>
     fn Unmap(&self) -> Fallible<()> {
         let cx = GlobalScope::get_cx();
         // Step 1
@@ -181,7 +181,7 @@ impl GPUBufferMethods for GPUBuffer {
         Ok(())
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy>
     fn Destroy(&self) -> Fallible<()> {
         let state = self.state.get();
         match state {
@@ -206,7 +206,7 @@ impl GPUBufferMethods for GPUBuffer {
     }
 
     #[allow(unsafe_code)]
-    /// https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapasync-offset-size
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapasync-offset-size>
     fn MapAsync(
         &self,
         mode: u32,
@@ -278,7 +278,7 @@ impl GPUBufferMethods for GPUBuffer {
         promise
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange>
     #[allow(unsafe_code)]
     fn GetMappedRange(
         &self,
@@ -333,12 +333,12 @@ impl GPUBufferMethods for GPUBuffer {
         Ok(NonNull::new(array_buffer).unwrap())
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -100,14 +100,14 @@ pub struct GPUCanvasContext {
     #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas>
     canvas: HTMLCanvasElementOrOffscreenCanvas,
     // TODO: can we have wgpu surface that is hw accelerated inside wr ...
     #[ignore_malloc_size_of = "Defined in webrender"]
     #[no_trace]
     webrender_image: Cell<Option<webrender_api::ImageKey>>,
     context_id: WebGPUContextId,
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-currenttexture-slot
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-currenttexture-slot>
     texture: MutNullableDom<GPUTexture>,
 }
 
@@ -206,12 +206,12 @@ impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, GPUCanvasContext> {
 }
 
 impl GPUCanvasContextMethods for GPUCanvasContext {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas>
     fn Canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
         self.canvas.clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure>
     fn Configure(&self, descriptor: &GPUCanvasConfiguration) {
         // Step 1 is let
         // Step 2
@@ -293,7 +293,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         self.webrender_image.set(Some(receiver.recv().unwrap()));
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-unconfigure
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-unconfigure>
     fn Unconfigure(&self) {
         if let Some(image_key) = self.webrender_image.take() {
             if let Err(e) = self.channel.0.send((
@@ -312,7 +312,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         self.texture.take();
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getcurrenttexture
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getcurrenttexture>
     fn GetCurrentTexture(&self) -> Fallible<DomRoot<GPUTexture>> {
         // Step 5.
         self.mark_as_dirty();

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -95,12 +95,12 @@ impl GPUCommandBuffer {
 }
 
 impl GPUCommandBufferMethods for GPUCommandBuffer {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -107,17 +107,17 @@ impl GPUCommandEncoder {
 }
 
 impl GPUCommandEncoderMethods for GPUCommandEncoder {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-begincomputepass
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-begincomputepass>
     fn BeginComputePass(
         &self,
         descriptor: &GPUComputePassDescriptor,
@@ -152,7 +152,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-beginrenderpass
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-beginrenderpass>
     fn BeginRenderPass(
         &self,
         descriptor: &GPURenderPassDescriptor,
@@ -250,7 +250,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertobuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertobuffer>
     fn CopyBufferToBuffer(
         &self,
         source: &GPUBuffer,
@@ -284,7 +284,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .expect("Failed to send CopyBufferToBuffer");
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture>
     fn CopyBufferToTexture(
         &self,
         source: &GPUImageCopyBuffer,
@@ -316,7 +316,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .expect("Failed to send CopyBufferToTexture");
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture>
     fn CopyTextureToBuffer(
         &self,
         source: &GPUImageCopyTexture,
@@ -348,7 +348,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .expect("Failed to send CopyTextureToBuffer");
     }
 
-    /// https://gpuweb.github.io/gpuweb/#GPUCommandEncoder-copyTextureToTexture
+    /// <https://gpuweb.github.io/gpuweb/#GPUCommandEncoder-copyTextureToTexture>
     fn CopyTextureToTexture(
         &self,
         source: &GPUImageCopyTexture,
@@ -376,7 +376,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .expect("Failed to send CopyTextureToTexture");
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-finish
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-finish>
     fn Finish(&self, descriptor: &GPUCommandBufferDescriptor) -> DomRoot<GPUCommandBuffer> {
         self.channel
             .0

--- a/components/script/dom/gpucompilationinfo.rs
+++ b/components/script/dom/gpucompilationinfo.rs
@@ -19,7 +19,7 @@ pub struct GPUCompilationInfo {
 
 // TODO: wgpu does not expose right fields right now
 impl GPUCompilationInfoMethods for GPUCompilationInfo {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationinfo-messages
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationinfo-messages>
     fn Messages(&self, _cx: JSContext) -> JSVal {
         todo!()
     }

--- a/components/script/dom/gpucompilationmessage.rs
+++ b/components/script/dom/gpucompilationmessage.rs
@@ -65,32 +65,32 @@ impl GPUCompilationMessage {
 }
 
 impl GPUCompilationMessageMethods for GPUCompilationMessage {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-message
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-message>
     fn Message(&self) -> DOMString {
         self.message.to_owned()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-type
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-type>
     fn Type(&self) -> GPUCompilationMessageType {
         self.mtype
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-linenum
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-linenum>
     fn LineNum(&self) -> u64 {
         self.line_num
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-linepos
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-linepos>
     fn LinePos(&self) -> u64 {
         self.line_pos
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-offset
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-offset>
     fn Offset(&self) -> u64 {
         self.offset
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-length
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-length>
     fn Length(&self) -> u64 {
         self.length
     }

--- a/components/script/dom/gpucomputepassencoder.rs
+++ b/components/script/dom/gpucomputepassencoder.rs
@@ -67,24 +67,24 @@ impl GPUComputePassEncoder {
 }
 
 impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroups
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroups>
     fn DispatchWorkgroups(&self, x: u32, y: u32, z: u32) {
         if let Some(compute_pass) = self.compute_pass.borrow_mut().as_mut() {
             wgpu_comp::wgpu_compute_pass_dispatch_workgroups(compute_pass, x, y, z);
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroupsindirect
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroupsindirect>
     fn DispatchWorkgroupsIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
         if let Some(compute_pass) = self.compute_pass.borrow_mut().as_mut() {
             wgpu_comp::wgpu_compute_pass_dispatch_workgroups_indirect(
@@ -95,7 +95,7 @@ impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-endpass
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-endpass>
     fn End(&self) -> Fallible<()> {
         let compute_pass = self.compute_pass.borrow_mut().take();
         self.channel
@@ -116,7 +116,7 @@ impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
         Ok(())
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
     #[allow(unsafe_code)]
     fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
         if let Some(compute_pass) = self.compute_pass.borrow_mut().as_mut() {
@@ -132,7 +132,7 @@ impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-setpipeline
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-setpipeline>
     fn SetPipeline(&self, pipeline: &GPUComputePipeline) {
         if let Some(compute_pass) = self.compute_pass.borrow_mut().as_mut() {
             wgpu_comp::wgpu_compute_pass_set_pipeline(compute_pass, pipeline.id().0);

--- a/components/script/dom/gpucomputepipeline.rs
+++ b/components/script/dom/gpucomputepipeline.rs
@@ -70,17 +70,17 @@ impl GPUComputePipeline {
 }
 
 impl GPUComputePipelineMethods for GPUComputePipeline {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>
     fn GetBindGroupLayout(&self, index: u32) -> Fallible<DomRoot<GPUBindGroupLayout>> {
         if index > self.bind_group_layouts.len() as u32 {
             return Err(Error::Range(String::from("Index out of bounds")));

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -311,7 +311,7 @@ impl GPUDevice {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#lose-the-device
+    /// <https://gpuweb.github.io/gpuweb/#lose-the-device>
     pub fn lose(&self, reason: GPUDeviceLostReason) {
         if let Some(ref lost_promise) = *self.lost_promise.borrow() {
             let global = &self.global();
@@ -328,39 +328,39 @@ impl GPUDevice {
 }
 
 impl GPUDeviceMethods for GPUDevice {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-features
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-features>
     fn Features(&self) -> DomRoot<GPUSupportedFeatures> {
         DomRoot::from_ref(&self.features)
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-limits
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-limits>
     fn Limits(&self) -> DomRoot<GPUSupportedLimits> {
         DomRoot::from_ref(&self.limits)
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-queue
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-queue>
     fn GetQueue(&self) -> DomRoot<GPUQueue> {
         DomRoot::from_ref(&self.default_queue)
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
     fn GetLost(&self, comp: InRealm) -> Fallible<Rc<Promise>> {
         let promise = Promise::new_in_current_realm(comp);
         *self.lost_promise.borrow_mut() = Some(promise.clone());
         Ok(promise)
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
     fn CreateBuffer(&self, descriptor: &GPUBufferDescriptor) -> Fallible<DomRoot<GPUBuffer>> {
         let desc =
             wgt::BufferUsages::from_bits(descriptor.usage).map(|usg| wgpu_res::BufferDescriptor {
@@ -425,7 +425,7 @@ impl GPUDeviceMethods for GPUDevice {
         ))
     }
 
-    /// https://gpuweb.github.io/gpuweb/#GPUDevice-createBindGroupLayout
+    /// <https://gpuweb.github.io/gpuweb/#GPUDevice-createBindGroupLayout>
     #[allow(non_snake_case)]
     fn CreateBindGroupLayout(
         &self,
@@ -546,7 +546,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout>
     fn CreatePipelineLayout(
         &self,
         descriptor: &GPUPipelineLayoutDescriptor,
@@ -596,7 +596,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgroup
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgroup>
     fn CreateBindGroup(&self, descriptor: &GPUBindGroupDescriptor) -> DomRoot<GPUBindGroup> {
         let entries = descriptor
             .entries
@@ -657,7 +657,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
     fn CreateShaderModule(
         &self,
         descriptor: RootedTraceableBox<GPUShaderModuleDescriptor>,
@@ -690,7 +690,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipeline
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipeline>
     fn CreateComputePipeline(
         &self,
         descriptor: &GPUComputePipelineDescriptor,
@@ -736,7 +736,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder>
     fn CreateCommandEncoder(
         &self,
         descriptor: &GPUCommandEncoderDescriptor,
@@ -770,7 +770,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
     fn CreateTexture(&self, descriptor: &GPUTextureDescriptor) -> DomRoot<GPUTexture> {
         let size = convert_texture_size_to_dict(&descriptor.size);
         let desc = wgt::TextureUsages::from_bits(descriptor.usage).map(|usg| {
@@ -836,7 +836,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler>
     fn CreateSampler(&self, descriptor: &GPUSamplerDescriptor) -> DomRoot<GPUSampler> {
         let sampler_id = self
             .global()
@@ -885,7 +885,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline>
     fn CreateRenderPipeline(
         &self,
         descriptor: &GPURenderPipelineDescriptor,
@@ -1039,7 +1039,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder>
     fn CreateRenderBundleEncoder(
         &self,
         descriptor: &GPURenderBundleEncoderDescriptor,
@@ -1078,7 +1078,7 @@ impl GPUDeviceMethods for GPUDevice {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope>
     fn PushErrorScope(&self, filter: GPUErrorFilter) {
         let mut context = self.scope_context.borrow_mut();
         let scope_id = context.next_scope_id;
@@ -1097,7 +1097,7 @@ impl GPUDeviceMethods for GPUDevice {
         assert!(res.is_none());
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope>
     fn PopErrorScope(&self, comp: InRealm) -> Rc<Promise> {
         let mut context = self.scope_context.borrow_mut();
         let promise = Promise::new_in_current_realm(comp);
@@ -1131,7 +1131,7 @@ impl GPUDeviceMethods for GPUDevice {
     // https://gpuweb.github.io/gpuweb/#dom-gpudevice-onuncapturederror
     event_handler!(uncapturederror, GetOnuncapturederror, SetOnuncapturederror);
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-destroy
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-destroy>
     fn Destroy(&self) {
         if self.valid.get() {
             self.valid.set(false);
@@ -1148,7 +1148,7 @@ impl GPUDeviceMethods for GPUDevice {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipelineasync
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipelineasync>
     fn CreateComputePipelineAsync(
         &self,
         _descriptor: &GPUComputePipelineDescriptor,
@@ -1156,7 +1156,7 @@ impl GPUDeviceMethods for GPUDevice {
         todo!()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipelineasync
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipelineasync>
     fn CreateRenderPipelineAsync(&self, _descriptor: &GPURenderPipelineDescriptor) -> Rc<Promise> {
         todo!()
     }

--- a/components/script/dom/gpudevicelostinfo.rs
+++ b/components/script/dom/gpudevicelostinfo.rs
@@ -42,12 +42,12 @@ impl GPUDeviceLostInfo {
 }
 
 impl GPUDeviceLostInfoMethods for GPUDeviceLostInfo {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-message
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-message>
     fn Message(&self) -> DOMString {
         self.message.clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-reason
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-reason>
     fn Reason(&self) -> GPUDeviceLostReason {
         self.reason
     }

--- a/components/script/dom/gpuoutofmemoryerror.rs
+++ b/components/script/dom/gpuoutofmemoryerror.rs
@@ -33,7 +33,7 @@ impl GPUOutOfMemoryError {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuoutofmemoryerror-gpuoutofmemoryerror
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuoutofmemoryerror-gpuoutofmemoryerror>
     #[allow(non_snake_case)]
     pub fn Constructor(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Self> {
         GPUOutOfMemoryError::new_with_proto(global, proto)

--- a/components/script/dom/gpupipelinelayout.rs
+++ b/components/script/dom/gpupipelinelayout.rs
@@ -64,12 +64,12 @@ impl GPUPipelineLayout {
 }
 
 impl GPUPipelineLayoutMethods for GPUPipelineLayout {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpuqueryset.rs
+++ b/components/script/dom/gpuqueryset.rs
@@ -18,17 +18,17 @@ pub struct GPUQuerySet {
 
 // TODO: wgpu does not expose right fields right now
 impl GPUQuerySetMethods for GPUQuerySet {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy>
     fn Destroy(&self) {
         todo!()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         todo!()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, _value: USVString) {
         todo!()
     }

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -58,17 +58,17 @@ impl GPUQueue {
 }
 
 impl GPUQueueMethods for GPUQueue {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit>
     fn Submit(&self, command_buffers: Vec<DomRoot<GPUCommandBuffer>>) {
         let valid = command_buffers.iter().all(|cb| {
             cb.buffers().iter().all(|b| match b.state() {
@@ -99,7 +99,7 @@ impl GPUQueueMethods for GPUQueue {
             .unwrap();
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writebuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writebuffer>
     #[allow(unsafe_code)]
     fn WriteBuffer(
         &self,
@@ -146,7 +146,7 @@ impl GPUQueueMethods for GPUQueue {
         Ok(())
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writetexture
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writetexture>
     fn WriteTexture(
         &self,
         destination: &GPUImageCopyTexture,

--- a/components/script/dom/gpurenderbundle.rs
+++ b/components/script/dom/gpurenderbundle.rs
@@ -67,12 +67,12 @@ impl GPURenderBundle {
 }
 
 impl GPURenderBundleMethods for GPURenderBundle {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpurenderbundleencoder.rs
+++ b/components/script/dom/gpurenderbundleencoder.rs
@@ -70,17 +70,17 @@ impl GPURenderBundleEncoder {
 }
 
 impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
     #[allow(unsafe_code)]
     fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
         if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
@@ -96,14 +96,14 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline>
     fn SetPipeline(&self, pipeline: &GPURenderPipeline) {
         if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
             wgpu_bundle::wgpu_render_bundle_set_pipeline(encoder, pipeline.id().0);
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setindexbuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setindexbuffer>
     fn SetIndexBuffer(
         &self,
         buffer: &GPUBuffer,
@@ -125,7 +125,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer>
     fn SetVertexBuffer(&self, slot: u32, buffer: &GPUBuffer, offset: u64, size: u64) {
         if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
             wgpu_bundle::wgpu_render_bundle_set_vertex_buffer(
@@ -138,7 +138,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-draw
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-draw>
     fn Draw(&self, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) {
         if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw(
@@ -151,7 +151,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexed
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexed>
     fn DrawIndexed(
         &self,
         index_count: u32,
@@ -172,7 +172,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect>
     fn DrawIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
         if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw_indirect(
@@ -183,7 +183,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect>
     fn DrawIndexedIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
         if let Some(encoder) = self.render_bundle_encoder.borrow_mut().as_mut() {
             wgpu_bundle::wgpu_render_bundle_draw_indexed_indirect(
@@ -194,7 +194,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish>
     fn Finish(&self, descriptor: &GPURenderBundleDescriptor) -> DomRoot<GPURenderBundle> {
         let desc = wgt::RenderBundleDescriptor {
             label: convert_label(&descriptor.parent),

--- a/components/script/dom/gpurenderpassencoder.rs
+++ b/components/script/dom/gpurenderpassencoder.rs
@@ -72,17 +72,17 @@ impl GPURenderPassEncoder {
 }
 
 impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuprogrammablepassencoder-setbindgroup>
     #[allow(unsafe_code)]
     fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
@@ -98,7 +98,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setviewport
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setviewport>
     fn SetViewport(
         &self,
         x: Finite<f32>,
@@ -121,14 +121,14 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setscissorrect
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setscissorrect>
     fn SetScissorRect(&self, x: u32, y: u32, width: u32, height: u32) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_set_scissor_rect(render_pass, x, y, width, height);
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setblendcolor
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setblendcolor>
     fn SetBlendConstant(&self, color: GPUColor) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             let colors = match color {
@@ -155,14 +155,14 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setstencilreference
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setstencilreference>
     fn SetStencilReference(&self, reference: u32) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_set_stencil_reference(render_pass, reference);
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-end
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-end>
     fn End(&self) -> Fallible<()> {
         let render_pass = self.render_pass.borrow_mut().take();
         self.channel
@@ -183,14 +183,14 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         Ok(())
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setpipeline>
     fn SetPipeline(&self, pipeline: &GPURenderPipeline) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_set_pipeline(render_pass, pipeline.id().0);
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setindexbuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setindexbuffer>
     fn SetIndexBuffer(
         &self,
         buffer: &GPUBuffer,
@@ -212,7 +212,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-setvertexbuffer>
     fn SetVertexBuffer(&self, slot: u32, buffer: &GPUBuffer, offset: u64, size: u64) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_set_vertex_buffer(
@@ -225,7 +225,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-draw
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-draw>
     fn Draw(&self, vertex_count: u32, instance_count: u32, first_vertex: u32, first_instance: u32) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_draw(
@@ -238,7 +238,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexed
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexed>
     fn DrawIndexed(
         &self,
         index_count: u32,
@@ -259,7 +259,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindirect>
     fn DrawIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_draw_indirect(
@@ -270,7 +270,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderencoderbase-drawindexedindirect>
     fn DrawIndexedIndirect(&self, indirect_buffer: &GPUBuffer, indirect_offset: u64) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
             wgpu_render::wgpu_render_pass_draw_indexed_indirect(
@@ -281,7 +281,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         }
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-executebundles
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-executebundles>
     #[allow(unsafe_code)]
     fn ExecuteBundles(&self, bundles: Vec<DomRoot<GPURenderBundle>>) {
         let bundle_ids = bundles.iter().map(|b| b.id().0).collect::<Vec<_>>();

--- a/components/script/dom/gpurenderpipeline.rs
+++ b/components/script/dom/gpurenderpipeline.rs
@@ -70,17 +70,17 @@ impl GPURenderPipeline {
 }
 
 impl GPURenderPipelineMethods for GPURenderPipeline {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout>
     fn GetBindGroupLayout(&self, index: u32) -> Fallible<DomRoot<GPUBindGroupLayout>> {
         if index > self.bind_group_layouts.len() as u32 {
             return Err(Error::Range(String::from("Index out of bounds")));

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -65,12 +65,12 @@ impl GPUSampler {
 }
 
 impl GPUSamplerMethods for GPUSampler {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -52,17 +52,17 @@ impl GPUShaderModule {
 }
 
 impl GPUShaderModuleMethods for GPUShaderModule {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
     fn GetCompilationInfo(&self) -> Fallible<Rc<Promise>> {
         todo!("Missing in wgpu: https://github.com/gfx-rs/wgpu/issues/2170")
     }

--- a/components/script/dom/gpusupportedlimits.rs
+++ b/components/script/dom/gpusupportedlimits.rs
@@ -34,142 +34,142 @@ impl GPUSupportedLimits {
 }
 
 impl GPUSupportedLimitsMethods for GPUSupportedLimits {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d>
     fn MaxTextureDimension1D(&self) -> u32 {
         self.limits.max_texture_dimension_1d
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension2d
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension2d>
     fn MaxTextureDimension2D(&self) -> u32 {
         self.limits.max_texture_dimension_2d
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension3d
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension3d>
     fn MaxTextureDimension3D(&self) -> u32 {
         self.limits.max_texture_dimension_3d
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturearraylayers
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturearraylayers>
     fn MaxTextureArrayLayers(&self) -> u32 {
         self.limits.max_texture_array_layers
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroups
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroups>
     fn MaxBindGroups(&self) -> u32 {
         self.limits.max_bind_groups
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup>
     fn MaxBindingsPerBindGroup(&self) -> u32 {
         self.limits.max_bindings_per_bind_group
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicuniformbuffersperpipelinelayout
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicuniformbuffersperpipelinelayout>
     fn MaxDynamicUniformBuffersPerPipelineLayout(&self) -> u32 {
         self.limits.max_dynamic_uniform_buffers_per_pipeline_layout
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicstoragebuffersperpipelinelayout
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicstoragebuffersperpipelinelayout>
     fn MaxDynamicStorageBuffersPerPipelineLayout(&self) -> u32 {
         self.limits.max_dynamic_storage_buffers_per_pipeline_layout
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsampledtexturespershaderstage
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsampledtexturespershaderstage>
     fn MaxSampledTexturesPerShaderStage(&self) -> u32 {
         self.limits.max_sampled_textures_per_shader_stage
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsamplerspershaderstage
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsamplerspershaderstage>
     fn MaxSamplersPerShaderStage(&self) -> u32 {
         self.limits.max_samplers_per_shader_stage
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferspershaderstage
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferspershaderstage>
     fn MaxStorageBuffersPerShaderStage(&self) -> u32 {
         self.limits.max_storage_buffers_per_shader_stage
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturespershaderstage
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturespershaderstage>
     fn MaxStorageTexturesPerShaderStage(&self) -> u32 {
         self.limits.max_storage_textures_per_shader_stage
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferspershaderstage
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferspershaderstage>
     fn MaxUniformBuffersPerShaderStage(&self) -> u32 {
         self.limits.max_uniform_buffers_per_shader_stage
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferbindingsize
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferbindingsize>
     fn MaxUniformBufferBindingSize(&self) -> u64 {
         self.limits.max_uniform_buffer_binding_size as u64
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferbindingsize
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferbindingsize>
     fn MaxStorageBufferBindingSize(&self) -> u64 {
         self.limits.max_storage_buffer_binding_size as u64
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minuniformbufferoffsetalignment
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minuniformbufferoffsetalignment>
     fn MinUniformBufferOffsetAlignment(&self) -> u32 {
         self.limits.min_uniform_buffer_offset_alignment
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minstoragebufferoffsetalignment
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minstoragebufferoffsetalignment>
     fn MinStorageBufferOffsetAlignment(&self) -> u32 {
         self.limits.min_storage_buffer_offset_alignment
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbuffers
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbuffers>
     fn MaxVertexBuffers(&self) -> u32 {
         self.limits.max_vertex_buffers
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbuffersize
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbuffersize>
     fn MaxBufferSize(&self) -> u64 {
         self.limits.max_buffer_size
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexattributes
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexattributes>
     fn MaxVertexAttributes(&self) -> u32 {
         self.limits.max_vertex_attributes
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbufferarraystride
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbufferarraystride>
     fn MaxVertexBufferArrayStride(&self) -> u32 {
         self.limits.max_vertex_buffer_array_stride
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents>
     fn MaxInterStageShaderComponents(&self) -> u32 {
         self.limits.max_inter_stage_shader_components
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupstoragesize
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupstoragesize>
     fn MaxComputeWorkgroupStorageSize(&self) -> u32 {
         self.limits.max_compute_workgroup_storage_size
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeinvocationsperworkgroup
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeinvocationsperworkgroup>
     fn MaxComputeInvocationsPerWorkgroup(&self) -> u32 {
         self.limits.max_compute_invocations_per_workgroup
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizex
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizex>
     fn MaxComputeWorkgroupSizeX(&self) -> u32 {
         self.limits.max_compute_workgroup_size_x
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizey
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizey>
     fn MaxComputeWorkgroupSizeY(&self) -> u32 {
         self.limits.max_compute_workgroup_size_y
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizez
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizez>
     fn MaxComputeWorkgroupSizeZ(&self) -> u32 {
         self.limits.max_compute_workgroup_size_z
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsperdimension
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsperdimension>
     fn MaxComputeWorkgroupsPerDimension(&self) -> u32 {
         self.limits.max_compute_workgroups_per_dimension
     }

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -117,17 +117,17 @@ impl GPUTexture {
 }
 
 impl GPUTextureMethods for GPUTexture {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gputexture-createview
+    /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-createview>
     fn CreateView(&self, descriptor: &GPUTextureViewDescriptor) -> DomRoot<GPUTextureView> {
         let scope_id = self.device.use_current_scope();
 
@@ -189,7 +189,7 @@ impl GPUTextureMethods for GPUTexture {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy
+    /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy>
     fn Destroy(&self) {
         if self.destroyed.get() {
             return;

--- a/components/script/dom/gputextureview.rs
+++ b/components/script/dom/gputextureview.rs
@@ -56,12 +56,12 @@ impl GPUTextureView {
 }
 
 impl GPUTextureViewMethods for GPUTextureView {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn Label(&self) -> USVString {
         self.label.borrow().clone()
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
     }

--- a/components/script/dom/gpuuncapturederrorevent.rs
+++ b/components/script/dom/gpuuncapturederrorevent.rs
@@ -58,7 +58,7 @@ impl GPUUncapturedErrorEvent {
         ev
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-gpuuncapturederrorevent
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-gpuuncapturederrorevent>
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
@@ -77,12 +77,12 @@ impl GPUUncapturedErrorEvent {
 }
 
 impl GPUUncapturedErrorEventMethods for GPUUncapturedErrorEvent {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error>
     fn Error(&self) -> GPUError {
         clone_gpu_error(&self.gpu_error)
     }
 
-    /// https://dom.spec.whatwg.org/#dom-event-istrusted
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.event.IsTrusted()
     }

--- a/components/script/dom/gpuvalidationerror.rs
+++ b/components/script/dom/gpuvalidationerror.rs
@@ -42,7 +42,7 @@ impl GPUValidationError {
         )
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror>
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
@@ -54,7 +54,7 @@ impl GPUValidationError {
 }
 
 impl GPUValidationErrorMethods for GPUValidationError {
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-message
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-message>
     fn Message(&self) -> DOMString {
         self.message.clone()
     }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -610,7 +610,7 @@ pub fn get_element_target(subject: &Element) -> Option<DOMString> {
     };
 }
 
-///  < https://html.spec.whatwg.org/multipage/#get-an-element's-noopener>
+/// <https://html.spec.whatwg.org/multipage/#get-an-element's-noopener>
 pub fn get_element_noopener(subject: &Element, target_attribute_value: Option<DOMString>) -> bool {
     if !(subject.is::<HTMLAreaElement>() ||
         subject.is::<HTMLAnchorElement>() ||

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -442,7 +442,7 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
         Ok(USVString(url))
     }
 
-    /// https://w3c.github.io/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream
+    /// <https://w3c.github.io/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream>
     fn CaptureStream(&self, _frame_request_rate: Option<Finite<f64>>) -> DomRoot<MediaStream> {
         let global = self.global();
         let stream = MediaStream::new(&*global);

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -89,7 +89,7 @@ pub struct GenerationId(u32);
 pub struct HTMLFormElement {
     htmlelement: HTMLElement,
     marked_for_reset: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#constructing-entry-list
+    /// <https://html.spec.whatwg.org/multipage/#constructing-entry-list>
     constructing_entry_list: Cell<bool>,
     elements: DomOnceCell<HTMLFormControlsCollection>,
     generation_id: Cell<GenerationId>,
@@ -615,12 +615,12 @@ impl HTMLFormElementMethods for HTMLFormElement {
         return names_vec;
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-form-checkvalidity
+    /// <https://html.spec.whatwg.org/multipage/#dom-form-checkvalidity>
     fn CheckValidity(&self) -> bool {
         self.static_validation().is_ok()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity
+    /// <https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity>
     fn ReportValidity(&self) -> bool {
         self.interactive_validation().is_ok()
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -483,7 +483,7 @@ impl HTMLIFrameElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#iframe-load-event-steps steps 1-4
+    /// <https://html.spec.whatwg.org/multipage/#iframe-load-event-steps> steps 1-4
     pub fn iframe_load_event_steps(&self, loaded_pipeline: PipelineId) {
         // TODO(#9592): assert that the load blocker is present at all times when we
         //              can guarantee that it's created for the case of iframe.reload().

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -425,7 +425,7 @@ impl HTMLImageElement {
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
     }
 
-    /// Step 24 of https://html.spec.whatwg.org/multipage/#update-the-image-data
+    /// Step 24 of <https://html.spec.whatwg.org/multipage/#update-the-image-data>
     fn process_image_response(&self, image: ImageResponse) {
         // TODO: Handle multipart/x-mixed-replace
         let (trigger_image_load, trigger_image_error) = match (image, self.image_request.get()) {
@@ -674,7 +674,7 @@ impl HTMLImageElement {
         source_size_list.evaluate(&device, quirks_mode)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#matches-the-environment
+    /// <https://html.spec.whatwg.org/multipage/#matches-the-environment>
     fn matches_environment(&self, media_query: String) -> bool {
         let document = document_from_node(self);
         let quirks_mode = document.quirks_mode();
@@ -1019,7 +1019,7 @@ impl HTMLImageElement {
         ScriptThread::await_stable_state(Microtask::ImageElement(task));
     }
 
-    /// Step 2-12 of https://html.spec.whatwg.org/multipage/#img-environment-changes
+    /// Step 2-12 of <https://html.spec.whatwg.org/multipage/#img-environment-changes>
     fn react_to_environment_changes_sync_steps(&self, generation: u32) {
         // TODO reduce duplicacy of this code
 
@@ -1814,7 +1814,8 @@ where
     return (s, "");
 }
 
-/// Parse an `srcset` attribute - https://html.spec.whatwg.org/multipage/#parsing-a-srcset-attribute.
+/// Parse an `srcset` attribute:
+/// <https://html.spec.whatwg.org/multipage/#parsing-a-srcset-attribute>.
 pub fn parse_a_srcset_attribute(input: &str) -> Vec<ImageSource> {
     let mut url_len = 0;
     let mut candidates: Vec<ImageSource> = vec![];

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -346,19 +346,19 @@ pub struct HTMLMediaElement {
     #[ignore_malloc_size_of = "Arc"]
     #[no_trace]
     audio_renderer: DomRefCell<Option<Arc<Mutex<dyn AudioRenderer>>>>,
-    /// https://html.spec.whatwg.org/multipage/#show-poster-flag
+    /// <https://html.spec.whatwg.org/multipage/#show-poster-flag>
     show_poster: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-duration
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-duration>
     duration: Cell<f64>,
-    /// https://html.spec.whatwg.org/multipage/#official-playback-position
+    /// <https://html.spec.whatwg.org/multipage/#official-playback-position>
     playback_position: Cell<f64>,
-    /// https://html.spec.whatwg.org/multipage/#default-playback-start-position
+    /// <https://html.spec.whatwg.org/multipage/#default-playback-start-position>
     default_playback_start_position: Cell<f64>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-volume
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-volume>
     volume: Cell<f64>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-seeking
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-seeking>
     seeking: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-muted
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-muted>
     muted: Cell<bool>,
     /// URL of the media resource, if any.
     #[no_trace]
@@ -367,14 +367,14 @@ pub struct HTMLMediaElement {
     /// is a blob.
     #[no_trace]
     blob_url: DomRefCell<Option<ServoUrl>>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-played
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-played>
     #[ignore_malloc_size_of = "Rc"]
     played: DomRefCell<TimeRangesContainer>,
     // https://html.spec.whatwg.org/multipage/#dom-media-audiotracks
     audio_tracks_list: MutNullableDom<AudioTrackList>,
     // https://html.spec.whatwg.org/multipage/#dom-media-videotracks
     video_tracks_list: MutNullableDom<VideoTrackList>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-texttracks
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-texttracks>
     text_tracks_list: MutNullableDom<TextTrackList>,
     /// Time of last timeupdate notification.
     #[ignore_malloc_size_of = "Defined in std::time"]
@@ -498,7 +498,7 @@ impl HTMLMediaElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#time-marches-on
+    /// <https://html.spec.whatwg.org/multipage/#time-marches-on>
     fn time_marches_on(&self) {
         // Step 6.
         if Instant::now() > self.next_timeupdate_event.get() {
@@ -1316,7 +1316,7 @@ impl HTMLMediaElement {
         task_source.queue_simple_event(self.upcast(), atom!("seeked"), &window);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#poster-frame
+    /// <https://html.spec.whatwg.org/multipage/#poster-frame>
     pub fn process_poster_image_loaded(&self, image: Arc<Image>) {
         if !self.show_poster.get() {
             return;
@@ -2230,12 +2230,12 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
         self.paused.get()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-media-defaultplaybackrate
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-defaultplaybackrate>
     fn GetDefaultPlaybackRate(&self) -> Fallible<Finite<f64>> {
         Ok(Finite::wrap(self.defaultPlaybackRate.get()))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-media-defaultplaybackrate
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-defaultplaybackrate>
     fn SetDefaultPlaybackRate(&self, value: Finite<f64>) -> ErrorResult {
         let min_allowed = -64.0;
         let max_allowed = 64.0;
@@ -2251,12 +2251,12 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
         Ok(())
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-media-playbackrate
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-playbackrate>
     fn GetPlaybackRate(&self) -> Fallible<Finite<f64>> {
         Ok(Finite::wrap(self.playbackRate.get()))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-media-playbackrate
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-playbackrate>
     fn SetPlaybackRate(&self, value: Finite<f64>) -> ErrorResult {
         let min_allowed = -64.0;
         let max_allowed = 64.0;

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1073,7 +1073,7 @@ impl HTMLScriptElement {
     }
 
     #[allow(unsafe_code)]
-    /// https://html.spec.whatwg.org/multipage/#run-a-module-script
+    /// <https://html.spec.whatwg.org/multipage/#run-a-module-script>
     pub fn run_a_module_script(&self, script: &ScriptOrigin, _rethrow_errors: bool) {
         // TODO use a settings object rather than this element's document/window
         // Step 2

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -49,9 +49,9 @@ const DEFAULT_HEIGHT: u32 = 150;
 #[dom_struct]
 pub struct HTMLVideoElement {
     htmlmediaelement: HTMLMediaElement,
-    /// https://html.spec.whatwg.org/multipage/#dom-video-videowidth
+    /// <https://html.spec.whatwg.org/multipage/#dom-video-videowidth>
     video_width: Cell<u32>,
-    /// https://html.spec.whatwg.org/multipage/#dom-video-videoheight
+    /// <https://html.spec.whatwg.org/multipage/#dom-video-videoheight>
     video_height: Cell<u32>,
     /// Incremented whenever tasks associated with this element are cancelled.
     generation_id: Cell<u32>,
@@ -136,7 +136,7 @@ impl HTMLVideoElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#poster-frame
+    /// <https://html.spec.whatwg.org/multipage/#poster-frame>
     fn fetch_poster_frame(&self, poster_url: &str) {
         // Step 1.
         let cancel_receiver = self.poster_frame_canceller.borrow_mut().initialize();
@@ -182,7 +182,7 @@ impl HTMLVideoElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#poster-frame
+    /// <https://html.spec.whatwg.org/multipage/#poster-frame>
     fn do_fetch_poster_frame(
         &self,
         poster_url: ServoUrl,

--- a/components/script/dom/mediadeviceinfo.rs
+++ b/components/script/dom/mediadeviceinfo.rs
@@ -55,22 +55,22 @@ impl MediaDeviceInfo {
 }
 
 impl MediaDeviceInfoMethods for MediaDeviceInfo {
-    /// https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-deviceid
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-deviceid>
     fn DeviceId(&self) -> DOMString {
         self.device_id.clone()
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-kind
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-kind>
     fn Kind(&self) -> MediaDeviceKind {
         self.kind
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-label
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-label>
     fn Label(&self) -> DOMString {
         self.label.clone()
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-groupid
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-groupid>
     fn GroupId(&self) -> DOMString {
         self.group_id.clone()
     }

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -44,7 +44,7 @@ impl MediaDevices {
 }
 
 impl MediaDevicesMethods for MediaDevices {
-    /// https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia>
     #[allow(unsafe_code)]
     fn GetUserMedia(&self, constraints: &MediaStreamConstraints, comp: InRealm) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
@@ -67,7 +67,7 @@ impl MediaDevicesMethods for MediaDevices {
         p
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediadevices-enumeratedevices
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediadevices-enumeratedevices>
     fn EnumerateDevices(&self) -> Rc<Promise> {
         // Step 1.
         let in_realm_proof = AlreadyInRealm::assert();

--- a/components/script/dom/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/mediaelementaudiosourcenode.rs
@@ -83,7 +83,7 @@ impl MediaElementAudioSourceNode {
 }
 
 impl MediaElementAudioSourceNodeMethods for MediaElementAudioSourceNode {
-    /// https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelement
+    /// <https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelement>
     fn MediaElement(&self) -> DomRoot<HTMLMediaElement> {
         DomRoot::from_ref(&*self.media_element)
     }

--- a/components/script/dom/mediametadata.rs
+++ b/components/script/dom/mediametadata.rs
@@ -48,7 +48,7 @@ impl MediaMetadata {
         reflect_dom_object_with_proto(Box::new(MediaMetadata::new_inherited(init)), global, proto)
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata>
     #[allow(non_snake_case)]
     pub fn Constructor(
         window: &Window,
@@ -70,34 +70,34 @@ impl MediaMetadata {
 }
 
 impl MediaMetadataMethods for MediaMetadata {
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-title
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-title>
     fn Title(&self) -> DOMString {
         self.title.borrow().clone()
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-title
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-title>
     fn SetTitle(&self, value: DOMString) {
         *self.title.borrow_mut() = value;
         self.queue_update_metadata_algorithm();
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-artist
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-artist>
     fn Artist(&self) -> DOMString {
         self.artist.borrow().clone()
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-artist
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-artist>
     fn SetArtist(&self, value: DOMString) {
         *self.artist.borrow_mut() = value;
         self.queue_update_metadata_algorithm();
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-album
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-album>
     fn Album(&self) -> DOMString {
         self.album.borrow().clone()
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediametadata-album
+    /// <https://w3c.github.io/mediasession/#dom-mediametadata-album>
     fn SetAlbum(&self, value: DOMString) {
         *self.album.borrow_mut() = value;
         self.queue_update_metadata_algorithm();

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -32,13 +32,13 @@ use crate::realms::{enter_realm, InRealm};
 #[dom_struct]
 pub struct MediaSession {
     reflector_: Reflector,
-    /// https://w3c.github.io/mediasession/#dom-mediasession-metadata
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-metadata>
     #[ignore_malloc_size_of = "defined in embedder_traits"]
     #[no_trace]
     metadata: DomRefCell<Option<EmbedderMediaMetadata>>,
-    /// https://w3c.github.io/mediasession/#dom-mediasession-playbackstate
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-playbackstate>
     playback_state: DomRefCell<MediaSessionPlaybackState>,
-    /// https://w3c.github.io/mediasession/#supported-media-session-actions
+    /// <https://w3c.github.io/mediasession/#supported-media-session-actions>
     #[ignore_malloc_size_of = "Rc"]
     action_handlers:
         DomRefCell<HashMapTracedValues<MediaSessionActionType, Rc<MediaSessionActionHandler>>>,
@@ -125,7 +125,7 @@ impl MediaSession {
 }
 
 impl MediaSessionMethods for MediaSession {
-    /// https://w3c.github.io/mediasession/#dom-mediasession-metadata
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-metadata>
     fn GetMetadata(&self) -> Option<DomRoot<MediaMetadata>> {
         if let Some(ref metadata) = *self.metadata.borrow() {
             let mut init = MediaMetadataInit::empty();
@@ -139,7 +139,7 @@ impl MediaSessionMethods for MediaSession {
         }
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediasession-metadata
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-metadata>
     fn SetMetadata(&self, metadata: Option<&MediaMetadata>) {
         if let Some(ref metadata) = metadata {
             metadata.set_session(self);
@@ -168,17 +168,17 @@ impl MediaSessionMethods for MediaSession {
         self.send_event(MediaSessionEvent::SetMetadata(_metadata));
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediasession-playbackstate
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-playbackstate>
     fn PlaybackState(&self) -> MediaSessionPlaybackState {
         *self.playback_state.borrow()
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediasession-playbackstate
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-playbackstate>
     fn SetPlaybackState(&self, state: MediaSessionPlaybackState) {
         *self.playback_state.borrow_mut() = state;
     }
 
-    /// https://w3c.github.io/mediasession/#update-action-handler-algorithm
+    /// <https://w3c.github.io/mediasession/#update-action-handler-algorithm>
     fn SetActionHandler(
         &self,
         action: MediaSessionAction,
@@ -193,7 +193,7 @@ impl MediaSessionMethods for MediaSession {
         };
     }
 
-    /// https://w3c.github.io/mediasession/#dom-mediasession-setpositionstate
+    /// <https://w3c.github.io/mediasession/#dom-mediasession-setpositionstate>
     fn SetPositionState(&self, state: &MediaPositionState) -> Fallible<()> {
         // If the state is an empty dictionary then clear the position state.
         if state.duration.is_none() && state.position.is_none() && state.playbackRate.is_none() {

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -91,7 +91,7 @@ impl MediaStream {
 }
 
 impl MediaStreamMethods for MediaStream {
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-gettracks
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-gettracks>
     fn GetTracks(&self) -> Vec<DomRoot<MediaStreamTrack>> {
         self.tracks
             .borrow()
@@ -100,7 +100,7 @@ impl MediaStreamMethods for MediaStream {
             .collect()
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-getaudiotracks
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-getaudiotracks>
     fn GetAudioTracks(&self) -> Vec<DomRoot<MediaStreamTrack>> {
         self.tracks
             .borrow()
@@ -110,7 +110,7 @@ impl MediaStreamMethods for MediaStream {
             .collect()
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-getvideotracks
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-getvideotracks>
     fn GetVideoTracks(&self) -> Vec<DomRoot<MediaStreamTrack>> {
         self.tracks
             .borrow()
@@ -120,7 +120,7 @@ impl MediaStreamMethods for MediaStream {
             .collect()
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-gettrackbyid
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-gettrackbyid>
     fn GetTrackById(&self, id: DOMString) -> Option<DomRoot<MediaStreamTrack>> {
         self.tracks
             .borrow()
@@ -129,7 +129,7 @@ impl MediaStreamMethods for MediaStream {
             .map(|x| DomRoot::from_ref(&**x))
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-addtrack
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-addtrack>
     fn AddTrack(&self, track: &MediaStreamTrack) {
         let existing = self.tracks.borrow().iter().find(|x| *x == &track).is_some();
 
@@ -139,12 +139,12 @@ impl MediaStreamMethods for MediaStream {
         self.add_track(track)
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-removetrack
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-removetrack>
     fn RemoveTrack(&self, track: &MediaStreamTrack) {
         self.tracks.borrow_mut().retain(|x| *x != track);
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastream-clone
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
     fn Clone(&self) -> DomRoot<MediaStream> {
         self.clone_with_proto(None)
     }

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -85,7 +85,7 @@ impl MediaStreamAudioDestinationNode {
 }
 
 impl MediaStreamAudioDestinationNodeMethods for MediaStreamAudioDestinationNode {
-    /// https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-stream
+    /// <https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-stream>
     fn Stream(&self) -> DomRoot<MediaStream> {
         DomRoot::from_ref(&self.stream)
     }

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -81,7 +81,7 @@ impl MediaStreamAudioSourceNode {
 }
 
 impl MediaStreamAudioSourceNodeMethods for MediaStreamAudioSourceNode {
-    /// https://webaudio.github.io/web-audio-api/#dom-MediaStreamAudioSourceNode-stream
+    /// <https://webaudio.github.io/web-audio-api/#dom-MediaStreamAudioSourceNode-stream>
     fn MediaStream(&self) -> DomRoot<MediaStream> {
         DomRoot::from_ref(&self.stream)
     }

--- a/components/script/dom/mediastreamtrack.rs
+++ b/components/script/dom/mediastreamtrack.rs
@@ -51,7 +51,7 @@ impl MediaStreamTrack {
 }
 
 impl MediaStreamTrackMethods for MediaStreamTrack {
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind>
     fn Kind(&self) -> DOMString {
         match self.ty {
             MediaStreamType::Video => "video".into(),
@@ -59,12 +59,12 @@ impl MediaStreamTrackMethods for MediaStreamTrack {
         }
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-id
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-id>
     fn Id(&self) -> DOMString {
         self.id.id().to_string().into()
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone
+    /// <https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone>
     fn Clone(&self) -> DomRoot<MediaStreamTrack> {
         MediaStreamTrack::new(&self.global(), self.id, self.ty)
     }

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -199,7 +199,7 @@ impl Transferable for MessagePort {
         Ok(u64::from_ne_bytes(big))
     }
 
-    /// https://html.spec.whatwg.org/multipage/#message-ports:transfer-receiving-steps
+    /// <https://html.spec.whatwg.org/multipage/#message-ports:transfer-receiving-steps>
     fn transfer_receive(
         owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -351,14 +351,14 @@ impl MutationObserverMethods for MutationObserver {
         Ok(())
     }
 
-    /// https://dom.spec.whatwg.org/#dom-mutationobserver-takerecords
+    /// <https://dom.spec.whatwg.org/#dom-mutationobserver-takerecords>
     fn TakeRecords(&self) -> Vec<DomRoot<MutationRecord>> {
         let records: Vec<DomRoot<MutationRecord>> = self.record_queue.borrow().clone();
         self.record_queue.borrow_mut().clear();
         records
     }
 
-    /// https://dom.spec.whatwg.org/#dom-mutationobserver-disconnect
+    /// <https://dom.spec.whatwg.org/#dom-mutationobserver-disconnect>
     fn Disconnect(&self) {
         // Step 1
         let mut nodes = self.node_list.borrow_mut();

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -174,19 +174,19 @@ impl NavigatorMethods for Navigator {
             .or_init(|| Permissions::new(&self.global()))
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-navigator-xr
+    /// <https://immersive-web.github.io/webxr/#dom-navigator-xr>
     fn Xr(&self) -> DomRoot<XRSystem> {
         self.xr
             .or_init(|| XRSystem::new(&self.global().as_window()))
     }
 
-    /// https://w3c.github.io/mediacapture-main/#dom-navigator-mediadevices
+    /// <https://w3c.github.io/mediacapture-main/#dom-navigator-mediadevices>
     fn MediaDevices(&self) -> DomRoot<MediaDevices> {
         self.mediadevices
             .or_init(|| MediaDevices::new(&self.global()))
     }
 
-    /// https://w3c.github.io/mediasession/#dom-navigator-mediasession
+    /// <https://w3c.github.io/mediasession/#dom-navigator-mediasession>
     fn MediaSession(&self) -> DomRoot<MediaSession> {
         self.mediasession.or_init(|| {
             // There is a single MediaSession instance per Pipeline

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1017,7 +1017,7 @@ impl Node {
         }
     }
 
-    /// https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor
+    /// <https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor>
     pub fn inclusive_ancestors(
         &self,
         shadow_including: ShadowIncluding,
@@ -1231,7 +1231,7 @@ impl Node {
         }
     }
 
-    /// https://dom.spec.whatwg.org/#retarget
+    /// <https://dom.spec.whatwg.org/#retarget>
     pub fn retarget(&self, b: &Node) -> DomRoot<Node> {
         let mut a = DomRoot::from_ref(&*self);
         loop {

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -57,7 +57,7 @@ const INVALID_ENTRY_NAMES: &'static [&'static str] = &[
 /// Performance and PerformanceObserverEntryList interfaces implementations.
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct PerformanceEntryList {
-    /// https://w3c.github.io/performance-timeline/#dfn-performance-entry-buffer
+    /// <https://w3c.github.io/performance-timeline/#dfn-performance-entry-buffer>
     entries: DOMPerformanceEntryList,
 }
 
@@ -142,7 +142,7 @@ pub struct Performance {
     observers: DomRefCell<Vec<PerformanceObserver>>,
     pending_notification_observers_task: Cell<bool>,
     navigation_start_precise: u64,
-    /// https://w3c.github.io/performance-timeline/#dfn-maxbuffersize
+    /// <https://w3c.github.io/performance-timeline/#dfn-maxbuffersize>
     /// The max-size of the buffer, set to 0 once the pipeline exits.
     /// TODO: have one max-size per entry type.
     resource_timing_buffer_size_limit: Cell<usize>,
@@ -372,7 +372,7 @@ impl Performance {
         self.resource_timing_buffer_pending_full_event.set(false);
     }
     /// `add a PerformanceResourceTiming entry` paragraph of
-    /// https://w3c.github.io/resource-timing/#sec-extensions-performance-interface
+    /// <https://w3c.github.io/resource-timing/#sec-extensions-performance-interface>
     fn should_queue_resource_entry(&self, entry: &PerformanceEntry) -> bool {
         // Step 1 is done in the args list.
         if !self.resource_timing_buffer_pending_full_event.get() {

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -35,7 +35,7 @@ pub struct NodeRareData {
 #[derive(Default, JSTraceable, MallocSizeOf)]
 #[crown::unrooted_must_root_lint::must_root]
 pub struct ElementRareData {
-    /// https://dom.spec.whatwg.org/#dom-element-shadowroot
+    /// <https://dom.spec.whatwg.org/#dom-element-shadowroot>
     /// The ShadowRoot this element is host of.
     /// XXX This is currently not exposed to web content. Only for
     ///     internal use.

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -47,7 +47,7 @@ pub struct Response {
     url: DomRefCell<Option<ServoUrl>>,
     #[no_trace]
     url_list: DomRefCell<Vec<ServoUrl>>,
-    /// The stream of https://fetch.spec.whatwg.org/#body.
+    /// The stream of <https://fetch.spec.whatwg.org/#body>.
     body_stream: MutNullableDom<ReadableStream>,
     #[ignore_malloc_size_of = "StreamConsumer"]
     stream_consumer: DomRefCell<Option<StreamConsumer>>,

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -100,27 +100,27 @@ impl RTCIceCandidate {
 }
 
 impl RTCIceCandidateMethods for RTCIceCandidate {
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-candidate
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-candidate>
     fn Candidate(&self) -> DOMString {
         self.candidate.clone()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-sdpmid
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-sdpmid>
     fn GetSdpMid(&self) -> Option<DOMString> {
         self.sdp_m_id.clone()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-sdpmlineindex
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-sdpmlineindex>
     fn GetSdpMLineIndex(&self) -> Option<u16> {
         self.sdp_m_line_index.clone()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-usernamefragment
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-usernamefragment>
     fn GetUsernameFragment(&self) -> Option<DOMString> {
         self.username_fragment.clone()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson>
     fn ToJSON(&self) -> RTCIceCandidateInit {
         RTCIceCandidateInit {
             candidate: self.candidate.clone(),

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -360,7 +360,7 @@ impl RTCPeerConnection {
         self.data_channels.borrow_mut().remove(&id);
     }
 
-    /// https://www.w3.org/TR/webrtc/#update-ice-gathering-state
+    /// <https://www.w3.org/TR/webrtc/#update-ice-gathering-state>
     fn update_gathering_state(&self, state: GatheringState) {
         // step 1
         if self.closed.get() {
@@ -400,7 +400,7 @@ impl RTCPeerConnection {
         }
     }
 
-    /// https://www.w3.org/TR/webrtc/#update-ice-connection-state
+    /// <https://www.w3.org/TR/webrtc/#update-ice-connection-state>
     fn update_ice_connection_state(&self, state: IceConnectionState) {
         // step 1
         if self.closed.get() {
@@ -553,7 +553,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     // https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-ondatachannel
     event_handler!(datachannel, GetOndatachannel, SetOndatachannel);
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addicecandidate
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addicecandidate>
     fn AddIceCandidate(&self, candidate: &RTCIceCandidateInit, comp: InRealm) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
@@ -588,7 +588,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         p
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer>
     fn CreateOffer(&self, _options: &RTCOfferOptions, comp: InRealm) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
         if self.closed.get() {
@@ -600,7 +600,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         p
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer>
     fn CreateAnswer(&self, _options: &RTCAnswerOptions, comp: InRealm) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
         if self.closed.get() {
@@ -612,17 +612,17 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         p
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-localdescription
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-localdescription>
     fn GetLocalDescription(&self) -> Option<DomRoot<RTCSessionDescription>> {
         self.local_description.get()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-remotedescription
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-remotedescription>
     fn GetRemoteDescription(&self) -> Option<DomRoot<RTCSessionDescription>> {
         self.remote_description.get()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setlocaldescription
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setlocaldescription>
     fn SetLocalDescription(&self, desc: &RTCSessionDescriptionInit, comp: InRealm) -> Rc<Promise> {
         // XXXManishearth validate the current state
         let p = Promise::new_in_current_realm(comp);
@@ -662,7 +662,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         p
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setremotedescription
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setremotedescription>
     fn SetRemoteDescription(&self, desc: &RTCSessionDescriptionInit, comp: InRealm) -> Rc<Promise> {
         // XXXManishearth validate the current state
         let p = Promise::new_in_current_realm(comp);
@@ -713,22 +713,22 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         }
     }
 
-    /// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-icegatheringstate
+    /// <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-icegatheringstate>
     fn IceGatheringState(&self) -> RTCIceGatheringState {
         self.gathering_state.get()
     }
 
-    /// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-iceconnectionstate
+    /// <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-iceconnectionstate>
     fn IceConnectionState(&self) -> RTCIceConnectionState {
         self.ice_connection_state.get()
     }
 
-    /// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-signalingstate
+    /// <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-signalingstate>
     fn SignalingState(&self) -> RTCSignalingState {
         self.signaling_state.get()
     }
 
-    /// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close
+    /// <https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close>
     fn Close(&self) {
         // Step 1
         if self.closed.get() {
@@ -758,7 +758,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         // (no current support for connection state)
     }
 
-    /// https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel
+    /// <https://www.w3.org/TR/webrtc/#dom-peerconnection-createdatachannel>
     fn CreateDataChannel(
         &self,
         label: USVString,
@@ -767,7 +767,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         RTCDataChannel::new(&self.global(), &self, label, init, None)
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver>
     fn AddTransceiver(
         &self,
         _track_or_kind: MediaStreamTrackOrString,

--- a/components/script/dom/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/rtcpeerconnectioniceevent.rs
@@ -90,17 +90,17 @@ impl RTCPeerConnectionIceEvent {
 }
 
 impl RTCPeerConnectionIceEventMethods for RTCPeerConnectionIceEvent {
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-candidate
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-candidate>
     fn GetCandidate(&self) -> Option<DomRoot<RTCIceCandidate>> {
         self.candidate.as_ref().map(|x| DomRoot::from_ref(&**x))
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-url
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-url>
     fn GetUrl(&self) -> Option<DOMString> {
         self.url.clone()
     }
 
-    /// https://dom.spec.whatwg.org/#dom-event-istrusted
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.event.IsTrusted()
     }

--- a/components/script/dom/rtcrtptransceiver.rs
+++ b/components/script/dom/rtcrtptransceiver.rs
@@ -40,17 +40,17 @@ impl RTCRtpTransceiver {
 }
 
 impl RTCRtpTransceiverMethods for RTCRtpTransceiver {
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction>
     fn Direction(&self) -> RTCRtpTransceiverDirection {
         self.direction.get()
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-direction>
     fn SetDirection(&self, direction: RTCRtpTransceiverDirection) {
         self.direction.set(direction);
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-sender
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-sender>
     fn Sender(&self) -> DomRoot<RTCRtpSender> {
         DomRoot::from_ref(&*self.sender)
     }

--- a/components/script/dom/rtcsessiondescription.rs
+++ b/components/script/dom/rtcsessiondescription.rs
@@ -60,12 +60,12 @@ impl RTCSessionDescription {
 }
 
 impl RTCSessionDescriptionMethods for RTCSessionDescription {
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-type
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-type>
     fn Type(&self) -> RTCSdpType {
         self.ty
     }
 
-    /// https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-sdp
+    /// <https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-sdp>
     fn Sdp(&self) -> DOMString {
         self.sdp.clone()
     }

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -89,7 +89,7 @@ impl ServiceWorker {
         ServoUrl::parse(&self.script_url.borrow().clone()).unwrap()
     }
 
-    /// https://w3c.github.io/ServiceWorker/#service-worker-postmessage
+    /// <https://w3c.github.io/ServiceWorker/#service-worker-postmessage>
     fn post_message_impl(
         &self,
         cx: JSContext,
@@ -129,7 +129,7 @@ impl ServiceWorkerMethods for ServiceWorker {
         USVString(self.script_url.borrow().clone())
     }
 
-    /// https://w3c.github.io/ServiceWorker/#service-worker-postmessage
+    /// <https://w3c.github.io/ServiceWorker/#service-worker-postmessage>
     fn PostMessage(
         &self,
         cx: JSContext,
@@ -139,7 +139,7 @@ impl ServiceWorkerMethods for ServiceWorker {
         self.post_message_impl(cx, message, transfer)
     }
 
-    /// https://w3c.github.io/ServiceWorker/#service-worker-postmessage
+    /// <https://w3c.github.io/ServiceWorker/#service-worker-postmessage>
     fn PostMessage_(
         &self,
         cx: JSContext,

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -59,8 +59,8 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
         self.client.get_controller()
     }
 
-    /// https://w3c.github.io/ServiceWorker/#dom-serviceworkercontainer-register - A
-    /// and https://w3c.github.io/ServiceWorker/#start-register - B
+    /// <https://w3c.github.io/ServiceWorker/#dom-serviceworkercontainer-register> - A
+    /// and <https://w3c.github.io/ServiceWorker/#start-register> - B
     fn Register(
         &self,
         script_url: USVString,

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -880,7 +880,7 @@ impl TreeSink for Sink {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#html-integration-point>
-    /// Specifically, the <annotation-xml> cases.
+    /// Specifically, the `<annotation-xml>` cases.
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Self::Handle) -> bool {
         let node_data = self.get_parse_node_data(&handle.id);
         node_data.is_integration_point

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -339,7 +339,7 @@ impl ServoParser {
         self.script_created_parser || self.script_nesting_level.get() > 0
     }
 
-    /// Steps 6-8 of https://html.spec.whatwg.org/multipage/#document.write()
+    /// Steps 6-8 of <https://html.spec.whatwg.org/multipage/#document.write()>
     pub fn write(&self, text: Vec<DOMString>) {
         assert!(self.can_write());
 
@@ -1301,7 +1301,7 @@ impl TreeSink for Sink {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token
+/// <https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token>
 fn create_element_for_token(
     name: QualName,
     attrs: Vec<ElementAttribute>,

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -217,12 +217,12 @@ impl ShadowRootMethods for ShadowRoot {
         elements
     }
 
-    /// https://dom.spec.whatwg.org/#dom-shadowroot-mode
+    /// <https://dom.spec.whatwg.org/#dom-shadowroot-mode>
     fn Mode(&self) -> ShadowRootMode {
         ShadowRootMode::Closed
     }
 
-    /// https://dom.spec.whatwg.org/#dom-shadowroot-host
+    /// <https://dom.spec.whatwg.org/#dom-shadowroot-host>
     fn Host(&self) -> DomRoot<Element> {
         let host = self.host.get();
         host.expect("Trying to get host from a detached shadow root")

--- a/components/script/dom/submitevent.rs
+++ b/components/script/dom/submitevent.rs
@@ -87,7 +87,7 @@ impl SubmitEventMethods for SubmitEvent {
         self.event.IsTrusted()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-submitevent-submitter
+    /// <https://html.spec.whatwg.org/multipage/#dom-submitevent-submitter>
     fn GetSubmitter(&self) -> Option<DomRoot<HTMLElement>> {
         self.submitter.as_ref().map(|s| DomRoot::from_ref(&**s))
     }

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -5,7 +5,7 @@
 //! This is an abstraction used by `HTMLInputElement` and `HTMLTextAreaElement` to implement the
 //! text control selection DOM API.
 //!
-//! https://html.spec.whatwg.org/multipage/#textFieldSelection
+//! <https://html.spec.whatwg.org/multipage/#textFieldSelection>
 
 use script_traits::ScriptToConstellationChan;
 

--- a/components/script/dom/textmetrics.rs
+++ b/components/script/dom/textmetrics.rs
@@ -97,62 +97,62 @@ impl TextMetrics {
 }
 
 impl TextMetricsMethods for TextMetrics {
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-width
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-width>
     fn Width(&self) -> Finite<f64> {
         self.width
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxleft
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxleft>
     fn ActualBoundingBoxLeft(&self) -> Finite<f64> {
         self.actualBoundingBoxLeft
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxright
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxright>
     fn ActualBoundingBoxRight(&self) -> Finite<f64> {
         self.actualBoundingBoxRight
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-fontboundingboxascent
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-fontboundingboxascent>
     fn FontBoundingBoxAscent(&self) -> Finite<f64> {
         self.fontBoundingBoxAscent
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-fontboundingboxascent
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-fontboundingboxascent>
     fn FontBoundingBoxDescent(&self) -> Finite<f64> {
         self.fontBoundingBoxDescent
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxascent
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxascent>
     fn ActualBoundingBoxAscent(&self) -> Finite<f64> {
         self.actualBoundingBoxAscent
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxdescent
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-actualboundingboxdescent>
     fn ActualBoundingBoxDescent(&self) -> Finite<f64> {
         self.actualBoundingBoxDescent
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-emheightascent
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-emheightascent>
     fn EmHeightAscent(&self) -> Finite<f64> {
         self.emHeightAscent
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-emheightdescent
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-emheightdescent>
     fn EmHeightDescent(&self) -> Finite<f64> {
         self.emHeightDescent
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-hangingbaseline
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-hangingbaseline>
     fn HangingBaseline(&self) -> Finite<f64> {
         self.hangingBaseline
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-alphabeticbaseline
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-alphabeticbaseline>
     fn AlphabeticBaseline(&self) -> Finite<f64> {
         self.alphabeticBaseline
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-textmetrics-ideographicbaseline
+    /// <https://html.spec.whatwg.org/multipage/#dom-textmetrics-ideographicbaseline>
     fn IdeographicBaseline(&self) -> Finite<f64> {
         self.ideographicBaseline
     }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -899,32 +899,32 @@ impl WebGL2RenderingContext {
 }
 
 impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1>
     fn Canvas(&self) -> DomRoot<HTMLCanvasElement> {
         self.base.Canvas()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn Flush(&self) {
         self.base.Flush()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn Finish(&self) {
         self.base.Finish()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1>
     fn DrawingBufferWidth(&self) -> i32 {
         self.base.DrawingBufferWidth()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1>
     fn DrawingBufferHeight(&self) -> i32 {
         self.base.DrawingBufferHeight()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn GetBufferParameter(&self, _cx: JSContext, target: u32, parameter: u32) -> JSVal {
         let buffer =
             handle_potential_webgl_error!(self.base, self.bound_buffer(target), return NullValue());
@@ -932,7 +932,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     #[allow(unsafe_code)]
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn GetParameter(&self, cx: JSContext, parameter: u32) -> JSVal {
         match parameter {
             constants::VERSION => unsafe {
@@ -1109,17 +1109,17 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetParameter(cx, parameter)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn GetTexParameter(&self, cx: JSContext, target: u32, pname: u32) -> JSVal {
         self.base.GetTexParameter(cx, target, pname)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn GetError(&self) -> u32 {
         self.base.GetError()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.2
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.2>
     fn GetContextAttributes(&self) -> Option<WebGLContextAttributes> {
         self.base.GetContextAttributes()
     }
@@ -1129,17 +1129,17 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.IsContextLost()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14>
     fn GetSupportedExtensions(&self) -> Option<Vec<DOMString>> {
         self.base.GetSupportedExtensions()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14>
     fn GetExtension(&self, cx: JSContext, name: DOMString) -> Option<NonNull<JSObject>> {
         self.base.GetExtension(cx, name)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4>
     fn GetFramebufferAttachmentParameter(
         &self,
         cx: JSContext,
@@ -1176,58 +1176,58 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
     fn GetRenderbufferParameter(&self, cx: JSContext, target: u32, pname: u32) -> JSVal {
         self.base.GetRenderbufferParameter(cx, target, pname)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn ActiveTexture(&self, texture: u32) {
         self.base.ActiveTexture(texture)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn BlendColor(&self, r: f32, g: f32, b: f32, a: f32) {
         self.base.BlendColor(r, g, b, a)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn BlendEquation(&self, mode: u32) {
         self.base.BlendEquation(mode)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn BlendEquationSeparate(&self, mode_rgb: u32, mode_alpha: u32) {
         self.base.BlendEquationSeparate(mode_rgb, mode_alpha)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn BlendFunc(&self, src_factor: u32, dest_factor: u32) {
         self.base.BlendFunc(src_factor, dest_factor)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn BlendFuncSeparate(&self, src_rgb: u32, dest_rgb: u32, src_alpha: u32, dest_alpha: u32) {
         self.base
             .BlendFuncSeparate(src_rgb, dest_rgb, src_alpha, dest_alpha)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn AttachShader(&self, program: &WebGLProgram, shader: &WebGLShader) {
         self.base.AttachShader(program, shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn DetachShader(&self, program: &WebGLProgram, shader: &WebGLShader) {
         self.base.DetachShader(program, shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn BindAttribLocation(&self, program: &WebGLProgram, index: u32, name: DOMString) {
         self.base.BindAttribLocation(program, index, name)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2>
     fn BindBuffer(&self, target: u32, buffer: Option<&WebGLBuffer>) {
         let current_vao;
         let slot = match target {
@@ -1246,7 +1246,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.bind_buffer_maybe(&slot, target, buffer);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn BindFramebuffer(&self, target: u32, framebuffer: Option<&WebGLFramebuffer>) {
         handle_potential_webgl_error!(
             self.base,
@@ -1276,22 +1276,22 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
     fn BindRenderbuffer(&self, target: u32, renderbuffer: Option<&WebGLRenderbuffer>) {
         self.base.BindRenderbuffer(target, renderbuffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn BindTexture(&self, target: u32, texture: Option<&WebGLTexture>) {
         self.base.BindTexture(target, texture)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn GenerateMipmap(&self, target: u32) {
         self.base.GenerateMipmap(target)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn BufferData_(&self, target: u32, data: Option<ArrayBufferViewOrArrayBuffer>, usage: u32) {
         let usage = handle_potential_webgl_error!(self.base, self.buffer_usage(usage), return);
         let bound_buffer =
@@ -1299,7 +1299,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.buffer_data(target, data, usage, bound_buffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn BufferData(&self, target: u32, size: i64, usage: u32) {
         let usage = handle_potential_webgl_error!(self.base, self.buffer_usage(usage), return);
         let bound_buffer =
@@ -1307,7 +1307,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.buffer_data_(target, size, usage, bound_buffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3>
     #[allow(unsafe_code)]
     fn BufferData__(
         &self,
@@ -1351,7 +1351,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         handle_potential_webgl_error!(self.base, bound_buffer.buffer_data(target, &data, usage));
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn BufferSubData(&self, target: u32, offset: i64, data: ArrayBufferViewOrArrayBuffer) {
         let bound_buffer =
             handle_potential_webgl_error!(self.base, self.bound_buffer(target), return);
@@ -1359,7 +1359,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .buffer_sub_data(target, offset, data, bound_buffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3>
     #[allow(unsafe_code)]
     fn BufferSubData_(
         &self,
@@ -1411,7 +1411,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         sender.send(data).unwrap();
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3>
     fn CopyBufferSubData(
         &self,
         read_target: u32,
@@ -1467,7 +1467,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         ));
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3>
     #[allow(unsafe_code)]
     fn GetBufferSubData(
         &self,
@@ -1524,7 +1524,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6>
     #[allow(unsafe_code)]
     fn CompressedTexImage2D(
         &self,
@@ -1559,7 +1559,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     #[allow(unsafe_code)]
     fn CompressedTexSubImage2D(
         &self,
@@ -1589,7 +1589,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn CopyTexImage2D(
         &self,
         target: u32,
@@ -1605,7 +1605,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .CopyTexImage2D(target, level, internal_format, x, y, width, height, border)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn CopyTexSubImage2D(
         &self,
         target: u32,
@@ -1621,56 +1621,56 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn Clear(&self, mask: u32) {
         self.base.Clear(mask)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn ClearColor(&self, red: f32, green: f32, blue: f32, alpha: f32) {
         self.base.ClearColor(red, green, blue, alpha)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn ClearDepth(&self, depth: f32) {
         self.base.ClearDepth(depth)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn ClearStencil(&self, stencil: i32) {
         self.base.ClearStencil(stencil)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn ColorMask(&self, r: bool, g: bool, b: bool, a: bool) {
         self.base.ColorMask(r, g, b, a)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn CullFace(&self, mode: u32) {
         self.base.CullFace(mode)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn FrontFace(&self, mode: u32) {
         self.base.FrontFace(mode)
     }
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn DepthFunc(&self, func: u32) {
         self.base.DepthFunc(func)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn DepthMask(&self, flag: bool) {
         self.base.DepthMask(flag)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn DepthRange(&self, near: f32, far: f32) {
         self.base.DepthRange(near, far)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn Enable(&self, cap: u32) {
         match cap {
             constants::RASTERIZER_DISCARD => {
@@ -1681,7 +1681,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn Disable(&self, cap: u32) {
         match cap {
             constants::RASTERIZER_DISCARD => {
@@ -1692,47 +1692,47 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn CompileShader(&self, shader: &WebGLShader) {
         self.base.CompileShader(shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn CreateBuffer(&self) -> Option<DomRoot<WebGLBuffer>> {
         self.base.CreateBuffer()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn CreateFramebuffer(&self) -> Option<DomRoot<WebGLFramebuffer>> {
         self.base.CreateFramebuffer()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
     fn CreateRenderbuffer(&self) -> Option<DomRoot<WebGLRenderbuffer>> {
         self.base.CreateRenderbuffer()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn CreateTexture(&self) -> Option<DomRoot<WebGLTexture>> {
         self.base.CreateTexture()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn CreateProgram(&self) -> Option<DomRoot<WebGLProgram>> {
         self.base.CreateProgram()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn CreateShader(&self, shader_type: u32) -> Option<DomRoot<WebGLShader>> {
         self.base.CreateShader(shader_type)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17>
     fn CreateVertexArray(&self) -> Option<DomRoot<WebGLVertexArrayObject>> {
         self.base.create_vertex_array_webgl2()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn DeleteBuffer(&self, buffer: Option<&WebGLBuffer>) {
         let buffer = match buffer {
             Some(buffer) => buffer,
@@ -1761,61 +1761,61 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         buffer.mark_for_deletion(Operation::Infallible);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn DeleteFramebuffer(&self, framebuffer: Option<&WebGLFramebuffer>) {
         self.base.DeleteFramebuffer(framebuffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
     fn DeleteRenderbuffer(&self, renderbuffer: Option<&WebGLRenderbuffer>) {
         self.base.DeleteRenderbuffer(renderbuffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn DeleteTexture(&self, texture: Option<&WebGLTexture>) {
         self.base.DeleteTexture(texture)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn DeleteProgram(&self, program: Option<&WebGLProgram>) {
         self.base.DeleteProgram(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn DeleteShader(&self, shader: Option<&WebGLShader>) {
         self.base.DeleteShader(shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17>
     fn DeleteVertexArray(&self, vertex_array: Option<&WebGLVertexArrayObject>) {
         self.base.delete_vertex_array_webgl2(vertex_array);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn DrawArrays(&self, mode: u32, first: i32, count: i32) {
         self.validate_uniform_block_for_draw();
         self.validate_vertex_attribs_for_draw();
         self.base.DrawArrays(mode, first, count)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn DrawElements(&self, mode: u32, count: i32, type_: u32, offset: i64) {
         self.validate_uniform_block_for_draw();
         self.validate_vertex_attribs_for_draw();
         self.base.DrawElements(mode, count, type_, offset)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn EnableVertexAttribArray(&self, attrib_id: u32) {
         self.base.EnableVertexAttribArray(attrib_id)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn DisableVertexAttribArray(&self, attrib_id: u32) {
         self.base.DisableVertexAttribArray(attrib_id)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetActiveUniform(
         &self,
         program: &WebGLProgram,
@@ -1824,7 +1824,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetActiveUniform(program, index)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetActiveAttrib(
         &self,
         program: &WebGLProgram,
@@ -1833,23 +1833,23 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetActiveAttrib(program, index)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetAttribLocation(&self, program: &WebGLProgram, name: DOMString) -> i32 {
         self.base.GetAttribLocation(program, name)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7>
     fn GetFragDataLocation(&self, program: &WebGLProgram, name: DOMString) -> i32 {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(program), return -1);
         handle_potential_webgl_error!(self.base, program.get_frag_data_location(name), -1)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetProgramInfoLog(&self, program: &WebGLProgram) -> Option<DOMString> {
         self.base.GetProgramInfoLog(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetProgramParameter(&self, cx: JSContext, program: &WebGLProgram, param_id: u32) -> JSVal {
         handle_potential_webgl_error!(
             self.base,
@@ -1871,17 +1871,17 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetShaderInfoLog(&self, shader: &WebGLShader) -> Option<DOMString> {
         self.base.GetShaderInfoLog(shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetShaderParameter(&self, cx: JSContext, shader: &WebGLShader, param_id: u32) -> JSVal {
         self.base.GetShaderParameter(cx, shader, param_id)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetShaderPrecisionFormat(
         &self,
         shader_type: u32,
@@ -1891,7 +1891,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .GetShaderPrecisionFormat(shader_type, precision_type)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2>
     #[allow(unsafe_code)]
     fn GetIndexedParameter(&self, cx: JSContext, target: u32, index: u32) -> JSVal {
         let bindings = match target {
@@ -1931,7 +1931,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetUniformLocation(
         &self,
         program: &WebGLProgram,
@@ -1940,28 +1940,28 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetUniformLocation(program, name)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetVertexAttrib(&self, cx: JSContext, index: u32, pname: u32) -> JSVal {
         self.base.GetVertexAttrib(cx, index, pname)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn GetVertexAttribOffset(&self, index: u32, pname: u32) -> i64 {
         self.base.GetVertexAttribOffset(index, pname)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn Hint(&self, target: u32, mode: u32) {
         self.base.Hint(target, mode)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn IsBuffer(&self, buffer: Option<&WebGLBuffer>) -> bool {
         self.base.IsBuffer(buffer)
     }
 
     // TODO: We could write this without IPC, recording the calls to `enable` and `disable`.
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2>
     fn IsEnabled(&self, cap: u32) -> bool {
         match cap {
             constants::RASTERIZER_DISCARD => self.enable_rasterizer_discard.get(),
@@ -1969,42 +1969,42 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn IsFramebuffer(&self, frame_buffer: Option<&WebGLFramebuffer>) -> bool {
         self.base.IsFramebuffer(frame_buffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn IsProgram(&self, program: Option<&WebGLProgram>) -> bool {
         self.base.IsProgram(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
     fn IsRenderbuffer(&self, render_buffer: Option<&WebGLRenderbuffer>) -> bool {
         self.base.IsRenderbuffer(render_buffer)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn IsShader(&self, shader: Option<&WebGLShader>) -> bool {
         self.base.IsShader(shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn IsTexture(&self, texture: Option<&WebGLTexture>) -> bool {
         self.base.IsTexture(texture)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17>
     fn IsVertexArray(&self, vertex_array: Option<&WebGLVertexArrayObject>) -> bool {
         self.base.is_vertex_array_webgl2(vertex_array)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn LineWidth(&self, width: f32) {
         self.base.LineWidth(width)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2>
     fn PixelStorei(&self, param_name: u32, param_value: i32) {
         if param_value < 0 {
             return self.base.webgl_error(InvalidValue);
@@ -2018,12 +2018,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn PolygonOffset(&self, factor: f32, units: f32) {
         self.base.PolygonOffset(factor, units)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12>
     fn ReadPixels(
         &self,
         x: i32,
@@ -2040,7 +2040,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.read_pixels_into(x, y, width, height, format, pixel_type, pixels, 0)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.10>
     fn ReadPixels_(
         &self,
         x: i32,
@@ -2131,7 +2131,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         ));
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.10>
     #[allow(unsafe_code)]
     fn ReadPixels__(
         &self,
@@ -2156,72 +2156,72 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn SampleCoverage(&self, value: f32, invert: bool) {
         self.base.SampleCoverage(value, invert)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4>
     fn Scissor(&self, x: i32, y: i32, width: i32, height: i32) {
         self.base.Scissor(x, y, width, height)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilFunc(&self, func: u32, ref_: i32, mask: u32) {
         self.base.StencilFunc(func, ref_, mask)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilFuncSeparate(&self, face: u32, func: u32, ref_: i32, mask: u32) {
         self.base.StencilFuncSeparate(face, func, ref_, mask)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilMask(&self, mask: u32) {
         self.base.StencilMask(mask)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilMaskSeparate(&self, face: u32, mask: u32) {
         self.base.StencilMaskSeparate(face, mask)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilOp(&self, fail: u32, zfail: u32, zpass: u32) {
         self.base.StencilOp(fail, zfail, zpass)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilOpSeparate(&self, face: u32, fail: u32, zfail: u32, zpass: u32) {
         self.base.StencilOpSeparate(face, fail, zfail, zpass)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn LinkProgram(&self, program: &WebGLProgram) {
         self.base.LinkProgram(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn ShaderSource(&self, shader: &WebGLShader, source: DOMString) {
         self.base.ShaderSource(shader, source)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetShaderSource(&self, shader: &WebGLShader) -> Option<DOMString> {
         self.base.GetShaderSource(shader)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform1f(&self, location: Option<&WebGLUniformLocation>, val: f32) {
         self.base.Uniform1f(location, val)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform1i(&self, location: Option<&WebGLUniformLocation>, val: i32) {
         self.base.Uniform1i(location, val)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform1iv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2283,7 +2283,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform1fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2294,12 +2294,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.uniform1fv(location, v, src_offset, src_length);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform2f(&self, location: Option<&WebGLUniformLocation>, x: f32, y: f32) {
         self.base.Uniform2f(location, x, y)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform2fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2310,12 +2310,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.uniform2fv(location, v, src_offset, src_length);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform2i(&self, location: Option<&WebGLUniformLocation>, x: i32, y: i32) {
         self.base.Uniform2i(location, x, y)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform2iv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2359,12 +2359,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform3f(&self, location: Option<&WebGLUniformLocation>, x: f32, y: f32, z: f32) {
         self.base.Uniform3f(location, x, y, z)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform3fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2375,12 +2375,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.uniform3fv(location, v, src_offset, src_length);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform3i(&self, location: Option<&WebGLUniformLocation>, x: i32, y: i32, z: i32) {
         self.base.Uniform3i(location, x, y, z)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform3iv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2424,12 +2424,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform4i(&self, location: Option<&WebGLUniformLocation>, x: i32, y: i32, z: i32, w: i32) {
         self.base.Uniform4i(location, x, y, z, w)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform4iv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2473,12 +2473,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform4f(&self, location: Option<&WebGLUniformLocation>, x: f32, y: f32, z: f32, w: f32) {
         self.base.Uniform4f(location, x, y, z, w)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn Uniform4fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2489,7 +2489,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.uniform4fv(location, v, src_offset, src_length);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn UniformMatrix2fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2502,7 +2502,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .uniform_matrix_2fv(location, transpose, v, src_offset, src_length)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn UniformMatrix3fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2515,7 +2515,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .uniform_matrix_3fv(location, transpose, v, src_offset, src_length)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn UniformMatrix4fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2528,7 +2528,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .uniform_matrix_4fv(location, transpose, v, src_offset, src_length)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn UniformMatrix3x2fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2556,7 +2556,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn UniformMatrix4x2fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2584,7 +2584,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn UniformMatrix2x3fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2612,7 +2612,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn UniformMatrix4x3fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2640,7 +2640,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn UniformMatrix2x4fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2668,7 +2668,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn UniformMatrix3x4fv(
         &self,
         location: Option<&WebGLUniformLocation>,
@@ -2696,7 +2696,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         });
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     #[allow(unsafe_code)]
     fn GetUniform(
         &self,
@@ -2768,62 +2768,62 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn UseProgram(&self, program: Option<&WebGLProgram>) {
         self.base.UseProgram(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn ValidateProgram(&self, program: &WebGLProgram) {
         self.base.ValidateProgram(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib1f(&self, indx: u32, x: f32) {
         self.base.VertexAttrib1f(indx, x)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib1fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
         self.base.VertexAttrib1fv(indx, v)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib2f(&self, indx: u32, x: f32, y: f32) {
         self.base.VertexAttrib2f(indx, x, y)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib2fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
         self.base.VertexAttrib2fv(indx, v)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib3f(&self, indx: u32, x: f32, y: f32, z: f32) {
         self.base.VertexAttrib3f(indx, x, y, z)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib3fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
         self.base.VertexAttrib3fv(indx, v)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib4f(&self, indx: u32, x: f32, y: f32, z: f32, w: f32) {
         self.base.VertexAttrib4f(indx, x, y, z, w)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttrib4fv(&self, indx: u32, v: Float32ArrayOrUnrestrictedFloatSequence) {
         self.base.VertexAttrib4fv(indx, v)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn VertexAttribI4i(&self, index: u32, x: i32, y: i32, z: i32, w: i32) {
         self.vertex_attrib_i(index, x, y, z, w)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn VertexAttribI4iv(&self, index: u32, v: Int32ArrayOrLongSequence) {
         let values = match v {
             Int32ArrayOrLongSequence::Int32Array(v) => v.to_vec(),
@@ -2835,12 +2835,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.vertex_attrib_i(index, values[0], values[1], values[2], values[3]);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn VertexAttribI4ui(&self, index: u32, x: u32, y: u32, z: u32, w: u32) {
         self.vertex_attrib_u(index, x, y, z, w)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn VertexAttribI4uiv(&self, index: u32, v: Uint32ArrayOrUnsignedLongSequence) {
         let values = match v {
             Uint32ArrayOrUnsignedLongSequence::Uint32Array(v) => v.to_vec(),
@@ -2852,7 +2852,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.vertex_attrib_u(index, values[0], values[1], values[2], values[3]);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10>
     fn VertexAttribPointer(
         &self,
         attrib_id: u32,
@@ -2866,7 +2866,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .VertexAttribPointer(attrib_id, size, data_type, normalized, stride, offset)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8>
     fn VertexAttribIPointer(&self, index: u32, size: i32, type_: u32, stride: i32, offset: i64) {
         match type_ {
             constants::BYTE |
@@ -2881,12 +2881,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .VertexAttribPointer(index, size, type_, false, stride, offset)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4>
     fn Viewport(&self, x: i32, y: i32, width: i32, height: i32) {
         self.base.Viewport(x, y, width, height)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexImage2D(
         &self,
         target: u32,
@@ -2912,7 +2912,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexImage2D_(
         &self,
         target: u32,
@@ -2926,7 +2926,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .TexImage2D_(target, level, internal_format, format, data_type, source)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6>
     fn TexImage2D__(
         &self,
         target: u32,
@@ -2999,7 +2999,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         Ok(())
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6>
     fn TexImage2D___(
         &self,
         target: u32,
@@ -3066,7 +3066,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         Ok(())
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6>
     #[allow(unsafe_code)]
     fn TexImage2D____(
         &self,
@@ -3163,7 +3163,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         Ok(())
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexSubImage2D(
         &self,
         target: u32,
@@ -3181,7 +3181,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexSubImage2D_(
         &self,
         target: u32,
@@ -3196,17 +3196,17 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .TexSubImage2D_(target, level, xoffset, yoffset, format, data_type, source)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexParameterf(&self, target: u32, name: u32, value: f32) {
         self.base.TexParameterf(target, name, value)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>
     fn TexParameteri(&self, target: u32, name: u32, value: i32) {
         self.base.TexParameteri(target, name, value)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn CheckFramebufferStatus(&self, target: u32) -> u32 {
         let fb_slot = match target {
             constants::FRAMEBUFFER | constants::DRAW_FRAMEBUFFER => {
@@ -3224,13 +3224,13 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7>
     fn RenderbufferStorage(&self, target: u32, internal_format: u32, width: i32, height: i32) {
         self.base
             .RenderbufferStorage(target, internal_format, width, height)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn FramebufferRenderbuffer(
         &self,
         target: u32,
@@ -3272,7 +3272,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         };
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>
     fn FramebufferTexture2D(
         &self,
         target: u32,
@@ -3301,12 +3301,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetAttachedShaders(&self, program: &WebGLProgram) -> Option<Vec<DomRoot<WebGLShader>>> {
         self.base.GetAttachedShaders(program)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9>
     fn DrawArraysInstanced(&self, mode: u32, first: i32, count: i32, primcount: i32) {
         self.validate_uniform_block_for_draw();
         self.validate_vertex_attribs_for_draw();
@@ -3317,7 +3317,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9>
     fn DrawElementsInstanced(
         &self,
         mode: u32,
@@ -3335,7 +3335,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9>
     fn DrawRangeElements(
         &self,
         mode: u32,
@@ -3358,17 +3358,17 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9>
     fn VertexAttribDivisor(&self, index: u32, divisor: u32) {
         self.base.vertex_attrib_divisor(index, divisor);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     fn CreateQuery(&self) -> Option<DomRoot<WebGLQuery>> {
         Some(WebGLQuery::new(&self.base))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn DeleteQuery(&self, query: Option<&WebGLQuery>) {
         if let Some(query) = query {
@@ -3396,7 +3396,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     fn IsQuery(&self, query: Option<&WebGLQuery>) -> bool {
         match query {
             Some(query) => self.base.validate_ownership(query).is_ok() && query.is_valid(),
@@ -3404,12 +3404,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn CreateSampler(&self) -> Option<DomRoot<WebGLSampler>> {
         Some(WebGLSampler::new(&self.base))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn DeleteSampler(&self, sampler: Option<&WebGLSampler>) {
         if let Some(sampler) = sampler {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(sampler), return);
@@ -3422,7 +3422,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn IsSampler(&self, sampler: Option<&WebGLSampler>) -> bool {
         match sampler {
             Some(sampler) => self.base.validate_ownership(sampler).is_ok() && sampler.is_valid(),
@@ -3430,7 +3430,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn BeginQuery(&self, target: u32, query: &WebGLQuery) {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
@@ -3459,7 +3459,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn EndQuery(&self, target: u32) {
         let active_query = match target {
@@ -3486,7 +3486,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn GetQuery(&self, target: u32, pname: u32) -> Option<DomRoot<WebGLQuery>> {
         if pname != constants::CURRENT_QUERY {
@@ -3514,7 +3514,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         active_query
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn GetQueryParameter(&self, _cx: JSContext, query: &WebGLQuery, pname: u32) -> JSVal {
         handle_potential_webgl_error!(
@@ -3535,7 +3535,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
     fn FenceSync(&self, condition: u32, flags: u32) -> Option<DomRoot<WebGLSync>> {
         if flags != 0 {
             self.base.webgl_error(InvalidValue);
@@ -3549,7 +3549,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         Some(WebGLSync::new(&self.base))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
     fn IsSync(&self, sync: Option<&WebGLSync>) -> bool {
         match sync {
             Some(sync) => {
@@ -3570,7 +3570,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
     fn ClientWaitSync(&self, sync: &WebGLSync, flags: u32, timeout: u64) -> u32 {
         if !sync.is_valid() {
             self.base.webgl_error(InvalidOperation);
@@ -3596,7 +3596,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
     fn WaitSync(&self, sync: &WebGLSync, flags: u32, timeout: i64) {
         if !sync.is_valid() {
             self.base.webgl_error(InvalidOperation);
@@ -3616,7 +3616,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .send_command(WebGLCommand::WaitSync(sync.id(), flags, timeout));
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
     fn GetSyncParameter(&self, _cx: JSContext, sync: &WebGLSync, pname: u32) -> JSVal {
         if !sync.is_valid() {
             self.base.webgl_error(InvalidOperation);
@@ -3645,7 +3645,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14>
     fn DeleteSync(&self, sync: Option<&WebGLSync>) {
         if let Some(sync) = sync {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(sync), return);
@@ -3653,7 +3653,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn BindSampler(&self, unit: u32, sampler: Option<&WebGLSampler>) {
         if let Some(sampler) = sampler {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(sampler), return);
@@ -3671,12 +3671,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.17>
     fn BindVertexArray(&self, array: Option<&WebGLVertexArrayObject>) {
         self.base.bind_vertex_array_webgl2(array);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn SamplerParameteri(&self, sampler: &WebGLSampler, pname: u32, param: i32) {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(sampler), return);
         let param = WebGLSamplerValue::GLenum(param as u32);
@@ -3686,7 +3686,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn SamplerParameterf(&self, sampler: &WebGLSampler, pname: u32, param: f32) {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(sampler), return);
         let param = WebGLSamplerValue::Float(param);
@@ -3696,7 +3696,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13>
     fn GetSamplerParameter(&self, _cx: JSContext, sampler: &WebGLSampler, pname: u32) -> JSVal {
         handle_potential_webgl_error!(
             self.base,
@@ -3715,12 +3715,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn CreateTransformFeedback(&self) -> Option<DomRoot<WebGLTransformFeedback>> {
         Some(WebGLTransformFeedback::new(&self.base))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn DeleteTransformFeedback(&self, tf: Option<&WebGLTransformFeedback>) {
         if let Some(tf) = tf {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(tf), return);
@@ -3733,7 +3733,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn IsTransformFeedback(&self, tf: Option<&WebGLTransformFeedback>) -> bool {
         match tf {
             Some(tf) => {
@@ -3754,7 +3754,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn BindTransformFeedback(&self, target: u32, tf: Option<&WebGLTransformFeedback>) {
         if target != constants::TRANSFORM_FEEDBACK {
             self.base.webgl_error(InvalidEnum);
@@ -3787,7 +3787,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     #[allow(non_snake_case)]
     fn BeginTransformFeedback(&self, primitiveMode: u32) {
         match primitiveMode {
@@ -3822,7 +3822,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         current_tf.begin(&self.base, primitiveMode);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn EndTransformFeedback(&self) {
         if let Some(current_tf) = self.current_transform_feedback.get() {
             if !current_tf.is_active() {
@@ -3833,7 +3833,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn ResumeTransformFeedback(&self) {
         if let Some(current_tf) = self.current_transform_feedback.get() {
             if !current_tf.is_active() || !current_tf.is_paused() {
@@ -3844,7 +3844,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn PauseTransformFeedback(&self) {
         if let Some(current_tf) = self.current_transform_feedback.get() {
             if !current_tf.is_active() || current_tf.is_paused() {
@@ -3855,7 +3855,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     #[allow(non_snake_case)]
     fn TransformFeedbackVaryings(
         &self,
@@ -3895,7 +3895,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15>
     fn GetTransformFeedbackVarying(
         &self,
         program: &WebGLProgram,
@@ -3923,7 +3923,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         ))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     fn BindBufferBase(&self, target: u32, index: u32, buffer: Option<&WebGLBuffer>) {
         let (generic_slot, indexed_bindings) = match target {
             constants::TRANSFORM_FEEDBACK_BUFFER => (
@@ -3970,7 +3970,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         indexed_binding.size.set(0);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     fn BindBufferRange(
         &self,
         target: u32,
@@ -4048,7 +4048,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         indexed_binding.size.set(size);
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     fn GetUniformIndices(&self, program: &WebGLProgram, names: Vec<DOMString>) -> Option<Vec<u32>> {
         handle_potential_webgl_error!(
             self.base,
@@ -4063,7 +4063,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         Some(indices)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     #[allow(unsafe_code)]
     fn GetActiveUniforms(
         &self,
@@ -4102,7 +4102,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         rval.get()
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     fn GetUniformBlockIndex(&self, program: &WebGLProgram, block_name: DOMString) -> u32 {
         handle_potential_webgl_error!(
             self.base,
@@ -4117,7 +4117,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         index
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     #[allow(unsafe_code)]
     fn GetActiveUniformBlockParameter(
         &self,
@@ -4159,7 +4159,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     fn GetActiveUniformBlockName(
         &self,
         program: &WebGLProgram,
@@ -4178,7 +4178,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         Some(DOMString::from(name))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>
     fn UniformBlockBinding(&self, program: &WebGLProgram, block_index: u32, block_binding: u32) {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(program), return);
 
@@ -4193,7 +4193,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11>
     fn ClearBufferfv(
         &self,
         buffer: u32,
@@ -4215,7 +4215,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11>
     fn ClearBufferiv(
         &self,
         buffer: u32,
@@ -4237,7 +4237,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11>
     fn ClearBufferuiv(
         &self,
         buffer: u32,
@@ -4259,7 +4259,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         )
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11>
     fn ClearBufferfi(&self, buffer: u32, draw_buffer: i32, depth: f32, stencil: i32) {
         if buffer != constants::DEPTH_STENCIL {
             return self.base.webgl_error(InvalidEnum);
@@ -4279,7 +4279,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         ));
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4>
     fn InvalidateFramebuffer(&self, target: u32, attachments: Vec<u32>) {
         if !self.valid_fb_attachment_values(target, &attachments) {
             return;
@@ -4289,7 +4289,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .send_command(WebGLCommand::InvalidateFramebuffer(target, attachments))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4>
     fn InvalidateSubFramebuffer(
         &self,
         target: u32,
@@ -4318,7 +4318,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             ))
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4>
     fn FramebufferTextureLayer(
         &self,
         target: u32,
@@ -4348,7 +4348,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5>
     #[allow(unsafe_code)]
     fn GetInternalformatParameter(
         &self,
@@ -4389,7 +4389,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5>
     fn RenderbufferStorageMultisample(
         &self,
         target: u32,
@@ -4402,7 +4402,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .renderbuffer_storage(target, samples, internal_format, width, height)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4>
     fn ReadBuffer(&self, src: u32) {
         match src {
             constants::BACK | constants::NONE => {},
@@ -4423,7 +4423,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11>
     fn DrawBuffers(&self, buffers: Vec<u32>) {
         if let Some(fb) = self.base.get_draw_framebuffer_slot().get() {
             handle_potential_webgl_error!(self.base, fb.set_draw_buffers(buffers), return)
@@ -4442,7 +4442,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6>
     fn TexStorage2D(
         &self,
         target: u32,
@@ -4454,7 +4454,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.tex_storage(2, target, levels, internal_format, width, height, 1)
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6>
     fn TexStorage3D(
         &self,
         target: u32,

--- a/components/script/dom/webgl_extensions/wrapper.rs
+++ b/components/script/dom/webgl_extensions/wrapper.rs
@@ -37,7 +37,7 @@ pub struct TypedWebGLExtensionWrapper<T: WebGLExtension> {
 }
 
 /// Typed WebGL Extension implementation.
-/// Exposes the exact MutNullableDom<DOMObject> type defined by the extension.
+/// Exposes the exact `MutNullableDom<DOMObject>` type defined by the extension.
 impl<T: WebGLExtension> TypedWebGLExtensionWrapper<T> {
     pub fn new() -> TypedWebGLExtensionWrapper<T> {
         TypedWebGLExtensionWrapper {

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -32,7 +32,7 @@ pub struct WebGLBuffer {
     capacity: Cell<usize>,
     marked_for_deletion: Cell<bool>,
     attached_counter: Cell<u32>,
-    /// https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetBufferParameteriv.xml
+    /// <https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetBufferParameteriv.xml>
     usage: Cell<u32>,
 }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -4656,13 +4656,13 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         };
     }
 
-    /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9>
     fn GetAttachedShaders(&self, program: &WebGLProgram) -> Option<Vec<DomRoot<WebGLShader>>> {
         handle_potential_webgl_error!(self, self.validate_ownership(program), return None);
         handle_potential_webgl_error!(self, program.attached_shaders().map(Some), None)
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-webglrenderingcontextbase-makexrcompatible
+    /// <https://immersive-web.github.io/webxr/#dom-webglrenderingcontextbase-makexrcompatible>
     fn MakeXRCompatible(&self) -> Rc<Promise> {
         // XXXManishearth Fill in with compatibility checks when rust-webxr supports this
         let p = Promise::new(&self.global());

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -280,8 +280,7 @@ impl WebGLTexture {
     }
 
     /// We have to follow the conversion rules for GLES 2.0. See:
-    ///   https://www.khronos.org/webgl/public-mailing-list/archives/1008/msg00014.html
-    ///
+    /// <https://www.khronos.org/webgl/public-mailing-list/archives/1008/msg00014.html>
     pub fn tex_parameter(&self, param: u32, value: TexParameterValue) -> WebGLResult<()> {
         let target = self.target().unwrap();
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -374,7 +374,7 @@ pub struct Window {
     #[ignore_malloc_size_of = "Rc is hard"]
     layout_marker: DomRefCell<Rc<Cell<bool>>>,
 
-    /// https://dom.spec.whatwg.org/#window-current-event
+    /// <https://dom.spec.whatwg.org/#window-current-event>
     current_event: DomRefCell<Option<Dom<Event>>>,
 }
 
@@ -404,7 +404,7 @@ impl Window {
     }
 
     /// A convenience method for
-    /// https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded
+    /// <https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded>
     pub fn discard_browsing_context(&self) {
         let proxy = match self.window_proxy.get() {
             Some(proxy) => proxy,
@@ -1593,7 +1593,7 @@ impl Window {
         current
     }
 
-    /// https://html.spec.whatwg.org/multipage/#window-post-message-steps
+    /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>
     fn post_message_impl(
         &self,
         target_origin: &USVString,
@@ -2212,7 +2212,7 @@ impl Window {
 
     /// Commence a new URL load which will either replace this window or scroll to a fragment.
     ///
-    /// https://html.spec.whatwg.org/multipage/#navigating-across-documents
+    /// <https://html.spec.whatwg.org/multipage/#navigating-across-documents>
     pub fn load_url(
         &self,
         replace: HistoryEntryReplacement,

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -100,7 +100,7 @@ pub struct WindowProxy {
     /// Has the browsing context been disowned?
     disowned: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/#is-closing
+    /// <https://html.spec.whatwg.org/multipage/#is-closing>
     is_closing: Cell<bool>,
 
     /// The containing iframe element, if this is a same-origin iframe
@@ -109,7 +109,7 @@ pub struct WindowProxy {
     /// The parent browsing context's window proxy, if this is a nested browsing context
     parent: Option<Dom<WindowProxy>>,
 
-    /// https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     delaying_load_events_mode: Cell<bool>,
 
     /// The creator browsing context's base url.
@@ -356,17 +356,17 @@ impl WindowProxy {
         None
     }
 
-    /// https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub fn is_delaying_load_events_mode(&self) -> bool {
         self.delaying_load_events_mode.get()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub fn start_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(true);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub fn stop_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(false);
         if let Some(document) = self.document() {
@@ -381,18 +381,18 @@ impl WindowProxy {
         self.disowned.set(true);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-close
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-close>
     /// Step 3.1, set BCs `is_closing` to true.
     pub fn close(&self) {
         self.is_closing.set(true);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#is-closing
+    /// <https://html.spec.whatwg.org/multipage/#is-closing>
     pub fn is_closing(&self) -> bool {
         self.is_closing.get()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#creator-base-url
+    /// <https://html.spec.whatwg.org/multipage/#creator-base-url>
     pub fn creator_base_url(&self) -> Option<ServoUrl> {
         self.creator_base_url.clone()
     }
@@ -401,7 +401,7 @@ impl WindowProxy {
         self.creator_base_url.is_some()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#creator-url
+    /// <https://html.spec.whatwg.org/multipage/#creator-url>
     pub fn creator_url(&self) -> Option<ServoUrl> {
         self.creator_url.clone()
     }
@@ -410,7 +410,7 @@ impl WindowProxy {
         self.creator_base_url.is_some()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#creator-origin
+    /// <https://html.spec.whatwg.org/multipage/#creator-origin>
     pub fn creator_origin(&self) -> Option<ImmutableOrigin> {
         self.creator_origin.clone()
     }
@@ -720,7 +720,7 @@ impl WindowProxy {
 /// active document of that creator browsing context at the time A was created is the creator
 /// Document.
 ///
-/// See: https://html.spec.whatwg.org/multipage/#creating-browsing-contexts
+/// See: <https://html.spec.whatwg.org/multipage/#creating-browsing-contexts>
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CreatorBrowsingContextInfo {
     /// Creator document URL.

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -204,7 +204,7 @@ impl Worker {
         worker.upcast().fire_event(atom!("error"));
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage>
     fn post_message_impl(
         &self,
         cx: JSContext,
@@ -228,7 +228,7 @@ impl Worker {
 }
 
 impl WorkerMethods for Worker {
-    /// https://html.spec.whatwg.org/multipage/#dom-worker-postmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-worker-postmessage>
     fn PostMessage(
         &self,
         cx: JSContext,
@@ -238,7 +238,7 @@ impl WorkerMethods for Worker {
         self.post_message_impl(cx, message, transfer)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-worker-postmessage
+    /// <https://html.spec.whatwg.org/multipage/#dom-worker-postmessage>
     fn PostMessage_(
         &self,
         cx: JSContext,

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -49,12 +49,12 @@ impl XRFrame {
         reflect_dom_object(Box::new(XRFrame::new_inherited(session, data)), global)
     }
 
-    /// https://immersive-web.github.io/webxr/#xrframe-active
+    /// <https://immersive-web.github.io/webxr/#xrframe-active>
     pub fn set_active(&self, active: bool) {
         self.active.set(active);
     }
 
-    /// https://immersive-web.github.io/webxr/#xrframe-animationframe
+    /// <https://immersive-web.github.io/webxr/#xrframe-animationframe>
     pub fn set_animation_frame(&self, animation_frame: bool) {
         self.animation_frame.set(animation_frame);
     }
@@ -73,12 +73,12 @@ impl XRFrame {
 }
 
 impl XRFrameMethods for XRFrame {
-    /// https://immersive-web.github.io/webxr/#dom-xrframe-session
+    /// <https://immersive-web.github.io/webxr/#dom-xrframe-session>
     fn Session(&self) -> DomRoot<XRSession> {
         DomRoot::from_ref(&self.session)
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose
+    /// <https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose>
     fn GetViewerPose(
         &self,
         reference: &XRReferenceSpace,
@@ -109,7 +109,7 @@ impl XRFrameMethods for XRFrame {
         )))
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrframe-getpose
+    /// <https://immersive-web.github.io/webxr/#dom-xrframe-getpose>
     fn GetPose(
         &self,
         space: &XRSpace,
@@ -135,7 +135,7 @@ impl XRFrameMethods for XRFrame {
         Ok(Some(XRPose::new(&self.global(), pose)))
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrframe-getpose
+    /// <https://immersive-web.github.io/webxr/#dom-xrframe-getpose>
     fn GetJointPose(
         &self,
         space: &XRJointSpace,
@@ -167,7 +167,7 @@ impl XRFrameMethods for XRFrame {
         )))
     }
 
-    /// https://immersive-web.github.io/hit-test/#dom-xrframe-gethittestresults
+    /// <https://immersive-web.github.io/hit-test/#dom-xrframe-gethittestresults>
     fn GetHitTestResults(&self, source: &XRHitTestSource) -> Vec<DomRoot<XRHitTestResult>> {
         self.data
             .hit_test_results

--- a/components/script/dom/xrhand.rs
+++ b/components/script/dom/xrhand.rs
@@ -41,12 +41,12 @@ impl XRHand {
 }
 
 impl XRHandMethods for XRHand {
-    /// https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md
+    /// <https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md>
     fn Length(&self) -> i32 {
         XRHandConstants::LITTLE_PHALANX_TIP as i32 + 1
     }
 
-    /// https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md
+    /// <https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md>
     fn IndexedGetter(&self, joint_index: u32) -> Option<DomRoot<XRJointSpace>> {
         let joint = match joint_index {
             XRHandConstants::WRIST => Joint::Wrist,

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -78,7 +78,7 @@ impl XRInputSource {
 }
 
 impl XRInputSourceMethods for XRInputSource {
-    /// https://immersive-web.github.io/webxr/#dom-xrinputsource-handedness
+    /// <https://immersive-web.github.io/webxr/#dom-xrinputsource-handedness>
     fn Handedness(&self) -> XRHandedness {
         match self.info.handedness {
             Handedness::None => XRHandedness::None,
@@ -87,7 +87,7 @@ impl XRInputSourceMethods for XRInputSource {
         }
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode
+    /// <https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode>
     fn TargetRayMode(&self) -> XRTargetRayMode {
         match self.info.target_ray_mode {
             TargetRayMode::Gaze => XRTargetRayMode::Gaze,
@@ -96,7 +96,7 @@ impl XRInputSourceMethods for XRInputSource {
         }
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace
+    /// <https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace>
     fn TargetRaySpace(&self) -> DomRoot<XRSpace> {
         self.target_ray_space.or_init(|| {
             let global = self.global();
@@ -104,7 +104,7 @@ impl XRInputSourceMethods for XRInputSource {
         })
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace
+    /// <https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace>
     fn GetGripSpace(&self) -> Option<DomRoot<XRSpace>> {
         if self.info.supports_grip {
             Some(self.grip_space.or_init(|| {

--- a/components/script/dom/xrinputsourcearray.rs
+++ b/components/script/dom/xrinputsourcearray.rs
@@ -130,12 +130,12 @@ impl XRInputSourceArray {
 }
 
 impl XRInputSourceArrayMethods for XRInputSourceArray {
-    /// https://immersive-web.github.io/webxr/#dom-xrinputsourcearray-length
+    /// <https://immersive-web.github.io/webxr/#dom-xrinputsourcearray-length>
     fn Length(&self) -> u32 {
         self.input_sources.borrow().len() as u32
     }
 
-    /// https://immersive-web.github.io/webxr/#xrinputsourcearray
+    /// <https://immersive-web.github.io/webxr/#xrinputsourcearray>
     fn IndexedGetter(&self, n: u32) -> Option<DomRoot<XRInputSource>> {
         self.input_sources
             .borrow()

--- a/components/script/dom/xrjointpose.rs
+++ b/components/script/dom/xrjointpose.rs
@@ -42,7 +42,7 @@ impl XRJointPose {
 }
 
 impl XRJointPoseMethods for XRJointPose {
-    /// https://immersive-web.github.io/webxr/#dom-XRJointPose-views
+    /// <https://immersive-web.github.io/webxr/#dom-XRJointPose-views>
     fn GetRadius(&self) -> Option<Finite<f32>> {
         self.radius.map(Finite::wrap)
     }

--- a/components/script/dom/xrmediabinding.rs
+++ b/components/script/dom/xrmediabinding.rs
@@ -65,7 +65,7 @@ impl XRMediaBinding {
 }
 
 impl XRMediaBindingMethods for XRMediaBinding {
-    /// https://immersive-web.github.io/layers/#dom-xrmediabinding-createquadlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-createquadlayer>
     fn CreateQuadLayer(
         &self,
         _: &HTMLVideoElement,
@@ -75,7 +75,7 @@ impl XRMediaBindingMethods for XRMediaBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrmediabinding-createcylinderlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-createcylinderlayer>
     fn CreateCylinderLayer(
         &self,
         _: &HTMLVideoElement,
@@ -85,7 +85,7 @@ impl XRMediaBindingMethods for XRMediaBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrmediabinding-createequirectlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-createequirectlayer>
     fn CreateEquirectLayer(
         &self,
         _: &HTMLVideoElement,

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -33,7 +33,7 @@ impl XRPose {
 }
 
 impl XRPoseMethods for XRPose {
-    /// https://immersive-web.github.io/webxr/#dom-xrpose-transform
+    /// <https://immersive-web.github.io/webxr/#dom-xrpose-transform>
     fn Transform(&self) -> DomRoot<XRRigidTransform> {
         DomRoot::from_ref(&self.transform)
     }

--- a/components/script/dom/xrray.rs
+++ b/components/script/dom/xrray.rs
@@ -48,7 +48,7 @@ impl XRRay {
     }
 
     #[allow(non_snake_case)]
-    /// https://immersive-web.github.io/hit-test/#dom-xrray-xrray
+    /// <https://immersive-web.github.io/hit-test/#dom-xrray-xrray>
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
@@ -83,7 +83,7 @@ impl XRRay {
     }
 
     #[allow(non_snake_case)]
-    /// https://immersive-web.github.io/hit-test/#dom-xrray-xrray-transform
+    /// <https://immersive-web.github.io/hit-test/#dom-xrray-xrray-transform>
     pub fn Constructor_(
         window: &Window,
         proto: Option<HandleObject>,
@@ -108,7 +108,7 @@ impl XRRay {
 }
 
 impl XRRayMethods for XRRay {
-    /// https://immersive-web.github.io/hit-test/#dom-xrray-origin
+    /// <https://immersive-web.github.io/hit-test/#dom-xrray-origin>
     fn Origin(&self) -> DomRoot<DOMPointReadOnly> {
         DOMPointReadOnly::new(
             &self.global(),
@@ -119,7 +119,7 @@ impl XRRayMethods for XRRay {
         )
     }
 
-    /// https://immersive-web.github.io/hit-test/#dom-xrray-direction
+    /// <https://immersive-web.github.io/hit-test/#dom-xrray-direction>
     fn Direction(&self) -> DomRoot<DOMPointReadOnly> {
         DOMPointReadOnly::new(
             &self.global(),
@@ -130,7 +130,7 @@ impl XRRayMethods for XRRay {
         )
     }
 
-    /// https://immersive-web.github.io/hit-test/#dom-xrray-matrix
+    /// <https://immersive-web.github.io/hit-test/#dom-xrray-matrix>
     fn Matrix(&self, _cx: JSContext) -> Float32Array {
         // https://immersive-web.github.io/hit-test/#xrray-obtain-the-matrix
         if !self.matrix.is_initialized() {

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -73,7 +73,7 @@ impl XRReferenceSpace {
 }
 
 impl XRReferenceSpaceMethods for XRReferenceSpace {
-    /// https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
+    /// <https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace>
     fn GetOffsetReferenceSpace(&self, new: &XRRigidTransform) -> DomRoot<Self> {
         let offset = new.transform().then(&self.offset.transform());
         let offset = XRRigidTransform::new(&self.global(), offset);

--- a/components/script/dom/xrrenderstate.rs
+++ b/components/script/dom/xrrenderstate.rs
@@ -133,27 +133,27 @@ impl XRRenderState {
 }
 
 impl XRRenderStateMethods for XRRenderState {
-    /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear
+    /// <https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear>
     fn DepthNear(&self) -> Finite<f64> {
         Finite::wrap(self.depth_near.get())
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar
+    /// <https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar>
     fn DepthFar(&self) -> Finite<f64> {
         Finite::wrap(self.depth_far.get())
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-inlineverticalfieldofview
+    /// <https://immersive-web.github.io/webxr/#dom-xrrenderstate-inlineverticalfieldofview>
     fn GetInlineVerticalFieldOfView(&self) -> Option<Finite<f64>> {
         self.inline_vertical_fov.get().map(Finite::wrap)
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer
+    /// <https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer>
     fn GetBaseLayer(&self) -> Option<DomRoot<XRWebGLLayer>> {
         self.base_layer.get()
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrrenderstate-layers
+    /// <https://immersive-web.github.io/layers/#dom-xrrenderstate-layers>
     fn Layers(&self, cx: JSContext) -> JSVal {
         // TODO: cache this array?
         let layers = self.layers.borrow();

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -146,7 +146,7 @@ impl XRRigidTransformMethods for XRRigidTransform {
 }
 
 impl XRRigidTransform {
-    /// https://immersive-web.github.io/webxr/#dom-xrpose-transform
+    /// <https://immersive-web.github.io/webxr/#dom-xrpose-transform>
     pub fn transform(&self) -> ApiRigidTransform {
         self.transform
     }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -82,7 +82,7 @@ pub struct XRSession {
     // Any promises from calling end()
     #[ignore_malloc_size_of = "promises are hard"]
     end_promises: DomRefCell<Vec<Rc<Promise>>>,
-    /// https://immersive-web.github.io/webxr/#ended
+    /// <https://immersive-web.github.io/webxr/#ended>
     ended: Cell<bool>,
     #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
@@ -90,7 +90,7 @@ pub struct XRSession {
     #[ignore_malloc_size_of = "defined in webxr"]
     pending_hit_test_promises: DomRefCell<HashMapTracedValues<HitTestId, Rc<Promise>>>,
     /// Opaque framebuffers need to know the session is "outside of a requestAnimationFrame"
-    /// https://immersive-web.github.io/webxr/#opaque-framebuffer
+    /// <https://immersive-web.github.io/webxr/#opaque-framebuffer>
     outside_raf: Cell<bool>,
 }
 
@@ -362,7 +362,7 @@ impl XRSession {
         }
     }
 
-    /// https://immersive-web.github.io/webxr/#xr-animation-frame
+    /// <https://immersive-web.github.io/webxr/#xr-animation-frame>
     fn raf_callback(&self, mut frame: Frame) {
         debug!("WebXR RAF callback {:?}", frame);
         #[cfg(feature = "xr-profile")]
@@ -533,7 +533,7 @@ impl XRSession {
         });
     }
 
-    /// https://immersive-web.github.io/webxr/#xrframe-apply-frame-updates
+    /// <https://immersive-web.github.io/webxr/#xrframe-apply-frame-updates>
     fn apply_frame_updates(&self, _frame: &XRFrame) {
         // TODO: add a comment about why this is empty right now!
     }
@@ -596,7 +596,7 @@ impl XRSessionMethods for XRSession {
         self.active_render_state.get()
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate>
     fn UpdateRenderState(&self, init: &XRRenderStateInit, _: InRealm) -> ErrorResult {
         // Step 2
         if self.ended.get() {
@@ -725,7 +725,7 @@ impl XRSessionMethods for XRSession {
         Ok(())
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe>
     fn RequestAnimationFrame(&self, callback: Rc<XRFrameRequestCallback>) -> i32 {
         // queue up RAF callback, obtain ID
         let raf_id = self.next_raf_id.get();
@@ -737,7 +737,7 @@ impl XRSessionMethods for XRSession {
         raf_id
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-cancelanimationframe
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-cancelanimationframe>
     fn CancelAnimationFrame(&self, frame: i32) {
         let mut list = self.raf_callback_list.borrow_mut();
         if let Some(pair) = list.iter_mut().find(|pair| pair.0 == frame) {
@@ -750,17 +750,17 @@ impl XRSessionMethods for XRSession {
         }
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-environmentblendmode
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-environmentblendmode>
     fn EnvironmentBlendMode(&self) -> XREnvironmentBlendMode {
         self.blend_mode
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate>
     fn VisibilityState(&self) -> XRVisibilityState {
         self.visibility_state.get()
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-requestreferencespace
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-requestreferencespace>
     fn RequestReferenceSpace(&self, ty: XRReferenceSpaceType, comp: InRealm) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
 
@@ -797,12 +797,12 @@ impl XRSessionMethods for XRSession {
         p
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-inputsources
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-inputsources>
     fn InputSources(&self) -> DomRoot<XRInputSourceArray> {
         DomRoot::from_ref(&*self.input_sources)
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-end
+    /// <https://immersive-web.github.io/webxr/#dom-xrsession-end>
     fn End(&self) -> Rc<Promise> {
         let global = self.global();
         let p = Promise::new(&global);

--- a/components/script/dom/xrsubimage.rs
+++ b/components/script/dom/xrsubimage.rs
@@ -16,7 +16,7 @@ pub struct XRSubImage {
 }
 
 impl XRSubImageMethods for XRSubImage {
-    /// https://immersive-web.github.io/layers/#dom-xrsubimage-viewport
+    /// <https://immersive-web.github.io/layers/#dom-xrsubimage-viewport>
     fn Viewport(&self) -> DomRoot<XRViewport> {
         DomRoot::from_ref(&self.viewport)
     }

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -82,7 +82,7 @@ impl XRSystem {
         self.active_immersive_session.set(Some(session))
     }
 
-    /// https://immersive-web.github.io/webxr/#ref-for-eventdef-xrsession-end
+    /// <https://immersive-web.github.io/webxr/#ref-for-eventdef-xrsession-end>
     pub fn end_session(&self, session: &XRSession) {
         // Step 3
         if let Some(active) = self.active_immersive_session.get() {
@@ -110,7 +110,7 @@ impl Into<SessionMode> for XRSessionMode {
 }
 
 impl XRSystemMethods for XRSystem {
-    /// https://immersive-web.github.io/webxr/#dom-xr-issessionsupported
+    /// <https://immersive-web.github.io/webxr/#dom-xr-issessionsupported>
     fn IsSessionSupported(&self, mode: XRSessionMode) -> Rc<Promise> {
         // XXXManishearth this should select an XR device first
         let promise = Promise::new(&self.global());
@@ -153,7 +153,7 @@ impl XRSystemMethods for XRSystem {
         promise
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xr-requestsession
+    /// <https://immersive-web.github.io/webxr/#dom-xr-requestsession>
     #[allow(unsafe_code)]
     fn RequestSession(
         &self,

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -65,7 +65,7 @@ impl XRTest {
 }
 
 impl XRTestMethods for XRTest {
-    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     #[allow(unsafe_code)]
     fn SimulateDeviceConnection(&self, init: &FakeXRDeviceInit) -> Rc<Promise> {
         let global = self.global();
@@ -180,14 +180,14 @@ impl XRTestMethods for XRTest {
         p
     }
 
-    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     fn SimulateUserActivation(&self, f: Rc<Function>) {
         ScriptThread::set_user_interacting(true);
         let _ = f.Call__(vec![], ExceptionHandling::Rethrow);
         ScriptThread::set_user_interacting(false);
     }
 
-    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     fn DisconnectAllDevices(&self) -> Rc<Promise> {
         // XXXManishearth implement device disconnection and session ending
         let global = self.global();

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -82,12 +82,12 @@ impl XRView {
 }
 
 impl XRViewMethods for XRView {
-    /// https://immersive-web.github.io/webxr/#dom-xrview-eye
+    /// <https://immersive-web.github.io/webxr/#dom-xrview-eye>
     fn Eye(&self) -> XREye {
         self.eye
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix
+    /// <https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix>
     fn ProjectionMatrix(&self, _cx: JSContext) -> Float32Array {
         if !self.proj.is_initialized() {
             let cx = GlobalScope::get_cx();
@@ -102,7 +102,7 @@ impl XRViewMethods for XRView {
             .expect("Failed to get projection matrix.")
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrview-transform
+    /// <https://immersive-web.github.io/webxr/#dom-xrview-transform>
     fn Transform(&self) -> DomRoot<XRRigidTransform> {
         DomRoot::from_ref(&self.transform)
     }

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -167,7 +167,7 @@ impl XRViewerPose {
 }
 
 impl XRViewerPoseMethods for XRViewerPose {
-    /// https://immersive-web.github.io/webxr/#dom-xrviewerpose-views
+    /// <https://immersive-web.github.io/webxr/#dom-xrviewerpose-views>
     fn Views(&self, _cx: JSContext) -> JSVal {
         self.views.get()
     }

--- a/components/script/dom/xrviewport.rs
+++ b/components/script/dom/xrviewport.rs
@@ -32,22 +32,22 @@ impl XRViewport {
 }
 
 impl XRViewportMethods for XRViewport {
-    /// https://immersive-web.github.io/webxr/#dom-xrviewport-x
+    /// <https://immersive-web.github.io/webxr/#dom-xrviewport-x>
     fn X(&self) -> i32 {
         self.viewport.origin.x
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrviewport-y
+    /// <https://immersive-web.github.io/webxr/#dom-xrviewport-y>
     fn Y(&self) -> i32 {
         self.viewport.origin.y
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrviewport-width
+    /// <https://immersive-web.github.io/webxr/#dom-xrviewport-width>
     fn Width(&self) -> i32 {
         self.viewport.size.width
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrviewport-height
+    /// <https://immersive-web.github.io/webxr/#dom-xrviewport-height>
     fn Height(&self) -> i32 {
         self.viewport.size.height
     }

--- a/components/script/dom/xrwebglbinding.rs
+++ b/components/script/dom/xrwebglbinding.rs
@@ -75,7 +75,7 @@ impl XRWebGLBinding {
 }
 
 impl XRWebGLBindingMethods for XRWebGLBinding {
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-createprojectionlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createprojectionlayer>
     fn CreateProjectionLayer(
         &self,
         _: XRTextureType,
@@ -85,7 +85,7 @@ impl XRWebGLBindingMethods for XRWebGLBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-createquadlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createquadlayer>
     fn CreateQuadLayer(
         &self,
         _: XRTextureType,
@@ -95,7 +95,7 @@ impl XRWebGLBindingMethods for XRWebGLBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-createcylinderlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createcylinderlayer>
     fn CreateCylinderLayer(
         &self,
         _: XRTextureType,
@@ -105,7 +105,7 @@ impl XRWebGLBindingMethods for XRWebGLBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-createequirectlayer
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createequirectlayer>
     fn CreateEquirectLayer(
         &self,
         _: XRTextureType,
@@ -115,13 +115,13 @@ impl XRWebGLBindingMethods for XRWebGLBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-createcubelayer
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createcubelayer>
     fn CreateCubeLayer(&self, _: &Option<XRCubeLayerInit>) -> Fallible<DomRoot<XRCubeLayer>> {
         // https://github.com/servo/servo/issues/27493
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-getsubimage
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-getsubimage>
     fn GetSubImage(
         &self,
         _: &XRCompositionLayer,
@@ -132,7 +132,7 @@ impl XRWebGLBindingMethods for XRWebGLBinding {
         Err(Error::NotSupported)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglbinding-getviewsubimage
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-getviewsubimage>
     fn GetViewSubImage(
         &self,
         _: &XRProjectionLayer,

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -97,7 +97,7 @@ impl XRWebGLLayer {
         )
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-xrwebgllayer
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-xrwebgllayer>
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &Window,
@@ -282,32 +282,32 @@ impl XRWebGLLayer {
 }
 
 impl XRWebGLLayerMethods for XRWebGLLayer {
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-antialias
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-antialias>
     fn Antialias(&self) -> bool {
         self.antialias
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-ignoredepthvalues
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-ignoredepthvalues>
     fn IgnoreDepthValues(&self) -> bool {
         self.ignore_depth_values
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-framebuffer
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-framebuffer>
     fn GetFramebuffer(&self) -> Option<DomRoot<WebGLFramebuffer>> {
         self.framebuffer.as_ref().map(|x| DomRoot::from_ref(&**x))
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-framebufferwidth
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-framebufferwidth>
     fn FramebufferWidth(&self) -> u32 {
         self.size().width
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-framebufferheight
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-framebufferheight>
     fn FramebufferHeight(&self) -> u32 {
         self.size().height
     }
 
-    /// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport
+    /// <https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport>
     fn GetViewport(&self, view: &XRView) -> Option<DomRoot<XRViewport>> {
         if self.session() != view.session() {
             return None;

--- a/components/script/dom/xrwebglsubimage.rs
+++ b/components/script/dom/xrwebglsubimage.rs
@@ -22,27 +22,27 @@ pub struct XRWebGLSubImage {
 }
 
 impl XRWebGLSubImageMethods for XRWebGLSubImage {
-    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-colortexture
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglsubimage-colortexture>
     fn ColorTexture(&self) -> DomRoot<WebGLTexture> {
         DomRoot::from_ref(&self.color_texture)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-depthstenciltexture
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglsubimage-depthstenciltexture>
     fn GetDepthStencilTexture(&self) -> Option<DomRoot<WebGLTexture>> {
         self.depth_stencil_texture.as_deref().map(DomRoot::from_ref)
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-imageindex
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglsubimage-imageindex>
     fn GetImageIndex(&self) -> Option<u32> {
         self.image_index
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-texturewidth
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglsubimage-texturewidth>
     fn TextureWidth(&self) -> u32 {
         self.size.width
     }
 
-    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-textureheight
+    /// <https://immersive-web.github.io/layers/#dom-xrwebglsubimage-textureheight>
     fn TextureHeight(&self) -> u32 {
         self.size.height
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -356,7 +356,7 @@ pub fn load_whole_resource(
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request
+/// <https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request>
 pub(crate) fn create_a_potential_cors_request(
     url: ServoUrl,
     destination: Destination,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -414,7 +414,7 @@ pub enum ModuleStatus {
 
 impl ModuleTree {
     #[allow(unsafe_code)]
-    /// https://html.spec.whatwg.org/multipage/#creating-a-module-script
+    /// <https://html.spec.whatwg.org/multipage/#creating-a-module-script>
     /// Step 7-11.
     fn compile_module_script(
         &self,
@@ -467,7 +467,7 @@ impl ModuleTree {
     }
 
     #[allow(unsafe_code)]
-    /// https://html.spec.whatwg.org/multipage/#fetch-the-descendants-of-and-link-a-module-script
+    /// <https://html.spec.whatwg.org/multipage/#fetch-the-descendants-of-and-link-a-module-script>
     /// Step 5-2.
     pub fn instantiate_module_tree(
         &self,
@@ -600,7 +600,7 @@ impl ModuleTree {
     ///
     /// Bareword module specifiers are currently disallowed as these may be given
     /// special meanings in the future.
-    /// https://html.spec.whatwg.org/multipage/#resolve-a-module-specifier
+    /// <https://html.spec.whatwg.org/multipage/#resolve-a-module-specifier>
     #[allow(unsafe_code)]
     fn resolve_module_specifier(
         cx: *mut JSContext,
@@ -626,7 +626,7 @@ impl ModuleTree {
         return ServoUrl::parse_with_base(Some(url), &specifier_str.clone());
     }
 
-    /// https://html.spec.whatwg.org/multipage/#finding-the-first-parse-error
+    /// <https://html.spec.whatwg.org/multipage/#finding-the-first-parse-error>
     fn find_first_parse_error(
         &self,
         global: &GlobalScope,
@@ -684,7 +684,7 @@ impl ModuleTree {
     }
 
     #[allow(unsafe_code)]
-    /// https://html.spec.whatwg.org/multipage/#fetch-the-descendants-of-a-module-script
+    /// <https://html.spec.whatwg.org/multipage/#fetch-the-descendants-of-a-module-script>
     fn fetch_module_descendants(
         &self,
         owner: &ModuleOwner,
@@ -784,7 +784,7 @@ impl ModuleTree {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#fetch-the-descendants-of-and-link-a-module-script
+    /// <https://html.spec.whatwg.org/multipage/#fetch-the-descendants-of-and-link-a-module-script>
     /// step 4-7.
     fn advance_finished_and_link(&self, global: &GlobalScope) {
         {
@@ -1388,8 +1388,8 @@ fn fetch_an_import_module_script_graph(
 }
 
 #[allow(unsafe_code, non_snake_case)]
-/// https://tc39.github.io/ecma262/#sec-hostresolveimportedmodule
-/// https://html.spec.whatwg.org/multipage/#hostresolveimportedmodule(referencingscriptormodule%2C-specifier)
+/// <https://tc39.github.io/ecma262/#sec-hostresolveimportedmodule>
+/// <https://html.spec.whatwg.org/multipage/#hostresolveimportedmodule(referencingscriptormodule%2C-specifier)>
 unsafe extern "C" fn HostResolveImportedModule(
     cx: *mut JSContext,
     reference_private: RawHandleValue,
@@ -1442,8 +1442,8 @@ unsafe extern "C" fn HostResolveImportedModule(
 }
 
 #[allow(unsafe_code, non_snake_case)]
-/// https://tc39.es/ecma262/#sec-hostgetimportmetaproperties
-/// https://html.spec.whatwg.org/multipage/#hostgetimportmetaproperties
+/// <https://tc39.es/ecma262/#sec-hostgetimportmetaproperties>
+/// <https://html.spec.whatwg.org/multipage/#hostgetimportmetaproperties>
 unsafe extern "C" fn HostPopulateImportMeta(
     cx: *mut JSContext,
     reference_private: RawHandleValue,
@@ -1474,7 +1474,7 @@ unsafe extern "C" fn HostPopulateImportMeta(
     )
 }
 
-/// https://html.spec.whatwg.org/multipage/#fetch-a-module-script-tree
+/// <https://html.spec.whatwg.org/multipage/#fetch-a-module-script-tree>
 pub(crate) fn fetch_external_module_script(
     owner: ModuleOwner,
     url: ServoUrl,
@@ -1545,7 +1545,7 @@ struct DynamicModule {
     id: DynamicModuleId,
 }
 
-/// https://html.spec.whatwg.org/multipage/#fetch-a-single-module-script
+/// <https://html.spec.whatwg.org/multipage/#fetch-a-single-module-script>
 fn fetch_single_module_script(
     owner: ModuleOwner,
     url: ServoUrl,
@@ -1698,7 +1698,7 @@ fn fetch_single_module_script(
 }
 
 #[allow(unsafe_code)]
-/// https://html.spec.whatwg.org/multipage/#fetch-an-inline-module-script-graph
+/// <https://html.spec.whatwg.org/multipage/#fetch-an-inline-module-script-graph>
 pub(crate) fn fetch_inline_module_script(
     owner: ModuleOwner,
     module_script_text: Rc<DOMString>,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -233,7 +233,7 @@ unsafe extern "C" fn enqueue_promise_job(
 }
 
 #[allow(unsafe_code, crown::unrooted_must_root)]
-/// https://html.spec.whatwg.org/multipage/#the-hostpromiserejectiontracker-implementation
+/// <https://html.spec.whatwg.org/multipage/#the-hostpromiserejectiontracker-implementation>
 unsafe extern "C" fn promise_rejection_tracker(
     cx: *mut RawJSContext,
     _muted_errors: bool,
@@ -311,7 +311,7 @@ unsafe extern "C" fn promise_rejection_tracker(
 }
 
 #[allow(unsafe_code, crown::unrooted_must_root)]
-/// https://html.spec.whatwg.org/multipage/#notify-about-rejected-promises
+/// <https://html.spec.whatwg.org/multipage/#notify-about-rejected-promises>
 pub fn notify_about_rejected_promises(global: &GlobalScope) {
     let cx = GlobalScope::get_cx();
     unsafe {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -975,7 +975,7 @@ impl ScriptThread {
     /// Check that two origins are "similar enough",
     /// for now only used to prevent cross-origin JS url evaluation.
     ///
-    /// https://github.com/whatwg/html/issues/2591
+    /// <https://github.com/whatwg/html/issues/2591>
     pub fn check_load_origin(source: &LoadOrigin, target: &ImmutableOrigin) -> bool {
         match (source, target) {
             (LoadOrigin::Constellation, _) | (LoadOrigin::WebDriver, _) => {
@@ -992,7 +992,7 @@ impl ScriptThread {
         }
     }
 
-    /// Step 13 of https://html.spec.whatwg.org/multipage/#navigate
+    /// Step 13 of <https://html.spec.whatwg.org/multipage/#navigate>
     pub fn navigate(
         browsing_context: BrowsingContextId,
         pipeline_id: PipelineId,
@@ -3750,7 +3750,7 @@ impl ScriptThread {
     }
 
     /// Turn javascript: URL into JS code to eval, according to the steps in
-    /// https://html.spec.whatwg.org/multipage/#javascript-protocol
+    /// <https://html.spec.whatwg.org/multipage/#javascript-protocol>
     pub fn eval_js_url(global_scope: &GlobalScope, load_data: &mut LoadData) {
         // This slice of the URL’s serialization is equivalent to (5.) to (7.):
         // Start with the scheme data of the parsed URL;

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -118,15 +118,15 @@ impl Drop for ServiceWorkerRegistration {
     }
 }
 
-/// https://w3c.github.io/ServiceWorker/#service-worker-registration-concept
+/// <https://w3c.github.io/ServiceWorker/#service-worker-registration-concept>
 struct ServiceWorkerRegistration {
     /// A unique identifer.
     id: ServiceWorkerRegistrationId,
-    /// https://w3c.github.io/ServiceWorker/#dfn-active-worker
+    /// <https://w3c.github.io/ServiceWorker/#dfn-active-worker>
     active_worker: Option<ServiceWorker>,
-    /// https://w3c.github.io/ServiceWorker/#dfn-waiting-worker
+    /// <https://w3c.github.io/ServiceWorker/#dfn-waiting-worker>
     waiting_worker: Option<ServiceWorker>,
-    /// https://w3c.github.io/ServiceWorker/#dfn-installing-worker
+    /// <https://w3c.github.io/ServiceWorker/#dfn-installing-worker>
     installing_worker: Option<ServiceWorker>,
     /// A channel to send control message to the worker,
     /// currently only used to signal shutdown.
@@ -209,7 +209,7 @@ impl ServiceWorkerRegistration {
 
 /// A structure managing all registrations and workers for a given origin.
 pub struct ServiceWorkerManager {
-    /// https://w3c.github.io/ServiceWorker/#dfn-scope-to-registration-map
+    /// <https://w3c.github.io/ServiceWorker/#dfn-scope-to-registration-map>
     registrations: HashMap<ServoUrl, ServiceWorkerRegistration>,
     // Will be useful to implement posting a message to a client.
     // See https://github.com/servo/servo/issues/24660

--- a/components/script/task_queue.rs
+++ b/components/script/task_queue.rs
@@ -65,7 +65,7 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
     }
 
     /// Release previously held-back tasks for documents that are now fully-active.
-    /// https://html.spec.whatwg.org/multipage/#event-loop-processing-model:fully-active
+    /// <https://html.spec.whatwg.org/multipage/#event-loop-processing-model:fully-active>
     fn release_tasks_for_fully_active_documents(
         &self,
         fully_active: &HashSet<PipelineId>,
@@ -83,7 +83,7 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
     }
 
     /// Hold back tasks for currently not fully-active documents.
-    /// https://html.spec.whatwg.org/multipage/#event-loop-processing-model:fully-active
+    /// <https://html.spec.whatwg.org/multipage/#event-loop-processing-model:fully-active>
     fn store_task_for_inactive_pipeline(&self, msg: T, pipeline_id: &PipelineId) {
         let mut inactive = self.inactive.borrow_mut();
         let inactive_queue = inactive.entry(pipeline_id.clone()).or_default();

--- a/components/script/task_source/timer.rs
+++ b/components/script/task_source/timer.rs
@@ -11,7 +11,7 @@ use crate::task::{TaskCanceller, TaskOnce};
 use crate::task_source::{TaskSource, TaskSourceName};
 
 #[derive(JSTraceable)]
-/// https://html.spec.whatwg.org/multipage/#timer-task-source
+/// <https://html.spec.whatwg.org/multipage/#timer-task-source>
 pub struct TimerTaskSource(
     pub Box<dyn ScriptChan + Send + 'static>,
     #[no_trace] pub PipelineId,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -361,7 +361,7 @@ pub struct JsTimerHandle(i32);
 #[derive(DenyPublicFields, JSTraceable, MallocSizeOf)]
 pub struct JsTimers {
     next_timer_handle: Cell<JsTimerHandle>,
-    /// https://html.spec.whatwg.org/multipage/#list-of-active-timers
+    /// <https://html.spec.whatwg.org/multipage/#list-of-active-timers>
     active_timers: DomRefCell<HashMap<JsTimerHandle, JsTimerEntry>>,
     /// The nesting level of the currently executing timer task or 0.
     nesting_level: Cell<u32>,

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -111,10 +111,10 @@ pub struct WebGLCreateContextResult {
 /// Defines the WebGL version
 #[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, PartialOrd, Serialize)]
 pub enum WebGLVersion {
-    /// https://www.khronos.org/registry/webgl/specs/1.0.2/
+    /// <https://www.khronos.org/registry/webgl/specs/1.0.2/>
     /// Conforms closely to the OpenGL ES 2.0 API
     WebGL1,
-    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/>
     /// Conforms closely to the OpenGL ES 3.0 API
     WebGL2,
 }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -270,7 +270,7 @@ impl Debug for EmbedderMsg {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FilterPattern(pub String);
 
-/// https://w3c.github.io/mediasession/#mediametadata
+/// <https://w3c.github.io/mediasession/#mediametadata>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MediaMetadata {
     /// Title
@@ -291,7 +291,7 @@ impl MediaMetadata {
     }
 }
 
-/// https://w3c.github.io/mediasession/#enumdef-mediasessionplaybackstate
+/// <https://w3c.github.io/mediasession/#enumdef-mediasessionplaybackstate>
 #[repr(i32)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MediaSessionPlaybackState {
@@ -303,7 +303,7 @@ pub enum MediaSessionPlaybackState {
     Paused,
 }
 
-/// https://w3c.github.io/mediasession/#dictdef-mediapositionstate
+/// <https://w3c.github.io/mediasession/#dictdef-mediapositionstate>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MediaPositionState {
     pub duration: f64,

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -116,7 +116,7 @@ pub struct Response {
     pub internal_response: Option<Box<Response>>,
     /// whether or not to try to return the internal_response when asked for actual_response
     pub return_internal: bool,
-    /// https://fetch.spec.whatwg.org/#concept-response-aborted
+    /// <https://fetch.spec.whatwg.org/#concept-response-aborted>
     #[ignore_malloc_size_of = "AtomicBool heap size undefined"]
     pub aborted: Arc<AtomicBool>,
     /// track network metrics

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -288,7 +288,7 @@ pub enum UpdatePipelineIdReason {
 pub enum ConstellationControlMsg {
     /// Takes the associated window proxy out of "delaying-load-events-mode",
     /// used if a scheduled navigated was refused by the embedder.
-    /// https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     StopDelayingLoadEventsMode(PipelineId),
     /// Sends the final response to script thread for fetching after all redirections
     /// have been resolved
@@ -344,7 +344,7 @@ pub enum ConstellationControlMsg {
         /// The expected origin of the target.
         target_origin: Option<ImmutableOrigin>,
         /// The source origin of the message.
-        /// https://html.spec.whatwg.org/multipage/#dom-messageevent-origin
+        /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-origin>
         source_origin: ImmutableOrigin,
         /// The data to be posted.
         data: StructuredSerializedData,
@@ -1016,7 +1016,7 @@ impl StructuredSerializedData {
     }
 }
 
-/// A task on the https://html.spec.whatwg.org/multipage/#port-message-queue
+/// A task on the <https://html.spec.whatwg.org/multipage/#port-message-queue>
 #[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct PortMessageTask {
     /// The origin of this task.
@@ -1062,7 +1062,7 @@ impl Clone for BroadcastMsg {
 }
 
 /// The type of MediaSession action.
-/// https://w3c.github.io/mediasession/#enumdef-mediasessionaction
+/// <https://w3c.github.io/mediasession/#enumdef-mediasessionaction>
 #[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum MediaSessionActionType {
     /// The action intent is to resume playback.

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -87,7 +87,7 @@ pub enum LogEntry {
     Warn(String),
 }
 
-/// https://html.spec.whatwg.org/multipage/#replacement-enabled
+/// <https://html.spec.whatwg.org/multipage/#replacement-enabled>
 #[derive(Debug, Deserialize, Serialize)]
 pub enum HistoryEntryReplacement {
     /// Traverse the history with replacement enabled.
@@ -197,7 +197,7 @@ pub enum ScriptMsg {
         /// The expected origin of the target.
         target_origin: Option<ImmutableOrigin>,
         /// The source origin of the message.
-        /// https://html.spec.whatwg.org/multipage/#dom-messageevent-origin
+        /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-origin>
         source_origin: ImmutableOrigin,
         /// The data to be posted.
         data: StructuredSerializedData,
@@ -245,7 +245,7 @@ pub enum ScriptMsg {
     /// Send messages from postMessage calls from serviceworker
     /// to constellation for storing in service worker manager
     ForwardDOMMessage(DOMMessage, ServoUrl),
-    /// https://w3c.github.io/ServiceWorker/#schedule-job-algorithm.
+    /// <https://w3c.github.io/ServiceWorker/#schedule-job-algorithm>
     ScheduleJob(Job),
     /// Get Window Informations size and position
     GetClientWindow(IpcSender<(DeviceIntSize, DeviceIntPoint)>),
@@ -375,29 +375,29 @@ pub enum ServiceWorkerMsg {
     Timeout(ServoUrl),
     /// Message sent by constellation to forward to a running service worker
     ForwardDOMMessage(DOMMessage, ServoUrl),
-    /// https://w3c.github.io/ServiceWorker/#schedule-job-algorithm
+    /// <https://w3c.github.io/ServiceWorker/#schedule-job-algorithm>
     ScheduleJob(Job),
     /// Exit the service worker manager
     Exit,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-/// https://w3c.github.io/ServiceWorker/#dfn-job-type
+/// <https://w3c.github.io/ServiceWorker/#dfn-job-type>
 pub enum JobType {
     /// <https://w3c.github.io/ServiceWorker/#register>
     Register,
     /// <https://w3c.github.io/ServiceWorker/#unregister-algorithm>
     Unregister,
-    /// <https://w3c.github.io/ServiceWorker/#update-algorithm
+    /// <https://w3c.github.io/ServiceWorker/#update-algorithm>
     Update,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 /// The kind of error the job promise should be rejected with.
 pub enum JobError {
-    /// https://w3c.github.io/ServiceWorker/#reject-job-promise
+    /// <https://w3c.github.io/ServiceWorker/#reject-job-promise>
     TypeError,
-    /// https://w3c.github.io/ServiceWorker/#reject-job-promise
+    /// <https://w3c.github.io/ServiceWorker/#reject-job-promise>
     SecurityError,
 }
 
@@ -405,9 +405,9 @@ pub enum JobError {
 /// Messages sent from Job algorithms steps running in the SW manager,
 /// in order to resolve or reject the job promise.
 pub enum JobResult {
-    /// https://w3c.github.io/ServiceWorker/#reject-job-promise
+    /// <https://w3c.github.io/ServiceWorker/#reject-job-promise>
     RejectPromise(JobError),
-    /// https://w3c.github.io/ServiceWorker/#resolve-job-promise
+    /// <https://w3c.github.io/ServiceWorker/#resolve-job-promise>
     ResolvePromise(Job, JobResultValue),
 }
 
@@ -428,7 +428,7 @@ pub enum JobResultValue {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-/// https://w3c.github.io/ServiceWorker/#dfn-job
+/// <https://w3c.github.io/ServiceWorker/#dfn-job>
 pub struct Job {
     /// <https://w3c.github.io/ServiceWorker/#dfn-job-type>
     pub job_type: JobType,
@@ -445,7 +445,7 @@ pub struct Job {
 }
 
 impl Job {
-    /// https://w3c.github.io/ServiceWorker/#create-job-algorithm
+    /// <https://w3c.github.io/ServiceWorker/#create-job-algorithm>
     pub fn create_job(
         job_type: JobType,
         scope_url: ServoUrl,
@@ -466,7 +466,7 @@ impl Job {
 }
 
 impl PartialEq for Job {
-    /// Equality criteria as described in https://w3c.github.io/ServiceWorker/#dfn-job-equivalent
+    /// Equality criteria as described in <https://w3c.github.io/ServiceWorker/#dfn-job-equivalent>
     fn eq(&self, other: &Self) -> bool {
         // TODO: match on job type, take worker type and `update_via_cache_mode` into account.
         let same_job = self.job_type == other.job_type;
@@ -488,6 +488,6 @@ impl PartialEq for Job {
 pub enum SWManagerMsg {
     /// Placeholder to keep the enum,
     /// as it will be needed when implementing
-    /// https://github.com/servo/servo/issues/24660
+    /// <https://github.com/servo/servo/issues/24660>
     PostMessageToClient,
 }

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! This module contains implementations in script that are serializable,
-//! as per https://html.spec.whatwg.org/multipage/#serializable-objects.
+//! as per <https://html.spec.whatwg.org/multipage/#serializable-objects>.
 //! The implementations are here instead of in script
 //! so that the other modules involved in the serialization don't have
 //! to depend on script.

--- a/ports/servoshell/backtrace.rs
+++ b/ports/servoshell/backtrace.rs
@@ -4,10 +4,10 @@
 
 //! Similar to `println!("{:?}", Backtrace::new())`, but doesn’t allocate.
 //!
-//! Seems to fix some deadlocks: https://github.com/servo/servo/issues/24881
+//! Seems to fix some deadlocks: <https://github.com/servo/servo/issues/24881>
 //!
 //! FIXME: if/when a future version of the `backtrace` crate has
-//! https://github.com/rust-lang/backtrace-rs/pull/265, use that instead.
+//! <https://github.com/rust-lang/backtrace-rs/pull/265>, use that instead.
 
 use std::fmt::{self, Write};
 


### PR DESCRIPTION
This fixes many rustdoc errors that occur due to raw URLs in rustdoc
comments as well as unescaped Rust code that should be in backticks.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
