### PR TITLE
webidlg: Handle `Float64Array` as a `TypedArray` rather than a raw `JSObject`

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -127,6 +127,7 @@ builtinNames = {
     IDLType.Tags.int32array: 'Int32Array',
     IDLType.Tags.uint32array: 'Uint32Array',
     IDLType.Tags.float32array: 'Float32Array',
+    IDLType.Tags.float64array: 'Float64Array',
 }
 
 numericTags = [
@@ -6514,6 +6515,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::typedarray::Int32Array',
         'js::typedarray::Uint32Array',
         'js::typedarray::Float32Array',
+        'js::typedarray::Float64Array',
         'crate::dom',
         'crate::dom::bindings',
         'crate::dom::bindings::codegen::InterfaceObjectMap',

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -691,13 +691,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array
     fn ToFloat64Array(&self, cx: JSContext) -> Float64Array {
-        let vec: Vec<f64> = self
-            .matrix
-            .borrow()
-            .to_array()
-            .iter()
-            .map(|&x| x as f64)
-            .collect();
+        let vec: Vec<f64> = self.matrix.borrow().to_array().to_vec();
 
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
         create_typed_array(cx, &vec, array.handle_mut())

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::ptr::NonNull;
 use std::{f64, ptr};
 
 use cssparser::{Parser, ParserInput};
@@ -12,7 +11,7 @@ use euclid::default::Transform3D;
 use euclid::Angle;
 use js::jsapi::JSObject;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
-use js::typedarray::{CreateWith, Float32Array, Float64Array};
+use js::typedarray::{Float32Array, Float64Array};
 use style::parser::ParserContext;
 
 use crate::dom::bindings::cell::{DomRefCell, Ref};
@@ -691,14 +690,18 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array
-    #[allow(unsafe_code)]
-    fn ToFloat64Array(&self, cx: JSContext) -> NonNull<JSObject> {
-        let arr = self.matrix.borrow().to_array();
-        unsafe {
-            rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-            let _ = Float64Array::create(*cx, CreateWith::Slice(&arr), array.handle_mut()).unwrap();
-            NonNull::new_unchecked(array.get())
-        }
+    fn ToFloat64Array(&self, cx: JSContext) -> Float64Array {
+        let vec: Vec<f64> = self
+            .matrix
+            .borrow()
+            .to_array()
+            .iter()
+            .map(|&x| x as f64)
+            .collect();
+
+        rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+        create_typed_array(cx, &vec, array.handle_mut())
+            .expect("Converting matrix to float64 array should never fail")
     }
 }
 

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -691,10 +691,8 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array
     fn ToFloat64Array(&self, cx: JSContext) -> Float64Array {
-        let vec: Vec<f64> = self.matrix.borrow().to_array().to_vec();
-
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-        create_typed_array(cx, &vec, array.handle_mut())
+        create_typed_array(cx, &self.matrix.borrow().to_array(), array.handle_mut())
             .expect("Converting matrix to float64 array should never fail")
     }
 }

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-use std::ptr::NonNull;
 
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSObject};
+use js::typedarray::{Float64, Float64Array};
 
+use super::bindings::typedarrays::HeapTypedArray;
 use crate::dom::bindings::codegen::Bindings::GamepadBinding::{GamepadHand, GamepadMethods};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
@@ -31,7 +31,7 @@ pub struct Gamepad {
     timestamp: Cell<f64>,
     mapping_type: String,
     #[ignore_malloc_size_of = "mozjs"]
-    axes: Heap<*mut JSObject>,
+    axes: HeapTypedArray<Float64>,
     buttons: Dom<GamepadButtonList>,
     pose: Option<Dom<GamepadPose>>,
     #[ignore_malloc_size_of = "Defined in rust-webvr"]
@@ -60,7 +60,7 @@ impl Gamepad {
             connected: Cell::new(connected),
             timestamp: Cell::new(timestamp),
             mapping_type: mapping_type,
-            axes: Heap::default(),
+            axes: HeapTypedArray::default(),
             buttons: Dom::from_ref(buttons),
             pose: pose.map(Dom::from_ref),
             hand: hand,
@@ -94,10 +94,11 @@ impl GamepadMethods for Gamepad {
         DOMString::from(self.mapping_type.clone())
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/gamepad/#dom-gamepad-axes
-    fn Axes(&self, _cx: JSContext) -> NonNull<JSObject> {
-        unsafe { NonNull::new_unchecked(self.axes.get()) }
+    fn Axes(&self, _cx: JSContext) -> Float64Array {
+        self.axes
+            .get_internal()
+            .expect("Failed to get gamepad axes.")
     }
 
     // https://w3c.github.io/gamepad/#dom-gamepad-buttons

--- a/third_party/WebIDL/WebIDL.py
+++ b/third_party/WebIDL/WebIDL.py
@@ -2408,6 +2408,7 @@ class IDLType(IDLObject):
         "int32array",
         "uint32array",
         "float32array",
+        "float64array",
         "dictionary",
         "enum",
         "callback",
@@ -3648,7 +3649,7 @@ class IDLBuiltinType(IDLType):
         Types.Int32Array: IDLType.Tags.int32array,
         Types.Uint32Array: IDLType.Tags.uint32array,
         Types.Float32Array: IDLType.Tags.float32array,
-        Types.Float64Array: IDLType.Tags.interface,
+        Types.Float64Array: IDLType.Tags.float64array,
         Types.ReadableStream: IDLType.Tags.interface,
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

part #31064

depends on #31167 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because there is not behavior change 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
