### PR TITLE
Allow using cached client_rect() for paint-only reflow

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -94,7 +94,9 @@ use crate::dom::create::create_element;
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReaction, CustomElementState,
 };
-use crate::dom::document::{determine_policy_for_token, Document, LayoutDocumentHelpers};
+use crate::dom::document::{
+    determine_policy_for_token, Document, LayoutDocumentHelpers, ReflowTriggerCondition,
+};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::domrect::DOMRect;
 use crate::dom::domtokenlist::DOMTokenList;
@@ -3380,7 +3382,10 @@ impl Element {
             .and_then(|data| data.client_rect.as_ref())
             .and_then(|rect| rect.get().ok())
         {
-            if doc.needs_reflow().is_none() {
+            if matches!(
+                doc.needs_reflow(),
+                None | Some(ReflowTriggerCondition::PaintPostponed)
+            ) {
                 return rect;
             }
         }


### PR DESCRIPTION
PR #31210 avoided the cache for all kinds of reflow, but it's actually fine to use it for ReflowTriggerCondition::PaintPostponed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behavior, just better perf

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
