### PR TITLE
tests: Add GStreamer library directory to DYLD_LIBRARY_PATH

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -488,6 +488,12 @@ class CommandBase(object):
             if gstreamer_root:
                 util.prepend_paths_to_env(env, "PATH", os.path.join(gstreamer_root, "bin"))
 
+                # FIXME: This is necessary to run unit tests, because they depend on dylibs from the
+                # GStreamer distribution (such as harfbuzz), but we only modify the rpath of the
+                # target binary (servoshell / libsimpleservo).
+                if platform.is_macos:
+                    util.prepend_paths_to_env(env, "DYLD_LIBRARY_PATH", os.path.join(gstreamer_root, "lib"))
+
         effective_target = self.cross_compile_target or servo.platform.host_triple()
         if "msvc" in effective_target:
             # Always build harfbuzz from source

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -26,9 +26,6 @@ class Base:
     def gstreamer_root(self, _cross_compilation_target: Optional[str]) -> Optional[str]:
         raise NotImplementedError("Do not know how to get GStreamer path for platform.")
 
-    def library_path_variable_name(self):
-        raise NotImplementedError("Do not know how to set library path for platform.")
-
     def executable_suffix(self) -> str:
         return ""
 

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -82,9 +82,6 @@ class Linux(Base):
         self.is_linux = True
         (self.distro, self.version) = Linux.get_distro_and_version()
 
-    def library_path_variable_name(self):
-        return "LD_LIBRARY_PATH"
-
     @staticmethod
     def get_distro_and_version() -> Tuple[str, str]:
         distrib = distro.name()

--- a/python/servo/platform/macos.py
+++ b/python/servo/platform/macos.py
@@ -26,9 +26,6 @@ class MacOS(Base):
         super().__init__(*args, **kwargs)
         self.is_macos = True
 
-    def library_path_variable_name(self):
-        return "DYLD_LIBRARY_PATH"
-
     def gstreamer_root(self, cross_compilation_target: Optional[str]) -> Optional[str]:
         # We do not support building with gstreamer while cross-compiling on MacOS.
         if cross_compilation_target or not os.path.exists(GSTREAMER_ROOT):

--- a/python/servo/platform/windows.py
+++ b/python/servo/platform/windows.py
@@ -41,9 +41,6 @@ class Windows(Base):
     def executable_suffix(self):
         return ".exe"
 
-    def library_path_variable_name(self):
-        return "LIB"
-
     @classmethod
     def download_and_extract_dependency(cls, zip_path: str, full_spec: str):
         if not os.path.isfile(zip_path):


### PR DESCRIPTION
This fixes an issue where the dylib for harfbuzz cannot be found when
running unit tests on some systems, because unit tests don't get their
rpaths adjusted during build. This is quite likely an issue with dylib
dependency management. We just need a bit more exploration of how this
is traditionally handled.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31116.
