### PR TITLE
Document media configs from prefs

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -469,9 +469,11 @@ mod gen {
             },
             media: {
                 glvideo: {
+                    /// Enable hardware acceleration for video playback.
                     enabled: bool,
                 },
                 testing: {
+                    /// Enable a non-standard event handler for verifying behavior of media elements during tests. 
                     enabled: bool,
                 }
             },


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Tried to add the missing doc comments for media prefs as mentioned in [zulip discussion](https://servo.zulipchat.com/#narrow/stream/263398-general/topic/Running.20servo.20with.20Audio/near/418574223).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these are doc comments.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
