### PR TITLE
Update Servo::get_events to return drain type

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -65,7 +65,7 @@ pub use gleam::gl;
 use ipc_channel::ipc::{self, IpcSender};
 use log::{error, trace, warn, Log, Metadata, Record};
 use media::{GLPlayerThreads, WindowGLContext};
-pub use msg::constellation_msg::TopLevelBrowsingContextId as BrowserId;
+pub use msg::constellation_msg::TopLevelBrowsingContextId;
 use msg::constellation_msg::{PipelineNamespace, PipelineNamespaceId};
 use net::resource_thread::new_resource_threads;
 use net_traits::IpcSend;
@@ -163,7 +163,7 @@ pub struct Servo<Window: WindowMethods + 'static + ?Sized> {
     compositor: IOCompositor<Window>,
     constellation_chan: Sender<ConstellationMsg>,
     embedder_receiver: EmbedderReceiver,
-    messages_for_embedder: Vec<(Option<BrowserId>, EmbedderMsg)>,
+    messages_for_embedder: Vec<(Option<TopLevelBrowsingContextId>, EmbedderMsg)>,
     profiler_enabled: bool,
     /// For single-process Servo instances, this field controls the initialization
     /// and deinitialization of the JS Engine. Multiprocess Servo instances have their
@@ -214,7 +214,7 @@ impl webrender_api::RenderNotifier for RenderNotifier {
 
 pub struct InitializedServo<Window: WindowMethods + 'static + ?Sized> {
     pub servo: Servo<Window>,
-    pub browser_id: BrowserId,
+    pub browser_id: TopLevelBrowsingContextId,
 }
 
 impl<Window> Servo<Window>
@@ -283,7 +283,7 @@ where
 
         // Reserving a namespace to create TopLevelBrowsingContextId.
         PipelineNamespace::install(PipelineNamespaceId(0));
-        let top_level_browsing_context_id = BrowserId::new();
+        let top_level_browsing_context_id = TopLevelBrowsingContextId::new();
 
         // Get both endpoints of a special channel for communication between
         // the client window and the compositor. This channel is unique because
@@ -723,7 +723,7 @@ where
         }
     }
 
-    pub fn get_events(&mut self) -> Drain<'_, (Option<BrowserId>, EmbedderMsg)> {
+    pub fn get_events(&mut self) -> Drain<'_, (Option<TopLevelBrowsingContextId>, EmbedderMsg)> {
         self.messages_for_embedder.drain(..)
     }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
+use std::vec::Drain;
 
 use bluetooth::BluetoothThreadFactory;
 use bluetooth_traits::BluetoothRequest;
@@ -722,8 +723,8 @@ where
         }
     }
 
-    pub fn get_events(&mut self) -> Vec<(Option<BrowserId>, EmbedderMsg)> {
-        ::std::mem::replace(&mut self.messages_for_embedder, Vec::new())
+    pub fn get_events(&mut self) -> Drain<'_, (Option<BrowserId>, EmbedderMsg)> {
+        self.messages_for_embedder.drain(..)
     }
 
     pub fn handle_events(&mut self, events: impl IntoIterator<Item = EmbedderEvent>) -> bool {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -462,7 +462,7 @@ impl App {
 
             // Take any new embedder messages from Servo itself.
             embedder_messages = self.servo.as_mut().unwrap().get_events();
-            if embedder_messages.is_empty() {
+            if embedder_messages.len() == 0 {
                 break;
             }
         }

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::Write;
 use std::rc::Rc;
 use std::time::Duration;
+use std::vec::Drain;
 use std::{env, thread};
 
 use arboard::Clipboard;
@@ -292,7 +293,7 @@ where
     /// Returns true if the caller needs to manually present a new frame.
     pub fn handle_servo_events(
         &mut self,
-        events: Vec<(Option<WebViewId>, EmbedderMsg)>,
+        events: Drain<'_, (Option<WebViewId>, EmbedderMsg)>,
     ) -> ServoEventResponse {
         let mut need_present = false;
         let mut history_changed = false;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Another improvement I hope it can see. Servo created a new vector every time when embedder calls `get_events.`
Using drain type could prevent this allocation.
I also remove the type alias for TopLevelBrowsingContextId because Servoshell and I are all aliases with other names.
It's better to keep the original name and re-export it.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests but servoshell should be built successfully.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
