### PR TITLE
libservo: Handle GL video decoding setup internally

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -15,7 +15,6 @@ use libc::c_void;
 use msg::constellation_msg::{PipelineId, TopLevelBrowsingContextId, TraversalDirection};
 use script_traits::{MediaSessionActionType, MouseButton, TouchEventType, TouchId, WheelDelta};
 use servo_geometry::DeviceIndependentPixel;
-use servo_media::player::context::{GlApi, GlContext, NativeDisplay};
 use servo_url::ServoUrl;
 use style_traits::DevicePixel;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePoint};
@@ -171,13 +170,7 @@ pub trait WindowMethods {
     /// will want to avoid blocking on UI events, and just
     /// run the event loop at the vsync interval.
     fn set_animation_state(&self, _state: AnimationState);
-    /// Get the media GL context
-    fn get_gl_context(&self) -> GlContext;
-    /// Get the media native display
-    fn get_native_display(&self) -> NativeDisplay;
-    /// Get the GL api
-    fn get_gl_api(&self) -> GlApi;
-    /// Get the RenderingContext instance.
+    /// Get the [`RenderingContext`] of this Window.
     fn rendering_context(&self) -> RenderingContext;
 }
 

--- a/ports/jniapi/src/lib.rs
+++ b/ports/jniapi/src/lib.rs
@@ -126,11 +126,9 @@ pub fn Java_org_mozilla_servoview_JNIServo_init(
     let wakeup = Box::new(WakeupCallback::new(callbacks_ref.clone(), &env));
     let callbacks = Box::new(HostCallbacks::new(callbacks_ref, &env));
 
-    if let Err(err) = gl_glue::egl::init().and_then(|egl_init| {
-        opts.gl_context_pointer = Some(egl_init.gl_context);
-        opts.native_display_pointer = Some(egl_init.display);
-        simpleservo::init(opts, egl_init.gl_wrapper, wakeup, callbacks)
-    }) {
+    if let Err(err) = gl_glue::egl::init()
+        .and_then(|egl_init| simpleservo::init(opts, egl_init.gl_wrapper, wakeup, callbacks))
+    {
         throw(&env, err)
     };
 }
@@ -852,8 +850,6 @@ fn get_options(
         coordinates,
         density,
         xr_discovery: None,
-        gl_context_pointer: None,
-        native_display_pointer: None,
         surfman_integration: simpleservo::SurfmanIntegration::Widget(native_window),
         prefs: None,
     };

--- a/ports/jniapi/src/simpleservo.rs
+++ b/ports/jniapi/src/simpleservo.rs
@@ -39,7 +39,6 @@ pub use servo::webrender_api::units::DeviceIntRect;
 use servo::webrender_api::units::DevicePixel;
 use servo::webrender_api::ScrollLocation;
 use servo::{self, gl, Servo, TopLevelBrowsingContextId};
-use servo_media::player::context as MediaPlayerContext;
 use surfman::{Connection, SurfaceType};
 
 thread_local! {
@@ -56,8 +55,6 @@ pub struct InitOptions {
     pub coordinates: Coordinates,
     pub density: f32,
     pub xr_discovery: Option<webxr::Discovery>,
-    pub gl_context_pointer: Option<*const c_void>,
-    pub native_display_pointer: Option<*const c_void>,
     pub surfman_integration: SurfmanIntegration,
     pub prefs: Option<HashMap<String, PrefValue>>,
 }
@@ -292,8 +289,6 @@ pub fn init(
         host_callbacks: callbacks,
         coordinates: RefCell::new(init_opts.coordinates),
         density: init_opts.density,
-        gl_context_pointer: init_opts.gl_context_pointer,
-        native_display_pointer: init_opts.native_display_pointer,
         rendering_context: rendering_context.clone(),
     });
 
@@ -861,8 +856,6 @@ struct ServoWindowCallbacks {
     host_callbacks: Box<dyn HostTrait>,
     coordinates: RefCell<Coordinates>,
     density: f32,
-    gl_context_pointer: Option<*const c_void>,
-    native_display_pointer: Option<*const c_void>,
     rendering_context: RenderingContext,
 }
 
@@ -905,24 +898,6 @@ impl WindowMethods for ServoWindowCallbacks {
             screen_avail: coords.viewport.size,
             hidpi_factor: Scale::new(self.density),
         }
-    }
-
-    fn get_gl_context(&self) -> MediaPlayerContext::GlContext {
-        match self.gl_context_pointer {
-            Some(context) => MediaPlayerContext::GlContext::Egl(context as usize),
-            None => MediaPlayerContext::GlContext::Unknown,
-        }
-    }
-
-    fn get_native_display(&self) -> MediaPlayerContext::NativeDisplay {
-        match self.native_display_pointer {
-            Some(display) => MediaPlayerContext::NativeDisplay::Egl(display as usize),
-            None => MediaPlayerContext::NativeDisplay::Unknown,
-        }
-    }
-
-    fn get_gl_api(&self) -> MediaPlayerContext::GlApi {
-        MediaPlayerContext::GlApi::Gles2
     }
 }
 

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -14,7 +14,7 @@ use gleam::gl;
 use log::{info, trace, warn};
 use servo::compositing::windowing::EmbedderEvent;
 use servo::compositing::CompositeTarget;
-use servo::config::opts;
+use servo::config::{opts, set_pref};
 use servo::servo_config::pref;
 use servo::Servo;
 use surfman::GLApi;
@@ -67,6 +67,8 @@ impl App {
 
         // Implements window methods, used by compositor.
         let window = if opts::get().headless {
+            // GL video rendering is not supported on headless windows.
+            set_pref!(media.glvideo.enabled, false);
             headless_window::Window::new(
                 opts::get().initial_window_size,
                 device_pixel_ratio_override,

--- a/ports/servoshell/headless_window.rs
+++ b/ports/servoshell/headless_window.rs
@@ -15,7 +15,6 @@ use servo::rendering_context::RenderingContext;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::style_traits::DevicePixel;
 use servo::webrender_api::units::DeviceIntRect;
-use servo_media::player::context as MediaPlayerCtxt;
 use surfman::{Connection, Context, Device, SurfaceType};
 
 use crate::events_loop::WakerEvent;
@@ -142,18 +141,6 @@ impl WindowMethods for Window {
 
     fn set_animation_state(&self, state: AnimationState) {
         self.animation_state.set(state);
-    }
-
-    fn get_gl_context(&self) -> MediaPlayerCtxt::GlContext {
-        MediaPlayerCtxt::GlContext::Unknown
-    }
-
-    fn get_native_display(&self) -> MediaPlayerCtxt::NativeDisplay {
-        MediaPlayerCtxt::NativeDisplay::Unknown
-    }
-
-    fn get_gl_api(&self) -> MediaPlayerCtxt::GlApi {
-        MediaPlayerCtxt::GlApi::None
     }
 
     fn rendering_context(&self) -> RenderingContext {


### PR DESCRIPTION
Instead of making the client set up GL video decoding, have this done
inside libservo. The details necessary for decoding are fetched via
Surfman now. This also removes the setup for the context on Android --
which has no GStreamer support now anyway. In the future, this could be
enabled, but should likely be done using Surfman, instead of passing on
all these details manually.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
