### PR TITLE
mach: Error out sooner with Python < 3.10

### DIFF
--- a/mach
+++ b/mach
@@ -12,8 +12,8 @@
 import os
 import sys
 
-if sys.version_info < (3, 5):
-    print("mach does not support python < 3.5, please install python 3 >= 3.5")
+if sys.version_info < (3, 10):
+    print("mach does not support python < 3.10, please install python 3 >= 3.10")
     sys.exit(1)
 
 


### PR DESCRIPTION
We upgraded our Python dependency to 3.10, but neglected to update mach.
This change makes sure we error out sooner, rather than later.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just fix a mach issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
