### PR TITLE
Delete result job in leaf workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -87,19 +87,3 @@ jobs:
         with:
           name: android-${{ matrix.arch }}-${{ inputs.profile }}
           path: target/android/${{ matrix.arch }}/${{ inputs.profile }}/servoapp.apk
-
-  result:
-    name: Result
-    runs-on: ubuntu-latest
-    if: always()
-    # `needs: 'build'` is necessary to detect cancellation
-    needs:
-      - "build"
-    steps:
-      - name: Mark the job as successful
-        run: exit 0
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      - name: Mark the job as unsuccessful
-        run: exit 1
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -175,21 +175,3 @@ jobs:
       wpt-sync-from-upstream: ${{ inputs.wpt-sync-from-upstream }}
       wpt-layout: "layout-2013"
     secrets: inherit
-
-  result:
-    name: Result
-    runs-on: ubuntu-latest
-    if: always()
-    # needs all build to detect cancellation
-    needs:
-      - "build"
-      - "wpt-2020"
-      - "wpt-2013"
-
-    steps:
-      - name: Mark the job as successful
-        run: exit 0
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      - name: Mark the job as unsuccessful
-        run: exit 1
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -169,21 +169,3 @@ jobs:
       wpt-layout: "layout-2013"
       wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
     secrets: inherit
-
-  result:
-    name: Result
-    runs-on: ubuntu-latest
-    if: always()
-    # needs all build to detect cancellation
-    needs:
-      - "build"
-      - "wpt-2020"
-      - "wpt-2013"
-
-    steps:
-      - name: Mark the job as successful
-        run: exit 0
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      - name: Mark the job as unsuccessful
-        run: exit 1
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,20 +121,3 @@ jobs:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
-
-  result:
-    name: Result
-    runs-on: ubuntu-latest
-    if: always()
-    # needs all build to detect cancellation
-    needs:
-      - "build"
-
-    steps:
-      - name: Mark the job as successful
-        run: exit 0
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      - name: Mark the job as unsuccessful
-        run: exit 1
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-


### PR DESCRIPTION
Results in every workflow was needed for try runs when they where run with homu/bors.

The only place we still need this is main workflow for mq status check (but it is also kept in try workflow for now).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because remove unused CI stuff

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
