### PR TITLE
Don't use cached client_rect() when a reflow is needed

### DIFF
--- a/tests/wpt/meta-legacy-layout/css/cssom-view/subpixel-sizes-and-offsets.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/cssom-view/subpixel-sizes-and-offsets.tentative.html.ini
@@ -5,9 +5,6 @@
   [clientWidth, offsetWidth and scrollWidth round 5.9 to 6]
     expected: FAIL
 
-  [clientHeight, offsetHeight and scrollHeight round 5.1 to 5]
-    expected: FAIL
-
   [clientHeight, offsetHeight and scrollHeight round 5.5 to 6]
     expected: FAIL
 

--- a/tests/wpt/meta/css/cssom-view/subpixel-sizes-and-offsets.tentative.html.ini
+++ b/tests/wpt/meta/css/cssom-view/subpixel-sizes-and-offsets.tentative.html.ini
@@ -1,19 +1,4 @@
 [subpixel-sizes-and-offsets.tentative.html]
-  [clientWidth, offsetWidth and scrollWidth round 5.5 to 6]
-    expected: FAIL
-
-  [clientWidth, offsetWidth and scrollWidth round 5.9 to 6]
-    expected: FAIL
-
-  [clientHeight, offsetHeight and scrollHeight round 5.1 to 5]
-    expected: FAIL
-
-  [clientHeight, offsetHeight and scrollHeight round 5.5 to 6]
-    expected: FAIL
-
-  [clientHeight, offsetHeight and scrollHeight round 5.9 to 6]
-    expected: FAIL
-
   [clientLeft and clientTop don't round 44.9]
     expected: FAIL
 


### PR DESCRIPTION
Fixes #31195:

```js
element.style.width = "5px";
element.clientWidth; // 5
element.style.width = "15px";
element.clientWidth; // Was 5, now 15
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31195
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
