### PR TITLE
layout: Count word separators as justification opportunities when trimming whitespace

### DIFF
--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -434,7 +434,7 @@ pub struct GlyphStore {
 
     /// A cache of the number of word separators in the entire glyph store.
     /// See <https://drafts.csswg.org/css-text/#word-separator>.
-    total_word_separators: i32,
+    total_word_separators: usize,
 
     /// Used to check if fast path should be used in glyph iteration.
     has_detailed_glyphs: bool,
@@ -476,7 +476,7 @@ impl<'a> GlyphStore {
     }
 
     #[inline]
-    pub fn total_word_separators(&self) -> i32 {
+    pub fn total_word_separators(&self) -> usize {
         self.total_word_separators
     }
 
@@ -622,7 +622,7 @@ impl<'a> GlyphStore {
     #[inline]
     pub fn advance_for_byte_range(&self, range: &Range<ByteIndex>, extra_word_spacing: Au) -> Au {
         if range.begin() == ByteIndex(0) && range.end() == self.len() {
-            self.total_advance + extra_word_spacing * self.total_word_separators
+            self.total_advance + extra_word_spacing * (self.total_word_separators as i32)
         } else if !self.has_detailed_glyphs {
             self.advance_for_byte_range_simple_glyphs(range, extra_word_spacing)
         } else {

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -179,13 +179,14 @@ impl LineUnderConstruction {
         // >    as well as any trailing U+1680   OGHAM SPACE MARK whose white-space
         // >    property is normal, nowrap, or pre-line.
         let mut whitespace_trimmed = Length::zero();
-        let mut spaces_trimmed = 0;
+        let mut word_seperators_trimmed = 0;
         for item in self.line_items.iter_mut().rev() {
-            if !item.trim_whitespace_at_end(&mut whitespace_trimmed, &mut spaces_trimmed) {
+            if !item.trim_whitespace_at_end(&mut whitespace_trimmed, &mut word_seperators_trimmed) {
                 break;
             }
         }
-        self.justification_opportunities -= spaces_trimmed;
+
+        self.justification_opportunities -= word_seperators_trimmed;
         whitespace_trimmed
     }
 }
@@ -399,14 +400,15 @@ impl UnbreakableSegmentUnderConstruction {
     /// This prevents whitespace from being added to the beginning of a line.
     fn trim_leading_whitespace(&mut self) {
         let mut whitespace_trimmed = Length::zero();
-        let mut spaces_trimmed = 0;
+        let mut word_seperators_trimmed = 0;
         for item in self.line_items.iter_mut() {
-            if !item.trim_whitespace_at_start(&mut whitespace_trimmed, &mut spaces_trimmed) {
+            if !item.trim_whitespace_at_start(&mut whitespace_trimmed, &mut word_seperators_trimmed)
+            {
                 break;
             }
         }
         self.inline_size -= whitespace_trimmed;
-        self.justification_opportunities -= spaces_trimmed;
+        self.justification_opportunities -= word_seperators_trimmed;
     }
 
     /// Prepare this segment for placement on a new and empty line. This happens when the


### PR DESCRIPTION
Before counting whitepsace-only `GlyphStore`s where counted as a single
justification opportunity when trimming whitespace from the front and
back of lines. This isn't correct, instead count the actual number of
word seperators of the trimmed `GlyphStore`s.

These two counts can be different in the case where whitespace collapse
isn't happening yet (flexbox). In addition, using word seperators means
the code is making less assumptions about the contents of the line and
is more robust.

This fixes some crashes in flexbox tests on debug builds.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
