### PR TITLE
layout: Collect both start and end baselines for fragments

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -25,7 +25,7 @@ use super::geom::{
 use super::{FlexContainer, FlexLevelBox};
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::formatting_contexts::{IndependentFormattingContext, IndependentLayout};
+use crate::formatting_contexts::{Baselines, IndependentFormattingContext, IndependentLayout};
 use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment};
 use crate::geom::{AuOrAuto, LengthOrAuto, LogicalRect, LogicalSides, LogicalVec2};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
@@ -410,7 +410,7 @@ impl FlexContainer {
         IndependentLayout {
             fragments,
             content_block_size: content_block_size.into(),
-            last_inflow_baseline_offset: None,
+            baselines: Baselines::default(),
         }
     }
 }
@@ -848,6 +848,7 @@ impl FlexLine<'_> {
                 let margin = flex_context.sides_to_flow_relative(*margin);
                 let collapsed_margin = CollapsedBlockMargins::from_margin(&margin);
                 (
+                    // TODO: We should likely propagate baselines from `display: flex`.
                     BoxFragment::new(
                         item.box_.base_fragment_info(),
                         item.box_.style().clone(),
@@ -857,8 +858,6 @@ impl FlexLine<'_> {
                         flex_context.sides_to_flow_relative(item.border.map(|t| (*t).into())),
                         margin,
                         None, /* clearance */
-                        // TODO: We should likely propagate baselines from `display: flex`.
-                        None, /* last_inflow_baseline_offset */
                         collapsed_margin,
                     ),
                     item_result.positioning_context,

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -982,7 +982,6 @@ impl FloatBox {
                     // Clearance is handled internally by the float placement logic, so there's no need
                     // to store it explicitly in the fragment.
                     None, // clearance
-                    None, // last_inflow_baseline_offset
                     CollapsedBlockMargins::zero(),
                 )
             },

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -59,6 +59,14 @@ pub(crate) enum NonReplacedFormattingContextContents {
     // Other layout modes go here
 }
 
+/// The baselines of a layout or a [`BoxFragment`]. Some layout uses the first and some layout uses
+/// the last.
+#[derive(Default, Serialize)]
+pub(crate) struct Baselines {
+    pub first: Option<Au>,
+    pub last: Option<Au>,
+}
+
 pub(crate) struct IndependentLayout {
     pub fragments: Vec<Fragment>,
 
@@ -68,7 +76,7 @@ pub(crate) struct IndependentLayout {
     /// The offset of the last inflow baseline of this layout in the content area, if
     /// there was one. This is used to propagate baselines to the ancestors of `display:
     /// inline-block`.
-    pub last_inflow_baseline_offset: Option<Au>,
+    pub baselines: Baselines,
 }
 
 impl IndependentFormattingContext {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -706,7 +706,6 @@ impl HoistedAbsolutelyPositionedBox {
                 None, /* clearance */
                 // We do not set the baseline offset, because absolutely positioned
                 // elements are not inflow.
-                None, /* last_inflow_baseline_offset */
                 CollapsedBlockMargins::zero(),
                 physical_overconstrained,
             )

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -12,7 +12,7 @@ use style::values::generics::length::GenericLengthPercentageOrAuto::{Auto, Lengt
 
 use super::{Table, TableSlot, TableSlotCell};
 use crate::context::LayoutContext;
-use crate::formatting_contexts::IndependentLayout;
+use crate::formatting_contexts::{Baselines, IndependentLayout};
 use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment};
 use crate::geom::{LogicalRect, LogicalSides, LogicalVec2};
 use crate::positioned::{PositioningContext, PositioningContextLength};
@@ -1105,7 +1105,7 @@ impl Table {
         IndependentLayout {
             fragments,
             content_block_size,
-            last_inflow_baseline_offset: None,
+            baselines: Baselines::default(),
         }
     }
 }
@@ -1167,11 +1167,8 @@ impl TableSlotCell {
             layout.border,
             LogicalSides::zero(), /* margin */
             None,                 /* clearance */
-            layout
-                .layout
-                .last_inflow_baseline_offset
-                .map(|baseline| baseline.into()),
             CollapsedBlockMargins::zero(),
         )
+        .with_baselines(layout.layout.baselines)
     }
 }

--- a/tests/wpt/meta/css/CSS2/positioning/position-relative-032.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/position-relative-032.xht.ini
@@ -1,0 +1,2 @@
+[position-relative-032.xht]
+  expected: FAIL


### PR DESCRIPTION
This change starts collecting the starting baseline set for fragments,
which is necessary for some layout modes (flex and tables, namely) as
well as being important for the implementation of `align-items`. In
addition, it converts baseline measurement to use `Au` everywhere.

<!-- Please describe your changes on the following line: -->

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
