### PR TITLE
Lint layout_2013 with clippy

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1608,8 +1608,7 @@ impl BlockFlow {
         let mut inline_start_margin_edge = inline_start_content_edge;
         let mut inline_end_margin_edge = inline_end_content_edge;
 
-        let iterator = self.base.child_iter_mut().enumerate().peekable();
-        for (i, kid) in iterator {
+        for (i, kid) in self.base.child_iter_mut().enumerate().peekable() {
             kid.mut_base().block_container_explicit_block_size = explicit_content_size;
 
             // The inline-start margin edge of the child flow is at our inline-start content edge,
@@ -2607,7 +2606,6 @@ impl Flow for BlockFlow {
 
     fn compute_overflow(&self) -> Overflow {
         let flow_size = self.base.position.size.to_physical(self.base.writing_mode);
-
         self.fragment.compute_overflow(
             &flow_size,
             &self

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1940,10 +1940,12 @@ impl BlockFlow {
                     )
                 },
                 (Float::Left, _) => {
-                    left_float_width_accumulator += child_base.intrinsic_inline_sizes.preferred_inline_size;
+                    left_float_width_accumulator +=
+                        child_base.intrinsic_inline_sizes.preferred_inline_size;
                 },
                 (Float::Right, _) => {
-                    right_float_width_accumulator += child_base.intrinsic_inline_sizes.preferred_inline_size;
+                    right_float_width_accumulator +=
+                        child_base.intrinsic_inline_sizes.preferred_inline_size;
                 },
             }
         }
@@ -2605,7 +2607,7 @@ impl Flow for BlockFlow {
 
     fn compute_overflow(&self) -> Overflow {
         let flow_size = self.base.position.size.to_physical(self.base.writing_mode);
-        
+
         self.fragment.compute_overflow(
             &flow_size,
             &self

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -517,7 +517,7 @@ where
         let scanned_fragments =
             with_thread_local_font_context(self.layout_context, |font_context| {
                 TextRunScanner::new()
-                    .scan_for_runs(font_context, std::mem::take(&mut fragments.fragments))
+                    .scan_for_runs(font_context, mem::take(&mut fragments.fragments))
             });
         let mut inline_flow_ref = FlowRef::new(Arc::new(InlineFlow::from_fragments(
             scanned_fragments,

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -200,7 +200,7 @@ impl InlineBlockSplit {
                 InlineFragmentsAccumulator::from_inline_node(node, style_context),
             )
             .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(style_context),
-            flow: flow,
+            flow,
         };
 
         fragment_accumulator
@@ -381,7 +381,7 @@ where
     /// Creates a new flow constructor.
     pub fn new(layout_context: &'a LayoutContext<'a>) -> Self {
         FlowConstructor {
-            layout_context: layout_context,
+            layout_context,
             phantom2: PhantomData,
         }
     }
@@ -411,7 +411,7 @@ where
                     node.image_url(),
                     node.image_density(),
                     node,
-                    &self.layout_context,
+                    self.layout_context,
                 ));
                 SpecificFragmentInfo::Image(image_info)
             },
@@ -433,7 +433,7 @@ where
                     object_data,
                     None,
                     node,
-                    &self.layout_context,
+                    self.layout_context,
                 ));
                 SpecificFragmentInfo::Image(image_info)
             },
@@ -518,7 +518,7 @@ where
             with_thread_local_font_context(self.layout_context, |font_context| {
                 TextRunScanner::new().scan_for_runs(
                     font_context,
-                    mem::replace(&mut fragments.fragments, LinkedList::new()),
+                    std::mem::take(&mut fragments.fragments),
                 )
             });
         let mut inline_flow_ref = FlowRef::new(Arc::new(InlineFlow::from_fragments(
@@ -842,7 +842,7 @@ where
         match text_content {
             TextContent::Text(string) => {
                 let info = Box::new(UnscannedTextFragmentInfo::new(
-                    string.into(),
+                    string,
                     node.selection(),
                 ));
                 let specific_fragment_info = SpecificFragmentInfo::UnscannedText(info);
@@ -979,7 +979,7 @@ where
                     } else {
                         // Push the absolutely-positioned kid as an inline containing block.
                         let kid_node = flow.as_block().fragment.node;
-                        let kid_pseudo = flow.as_block().fragment.pseudo.clone();
+                        let kid_pseudo = flow.as_block().fragment.pseudo;
                         let kid_style = flow.as_block().fragment.style.clone();
                         let kid_selected_style = flow.as_block().fragment.selected_style.clone();
                         let kid_restyle_damage = flow.as_block().fragment.restyle_damage;
@@ -1062,9 +1062,9 @@ where
         }
 
         // Finally, make a new construction result.
-        if opt_inline_block_splits.len() > 0 ||
+        if !opt_inline_block_splits.is_empty() ||
             !fragment_accumulator.fragments.is_empty() ||
-            abs_descendants.len() > 0
+            !abs_descendants.is_empty()
         {
             fragment_accumulator
                 .fragments
@@ -1149,7 +1149,7 @@ where
         let construction_item =
             ConstructionItem::InlineFragments(InlineFragmentsConstructionResult {
                 splits: LinkedList::new(),
-                fragments: fragments,
+                fragments,
             });
         ConstructionResult::ConstructionItem(construction_item)
     }
@@ -1520,7 +1520,7 @@ where
                     url_value.url().cloned(),
                     None,
                     node,
-                    &self.layout_context,
+                    self.layout_context,
                 ));
                 vec![Fragment::new(
                     node,
@@ -1549,9 +1549,9 @@ where
                         self.layout_context,
                     ));
                     let marker_fragments =
-                        with_thread_local_font_context(self.layout_context, |mut font_context| {
+                        with_thread_local_font_context(self.layout_context, |font_context| {
                             TextRunScanner::new()
-                                .scan_for_runs(&mut font_context, unscanned_marker_fragments)
+                                .scan_for_runs(font_context, unscanned_marker_fragments)
                         });
                     marker_fragments.fragments
                 },
@@ -1716,7 +1716,7 @@ where
             let damage = node.restyle_damage();
             let mut data = node.mutate_layout_data().unwrap();
 
-            match *node.construction_result_mut(&mut *data) {
+            match *node.construction_result_mut(&mut data) {
                 ConstructionResult::None => true,
                 ConstructionResult::Flow(ref mut flow, _) => {
                     // The node's flow is of the same type and has the same set of children and can
@@ -1804,7 +1804,7 @@ where
         if set_has_newly_constructed_flow_flag {
             node.insert_flags(LayoutDataFlags::HAS_NEWLY_CONSTRUCTED_FLOW);
         }
-        return result;
+        result
     }
 }
 
@@ -2046,14 +2046,14 @@ where
     #[inline(always)]
     fn set_flow_construction_result(self, result: ConstructionResult) {
         let mut layout_data = self.mutate_layout_data().unwrap();
-        let dst = self.construction_result_mut(&mut *layout_data);
+        let dst = self.construction_result_mut(&mut layout_data);
         *dst = result;
     }
 
     #[inline(always)]
     fn get_construction_result(self) -> ConstructionResult {
         let mut layout_data = self.mutate_layout_data().unwrap();
-        self.construction_result_mut(&mut *layout_data).get()
+        self.construction_result_mut(&mut layout_data).get()
     }
 }
 
@@ -2464,7 +2464,7 @@ impl Legalizer {
 }
 
 pub fn is_image_data(uri: &str) -> bool {
-    static TYPES: &'static [&'static str] =
+    static TYPES: &[&str] =
         &["data:image/png", "data:image/gif", "data:image/jpeg"];
     TYPES.iter().any(|&type_| uri.starts_with(type_))
 }

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -516,10 +516,8 @@ where
         // remain. In that case the inline flow will compute its ascent and descent to be zero.
         let scanned_fragments =
             with_thread_local_font_context(self.layout_context, |font_context| {
-                TextRunScanner::new().scan_for_runs(
-                    font_context,
-                    std::mem::take(&mut fragments.fragments),
-                )
+                TextRunScanner::new()
+                    .scan_for_runs(font_context, std::mem::take(&mut fragments.fragments))
             });
         let mut inline_flow_ref = FlowRef::new(Arc::new(InlineFlow::from_fragments(
             scanned_fragments,
@@ -841,10 +839,7 @@ where
 
         match text_content {
             TextContent::Text(string) => {
-                let info = Box::new(UnscannedTextFragmentInfo::new(
-                    string,
-                    node.selection(),
-                ));
+                let info = Box::new(UnscannedTextFragmentInfo::new(string, node.selection()));
                 let specific_fragment_info = SpecificFragmentInfo::UnscannedText(info);
                 fragments
                     .fragments
@@ -2464,7 +2459,6 @@ impl Legalizer {
 }
 
 pub fn is_image_data(uri: &str) -> bool {
-    static TYPES: &[&str] =
-        &["data:image/png", "data:image/gif", "data:image/jpeg"];
+    static TYPES: &[&str] = &["data:image/png", "data:image/gif", "data:image/jpeg"];
     TYPES.iter().any(|&type_| uri.starts_with(type_))
 }

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -155,12 +155,12 @@ impl<'a> LayoutContext<'a> {
             .read()
             .get(&(url.clone(), use_placeholder))
         {
-            return Some((*existing_webrender_image).clone());
+            return Some(*existing_webrender_image);
         }
 
         match self.get_or_request_image_or_meta(node, url.clone(), use_placeholder) {
             Some(ImageOrMetadataAvailable::ImageAvailable { image, .. }) => {
-                let image_info = WebRenderImageInfo::from_image(&*image);
+                let image_info = WebRenderImageInfo::from_image(&image);
                 if image_info.key.is_none() {
                     Some(image_info)
                 } else {

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -456,10 +456,7 @@ impl<'a> DisplayListBuildState<'a> {
         list: &mut Vec<DisplayItem>,
         stacking_context: StackingContext,
     ) {
-        let mut child_items = self
-            .items
-            .remove(&stacking_context.id)
-            .unwrap_or_default();
+        let mut child_items = self.items.remove(&stacking_context.id).unwrap_or_default();
         child_items.sort_by(|a, b| a.base().section.cmp(&b.base().section));
         child_items.reverse();
 

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -150,7 +150,7 @@ impl StackingContextInfo {
     }
 
     fn take_children(&mut self) -> Vec<StackingContext> {
-        mem::replace(&mut self.children, Vec::new())
+        std::mem::take(&mut self.children)
     }
 }
 
@@ -220,7 +220,7 @@ impl StackingContextCollectionState {
         let clip_scroll_nodes = vec![ClipScrollNode::placeholder(), ClipScrollNode::placeholder()];
 
         StackingContextCollectionState {
-            pipeline_id: pipeline_id,
+            pipeline_id,
             root_stacking_context: StackingContext::root(),
             stacking_context_info,
             clip_scroll_nodes,
@@ -337,7 +337,7 @@ impl<'a> DisplayListBuildState<'a> {
         state: StackingContextCollectionState,
     ) -> DisplayListBuildState<'a> {
         DisplayListBuildState {
-            layout_context: layout_context,
+            layout_context,
             root_stacking_context: state.root_stacking_context,
             items: FnvHashMap::default(),
             stacking_context_info: state.stacking_context_info,
@@ -356,7 +356,7 @@ impl<'a> DisplayListBuildState<'a> {
         let items = self
             .items
             .entry(display_item.stacking_context_id())
-            .or_insert(Vec::new());
+            .or_default();
         items.push(display_item);
     }
 
@@ -446,7 +446,7 @@ impl<'a> DisplayListBuildState<'a> {
         self.to_display_list_for_stacking_context(&mut list, root_context);
 
         DisplayList {
-            list: list,
+            list,
             clip_scroll_nodes: self.clip_scroll_nodes,
         }
     }
@@ -459,7 +459,7 @@ impl<'a> DisplayListBuildState<'a> {
         let mut child_items = self
             .items
             .remove(&stacking_context.id)
-            .unwrap_or(Vec::new());
+            .unwrap_or_default();
         child_items.sort_by(|a, b| a.base().section.cmp(&b.base().section));
         child_items.reverse();
 
@@ -557,7 +557,7 @@ impl<'a> DisplayListBuildState<'a> {
 }
 
 /// The logical width of an insertion point: at the moment, a one-pixel-wide line.
-const INSERTION_POINT_LOGICAL_WIDTH: Au = Au(1 * AU_PER_PX);
+const INSERTION_POINT_LOGICAL_WIDTH: Au = Au(AU_PER_PX);
 
 /// Get the border radius for the rectangle inside of a rounded border. This is useful
 /// for building the clip for the content inside the border.
@@ -632,7 +632,7 @@ impl Fragment {
         let current_stacking_context_id = state.current_stacking_context_id;
         let stacking_context = self.create_stacking_context(
             self.stacking_context_id,
-            &base,
+            base,
             StackingContextType::Real,
             established_reference_frame,
             state.current_clipping_and_scrolling,
@@ -703,7 +703,7 @@ impl Fragment {
             let base = state.create_base_display_item(
                 bounds,
                 self.node,
-                get_cursor(&style, Cursor::Default),
+                get_cursor(style, Cursor::Default),
                 display_list_section,
             );
             state.add_display_item(DisplayItem::Rectangle(CommonDisplayItem::new(
@@ -843,7 +843,7 @@ impl Fragment {
             let base = state.create_base_display_item(
                 placement.clip_rect,
                 self.node,
-                get_cursor(&style, Cursor::Default),
+                get_cursor(style, Cursor::Default),
                 display_list_section,
             );
 
@@ -965,7 +965,7 @@ impl Fragment {
             let base = state.create_base_display_item(
                 placement.clip_rect,
                 self.node,
-                get_cursor(&style, Cursor::Default),
+                get_cursor(style, Cursor::Default),
                 display_list_section,
             );
 
@@ -1032,7 +1032,7 @@ impl Fragment {
             let base = state.create_base_display_item(
                 clip,
                 self.node,
-                get_cursor(&style, Cursor::Default),
+                get_cursor(style, Cursor::Default),
                 display_list_section,
             );
             let border_radius = border::radii(absolute_bounds, style.get_border());
@@ -1050,7 +1050,7 @@ impl Fragment {
                     ),
                     blur_radius: box_shadow.base.blur.px(),
                     spread_radius: box_shadow.spread.px(),
-                    border_radius: border_radius,
+                    border_radius,
                     clip_mode: if box_shadow.inset {
                         BoxShadowClipMode::Inset
                     } else {
@@ -1118,7 +1118,7 @@ impl Fragment {
         let base = state.create_base_display_item(
             clip,
             self.node,
-            get_cursor(&style, Cursor::Default),
+            get_cursor(style, Cursor::Default),
             display_list_section,
         );
 
@@ -1297,7 +1297,7 @@ impl Fragment {
     ) {
         use style::values::specified::outline::OutlineStyle;
 
-        let width = Au::from(style.get_outline().outline_width);
+        let width = style.get_outline().outline_width;
         if width == Au(0) {
             return;
         }
@@ -1323,7 +1323,7 @@ impl Fragment {
         let base = state.create_base_display_item(
             clip,
             self.node,
-            get_cursor(&style, Cursor::Default),
+            get_cursor(style, Cursor::Default),
             DisplayListSection::Outlines,
         );
         state.add_display_item(DisplayItem::Border(CommonDisplayItem::with_data(
@@ -1355,7 +1355,7 @@ impl Fragment {
         let base = state.create_base_display_item(
             clip,
             self.node,
-            get_cursor(&style, Cursor::Default),
+            get_cursor(style, Cursor::Default),
             DisplayListSection::Content,
         );
         state.add_display_item(DisplayItem::Border(CommonDisplayItem::with_data(
@@ -1378,14 +1378,14 @@ impl Fragment {
             stacking_relative_content_box,
             container_size,
         );
-        baseline.start.b = baseline.start.b + text_fragment.run.ascent();
+        baseline.start.b += text_fragment.run.ascent();
         baseline.size.block = Au(0);
         let baseline = baseline.to_physical(self.style.writing_mode, container_size);
 
         let base = state.create_base_display_item(
             clip,
             self.node,
-            get_cursor(&style, Cursor::Default),
+            get_cursor(style, Cursor::Default),
             DisplayListSection::Content,
         );
         // TODO(gw): Use a better estimate for wavy line thickness.
@@ -1591,14 +1591,14 @@ impl Fragment {
                 for node in inline_context.nodes.iter().rev() {
                     self.build_display_list_for_background_if_applicable(
                         state,
-                        &*node.style,
+                        &node.style,
                         display_list_section,
                         stacking_relative_border_box,
                     );
 
                     self.build_display_list_for_box_shadow_if_applicable(
                         state,
-                        &*node.style,
+                        &node.style,
                         display_list_section,
                         stacking_relative_border_box,
                         clip,
@@ -1606,7 +1606,7 @@ impl Fragment {
 
                     self.build_display_list_for_borders_if_applicable(
                         state,
-                        &*node.style,
+                        &node.style,
                         Some(InlineNodeBorderInfo {
                             is_first_fragment_of_element: node
                                 .flags
@@ -1625,7 +1625,7 @@ impl Fragment {
                     // fixup as border?
                     self.build_display_list_for_outline_if_applicable(
                         state,
-                        &*node.style,
+                        &node.style,
                         stacking_relative_border_box,
                         clip,
                     );
@@ -1635,14 +1635,14 @@ impl Fragment {
             if !self.is_scanned_text_fragment() {
                 self.build_display_list_for_background_if_applicable(
                     state,
-                    &*self.style,
+                    &self.style,
                     display_list_section,
                     stacking_relative_border_box,
                 );
 
                 self.build_display_list_for_box_shadow_if_applicable(
                     state,
-                    &*self.style,
+                    &self.style,
                     display_list_section,
                     stacking_relative_border_box,
                     clip,
@@ -1650,7 +1650,7 @@ impl Fragment {
 
                 self.build_display_list_for_borders_if_applicable(
                     state,
-                    &*self.style,
+                    &self.style,
                     /* inline_node_info = */ None,
                     border_painting_mode,
                     stacking_relative_border_box,
@@ -1660,7 +1660,7 @@ impl Fragment {
 
                 self.build_display_list_for_outline_if_applicable(
                     state,
-                    &*self.style,
+                    &self.style,
                     stacking_relative_border_box,
                     clip,
                 );
@@ -1769,7 +1769,7 @@ impl Fragment {
                 // Create the main text display item.
                 self.build_display_list_for_text_fragment(
                     state,
-                    &text_fragment,
+                    text_fragment,
                     stacking_relative_content_box,
                     &self.style.get_inherited_text().text_shadow.0,
                     clip,
@@ -1781,7 +1781,7 @@ impl Fragment {
                         self.style(),
                         stacking_relative_border_box,
                         stacking_relative_content_box,
-                        &text_fragment,
+                        text_fragment,
                         clip,
                     );
                 }
@@ -1790,7 +1790,7 @@ impl Fragment {
                 // Create the main text display item.
                 self.build_display_list_for_text_fragment(
                     state,
-                    &text_fragment,
+                    text_fragment,
                     stacking_relative_content_box,
                     &self.style.get_inherited_text().text_shadow.0,
                     clip,
@@ -1802,7 +1802,7 @@ impl Fragment {
                         self.style(),
                         stacking_relative_border_box,
                         stacking_relative_content_box,
-                        &text_fragment,
+                        text_fragment,
                         clip,
                     );
                 }
@@ -1914,7 +1914,7 @@ impl Fragment {
                             ipc_renderer
                                 .send(CanvasMsg::FromLayout(
                                     FromLayoutMsg::SendData(sender),
-                                    canvas_fragment_info.canvas_id.clone(),
+                                    canvas_fragment_info.canvas_id,
                                 ))
                                 .unwrap();
                             receiver.recv().unwrap().image_key
@@ -2235,7 +2235,7 @@ impl Fragment {
 
     fn unique_id(&self) -> u64 {
         let fragment_type = self.fragment_type();
-        let id = self.node.id() as usize;
+        let id = self.node.id();
         combine_id_with_fragment_type(id, fragment_type) as u64
     }
 
@@ -2707,7 +2707,7 @@ impl BlockFlow {
             ExternalScrollId(self.fragment.unique_id(), state.pipeline_id.to_webrender());
         let new_clip_scroll_index = state.add_clip_scroll_node(ClipScrollNode {
             parent_index: self.clipping_and_scrolling().scrolling,
-            clip: clip,
+            clip,
             content_rect: Rect::new(content_box.origin, content_size).to_layout(),
             node_type: ClipScrollNodeType::ScrollFrame(sensitivity, external_id),
             scroll_node_id: None,
@@ -3076,7 +3076,7 @@ pub struct IndexableText {
 
 impl IndexableText {
     fn insert(&mut self, node: OpaqueNode, item: IndexableTextItem) {
-        let entries = self.inner.entry(node).or_insert(Vec::new());
+        let entries = self.inner.entry(node).or_default();
         entries.push(item);
     }
 

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -150,7 +150,7 @@ impl StackingContextInfo {
     }
 
     fn take_children(&mut self) -> Vec<StackingContext> {
-        std::mem::take(&mut self.children)
+        mem::take(&mut self.children)
     }
 }
 

--- a/components/layout/display_list/gradient.rs
+++ b/components/layout/display_list/gradient.rs
@@ -166,7 +166,7 @@ fn convert_gradient_stops(
                     let (end_index, end_stop) = stop_items[(i + 1)..]
                         .iter()
                         .enumerate()
-                        .find(|&(_, ref stop)| stop.position.is_some())
+                        .find(|(_, stop)| stop.position.is_some())
                         .unwrap();
                     let end_offset =
                         position_to_offset(end_stop.position.as_ref().unwrap(), total_length);
@@ -191,7 +191,7 @@ fn convert_gradient_stops(
         };
         assert!(offset.is_finite());
         stops.push(GradientStop {
-            offset: offset,
+            offset,
             color: style.resolve_color(stop.color.clone()).to_layout(),
         })
     }

--- a/components/layout/display_list/items.rs
+++ b/components/layout/display_list/items.rs
@@ -109,7 +109,7 @@ impl DisplayList {
     /// stacking context.
     pub fn bounds(&self) -> LayoutRect {
         match self.list.get(0) {
-            Some(&DisplayItem::PushStackingContext(ref item)) => item.stacking_context.bounds,
+            Some(DisplayItem::PushStackingContext(item)) => item.stacking_context.bounds,
             Some(_) => unreachable!("Root element of display list not stacking context."),
             None => LayoutRect::zero(),
         }

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -120,10 +120,10 @@ impl FlexItem {
             base_size: Au(0),
             min_size: Au(0),
             max_size: MAX_AU,
-            index: index,
+            index,
             flex_grow: flex_grow.into(),
             flex_shrink: flex_shrink.into(),
-            order: order,
+            order,
             is_frozen: false,
             is_strut: false,
         }
@@ -202,7 +202,7 @@ impl FlexItem {
     /// Returns the outer main size of the item, including paddings and margins,
     /// clamped by max and min size.
     pub fn outer_main_size(&self, flow: &dyn Flow, direction: Direction) -> Au {
-        let ref fragment = flow.as_block().fragment;
+        let fragment = &flow.as_block().fragment;
         let outer_width = match direction {
             Direction::Inline => {
                 fragment.border_padding.inline_start_end() + fragment.margin.inline_start_end()
@@ -259,9 +259,9 @@ struct FlexLine {
 impl FlexLine {
     pub fn new(range: Range<usize>, free_space: Au, auto_margin_count: i32) -> FlexLine {
         FlexLine {
-            range: range,
-            auto_margin_count: auto_margin_count,
-            free_space: free_space,
+            range,
+            auto_margin_count,
+            free_space,
             cross_size: Au(0),
         }
     }
@@ -399,14 +399,14 @@ impl FlexFlow {
 
         FlexFlow {
             block_flow: BlockFlow::from_fragment_and_float_kind(fragment, flotation),
-            main_mode: main_mode,
+            main_mode,
             available_main_size: AxisSize::Infinite,
             available_cross_size: AxisSize::Infinite,
             lines: Vec::new(),
             items: Vec::new(),
-            main_reverse: main_reverse,
-            is_wrappable: is_wrappable,
-            cross_reverse: cross_reverse,
+            main_reverse,
+            is_wrappable,
+            cross_reverse,
         }
     }
 
@@ -709,9 +709,9 @@ impl FlexFlow {
             let base = children.get(item.index).mut_base();
             if !self.main_reverse {
                 base.position.start.b = cur_b;
-                cur_b = cur_b + base.position.size.block;
+                cur_b += base.position.size.block;
             } else {
-                cur_b = cur_b - base.position.size.block;
+                cur_b -= base.position.size.block;
                 base.position.start.b = cur_b;
             }
         }

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -157,7 +157,7 @@ impl Floats {
         Floats {
             list: FloatList::new(),
             offset: LogicalSize::zero(writing_mode),
-            writing_mode: writing_mode,
+            writing_mode,
         }
     }
 
@@ -170,10 +170,7 @@ impl Floats {
 
     /// Returns the position of the last float in flow coordinates.
     pub fn last_float_pos(&self) -> Option<LogicalRect<Au>> {
-        match self.list.floats.front() {
-            None => None,
-            Some(float) => Some(float.bounds.translate_by_size(self.offset)),
-        }
+        self.list.floats.front().map(|float| float.bounds.translate_by_size(self.offset))
     }
 
     /// Returns a rectangle that encloses the region from block-start to block-start + block-size,
@@ -522,10 +519,10 @@ impl SpeculatedFloatPlacement {
                     let speculated_inline_content_edge_offsets =
                         block_flow.fragment.guess_inline_content_edge_offsets();
                     if self.left > Au(0) && speculated_inline_content_edge_offsets.start > Au(0) {
-                        self.left = self.left + speculated_inline_content_edge_offsets.start
+                        self.left += speculated_inline_content_edge_offsets.start
                     }
                     if self.right > Au(0) && speculated_inline_content_edge_offsets.end > Au(0) {
-                        self.right = self.right + speculated_inline_content_edge_offsets.end
+                        self.right += speculated_inline_content_edge_offsets.end
                     }
                 }
 
@@ -546,30 +543,28 @@ impl SpeculatedFloatPlacement {
         }
 
         let mut float_inline_size = base_flow.intrinsic_inline_sizes.preferred_inline_size;
-        if float_inline_size == Au(0) {
-            if flow.is_block_like() {
-                // Hack: If the size of the float is not fixed, then there's no
-                // way we can guess at its size now. So just pick an arbitrary
-                // nonzero value (in this case, 1px) so that the layout
-                // traversal logic will know that objects later in the document
-                // might flow around this float.
-                let inline_size = flow.as_block().fragment.style.content_inline_size();
-                let fixed = match inline_size {
-                    Size::Auto => false,
-                    Size::LengthPercentage(ref lp) => {
-                        lp.0.is_definitely_zero() || lp.0.maybe_to_used_value(None).is_some()
-                    },
-                };
-                if !fixed {
-                    float_inline_size = Au::from_px(1)
-                }
+        if float_inline_size == Au(0) && flow.is_block_like() {
+            // Hack: If the size of the float is not fixed, then there's no
+            // way we can guess at its size now. So just pick an arbitrary
+            // nonzero value (in this case, 1px) so that the layout
+            // traversal logic will know that objects later in the document
+            // might flow around this float.
+            let inline_size = flow.as_block().fragment.style.content_inline_size();
+            let fixed = match inline_size {
+                Size::Auto => false,
+                Size::LengthPercentage(ref lp) => {
+                    lp.0.is_definitely_zero() || lp.0.maybe_to_used_value(None).is_some()
+                },
+            };
+            if !fixed {
+                float_inline_size = Au::from_px(1)
             }
         }
 
         match base_flow.flags.float_kind() {
             StyleFloat::None => {},
-            StyleFloat::Left => self.left = self.left + float_inline_size,
-            StyleFloat::Right => self.right = self.right + float_inline_size,
+            StyleFloat::Left => self.left += float_inline_size,
+            StyleFloat::Right => self.right += float_inline_size,
         }
     }
 

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -170,7 +170,10 @@ impl Floats {
 
     /// Returns the position of the last float in flow coordinates.
     pub fn last_float_pos(&self) -> Option<LogicalRect<Au>> {
-        self.list.floats.front().map(|float| float.bounds.translate_by_size(self.offset))
+        self.list
+            .floats
+            .front()
+            .map(|float| float.bounds.translate_by_size(self.offset))
     }
 
     /// Returns a rectangle that encloses the region from block-start to block-start + block-size,

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -696,12 +696,6 @@ pub struct AbsoluteDescendants {
     descendant_links: Vec<AbsoluteDescendantInfo>,
 }
 
-impl Default for AbsoluteDescendants {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl AbsoluteDescendants {
     pub fn new() -> AbsoluteDescendants {
         AbsoluteDescendants {
@@ -745,6 +739,12 @@ impl AbsoluteDescendants {
         for descendant_info in self.descendant_links.iter_mut() {
             descendant_info.has_reached_containing_block = true
         }
+    }
+}
+
+impl Default for AbsoluteDescendants {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -824,17 +824,17 @@ pub struct LateAbsolutePositionInfo {
     pub stacking_relative_position_of_absolute_containing_block: Point2D<Au>,
 }
 
-impl Default for LateAbsolutePositionInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl LateAbsolutePositionInfo {
     pub fn new() -> LateAbsolutePositionInfo {
         LateAbsolutePositionInfo {
             stacking_relative_position_of_absolute_containing_block: Point2D::zero(),
         }
+    }
+}
+
+impl Default for LateAbsolutePositionInfo {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -696,6 +696,12 @@ pub struct AbsoluteDescendants {
     descendant_links: Vec<AbsoluteDescendantInfo>,
 }
 
+impl Default for AbsoluteDescendants {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AbsoluteDescendants {
     pub fn new() -> AbsoluteDescendants {
         AbsoluteDescendants {
@@ -816,6 +822,12 @@ pub struct LateAbsolutePositionInfo {
     /// context. If the absolute containing block establishes the stacking context for this flow,
     /// and this flow is not itself absolutely-positioned, then this is (0, 0).
     pub stacking_relative_position_of_absolute_containing_block: Point2D<Au>,
+}
+
+impl Default for LateAbsolutePositionInfo {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LateAbsolutePositionInfo {
@@ -944,7 +956,7 @@ impl fmt::Debug for BaseFlow {
             "".to_owned()
         };
 
-        let absolute_descendants_string = if self.abs_descendants.len() > 0 {
+        let absolute_descendants_string = if !self.abs_descendants.is_empty() {
             format!("\nabs-descendents={}", self.abs_descendants.len())
         } else {
             "".to_owned()
@@ -1144,7 +1156,7 @@ impl BaseFlow {
     /// Return a new BaseFlow like this one but with the given children list
     pub fn clone_with_children(&self, children: FlowList) -> BaseFlow {
         BaseFlow {
-            children: children,
+            children,
             restyle_damage: self.restyle_damage |
                 ServoRestyleDamage::REPAINT |
                 ServoRestyleDamage::REFLOW_OUT_OF_FLOW |
@@ -1153,7 +1165,7 @@ impl BaseFlow {
             floats: self.floats.clone(),
             abs_descendants: self.abs_descendants.clone(),
             absolute_cb: self.absolute_cb.clone(),
-            clip: self.clip.clone(),
+            clip: self.clip,
 
             ..*self
         }

--- a/components/layout/flow_list.rs
+++ b/components/layout/flow_list.rs
@@ -63,12 +63,6 @@ pub struct FlowListIterator<'a> {
     it: linked_list::Iter<'a, FlowRef>,
 }
 
-impl Default for FlowList {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl FlowList {
     /// Add an element last in the list
     ///
@@ -144,6 +138,12 @@ impl FlowList {
         FlowList {
             flows: self.flows.split_off(i),
         }
+    }
+}
+
+impl Default for FlowList {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/flow_list.rs
+++ b/components/layout/flow_list.rs
@@ -63,6 +63,12 @@ pub struct FlowListIterator<'a> {
     it: linked_list::Iter<'a, FlowRef>,
 }
 
+impl Default for FlowList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlowList {
     /// Add an element last in the list
     ///
@@ -96,7 +102,7 @@ impl FlowList {
     /// SECURITY-NOTE(pcwalton): This does not hand out `FlowRef`s by design. Do not add a method
     /// to do so! See the comment above in `FlowList`.
     #[inline]
-    pub fn iter<'a>(&'a self) -> FlowListIterator {
+    pub fn iter(&self) -> FlowListIterator {
         FlowListIterator {
             it: self.flows.iter(),
         }
@@ -187,7 +193,7 @@ pub struct FlowListRandomAccessMut<'a> {
 }
 
 impl<'a> FlowListRandomAccessMut<'a> {
-    pub fn get<'b>(&'b mut self, index: usize) -> &'b mut dyn Flow {
+    pub fn get(&mut self, index: usize) -> &mut dyn Flow {
         while index >= self.cache.len() {
             match self.iterator.next() {
                 None => panic!("Flow index out of range!"),

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -470,10 +470,7 @@ impl ImageFragmentInfo {
                         width,
                         ..(*i).clone()
                     })),
-                    Some(ImageMetadata {
-                        height,
-                        width,
-                    }),
+                    Some(ImageMetadata { height, width }),
                 )
             },
             Some(ImageOrMetadata::Metadata(m)) => (
@@ -486,10 +483,7 @@ impl ImageFragmentInfo {
             None => (None, None),
         };
 
-        ImageFragmentInfo {
-            image,
-            metadata,
-        }
+        ImageFragmentInfo { image, metadata }
     }
 }
 
@@ -604,10 +598,7 @@ pub struct SplitInfo {
 impl SplitInfo {
     fn new(range: Range<ByteIndex>, info: &ScannedTextFragmentInfo) -> SplitInfo {
         let inline_size = info.run.advance_for_range(&range);
-        SplitInfo {
-            range,
-            inline_size,
-        }
+        SplitInfo { range, inline_size }
     }
 }
 
@@ -644,10 +635,7 @@ impl UnscannedTextFragmentInfo {
     /// Creates a new instance of `UnscannedTextFragmentInfo` from the given text.
     #[inline]
     pub fn new(text: Box<str>, selection: Option<Range<ByteIndex>>) -> UnscannedTextFragmentInfo {
-        UnscannedTextFragmentInfo {
-            text,
-            selection,
-        }
+        UnscannedTextFragmentInfo { text, selection }
     }
 }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -314,7 +314,7 @@ pub struct InlineAbsoluteHypotheticalFragmentInfo {
 
 impl InlineAbsoluteHypotheticalFragmentInfo {
     pub fn new(flow_ref: FlowRef) -> InlineAbsoluteHypotheticalFragmentInfo {
-        InlineAbsoluteHypotheticalFragmentInfo { flow_ref: flow_ref }
+        InlineAbsoluteHypotheticalFragmentInfo { flow_ref }
     }
 }
 
@@ -329,7 +329,7 @@ pub struct InlineBlockFragmentInfo {
 
 impl InlineBlockFragmentInfo {
     pub fn new(flow_ref: FlowRef) -> InlineBlockFragmentInfo {
-        InlineBlockFragmentInfo { flow_ref: flow_ref }
+        InlineBlockFragmentInfo { flow_ref }
     }
 }
 
@@ -345,7 +345,7 @@ pub struct InlineAbsoluteFragmentInfo {
 
 impl InlineAbsoluteFragmentInfo {
     pub fn new(flow_ref: FlowRef) -> InlineAbsoluteFragmentInfo {
-        InlineAbsoluteFragmentInfo { flow_ref: flow_ref }
+        InlineAbsoluteFragmentInfo { flow_ref }
     }
 }
 
@@ -375,7 +375,7 @@ impl CanvasFragmentInfo {
         };
 
         CanvasFragmentInfo {
-            source: source,
+            source,
             dom_width: Au::from_px(data.width as i32),
             dom_height: Au::from_px(data.height as i32),
             canvas_id: data.canvas_id,
@@ -466,13 +466,13 @@ impl ImageFragmentInfo {
                 let width = (i.width as f64 / current_pixel_density) as u32;
                 (
                     Some(Arc::new(Image {
-                        height: height,
-                        width: width,
+                        height,
+                        width,
                         ..(*i).clone()
                     })),
                     Some(ImageMetadata {
-                        height: height,
-                        width: width,
+                        height,
+                        width,
                     }),
                 )
             },
@@ -487,8 +487,8 @@ impl ImageFragmentInfo {
         };
 
         ImageFragmentInfo {
-            image: image,
-            metadata: metadata,
+            image,
+            metadata,
         }
     }
 }
@@ -509,8 +509,8 @@ impl IframeFragmentInfo {
         let browsing_context_id = node.iframe_browsing_context_id();
         let pipeline_id = node.iframe_pipeline_id();
         IframeFragmentInfo {
-            browsing_context_id: browsing_context_id,
-            pipeline_id: pipeline_id,
+            browsing_context_id,
+            pipeline_id,
         }
     }
 }
@@ -568,12 +568,12 @@ impl ScannedTextFragmentInfo {
         flags: ScannedTextFlags,
     ) -> ScannedTextFragmentInfo {
         ScannedTextFragmentInfo {
-            run: run,
-            range: range,
-            insertion_point: insertion_point,
-            content_size: content_size,
+            run,
+            range,
+            insertion_point,
+            content_size,
             range_end_including_stripped_whitespace: range.end(),
-            flags: flags,
+            flags,
         }
     }
 
@@ -605,8 +605,8 @@ impl SplitInfo {
     fn new(range: Range<ByteIndex>, info: &ScannedTextFragmentInfo) -> SplitInfo {
         let inline_size = info.run.advance_for_range(&range);
         SplitInfo {
-            range: range,
-            inline_size: inline_size,
+            range,
+            inline_size,
         }
     }
 }
@@ -645,8 +645,8 @@ impl UnscannedTextFragmentInfo {
     #[inline]
     pub fn new(text: Box<str>, selection: Option<Range<ByteIndex>>) -> UnscannedTextFragmentInfo {
         UnscannedTextFragmentInfo {
-            text: text,
-            selection: selection,
+            text,
+            selection,
         }
     }
 }
@@ -666,7 +666,7 @@ impl TableColumnFragmentInfo {
             .get_attr(&ns!(), &local_name!("span"))
             .and_then(|string| string.parse().ok())
             .unwrap_or(0);
-        TableColumnFragmentInfo { span: span }
+        TableColumnFragmentInfo { span }
     }
 }
 
@@ -734,16 +734,16 @@ impl Fragment {
         restyle_damage.remove(ServoRestyleDamage::RECONSTRUCT_FLOW);
 
         Fragment {
-            node: node,
-            style: style,
-            selected_style: selected_style,
-            restyle_damage: restyle_damage,
+            node,
+            style,
+            selected_style,
+            restyle_damage,
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
-            specific: specific,
+            specific,
             inline_context: None,
-            pseudo: pseudo,
+            pseudo,
             flags: FragmentFlags::empty(),
             debug_id: DebugId::new(),
             stacking_context_id: StackingContextId::root(),
@@ -762,13 +762,13 @@ impl Fragment {
         let writing_mode = style.writing_mode;
         Fragment {
             node: self.node,
-            style: style,
+            style,
             selected_style: self.selected_style.clone(),
             restyle_damage: self.restyle_damage,
             border_box: LogicalRect::zero(writing_mode),
             border_padding: LogicalMargin::zero(writing_mode),
             margin: LogicalMargin::zero(writing_mode),
-            specific: specific,
+            specific,
             inline_context: None,
             pseudo: self.pseudo,
             flags: FragmentFlags::empty(),
@@ -791,13 +791,13 @@ impl Fragment {
             node: self.node,
             style: self.style.clone(),
             selected_style: self.selected_style.clone(),
-            restyle_damage: restyle_damage,
+            restyle_damage,
             border_box: new_border_box,
             border_padding: self.border_padding,
             margin: self.margin,
             specific: info,
             inline_context: self.inline_context.clone(),
-            pseudo: self.pseudo.clone(),
+            pseudo: self.pseudo,
             flags: FragmentFlags::empty(),
             debug_id: self.debug_id.clone(),
             stacking_context_id: StackingContextId::root(),
@@ -1055,7 +1055,7 @@ impl Fragment {
             },
             SpecificFragmentInfo::Media(ref info) => {
                 if let Some((_, width, _)) = info.current_frame {
-                    Au::from_px(width as i32)
+                    Au::from_px(width)
                 } else {
                     Au(0)
                 }
@@ -1085,7 +1085,7 @@ impl Fragment {
             },
             SpecificFragmentInfo::Media(ref info) => {
                 if let Some((_, _, height)) = info.current_frame {
-                    Au::from_px(height as i32)
+                    Au::from_px(height)
                 } else {
                     Au(0)
                 }
@@ -1459,7 +1459,7 @@ impl Fragment {
             (&SpecificFragmentInfo::TableWrapper, _) => {
                 LogicalMargin::zero(self.style.writing_mode)
             },
-            (_, &Some(ref inline_fragment_context)) => {
+            (_, Some(inline_fragment_context)) => {
                 let writing_mode = self.style.writing_mode;
                 let zero_padding = LogicalMargin::zero(writing_mode);
                 inline_fragment_context
@@ -1467,7 +1467,7 @@ impl Fragment {
                     .iter()
                     .fold(zero_padding, |accumulator, node| {
                         let mut padding =
-                            model::padding_from_style(&*node.style, Au(0), writing_mode);
+                            model::padding_from_style(&node.style, Au(0), writing_mode);
                         if !node
                             .flags
                             .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT)
@@ -1519,7 +1519,7 @@ impl Fragment {
                 if node.style.get_box().position == Position::Relative {
                     // TODO(servo#30577) revert once underlying bug is fixed
                     // rel_pos = rel_pos + from_style(&*node.style, containing_block_size);
-                    rel_pos = rel_pos.add_or_warn(from_style(&*node.style, containing_block_size));
+                    rel_pos = rel_pos.add_or_warn(from_style(&node.style, containing_block_size));
                 }
             }
         }
@@ -1543,12 +1543,12 @@ impl Fragment {
 
     #[inline(always)]
     pub fn style(&self) -> &ComputedValues {
-        &*self.style
+        &self.style
     }
 
     #[inline(always)]
     pub fn selected_style(&self) -> &ComputedValues {
-        &*self.selected_style
+        &self.selected_style
     }
 
     pub fn white_space(&self) -> WhiteSpace {
@@ -1736,8 +1736,8 @@ impl Fragment {
         if let Some(ref context) = self.inline_context {
             for node in &context.nodes {
                 let mut border_width = node.style.logical_border_width();
-                let mut padding = model::padding_from_style(&*node.style, Au(0), writing_mode);
-                let mut margin = model::specified_margin_from_style(&*node.style, writing_mode);
+                let mut padding = model::padding_from_style(&node.style, Au(0), writing_mode);
+                let mut margin = model::specified_margin_from_style(&node.style, writing_mode);
                 if !node
                     .flags
                     .contains(InlineFragmentNodeFlags::FIRST_FRAGMENT_OF_ELEMENT)
@@ -1895,7 +1895,7 @@ impl Fragment {
         let mut result = self.transform(size, SpecificFragmentInfo::Generic);
         result.specific =
             SpecificFragmentInfo::TruncatedFragment(Box::new(TruncatedFragmentInfo {
-                text_info: text_info,
+                text_info,
                 full: self,
             }));
         result
@@ -1923,7 +1923,7 @@ impl Fragment {
 
         let split = split_info.inline_start?;
         Some(TruncationResult {
-            split: split,
+            split,
             text_run: split_info.text_run.clone(),
         })
     }
@@ -1975,7 +1975,7 @@ impl Fragment {
             if advance <= remaining_inline_size || slice.glyphs.is_whitespace() {
                 // Keep going; we haven't found the split point yet.
                 debug!("calculate_split_position_using_breaking_strategy: enlarging span");
-                remaining_inline_size = remaining_inline_size - advance;
+                remaining_inline_size -= advance;
                 inline_start_range.extend_by(slice.range.length());
                 continue;
             }
@@ -2039,16 +2039,16 @@ impl Fragment {
         let split_is_empty = inline_start_range.is_empty() &&
             !self.requires_line_break_afterward_if_wrapping_on_newlines();
         let inline_start = if !split_is_empty {
-            Some(SplitInfo::new(inline_start_range, &**text_fragment_info))
+            Some(SplitInfo::new(inline_start_range, text_fragment_info))
         } else {
             None
         };
         let inline_end = inline_end_range
-            .map(|inline_end_range| SplitInfo::new(inline_end_range, &**text_fragment_info));
+            .map(|inline_end_range| SplitInfo::new(inline_end_range, text_fragment_info));
 
         Some(SplitResult {
-            inline_start: inline_start,
-            inline_end: inline_end,
+            inline_start,
+            inline_end,
             text_run: text_fragment_info.run.clone(),
         })
     }
@@ -2059,7 +2059,7 @@ impl Fragment {
         match (&mut self.specific, &next_fragment.specific) {
             (
                 &mut SpecificFragmentInfo::ScannedText(ref mut this_info),
-                &SpecificFragmentInfo::ScannedText(ref other_info),
+                SpecificFragmentInfo::ScannedText(other_info),
             ) => {
                 debug_assert!(Arc::ptr_eq(&this_info.run, &other_info.run));
                 this_info.range_end_including_stripped_whitespace =
@@ -2188,7 +2188,7 @@ impl Fragment {
                 self.border_box.size.block = block_size + self.border_padding.block_start_end();
             },
 
-            ref unhandled @ _ => {
+            ref unhandled => {
                 panic!("this case should have been handled above: {:?}", unhandled)
             },
         }
@@ -2265,7 +2265,7 @@ impl Fragment {
             // Replaced elements
             _ if self.is_replaced() => {},
 
-            ref unhandled @ _ => panic!("should have been handled above: {:?}", unhandled),
+            ref unhandled => panic!("should have been handled above: {:?}", unhandled),
         }
     }
 
@@ -2315,7 +2315,7 @@ impl Fragment {
                 InlineMetrics {
                     space_above_baseline: ascent + self.margin.block_start,
                     space_below_baseline: Au(0),
-                    ascent: ascent,
+                    ascent,
                 }
             },
             SpecificFragmentInfo::TruncatedFragment(ref t) if t.text_info.is_some() => {
@@ -2326,10 +2326,10 @@ impl Fragment {
                 inline_metrics_of_text(info, self, layout_context)
             },
             SpecificFragmentInfo::InlineBlock(ref info) => {
-                inline_metrics_of_block(&info.flow_ref, &*self.style)
+                inline_metrics_of_block(&info.flow_ref, &self.style)
             },
             SpecificFragmentInfo::InlineAbsoluteHypothetical(ref info) => {
-                inline_metrics_of_block(&info.flow_ref, &*self.style)
+                inline_metrics_of_block(&info.flow_ref, &self.style)
             },
             SpecificFragmentInfo::TruncatedFragment(..) |
             SpecificFragmentInfo::InlineAbsolute(_) => InlineMetrics::new(Au(0), Au(0), Au(0)),
@@ -2360,7 +2360,7 @@ impl Fragment {
             let font_metrics = with_thread_local_font_context(layout_context, |font_context| {
                 text::font_metrics_for_style(font_context, self_.style.clone_font())
             });
-            let line_height = text::line_height_from_style(&*self_.style, &font_metrics);
+            let line_height = text::line_height_from_style(&self_.style, &font_metrics);
             InlineMetrics::from_font_metrics(&info.run.font_metrics, line_height)
         }
 
@@ -2510,7 +2510,7 @@ impl Fragment {
             None => content_inline_metrics.space_above_baseline,
             Some(actual_line_metrics) => actual_line_metrics.space_above_baseline,
         };
-        space_above_baseline = space_above_baseline - vertical_alignment_offset;
+        space_above_baseline -= vertical_alignment_offset;
         let space_below_baseline =
             content_inline_metrics.space_below_baseline + vertical_alignment_offset;
         let ascent = content_inline_metrics.ascent - vertical_alignment_offset;
@@ -2530,7 +2530,7 @@ impl Fragment {
     pub fn can_merge_with_fragment(&self, other: &Fragment) -> bool {
         match (&self.specific, &other.specific) {
             (
-                &SpecificFragmentInfo::UnscannedText(ref first_unscanned_text),
+                SpecificFragmentInfo::UnscannedText(first_unscanned_text),
                 &SpecificFragmentInfo::UnscannedText(_),
             ) => {
                 // FIXME: Should probably use a whitelist of styles that can safely differ (#3165)
@@ -2870,7 +2870,7 @@ impl Fragment {
         }
 
         // Outlines cause us to draw outside our border box.
-        let outline_width = Au::from(self.style.get_outline().outline_width);
+        let outline_width = self.style.get_outline().outline_width;
         if outline_width != Au(0) {
             overflow.paint = overflow
                 .paint
@@ -2944,7 +2944,7 @@ impl Fragment {
                 }
 
                 WhitespaceStrippingResult::from_unscanned_text_fragment_info(
-                    &unscanned_text_fragment_info,
+                    unscanned_text_fragment_info,
                 )
             },
             _ => WhitespaceStrippingResult::RetainFragment,
@@ -2966,9 +2966,8 @@ impl Fragment {
                 .run
                 .metrics_for_range(&whitespace_range)
                 .bounding_box;
-            border_box.size.inline = border_box.size.inline - text_bounds.size.width;
-            scanned_text_fragment_info.content_size.inline =
-                scanned_text_fragment_info.content_size.inline - text_bounds.size.width;
+            border_box.size.inline -= text_bounds.size.width;
+            scanned_text_fragment_info.content_size.inline -= text_bounds.size.width;
 
             scanned_text_fragment_info
                 .range
@@ -3017,7 +3016,7 @@ impl Fragment {
                 }
 
                 WhitespaceStrippingResult::from_unscanned_text_fragment_info(
-                    &unscanned_text_fragment_info,
+                    unscanned_text_fragment_info,
                 )
             },
             _ => WhitespaceStrippingResult::RetainFragment,
@@ -3396,7 +3395,7 @@ impl<'a> Iterator for InlineStyleIterator<'a> {
 impl<'a> InlineStyleIterator<'a> {
     fn new(fragment: &Fragment) -> InlineStyleIterator {
         InlineStyleIterator {
-            fragment: fragment,
+            fragment,
             inline_style_index: 0,
             primary_style_yielded: false,
         }
@@ -3430,6 +3429,12 @@ impl WhitespaceStrippingResult {
 pub struct Overflow {
     pub scroll: Rect<Au>,
     pub paint: Rect<Au>,
+}
+
+impl Default for Overflow {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Overflow {

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3419,12 +3419,6 @@ pub struct Overflow {
     pub paint: Rect<Au>,
 }
 
-impl Default for Overflow {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Overflow {
     pub fn new() -> Overflow {
         Overflow {
@@ -3448,6 +3442,12 @@ impl Overflow {
     pub fn translate(&mut self, by: &Vector2D<Au>) {
         self.scroll = self.scroll.translate(*by);
         self.paint = self.paint.translate(*by);
+    }
+}
+
+impl Default for Overflow {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -385,10 +385,7 @@ impl Counter {
         }
 
         // Otherwise, push a new instance of the counter.
-        self.values.push(CounterValue {
-            level,
-            value,
-        })
+        self.values.push(CounterValue { level, value })
     }
 
     fn truncate_to_level(&mut self, level: u32) {

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -125,7 +125,7 @@ impl<'a> ResolveGeneratedContent<'a> {
     /// Creates a new generated content resolution traversal.
     pub fn new(layout_context: &'a LayoutContext) -> ResolveGeneratedContent<'a> {
         ResolveGeneratedContent {
-            layout_context: layout_context,
+            layout_context,
             list_item: Counter::new(),
             counters: HashMap::new(),
             quote: 0,
@@ -138,7 +138,7 @@ impl<'a> InorderFlowTraversal for ResolveGeneratedContent<'a> {
     fn process(&mut self, flow: &mut dyn Flow, level: u32) {
         let mut mutator = ResolveGeneratedContentFragmentMutator {
             traversal: self,
-            level: level,
+            level,
             is_block: flow.is_block_like(),
             incremented: false,
         };
@@ -195,7 +195,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
                     new_info = self.traversal.list_item.render(
                         self.traversal.layout_context,
                         fragment.node,
-                        fragment.pseudo.clone(),
+                        fragment.pseudo,
                         fragment.style.clone(),
                         list_style_type,
                         RenderingMode::Suffix(".\u{00a0}"),
@@ -214,7 +214,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
                     new_info = counter.render(
                         self.traversal.layout_context,
                         fragment.node,
-                        fragment.pseudo.clone(),
+                        fragment.pseudo,
                         fragment.style.clone(),
                         counter_style,
                         RenderingMode::Plain,
@@ -237,7 +237,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
                         fragment.pseudo,
                         fragment.style.clone(),
                         counter_style,
-                        RenderingMode::All(&separator),
+                        RenderingMode::All(separator),
                     );
                 },
                 GeneratedContentInfo::ContentItem(ContentItem::OpenQuote) => {
@@ -246,7 +246,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
                         fragment.node,
                         fragment.pseudo,
                         fragment.style.clone(),
-                        self.quote(&*fragment.style, false),
+                        self.quote(&fragment.style, false),
                     );
                     self.traversal.quote += 1
                 },
@@ -260,7 +260,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
                         fragment.node,
                         fragment.pseudo,
                         fragment.style.clone(),
-                        self.quote(&*fragment.style, true),
+                        self.quote(&fragment.style, true),
                     );
                 },
                 GeneratedContentInfo::ContentItem(ContentItem::NoOpenQuote) => {
@@ -386,8 +386,8 @@ impl Counter {
 
         // Otherwise, push a new instance of the counter.
         self.values.push(CounterValue {
-            level: level,
-            value: value,
+            level,
+            value,
         })
     }
 
@@ -404,7 +404,7 @@ impl Counter {
         }
 
         self.values.push(CounterValue {
-            level: level,
+            level,
             value: amount,
         })
     }
@@ -422,14 +422,14 @@ impl Counter {
         match mode {
             RenderingMode::Plain => {
                 let value = match self.values.last() {
-                    Some(ref value) => value.value,
+                    Some(value) => value.value,
                     None => 0,
                 };
                 push_representation(value, list_style_type, &mut string)
             },
             RenderingMode::Suffix(suffix) => {
                 let value = match self.values.last() {
-                    Some(ref value) => value.value,
+                    Some(value) => value.value,
                     None => 0,
                 };
                 push_representation(value, list_style_type, &mut string);
@@ -585,11 +585,11 @@ fn push_alphabetic_representation(value: i32, system: &[char], accumulator: &mut
     let mut string: SmallVec<[char; 8]> = SmallVec::new();
     while abs_value != 0 {
         // Step 1.
-        abs_value = abs_value - 1;
+        abs_value -= 1;
         // Step 2.
         string.push(system[abs_value % system.len()]);
         // Step 3.
-        abs_value = abs_value / system.len();
+        abs_value /= system.len();
     }
 
     accumulator.extend(string.iter().cloned().rev())
@@ -612,7 +612,7 @@ fn push_numeric_representation(value: i32, system: &[char], accumulator: &mut St
         // Step 2.1.
         string.push(system[abs_value % system.len()]);
         // Step 2.2.
-        abs_value = abs_value / system.len();
+        abs_value /= system.len();
     }
 
     // Step 3.
@@ -629,7 +629,7 @@ fn handle_negative_value(value: i32, accumulator: &mut String) -> usize {
         // TODO: Support different negative signs using the 'negative' descriptor.
         // https://drafts.csswg.org/date/2015-07-16/css-counter-styles/#counter-style-negative
         accumulator.push('-');
-        value.abs() as usize
+        value.unsigned_abs() as usize
     } else {
         value as usize
     }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -269,7 +269,7 @@ impl LineBreaker {
             lines: Vec::new(),
             cur_b: Au(0),
             last_known_line_breaking_opportunity: None,
-            first_line_indentation: first_line_indentation,
+            first_line_indentation,
             minimum_metrics: *minimum_line_metrics,
         }
     }
@@ -327,7 +327,7 @@ impl LineBreaker {
             })
             .collect();
 
-        let mut lines = mem::replace(&mut self.lines, Vec::new());
+        let mut lines = std::mem::take(&mut self.lines);
 
         // If everything is LTR, don't bother with reordering.
         if bidi::level::has_rtl(&levels) {
@@ -352,16 +352,16 @@ impl LineBreaker {
         }
 
         // Place the fragments back into the flow.
-        old_fragments.fragments = mem::replace(&mut self.new_fragments, vec![]);
+        old_fragments.fragments = std::mem::take(&mut self.new_fragments);
         flow.fragments = old_fragments;
         flow.lines = lines;
     }
 
     /// Reflows the given fragments, which have been plucked out of the inline flow.
-    fn reflow_fragments<'a, I>(
+    fn reflow_fragments<I>(
         &mut self,
         mut old_fragment_iter: I,
-        flow: &'a InlineFlow,
+        flow: &InlineFlow,
         layout_context: &LayoutContext,
     ) where
         I: Iterator<Item = Fragment>,
@@ -428,7 +428,7 @@ impl LineBreaker {
             let need_to_merge = match (&mut result.specific, &candidate.specific) {
                 (
                     &mut SpecificFragmentInfo::ScannedText(ref mut result_info),
-                    &SpecificFragmentInfo::ScannedText(ref candidate_info),
+                    SpecificFragmentInfo::ScannedText(candidate_info),
                 ) => {
                     result.margin.inline_end == Au(0) &&
                         candidate.margin.inline_start == Au(0) &&
@@ -516,7 +516,7 @@ impl LineBreaker {
                 placement_inline_size,
                 first_fragment.border_box.size.block,
             ),
-            ceiling: ceiling,
+            ceiling,
             max_inline_size: flow.base.position.size.inline,
             kind: FloatKind::Left,
         });
@@ -809,7 +809,7 @@ impl LineBreaker {
                     None
                 }
             },
-            (&TextOverflowSide::String(ref string), _) => {
+            (TextOverflowSide::String(string), _) => {
                 if fragment.margin_box_inline_size() > available_inline_size {
                     Some(string.to_string())
                 } else {
@@ -924,6 +924,12 @@ pub struct InlineFragments {
     pub fragments: Vec<Fragment>,
 }
 
+impl Default for InlineFragments {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InlineFragments {
     /// Creates an empty set of inline fragments.
     pub fn new() -> InlineFragments {
@@ -983,7 +989,7 @@ impl InlineFlow {
     pub fn from_fragments(fragments: InlineFragments, writing_mode: WritingMode) -> InlineFlow {
         let mut flow = InlineFlow {
             base: BaseFlow::new(None, writing_mode, ForceNonfloatedFlag::ForceNonfloated),
-            fragments: fragments,
+            fragments,
             lines: Vec::new(),
             minimum_line_metrics: LineMetrics::new(Au(0), Au(0)),
             first_line_indentation: Au(0),
@@ -1047,12 +1053,10 @@ impl InlineFlow {
             },
             TextAlign::Justify | TextAlign::Start => {},
             TextAlign::Center | TextAlign::ServoCenter => {
-                inline_start_position_for_fragment =
-                    inline_start_position_for_fragment + slack_inline_size.scale_by(0.5)
+                inline_start_position_for_fragment += slack_inline_size.scale_by(0.5)
             },
             TextAlign::End => {
-                inline_start_position_for_fragment =
-                    inline_start_position_for_fragment + slack_inline_size
+                inline_start_position_for_fragment += slack_inline_size
             },
             TextAlign::Left | TextAlign::ServoLeft | TextAlign::Right | TextAlign::ServoRight => {
                 unreachable!()
@@ -1101,8 +1105,7 @@ impl InlineFlow {
 
             for fragment_index in fragment_indices {
                 let fragment = fragments.get_mut(fragment_index as usize);
-                inline_start_position_for_fragment =
-                    inline_start_position_for_fragment + fragment.margin.inline_start;
+                inline_start_position_for_fragment += fragment.margin.inline_start;
 
                 let border_start = if fragment.style.writing_mode.is_bidi_ltr() == is_ltr {
                     inline_start_position_for_fragment
@@ -1295,7 +1298,7 @@ impl InlineFlow {
             for node in &inline_context.nodes {
                 let font_style = node.style.clone_font();
                 let font_metrics = text::font_metrics_for_style(font_context, font_style);
-                let line_height = text::line_height_from_style(&*node.style, &font_metrics);
+                let line_height = text::line_height_from_style(&node.style, &font_metrics);
                 let inline_metrics = InlineMetrics::from_font_metrics(&font_metrics, line_height);
 
                 update_line_metrics_for_fragment(
@@ -1435,14 +1438,8 @@ impl InlineFlow {
 
     // Returns the last line that doesn't consist entirely of hypothetical boxes.
     fn last_line_containing_real_fragments(&self) -> Option<&Line> {
-        for line in self.lines.iter().rev() {
-            if (line.range.begin().get()..line.range.end().get())
-                .any(|index| !self.fragments.fragments[index as usize].is_hypothetical())
-            {
-                return Some(line);
-            }
-        }
-        None
+        self.lines.iter().rev().find(|&line| (line.range.begin().get()..line.range.end().get())
+                .any(|index| !self.fragments.fragments[index as usize].is_hypothetical()))
     }
 
     fn build_display_list_for_inline_fragment_at_index(
@@ -1825,7 +1822,7 @@ impl Flow for InlineFlow {
 
                     // Write the clip in our coordinate system into the child flow. (The kid will
                     // fix it up to be in its own coordinate system if necessary.)
-                    block_flow.base.clip = self.base.clip.clone()
+                    block_flow.base.clip = self.base.clip
                 },
                 SpecificFragmentInfo::InlineAbsoluteHypothetical(ref mut info) => {
                     let flow = FlowRef::deref_mut(&mut info.flow_ref);
@@ -1837,7 +1834,7 @@ impl Flow for InlineFlow {
                         stacking_relative_border_box.origin.to_vector();
 
                     // As above, this is in our coordinate system for now.
-                    block_flow.base.clip = self.base.clip.clone()
+                    block_flow.base.clip = self.base.clip
                 },
                 SpecificFragmentInfo::InlineAbsolute(ref mut info) => {
                     let flow = FlowRef::deref_mut(&mut info.flow_ref);
@@ -1857,7 +1854,7 @@ impl Flow for InlineFlow {
                         stacking_relative_border_box.origin.to_vector();
 
                     // As above, this is in our coordinate system for now.
-                    block_flow.base.clip = self.base.clip.clone()
+                    block_flow.base.clip = self.base.clip
                 },
                 _ => {},
             }
@@ -1957,7 +1954,7 @@ impl Flow for InlineFlow {
             .early_absolute_position_info
             .relative_containing_block_size;
         for fragment in &self.fragments.fragments {
-            overflow.union(&fragment.compute_overflow(&flow_size, &relative_containing_block_size))
+            overflow.union(&fragment.compute_overflow(&flow_size, relative_containing_block_size))
         }
         overflow
     }
@@ -2025,8 +2022,7 @@ impl Flow for InlineFlow {
             if fragment.is_absolutely_positioned() {
                 continue;
             }
-            containing_block_size.inline =
-                containing_block_size.inline + fragment.border_box.size.inline;
+            containing_block_size.inline += fragment.border_box.size.inline;
             containing_block_size.block =
                 max(containing_block_size.block, fragment.border_box.size.block);
         }
@@ -2082,6 +2078,12 @@ pub struct InlineFragmentContext {
     pub nodes: Vec<InlineFragmentNodeInfo>,
 }
 
+impl Default for InlineFragmentContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InlineFragmentContext {
     pub fn new() -> InlineFragmentContext {
         InlineFragmentContext { nodes: vec![] }
@@ -2091,8 +2093,7 @@ impl InlineFragmentContext {
     pub fn contains_node(&self, node_address: OpaqueNode) -> bool {
         self.nodes
             .iter()
-            .position(|node| node.address == node_address)
-            .is_some()
+            .any(|node| node.address == node_address)
     }
 
     fn ptr_eq(&self, other: &InlineFragmentContext) -> bool {
@@ -2113,7 +2114,7 @@ fn inline_contexts_are_equal(
     inline_context_b: &Option<InlineFragmentContext>,
 ) -> bool {
     match (inline_context_a, inline_context_b) {
-        (&Some(ref inline_context_a), &Some(ref inline_context_b)) => {
+        (Some(inline_context_a), Some(inline_context_b)) => {
             inline_context_a.ptr_eq(inline_context_b)
         },
         (&None, &None) => true,
@@ -2141,9 +2142,9 @@ impl InlineMetrics {
     /// Creates a new set of inline metrics.
     pub fn new(space_above_baseline: Au, space_below_baseline: Au, ascent: Au) -> InlineMetrics {
         InlineMetrics {
-            space_above_baseline: space_above_baseline,
-            space_below_baseline: space_below_baseline,
-            ascent: ascent,
+            space_above_baseline,
+            space_below_baseline,
+            ascent,
         }
     }
 
@@ -2185,8 +2186,8 @@ pub struct LineMetrics {
 impl LineMetrics {
     pub fn new(space_above_baseline: Au, space_below_baseline: Au) -> LineMetrics {
         LineMetrics {
-            space_above_baseline: space_above_baseline,
-            space_below_baseline: space_below_baseline,
+            space_above_baseline,
+            space_below_baseline,
         }
     }
 
@@ -2213,7 +2214,7 @@ impl LineMetrics {
         if !fragment.is_hypothetical() {
             let space_above_baseline = line.metrics.space_above_baseline;
             return LineMetrics {
-                space_above_baseline: space_above_baseline,
+                space_above_baseline,
                 space_below_baseline: line.bounds.size.block - space_above_baseline,
             };
         }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1055,9 +1055,7 @@ impl InlineFlow {
             TextAlign::Center | TextAlign::ServoCenter => {
                 inline_start_position_for_fragment += slack_inline_size.scale_by(0.5)
             },
-            TextAlign::End => {
-                inline_start_position_for_fragment += slack_inline_size
-            },
+            TextAlign::End => inline_start_position_for_fragment += slack_inline_size,
             TextAlign::Left | TextAlign::ServoLeft | TextAlign::Right | TextAlign::ServoRight => {
                 unreachable!()
             },
@@ -1438,8 +1436,10 @@ impl InlineFlow {
 
     // Returns the last line that doesn't consist entirely of hypothetical boxes.
     fn last_line_containing_real_fragments(&self) -> Option<&Line> {
-        self.lines.iter().rev().find(|&line| (line.range.begin().get()..line.range.end().get())
-                .any(|index| !self.fragments.fragments[index as usize].is_hypothetical()))
+        self.lines.iter().rev().find(|&line| {
+            (line.range.begin().get()..line.range.end().get())
+                .any(|index| !self.fragments.fragments[index as usize].is_hypothetical())
+        })
     }
 
     fn build_display_list_for_inline_fragment_at_index(
@@ -2091,9 +2091,7 @@ impl InlineFragmentContext {
 
     #[inline]
     pub fn contains_node(&self, node_address: OpaqueNode) -> bool {
-        self.nodes
-            .iter()
-            .any(|node| node.address == node_address)
+        self.nodes.iter().any(|node| node.address == node_address)
     }
 
     fn ptr_eq(&self, other: &InlineFragmentContext) -> bool {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -327,7 +327,7 @@ impl LineBreaker {
             })
             .collect();
 
-        let mut lines = std::mem::take(&mut self.lines);
+        let mut lines = mem::take(&mut self.lines);
 
         // If everything is LTR, don't bother with reordering.
         if bidi::level::has_rtl(&levels) {
@@ -352,7 +352,7 @@ impl LineBreaker {
         }
 
         // Place the fragments back into the flow.
-        old_fragments.fragments = std::mem::take(&mut self.new_fragments);
+        old_fragments.fragments = mem::take(&mut self.new_fragments);
         flow.fragments = old_fragments;
         flow.lines = lines;
     }
@@ -924,12 +924,6 @@ pub struct InlineFragments {
     pub fragments: Vec<Fragment>,
 }
 
-impl Default for InlineFragments {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl InlineFragments {
     /// Creates an empty set of inline fragments.
     pub fn new() -> InlineFragments {
@@ -955,6 +949,12 @@ impl InlineFragments {
     /// A convenience function to return a mutable reference to the fragment at a given index.
     pub fn get_mut(&mut self, index: usize) -> &mut Fragment {
         &mut self.fragments[index]
+    }
+}
+
+impl Default for InlineFragments {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -2078,12 +2078,6 @@ pub struct InlineFragmentContext {
     pub nodes: Vec<InlineFragmentNodeInfo>,
 }
 
-impl Default for InlineFragmentContext {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl InlineFragmentContext {
     pub fn new() -> InlineFragmentContext {
         InlineFragmentContext { nodes: vec![] }
@@ -2104,6 +2098,12 @@ impl InlineFragmentContext {
             }
         }
         true
+    }
+}
+
+impl Default for InlineFragmentContext {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/list_item.rs
+++ b/components/layout/list_item.rs
@@ -49,10 +49,10 @@ impl ListItemFlow {
     ) -> ListItemFlow {
         let mut this = ListItemFlow {
             block_flow: BlockFlow::from_fragment_and_float_kind(main_fragment, flotation),
-            marker_fragments: marker_fragments,
+            marker_fragments,
         };
 
-        if let Some(ref marker) = this.marker_fragments.first() {
+        if let Some(marker) = this.marker_fragments.first() {
             match marker.style().get_list().list_style_type {
                 ListStyleType::Disc |
                 ListStyleType::None |
@@ -107,7 +107,7 @@ impl ListItemFlow {
             marker.border_box.size.inline = intrinsic_inline_sizes
                 .content_intrinsic_sizes
                 .preferred_inline_size;
-            marker_inline_start = marker_inline_start - marker.border_box.size.inline;
+            marker_inline_start -= marker.border_box.size.inline;
             marker.border_box.start.i = marker_inline_start;
         }
     }
@@ -118,7 +118,7 @@ impl ListItemFlow {
             InlineFlow::minimum_line_metrics_for_fragments(
                 &self.marker_fragments,
                 font_context,
-                &*self.block_flow.fragment.style,
+                &self.block_flow.fragment.style,
             )
         });
 
@@ -235,7 +235,7 @@ impl Flow for ListItemFlow {
             .relative_containing_block_size;
 
         for fragment in &self.marker_fragments {
-            overflow.union(&fragment.compute_overflow(&flow_size, &relative_containing_block_size))
+            overflow.union(&fragment.compute_overflow(&flow_size, relative_containing_block_size))
         }
         overflow
     }

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -27,12 +27,6 @@ pub struct AdjoiningMargins {
     pub most_negative: Au,
 }
 
-impl Default for AdjoiningMargins {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl AdjoiningMargins {
     pub fn new() -> AdjoiningMargins {
         AdjoiningMargins {
@@ -65,6 +59,12 @@ impl AdjoiningMargins {
     }
 }
 
+impl Default for AdjoiningMargins {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Represents the block-start and block-end margins of a flow with collapsible margins. See CSS 2.1 § 8.3.1.
 #[derive(Clone, Copy, Debug)]
 pub enum CollapsibleMargins {
@@ -78,12 +78,6 @@ pub enum CollapsibleMargins {
     /// Margins collapse *through* this flow. This means, essentially, that the flow doesn’t
     /// have any border, padding, or out-of-flow (floating or positioned) content
     CollapseThrough(AdjoiningMargins),
-}
-
-impl Default for CollapsibleMargins {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl CollapsibleMargins {
@@ -108,6 +102,12 @@ impl CollapsibleMargins {
             CollapsibleMargins::Collapse(_, ref block_end) |
             CollapsibleMargins::CollapseThrough(ref block_end) => block_end.collapse(),
         }
+    }
+}
+
+impl Default for CollapsibleMargins {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -360,18 +360,18 @@ impl fmt::Debug for IntrinsicISizes {
     }
 }
 
-impl Default for IntrinsicISizes {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl IntrinsicISizes {
     pub fn new() -> IntrinsicISizes {
         IntrinsicISizes {
             minimum_inline_size: Au(0),
             preferred_inline_size: Au(0),
         }
+    }
+}
+
+impl Default for IntrinsicISizes {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -382,12 +382,6 @@ pub struct IntrinsicISizesContribution {
     pub content_intrinsic_sizes: IntrinsicISizes,
     /// The inline size of borders and padding, as well as margins if appropriate.
     pub surrounding_size: Au,
-}
-
-impl Default for IntrinsicISizesContribution {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl IntrinsicISizesContribution {
@@ -448,6 +442,12 @@ impl IntrinsicISizesContribution {
             self.content_intrinsic_sizes.preferred_inline_size,
             sizes.preferred_inline_size,
         )
+    }
+}
+
+impl Default for IntrinsicISizesContribution {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -27,6 +27,12 @@ pub struct AdjoiningMargins {
     pub most_negative: Au,
 }
 
+impl Default for AdjoiningMargins {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AdjoiningMargins {
     pub fn new() -> AdjoiningMargins {
         AdjoiningMargins {
@@ -72,6 +78,12 @@ pub enum CollapsibleMargins {
     /// Margins collapse *through* this flow. This means, essentially, that the flow doesn’t
     /// have any border, padding, or out-of-flow (floating or positioned) content
     CollapseThrough(AdjoiningMargins),
+}
+
+impl Default for CollapsibleMargins {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CollapsibleMargins {
@@ -348,6 +360,12 @@ impl fmt::Debug for IntrinsicISizes {
     }
 }
 
+impl Default for IntrinsicISizes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IntrinsicISizes {
     pub fn new() -> IntrinsicISizes {
         IntrinsicISizes {
@@ -364,6 +382,12 @@ pub struct IntrinsicISizesContribution {
     pub content_intrinsic_sizes: IntrinsicISizes,
     /// The inline size of borders and padding, as well as margins if appropriate.
     pub surrounding_size: Au,
+}
+
+impl Default for IntrinsicISizesContribution {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl IntrinsicISizesContribution {
@@ -397,8 +421,7 @@ impl IntrinsicISizesContribution {
             self.content_intrinsic_sizes.minimum_inline_size,
             sizes.minimum_inline_size,
         );
-        self.content_intrinsic_sizes.preferred_inline_size =
-            self.content_intrinsic_sizes.preferred_inline_size + sizes.preferred_inline_size
+        self.content_intrinsic_sizes.preferred_inline_size += sizes.preferred_inline_size
     }
 
     /// Updates the computation so that the minimum is the sum of the current minimum and the
@@ -406,10 +429,8 @@ impl IntrinsicISizesContribution {
     /// preferred. This is used when laying out fragments in the inline direction when
     /// `white-space` is `pre` or `nowrap`.
     pub fn union_nonbreaking_inline(&mut self, sizes: &IntrinsicISizes) {
-        self.content_intrinsic_sizes.minimum_inline_size =
-            self.content_intrinsic_sizes.minimum_inline_size + sizes.minimum_inline_size;
-        self.content_intrinsic_sizes.preferred_inline_size =
-            self.content_intrinsic_sizes.preferred_inline_size + sizes.preferred_inline_size
+        self.content_intrinsic_sizes.minimum_inline_size += sizes.minimum_inline_size;
+        self.content_intrinsic_sizes.preferred_inline_size += sizes.preferred_inline_size
     }
 
     /// Updates the computation so that the minimum is the maximum of the current minimum and the

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -131,7 +131,7 @@ impl Flow for MulticolFlow {
                     (content_inline_size + column_gap).0 / (column_width + column_gap).0,
                 );
                 if let ColumnCount::Integer(specified_column_count) = column_style.column_count {
-                    column_count = min(column_count, specified_column_count.0 as i32);
+                    column_count = min(column_count, specified_column_count.0);
                 }
             } else {
                 column_count = match column_style.column_count {
@@ -216,7 +216,7 @@ impl Flow for MulticolFlow {
         let pitch = pitch.to_physical(self.block_flow.base.writing_mode);
         for (i, child) in self.block_flow.base.children.iter_mut().enumerate() {
             let point = &mut child.mut_base().stacking_relative_position;
-            *point = *point + Vector2D::new(pitch.width * i as i32, pitch.height * i as i32);
+            *point += Vector2D::new(pitch.width * i as i32, pitch.height * i as i32);
         }
     }
 

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -51,18 +51,18 @@ pub struct FlowParallelInfo {
     pub parent: UnsafeFlow,
 }
 
-impl Default for FlowParallelInfo {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl FlowParallelInfo {
     pub fn new() -> FlowParallelInfo {
         FlowParallelInfo {
             children_count: AtomicIsize::new(0),
             parent: null_unsafe_flow(),
         }
+    }
+}
+
+impl Default for FlowParallelInfo {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -51,6 +51,12 @@ pub struct FlowParallelInfo {
     pub parent: UnsafeFlow,
 }
 
+impl Default for FlowParallelInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlowParallelInfo {
     pub fn new() -> FlowParallelInfo {
         FlowParallelInfo {
@@ -145,7 +151,7 @@ fn top_down_flow<'scope>(
 
         // If there were no more children, start assigning block-sizes.
         if !had_children {
-            bottom_up_flow(*unsafe_flow, &assign_bsize_traversal)
+            bottom_up_flow(*unsafe_flow, assign_bsize_traversal)
         }
     }
 
@@ -159,8 +165,8 @@ fn top_down_flow<'scope>(
             &discovered_child_flows,
             pool,
             scope,
-            &assign_isize_traversal,
-            &assign_bsize_traversal,
+            assign_isize_traversal,
+            assign_bsize_traversal,
         );
     } else {
         // Spawn a new work unit for each chunk after the first.
@@ -173,8 +179,8 @@ fn top_down_flow<'scope>(
                     &nodes,
                     pool,
                     scope,
-                    &assign_isize_traversal,
-                    &assign_bsize_traversal,
+                    assign_isize_traversal,
+                    assign_bsize_traversal,
                 );
             });
         }
@@ -183,8 +189,8 @@ fn top_down_flow<'scope>(
                 chunk,
                 pool,
                 scope,
-                &assign_isize_traversal,
-                &assign_bsize_traversal,
+                assign_isize_traversal,
+                assign_bsize_traversal,
             );
         }
     }
@@ -200,16 +206,16 @@ pub fn reflow(
 ) {
     if opts::get().debug.bubble_inline_sizes_separately {
         let bubble_inline_sizes = BubbleISizes {
-            layout_context: &context,
+            layout_context: context,
         };
         bubble_inline_sizes.traverse(root);
     }
 
     let assign_isize_traversal = &AssignISizes {
-        layout_context: &context,
+        layout_context: context,
     };
     let assign_bsize_traversal = &AssignBSizes {
-        layout_context: &context,
+        layout_context: context,
     };
     let nodes = [UnsafeFlow(root)];
 

--- a/components/layout/persistent_list.rs
+++ b/components/layout/persistent_list.rs
@@ -44,7 +44,7 @@ where
     pub fn prepend_elem(&self, value: T) -> PersistentList<T> {
         PersistentList {
             head: Some(Arc::new(PersistentListEntry {
-                value: value,
+                value,
                 next: self.head.clone(),
             })),
             length: self.length + 1,
@@ -56,7 +56,7 @@ where
         // This could clone (and would not need the lifetime if it did), but then it would incur
         // atomic operations on every call to `.next()`. Bad.
         PersistentListIterator {
-            entry: self.head.as_ref().map(|head| &**head),
+            entry: self.head.as_deref(),
         }
     }
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1102,12 +1102,7 @@ pub fn process_offset_parent_query(
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
 
     let node_offset_box = iterator.node_offset_box;
-    let parent_info = iterator
-        .parent_nodes
-        .into_iter()
-        .rev()
-        .flatten()
-        .next();
+    let parent_info = iterator.parent_nodes.into_iter().rev().flatten().next();
     match (node_offset_box, parent_info) {
         (Some(node_offset_box), Some(parent_info)) => {
             let origin = node_offset_box.offset - parent_info.origin.to_vector();

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -132,26 +132,26 @@ impl LayoutRPC for LayoutRPCImpl {
     // The neat thing here is that in order to answer the following two queries we only
     // need to compare nodes for equality. Thus we can safely work only with `OpaqueNode`.
     fn content_box(&self) -> ContentBoxResponse {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         ContentBoxResponse(rw_data.content_box_response)
     }
 
     /// Requests the dimensions of all the content boxes, as in the `getClientRects()` call.
     fn content_boxes(&self) -> ContentBoxesResponse {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         ContentBoxesResponse(rw_data.content_boxes_response.clone())
     }
 
     fn nodes_from_point_response(&self) -> Vec<UntrustedNodeAddress> {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.nodes_from_point_response.clone()
     }
 
     fn node_geometry(&self) -> NodeGeometryResponse {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         NodeGeometryResponse {
             client_rect: rw_data.client_rect_response,
@@ -176,39 +176,39 @@ impl LayoutRPC for LayoutRPCImpl {
 
     /// Retrieves the resolved value for a CSS style property.
     fn resolved_style(&self) -> ResolvedStyleResponse {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         ResolvedStyleResponse(rw_data.resolved_style_response.clone())
     }
 
     fn resolved_font_style(&self) -> Option<ServoArc<Font>> {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.resolved_font_style_response.clone()
     }
 
     fn offset_parent(&self) -> OffsetParentResponse {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.offset_parent_response.clone()
     }
 
     fn text_index(&self) -> TextIndexResponse {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.text_index_response.clone()
     }
 
     fn element_inner_text(&self) -> String {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
         rw_data.element_inner_text_response.clone()
     }
 
     fn inner_window_dimensions(&self) -> Option<TypedSize2D<f32, CSSPixel>> {
-        let &LayoutRPCImpl(ref rw_data) = self;
+        let LayoutRPCImpl(rw_data) = self;
         let rw_data = rw_data.lock().unwrap();
-        rw_data.inner_window_dimensions_response.clone()
+        rw_data.inner_window_dimensions_response
     }
 }
 
@@ -220,7 +220,7 @@ struct UnioningFragmentBorderBoxIterator {
 impl UnioningFragmentBorderBoxIterator {
     fn new(node_address: OpaqueNode) -> UnioningFragmentBorderBoxIterator {
         UnioningFragmentBorderBoxIterator {
-            node_address: node_address,
+            node_address,
             rect: None,
         }
     }
@@ -247,7 +247,7 @@ struct CollectingFragmentBorderBoxIterator {
 impl CollectingFragmentBorderBoxIterator {
     fn new(node_address: OpaqueNode) -> CollectingFragmentBorderBoxIterator {
         CollectingFragmentBorderBoxIterator {
-            node_address: node_address,
+            node_address,
             rects: Vec::new(),
         }
     }
@@ -306,9 +306,9 @@ impl PositionRetrievingFragmentBorderBoxIterator {
         position: Point2D<Au>,
     ) -> PositionRetrievingFragmentBorderBoxIterator {
         PositionRetrievingFragmentBorderBoxIterator {
-            node_address: node_address,
-            position: position,
-            property: property,
+            node_address,
+            position,
+            property,
             result: None,
         }
     }
@@ -353,11 +353,11 @@ impl MarginRetrievingFragmentBorderBoxIterator {
         writing_mode: WritingMode,
     ) -> MarginRetrievingFragmentBorderBoxIterator {
         MarginRetrievingFragmentBorderBoxIterator {
-            node_address: node_address,
-            side: side,
-            margin_padding: margin_padding,
+            node_address,
+            side,
+            margin_padding,
             result: None,
-            writing_mode: writing_mode,
+            writing_mode,
         }
     }
 }
@@ -411,7 +411,7 @@ struct FragmentClientRectQueryIterator {
 impl FragmentClientRectQueryIterator {
     fn new(node_address: OpaqueNode) -> FragmentClientRectQueryIterator {
         FragmentClientRectQueryIterator {
-            node_address: node_address,
+            node_address,
             client_rect: Rect::zero(),
         }
     }
@@ -429,7 +429,7 @@ struct UnioningFragmentScrollAreaIterator {
 impl UnioningFragmentScrollAreaIterator {
     fn new(node_address: OpaqueNode) -> UnioningFragmentScrollAreaIterator {
         UnioningFragmentScrollAreaIterator {
-            node_address: node_address,
+            node_address,
             union_rect: Rect::zero(),
             origin_rect: Rect::zero(),
             level: None,
@@ -460,7 +460,7 @@ struct ParentOffsetBorderBoxIterator {
 impl ParentOffsetBorderBoxIterator {
     fn new(node_address: OpaqueNode) -> ParentOffsetBorderBoxIterator {
         ParentOffsetBorderBoxIterator {
-            node_address: node_address,
+            node_address,
             has_processed_node: false,
             node_offset_box: None,
             parent_nodes: Vec::new(),
@@ -509,8 +509,8 @@ impl FragmentBorderBoxIterator for UnioningFragmentScrollAreaIterator {
         let (top_border, bottom_border) = (top_border.to_px(), bottom_border.to_px());
         let right_padding = border_box.size.width.to_px() - right_border - left_border;
         let bottom_padding = border_box.size.height.to_px() - bottom_border - top_border;
-        let top_padding = top_border as i32;
-        let left_padding = left_border as i32;
+        let top_padding = top_border;
+        let left_padding = left_border;
 
         match self.level {
             Some(start_level) if level <= start_level => {
@@ -826,14 +826,14 @@ where
     E: LayoutNode<'dom>,
 {
     let parent_style = match parent_style {
-        Some(parent) => &*parent,
+        Some(parent) => parent,
         None => context.stylist.device().default_computed_values(),
     };
     context
         .stylist
         .compute_for_declarations::<E::ConcreteElement>(
             &context.guards,
-            &*parent_style,
+            parent_style,
             ServoArc::new(shared_lock.wrap(declarations)),
         )
 }
@@ -1011,7 +1011,7 @@ fn process_resolved_style_request_internal<'dom>(
     {
         let maybe_data = layout_el.borrow_layout_data();
         let position = maybe_data.map_or(Point2D::zero(), |data| {
-            match (*data).flow_construction_result {
+            match data.flow_construction_result {
                 ConstructionResult::Flow(ref flow_ref, _) => flow_ref
                     .deref()
                     .base()
@@ -1040,7 +1040,7 @@ fn process_resolved_style_request_internal<'dom>(
         iterator
             .result
             .map(|r| r.to_css_string())
-            .unwrap_or(String::new())
+            .unwrap_or_default()
     }
 
     // TODO: we will return neither the computed nor used value for margin and padding.
@@ -1076,7 +1076,7 @@ fn process_resolved_style_request_internal<'dom>(
             iterator
                 .result
                 .map(|r| r.to_css_string())
-                .unwrap_or(String::new())
+                .unwrap_or_default()
         },
 
         LonghandId::Bottom | LonghandId::Top | LonghandId::Right | LonghandId::Left
@@ -1106,7 +1106,7 @@ pub fn process_offset_parent_query(
         .parent_nodes
         .into_iter()
         .rev()
-        .filter_map(|info| info)
+        .flatten()
         .next();
     match (node_offset_box, parent_info) {
         (Some(node_offset_box), Some(parent_info)) => {
@@ -1154,7 +1154,7 @@ pub fn process_element_inner_text_query<'dom>(
             },
             InnerTextItem::RequiredLineBreakCount(count) => {
                 // Step 4.
-                if inner_text.len() == 0 {
+                if inner_text.is_empty() {
                     // Remove required line break count at the start.
                     continue;
                 }

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -26,7 +26,7 @@ use crate::traversal::{
 };
 
 pub fn resolve_generated_content(root: &mut dyn Flow, layout_context: &LayoutContext) {
-    ResolveGeneratedContent::new(&layout_context).traverse(root, 0);
+    ResolveGeneratedContent::new(layout_context).traverse(root, 0);
 }
 
 /// Run the main layout passes sequentially.
@@ -60,16 +60,16 @@ pub fn reflow(root: &mut dyn Flow, layout_context: &LayoutContext, relayout_mode
 
     if opts::get().debug.bubble_inline_sizes_separately {
         let bubble_inline_sizes = BubbleISizes {
-            layout_context: &layout_context,
+            layout_context,
         };
         bubble_inline_sizes.traverse(root);
     }
 
     let assign_inline_sizes = AssignISizes {
-        layout_context: &layout_context,
+        layout_context,
     };
     let assign_block_sizes = AssignBSizes {
-        layout_context: &layout_context,
+        layout_context,
     };
 
     doit(root, assign_inline_sizes, assign_block_sizes, relayout_mode);
@@ -104,7 +104,7 @@ pub fn build_display_list_for_subtree<'a>(
         },
     )));
 
-    let mut build_display_list = BuildDisplayList { state: state };
+    let mut build_display_list = BuildDisplayList { state };
     build_display_list.traverse(flow_root);
     build_display_list.state
 }
@@ -133,8 +133,7 @@ pub fn iterate_through_flow_tree_fragment_border_boxes(
                     .stacking_relative_border_box(CoordinateSystem::Own);
                 if let Some(matrix) = kid.as_block().fragment.transform_matrix(&relative_position) {
                     let transform_matrix = matrix.transform_point2d(LayoutPoint::zero()).unwrap();
-                    stacking_context_position = stacking_context_position +
-                        Vector2D::new(
+                    stacking_context_position += Vector2D::new(
                             Au::from_f32_px(transform_matrix.x),
                             Au::from_f32_px(transform_matrix.y),
                         )

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -59,18 +59,12 @@ pub fn reflow(root: &mut dyn Flow, layout_context: &LayoutContext, relayout_mode
     }
 
     if opts::get().debug.bubble_inline_sizes_separately {
-        let bubble_inline_sizes = BubbleISizes {
-            layout_context,
-        };
+        let bubble_inline_sizes = BubbleISizes { layout_context };
         bubble_inline_sizes.traverse(root);
     }
 
-    let assign_inline_sizes = AssignISizes {
-        layout_context,
-    };
-    let assign_block_sizes = AssignBSizes {
-        layout_context,
-    };
+    let assign_inline_sizes = AssignISizes { layout_context };
+    let assign_block_sizes = AssignBSizes { layout_context };
 
     doit(root, assign_inline_sizes, assign_block_sizes, relayout_mode);
 }
@@ -134,9 +128,9 @@ pub fn iterate_through_flow_tree_fragment_border_boxes(
                 if let Some(matrix) = kid.as_block().fragment.transform_matrix(&relative_position) {
                     let transform_matrix = matrix.transform_point2d(LayoutPoint::zero()).unwrap();
                     stacking_context_position += Vector2D::new(
-                            Au::from_f32_px(transform_matrix.x),
-                            Au::from_f32_px(transform_matrix.y),
-                        )
+                        Au::from_f32_px(transform_matrix.x),
+                        Au::from_f32_px(transform_matrix.y),
+                    )
                 }
             }
             doit(kid, level + 1, iterator, &stacking_context_position);

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 use style::computed_values::{border_collapse, border_spacing, table_layout};
 use style::context::SharedStyleContext;
 use style::logical_geometry::LogicalSize;
-
 use style::properties::ComputedValues;
 use style::servo::restyle_damage::ServoRestyleDamage;
 use style::values::computed::Size;
@@ -973,7 +972,8 @@ impl TableLikeFlow for BlockFlow {
                     row.mut_base().restyle_damage.remove(
                         ServoRestyleDamage::REFLOW_OUT_OF_FLOW | ServoRestyleDamage::REFLOW,
                     );
-                    current_block_offset += border_spacing_for_row(&self.fragment, row, block_direction_spacing);
+                    current_block_offset +=
+                        border_spacing_for_row(&self.fragment, row, block_direction_spacing);
                     i += 1;
                 }
 
@@ -1228,8 +1228,6 @@ struct TableCellColumnIndexData {
     pub relative_offset: u32,
 }
 
-
-
 impl TableCellColumnIndexData {
     /// Moves forward by `amount` columns, updating the various indices used
     ///
@@ -1283,10 +1281,7 @@ impl<'table> Iterator for TableCellStyleIterator<'table> {
                 let (col_style, colgroup_style) = if let Some(column_style) =
                     self.column_styles.get(self.column_index.relative as usize)
                 {
-                    let styles = (
-                        column_style.col_style,
-                        column_style.colgroup_style,
-                    );
+                    let styles = (column_style.col_style, column_style.colgroup_style);
                     self.column_index
                         .advance(cell.column_span, &self.column_styles);
 

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -721,12 +721,6 @@ pub struct ColumnIntrinsicInlineSize {
     pub constrained: bool,
 }
 
-impl Default for ColumnIntrinsicInlineSize {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ColumnIntrinsicInlineSize {
     /// Returns a newly-initialized `ColumnIntrinsicInlineSize` with all fields blank.
     pub fn new() -> ColumnIntrinsicInlineSize {
@@ -745,6 +739,12 @@ impl ColumnIntrinsicInlineSize {
         } else {
             other.percentage
         }
+    }
+}
+
+impl Default for ColumnIntrinsicInlineSize {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -75,7 +75,7 @@ impl TableCellFlow {
             collapsed_borders: CollapsedBordersForCell::new(),
             column_span: node.get_colspan(),
             row_span: node.get_rowspan(),
-            visible: visible,
+            visible,
         }
     }
 
@@ -481,8 +481,8 @@ impl CollapsedBordersForCell {
         // FIXME(pcwalton): Get the real container size.
         let mut logical_bounds =
             LogicalRect::from_physical(writing_mode, *border_bounds, Size2D::new(Au(0), Au(0)));
-        logical_bounds.start.i = logical_bounds.start.i - inline_start_offset;
-        logical_bounds.start.b = logical_bounds.start.b - block_start_offset;
+        logical_bounds.start.i -= inline_start_offset;
+        logical_bounds.start.b -= block_start_offset;
         logical_bounds.size.inline =
             logical_bounds.size.inline + inline_start_offset + inline_end_offset;
         logical_bounds.size.block =

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -683,12 +683,6 @@ pub struct CollapsedBordersForRow {
     pub block_end: Vec<CollapsedBorder>,
 }
 
-impl Default for CollapsedBordersForRow {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl CollapsedBordersForRow {
     pub fn new() -> CollapsedBordersForRow {
         CollapsedBordersForRow {
@@ -703,6 +697,12 @@ impl CollapsedBordersForRow {
         self.inline.push(first_inline_border);
         self.block_start.clear();
         self.block_end.clear()
+    }
+}
+
+impl Default for CollapsedBordersForRow {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -761,12 +761,6 @@ pub enum CollapsedBorderProvenance {
     FromTableColumn = 2,
     FromTableColumnGroup = 1,
     FromTable = 0,
-}
-
-impl Default for CollapsedBorder {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl CollapsedBorder {
@@ -911,6 +905,12 @@ impl CollapsedBorder {
             _ if (self.provenance as i8) >= other.provenance as i8 => {},
             _ => *self = other.clone(),
         }
+    }
+}
+
+impl Default for CollapsedBorder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -6,7 +6,7 @@
 
 use std::cmp::max;
 use std::fmt;
-use std::iter::{Enumerate, IntoIterator, Peekable};
+use std::iter::{Enumerate, Peekable};
 
 use app_units::Au;
 use euclid::default::Point2D;
@@ -113,8 +113,8 @@ impl TableRowFlow {
     /// TODO(pcwalton): This doesn't handle floats and positioned elements right.
     ///
     /// Returns the block size
-    pub fn compute_block_size_table_row_base<'a>(
-        &'a mut self,
+    pub fn compute_block_size_table_row_base(
+        &mut self,
         layout_context: &LayoutContext,
         incoming_rowspan_data: &mut Vec<Au>,
         border_info: &[TableRowSizeData],
@@ -282,8 +282,7 @@ impl TableRowFlow {
         self.collapsed_border_spacing.inline.clear();
         self.collapsed_border_spacing.inline.extend(
             collapsed_inline_direction_border_widths_for_table
-                .into_iter()
-                .map(|x| *x),
+                .iter().copied(),
         );
 
         if let Some(collapsed_block_direction_border_width_for_table) =
@@ -389,7 +388,7 @@ impl Flow for TableRowFlow {
         let row_style = &*self.block_flow.fragment.style;
         self.preliminary_collapsed_borders
             .reset(CollapsedBorder::inline_start(
-                &row_style,
+                row_style,
                 CollapsedBorderProvenance::FromTableRow,
             ));
 
@@ -448,8 +447,8 @@ impl Flow for TableRowFlow {
                         Size::LengthPercentage(ref lp) => lp.0.maybe_to_used_value(None).is_some(),
                     },
                 };
-                min_inline_size = min_inline_size + child_column_inline_size.minimum_length;
-                pref_inline_size = pref_inline_size + child_column_inline_size.preferred;
+                min_inline_size += child_column_inline_size.minimum_length;
+                pref_inline_size += child_column_inline_size.preferred;
                 self.cell_intrinsic_inline_sizes
                     .push(CellIntrinsicInlineSize {
                         column_size: child_column_inline_size,
@@ -683,6 +682,12 @@ pub struct CollapsedBordersForRow {
     pub block_end: Vec<CollapsedBorder>,
 }
 
+impl Default for CollapsedBordersForRow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CollapsedBordersForRow {
     pub fn new() -> CollapsedBordersForRow {
         CollapsedBordersForRow {
@@ -757,6 +762,12 @@ pub enum CollapsedBorderProvenance {
     FromTable = 0,
 }
 
+impl Default for CollapsedBorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CollapsedBorder {
     /// Creates a collapsible border style for no border.
     pub fn new() -> CollapsedBorder {
@@ -773,9 +784,9 @@ impl CollapsedBorder {
     fn top(css_style: &ComputedValues, provenance: CollapsedBorderProvenance) -> CollapsedBorder {
         CollapsedBorder {
             style: css_style.get_border().border_top_style,
-            width: Au::from(css_style.get_border().border_top_width),
+            width: css_style.get_border().border_top_width,
             color: css_style.get_border().border_top_color.clone(),
-            provenance: provenance,
+            provenance,
         }
     }
 
@@ -784,9 +795,9 @@ impl CollapsedBorder {
     fn right(css_style: &ComputedValues, provenance: CollapsedBorderProvenance) -> CollapsedBorder {
         CollapsedBorder {
             style: css_style.get_border().border_right_style,
-            width: Au::from(css_style.get_border().border_right_width),
+            width: css_style.get_border().border_right_width,
             color: css_style.get_border().border_right_color.clone(),
-            provenance: provenance,
+            provenance,
         }
     }
 
@@ -798,9 +809,9 @@ impl CollapsedBorder {
     ) -> CollapsedBorder {
         CollapsedBorder {
             style: css_style.get_border().border_bottom_style,
-            width: Au::from(css_style.get_border().border_bottom_width),
+            width: css_style.get_border().border_bottom_width,
             color: css_style.get_border().border_bottom_color.clone(),
-            provenance: provenance,
+            provenance,
         }
     }
 
@@ -809,9 +820,9 @@ impl CollapsedBorder {
     fn left(css_style: &ComputedValues, provenance: CollapsedBorderProvenance) -> CollapsedBorder {
         CollapsedBorder {
             style: css_style.get_border().border_left_style,
-            width: Au::from(css_style.get_border().border_left_width),
+            width: css_style.get_border().border_left_width,
             color: css_style.get_border().border_left_color.clone(),
-            provenance: provenance,
+            provenance,
         }
     }
 
@@ -1107,7 +1118,7 @@ fn perform_inline_direction_border_collapse_for_row(
     if child_index == 0 {
         let first_inline_border = &mut preliminary_collapsed_borders.inline[0];
         first_inline_border.combine(&CollapsedBorder::inline_start(
-            &*child_table_cell.block_flow.fragment.style,
+            &child_table_cell.block_flow.fragment.style,
             CollapsedBorderProvenance::FromNextTableCell,
         ));
     }
@@ -1115,15 +1126,15 @@ fn perform_inline_direction_border_collapse_for_row(
     let inline_collapsed_border = preliminary_collapsed_borders.inline.push_or_set(
         child_index + 1,
         CollapsedBorder::inline_end(
-            &*child_table_cell.block_flow.fragment.style,
+            &child_table_cell.block_flow.fragment.style,
             CollapsedBorderProvenance::FromPreviousTableCell,
         ),
     );
 
-    if let Some(&(_, ref next_child_flow)) = iterator.peek() {
+    if let Some((_, next_child_flow)) = iterator.peek() {
         let next_child_flow = next_child_flow.as_block();
         inline_collapsed_border.combine(&CollapsedBorder::inline_start(
-            &*next_child_flow.fragment.style,
+            &next_child_flow.fragment.style,
             CollapsedBorderProvenance::FromNextTableCell,
         ))
     };
@@ -1132,13 +1143,13 @@ fn perform_inline_direction_border_collapse_for_row(
     // come from the row.
     if child_index + 1 == children_count {
         inline_collapsed_border.combine(&CollapsedBorder::inline_end(
-            &row_style,
+            row_style,
             CollapsedBorderProvenance::FromTableRow,
         ));
     }
 
     let mut block_start_border = CollapsedBorder::block_start(
-        &*child_table_cell.block_flow.fragment.style,
+        &child_table_cell.block_flow.fragment.style,
         CollapsedBorderProvenance::FromNextTableCell,
     );
     block_start_border.combine(&CollapsedBorder::block_start(
@@ -1149,7 +1160,7 @@ fn perform_inline_direction_border_collapse_for_row(
         .block_start
         .push_or_set(child_index, block_start_border);
     let mut block_end_border = CollapsedBorder::block_end(
-        &*child_table_cell.block_flow.fragment.style,
+        &child_table_cell.block_flow.fragment.style,
         CollapsedBorderProvenance::FromPreviousTableCell,
     );
     block_end_border.combine(&CollapsedBorder::block_end(

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -282,7 +282,8 @@ impl TableRowFlow {
         self.collapsed_border_spacing.inline.clear();
         self.collapsed_border_spacing.inline.extend(
             collapsed_inline_direction_border_widths_for_table
-                .iter().copied(),
+                .iter()
+                .copied(),
         );
 
         if let Some(collapsed_block_direction_border_width_for_table) =

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -79,7 +79,8 @@ impl TableRowGroupFlow {
         self.collapsed_inline_direction_border_widths_for_table
             .extend(
                 collapsed_inline_direction_border_widths_for_table
-                    .iter().copied(),
+                    .iter()
+                    .copied(),
             );
 
         for _ in 0..self.block_flow.base.children.len() {

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -5,7 +5,7 @@
 //! CSS table formatting contexts.
 
 use std::fmt;
-use std::iter::{IntoIterator, Iterator, Peekable};
+use std::iter::{Iterator, Peekable};
 
 use app_units::Au;
 use euclid::default::Point2D;
@@ -79,8 +79,7 @@ impl TableRowGroupFlow {
         self.collapsed_inline_direction_border_widths_for_table
             .extend(
                 collapsed_inline_direction_border_widths_for_table
-                    .into_iter()
-                    .map(|x| *x),
+                    .iter().copied(),
             );
 
         for _ in 0..self.block_flow.base.children.len() {

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -765,13 +765,15 @@ impl ExcessInlineSizeDistributionInfo {
         if !column_intrinsic_inline_size.constrained &&
             column_intrinsic_inline_size.percentage == 0.0
         {
-            self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage += column_intrinsic_inline_size.preferred;
+            self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage +=
+                column_intrinsic_inline_size.preferred;
             self.count_of_nonconstrained_columns_with_no_percentage += 1
         }
         if column_intrinsic_inline_size.constrained &&
             column_intrinsic_inline_size.percentage == 0.0
         {
-            self.preferred_inline_size_of_constrained_columns_with_no_percentage += column_intrinsic_inline_size.preferred
+            self.preferred_inline_size_of_constrained_columns_with_no_percentage +=
+                column_intrinsic_inline_size.preferred
         }
         self.total_percentage += column_intrinsic_inline_size.percentage;
         self.column_count += 1

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -80,9 +80,9 @@ impl TableWrapperFlow {
                 TableLayout::Auto
             };
         TableWrapperFlow {
-            block_flow: block_flow,
+            block_flow,
             column_intrinsic_inline_sizes: vec![],
-            table_layout: table_layout,
+            table_layout,
         }
     }
 
@@ -163,7 +163,7 @@ impl TableWrapperFlow {
         {
             intermediate_column_inline_size.size = guess.calculate(selection);
             // intermediate_column_inline_size.percentage = 0.0;
-            total_used_inline_size = total_used_inline_size + intermediate_column_inline_size.size
+            total_used_inline_size += intermediate_column_inline_size.size
         }
 
         // Distribute excess inline-size if necessary per INTRINSIC § 4.4.
@@ -269,8 +269,8 @@ impl TableWrapperFlow {
         // the constraint solutions in.
         if self.block_flow.base.flags.is_float() {
             let inline_size_computer = FloatedTable {
-                minimum_width_of_all_columns: minimum_width_of_all_columns,
-                preferred_width_of_all_columns: preferred_width_of_all_columns,
+                minimum_width_of_all_columns,
+                preferred_width_of_all_columns,
                 table_border_padding: border_padding,
             };
             let input = inline_size_computer.compute_inline_size_constraint_inputs(
@@ -295,8 +295,8 @@ impl TableWrapperFlow {
             .contains(FlowFlags::INLINE_POSITION_IS_STATIC)
         {
             let inline_size_computer = AbsoluteTable {
-                minimum_width_of_all_columns: minimum_width_of_all_columns,
-                preferred_width_of_all_columns: preferred_width_of_all_columns,
+                minimum_width_of_all_columns,
+                preferred_width_of_all_columns,
                 table_border_padding: border_padding,
             };
             let input = inline_size_computer.compute_inline_size_constraint_inputs(
@@ -315,8 +315,8 @@ impl TableWrapperFlow {
         }
 
         let inline_size_computer = Table {
-            minimum_width_of_all_columns: minimum_width_of_all_columns,
-            preferred_width_of_all_columns: preferred_width_of_all_columns,
+            minimum_width_of_all_columns,
+            preferred_width_of_all_columns,
             table_border_padding: border_padding,
         };
         let input = inline_size_computer.compute_inline_size_constraint_inputs(
@@ -625,7 +625,7 @@ impl AutoLayoutCandidateGuess {
         );
         AutoLayoutCandidateGuess {
             minimum_guess: column_intrinsic_inline_size.minimum_length,
-            minimum_percentage_guess: minimum_percentage_guess,
+            minimum_percentage_guess,
             // FIXME(pcwalton): We need the notion of *constrainedness* per INTRINSIC § 4 to
             // implement this one correctly.
             minimum_specified_guess: if column_intrinsic_inline_size.percentage > 0.0 {
@@ -765,17 +765,13 @@ impl ExcessInlineSizeDistributionInfo {
         if !column_intrinsic_inline_size.constrained &&
             column_intrinsic_inline_size.percentage == 0.0
         {
-            self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage = self
-                .preferred_inline_size_of_nonconstrained_columns_with_no_percentage +
-                column_intrinsic_inline_size.preferred;
+            self.preferred_inline_size_of_nonconstrained_columns_with_no_percentage += column_intrinsic_inline_size.preferred;
             self.count_of_nonconstrained_columns_with_no_percentage += 1
         }
         if column_intrinsic_inline_size.constrained &&
             column_intrinsic_inline_size.percentage == 0.0
         {
-            self.preferred_inline_size_of_constrained_columns_with_no_percentage = self
-                .preferred_inline_size_of_constrained_columns_with_no_percentage +
-                column_intrinsic_inline_size.preferred
+            self.preferred_inline_size_of_constrained_columns_with_no_percentage += column_intrinsic_inline_size.preferred
         }
         self.total_percentage += column_intrinsic_inline_size.percentage;
         self.column_count += 1
@@ -825,9 +821,8 @@ impl ExcessInlineSizeDistributionInfo {
             excess_inline_size.scale_by(proportion),
             excess_inline_size - *total_distributed_excess_size,
         );
-        *total_distributed_excess_size = *total_distributed_excess_size + amount_to_distribute;
-        intermediate_column_inline_size.size =
-            intermediate_column_inline_size.size + amount_to_distribute
+        *total_distributed_excess_size += amount_to_distribute;
+        intermediate_column_inline_size.size += amount_to_distribute
     }
 }
 

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::ToOwned;
 use std::collections::LinkedList;
-use std::mem;
+
 use std::sync::Arc;
 
 use app_units::Au;
@@ -50,7 +50,7 @@ fn text(fragments: &LinkedList<Fragment>) -> String {
             if fragment.white_space().preserve_newlines() {
                 text.push_str(&info.text);
             } else {
-                text.push_str(&info.text.replace("\n", " "));
+                text.push_str(&info.text.replace('\n', " "));
             }
         }
     }
@@ -151,7 +151,7 @@ impl TextRunScanner {
     /// be adjusted.
     fn flush_clump_to_list(
         &mut self,
-        mut font_context: &mut LayoutFontContext,
+        font_context: &mut LayoutFontContext,
         out_fragments: &mut Vec<Fragment>,
         paragraph_bytes_processed: &mut usize,
         bidi_levels: Option<&[bidi::Level]>,
@@ -207,7 +207,7 @@ impl TextRunScanner {
                     .unwrap_or_else(|| {
                         let space_width = font_group
                             .borrow_mut()
-                            .find_by_codepoint(&mut font_context, ' ')
+                            .find_by_codepoint(font_context, ' ')
                             .and_then(|font| {
                                 let font = font.borrow();
                                 font.glyph_index(' ')
@@ -252,7 +252,7 @@ impl TextRunScanner {
                     if !character.is_control() {
                         let font = font_group
                             .borrow_mut()
-                            .find_by_codepoint(&mut font_context, character);
+                            .find_by_codepoint(font_context, character);
 
                         let bidi_level = match bidi_levels {
                             Some(levels) => levels[*paragraph_bytes_processed],
@@ -290,7 +290,7 @@ impl TextRunScanner {
                                 mapping.flush(
                                     &mut mappings,
                                     &mut run_info,
-                                    &**text,
+                                    text,
                                     compression,
                                     text_transform,
                                     &mut last_whitespace,
@@ -298,7 +298,7 @@ impl TextRunScanner {
                                     end_position,
                                 );
                             }
-                            if run_info.text.len() > 0 {
+                            if !run_info.text.is_empty() {
                                 if flush_run {
                                     run_info.flush(&mut run_info_list, &mut insertion_point);
                                     run_info = RunInfo::new();
@@ -321,7 +321,7 @@ impl TextRunScanner {
                 mapping.flush(
                     &mut mappings,
                     &mut run_info,
-                    &**text,
+                    text,
                     compression,
                     text_transform,
                     &mut last_whitespace,
@@ -356,7 +356,7 @@ impl TextRunScanner {
                 },
                 word_spacing,
                 script: Script::Common,
-                flags: flags,
+                flags,
             };
 
             let mut result = Vec::with_capacity(run_info_list.len());
@@ -370,7 +370,7 @@ impl TextRunScanner {
                 // If no font is found (including fallbacks), there's no way we can render.
                 let font = match run_info
                     .font
-                    .or_else(|| font_group.borrow_mut().first(&mut font_context))
+                    .or_else(|| font_group.borrow_mut().first(font_context))
                 {
                     Some(font) => font,
                     None => {
@@ -380,7 +380,7 @@ impl TextRunScanner {
                 };
 
                 let (run, break_at_zero) = TextRun::new(
-                    &mut *font.borrow_mut(),
+                    &mut font.borrow_mut(),
                     run_info.text,
                     &options,
                     run_info.bidi_level,
@@ -402,7 +402,7 @@ impl TextRunScanner {
         let mut mappings = mappings.into_iter().peekable();
         let mut prev_fragments_to_meld = Vec::new();
 
-        for (logical_offset, old_fragment) in mem::replace(&mut self.clump, LinkedList::new())
+        for (logical_offset, old_fragment) in std::mem::take(&mut self.clump)
             .into_iter()
             .enumerate()
         {
@@ -539,11 +539,11 @@ fn bounding_box_for_run_metrics(
 /// Panics if no font can be found for the given font style.
 #[inline]
 pub fn font_metrics_for_style(
-    mut font_context: &mut LayoutFontContext,
+    font_context: &mut LayoutFontContext,
     style: crate::ServoArc<FontStyleStruct>,
 ) -> FontMetrics {
     let font_group = font_context.font_group(style);
-    let font = font_group.borrow_mut().first(&mut font_context);
+    let font = font_group.borrow_mut().first(font_context);
     let font = font.as_ref().unwrap().borrow();
 
     font.metrics.clone()
@@ -553,7 +553,7 @@ pub fn font_metrics_for_style(
 pub fn line_height_from_style(style: &ComputedValues, metrics: &FontMetrics) -> Au {
     let font_size = style.get_font().font_size.computed_size();
     match style.get_inherited_text().line_height {
-        LineHeight::Normal => Au::from(metrics.line_gap),
+        LineHeight::Normal => metrics.line_gap,
         LineHeight::Number(l) => Au::from(font_size * l.0),
         LineHeight::Length(l) => Au::from(l),
     }

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -6,7 +6,6 @@
 
 use std::borrow::ToOwned;
 use std::collections::LinkedList;
-
 use std::sync::Arc;
 
 use app_units::Au;
@@ -402,9 +401,8 @@ impl TextRunScanner {
         let mut mappings = mappings.into_iter().peekable();
         let mut prev_fragments_to_meld = Vec::new();
 
-        for (logical_offset, old_fragment) in std::mem::take(&mut self.clump)
-            .into_iter()
-            .enumerate()
+        for (logical_offset, old_fragment) in
+            std::mem::take(&mut self.clump).into_iter().enumerate()
         {
             let mut is_first_mapping_of_this_old_fragment = true;
             loop {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -27,7 +27,7 @@ pub struct RecalcStyleAndConstructFlows<'a> {
 impl<'a> RecalcStyleAndConstructFlows<'a> {
     /// Creates a traversal context, taking ownership of the shared layout context.
     pub fn new(context: LayoutContext<'a>) -> Self {
-        RecalcStyleAndConstructFlows { context: context }
+        RecalcStyleAndConstructFlows { context }
     }
 
     pub fn context(&self) -> &LayoutContext<'a> {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This was done with:
1. `CARGO_BUILD_RUSTC=rustc cargo clippy --fix -p layout_2013 --broken-code`
2. `./mach fmt`
3. Some manual cosmetic adjustments


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's just linting

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
