### PR TITLE
dependencies: Upgrade surfman to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5814,9 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "surfman"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2e4280229411d6eb8a8f873152dece1904df2682003bdc748adc181e003568"
+checksum = "29362235cba051e9e6eb5a136b32c1ab6933d2545e4fffd0ba22ac904498d0e2"
 dependencies = [
  "bitflags 1.3.2",
  "cfg_aliases",
@@ -5839,7 +5839,6 @@ dependencies = [
  "sparkle",
  "wayland-sys 0.30.1",
  "winapi",
- "winit",
  "wio",
  "x11",
 ]
@@ -6892,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3b2f303c0bdb70a8ca81ae30b012b4164c32fd40"
+source = "git+https://github.com/servo/webxr#f1cc78521616883ca1592129848b525dcf8b4136"
 dependencies = [
  "android_injected_glue",
  "bindgen 0.69.2",
@@ -6911,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3b2f303c0bdb70a8ca81ae30b012b4164c32fd40"
+source = "git+https://github.com/servo/webxr#f1cc78521616883ca1592129848b525dcf8b4136"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 style_traits = { path = "components/style_traits", features = ["servo"] }
 # NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
-surfman = { version = "0.8", features = ["chains", "sm-angle", "sm-angle-default"] }
+surfman = { version = "0.9", features = ["chains", "sm-angle", "sm-angle-default"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"

--- a/ports/servoshell/headed_window.rs
+++ b/ports/servoshell/headed_window.rs
@@ -133,7 +133,7 @@ impl Window {
             .expect("Failed to create adapter");
         let window_handle = winit_window.raw_window_handle();
         let native_widget = connection
-            .create_native_widget_from_rwh(window_handle)
+            .create_native_widget_from_raw_window_handle(window_handle, Size2D::new(width, height))
             .expect("Failed to create native widget");
         let surface_type = SurfaceType::Widget { native_widget };
         let rendering_context = RenderingContext::create(&connection, &adapter, surface_type)
@@ -671,9 +671,12 @@ impl webxr::glwindow::GlWindow for XRWindow {
         device: &mut Device,
         _context: &mut Context,
     ) -> webxr::glwindow::GlWindowRenderTarget {
+        let window_handle = self.winit_window.raw_window_handle();
+        let size = self.winit_window.inner_size();
+        let size = Size2D::new(size.width as i32, size.height as i32);
         let native_widget = device
             .connection()
-            .create_native_widget_from_winit_window(&self.winit_window)
+            .create_native_widget_from_raw_window_handle(window_handle, size)
             .expect("Failed to create native widget");
         webxr::glwindow::GlWindowRenderTarget::NativeWidget(native_widget)
     }


### PR DESCRIPTION
This upgrades surfman and webxr. The main benefit to this upgrade is
that surfman (and thus libservo) no longer depends on winit. servoshell
still does, but this should make upgrades a lot easier.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
