### PR TITLE
Make Android build optional on Nix

### DIFF
--- a/mach
+++ b/mach
@@ -36,10 +36,11 @@ if __name__ == '__main__':
         import subprocess
         from shlex import quote
         mach_dir = os.path.abspath(os.path.dirname(__file__))
+        build_android_args = ['--arg', 'buildAndroid', 'true'] if 'SERVO_ANDROID_BUILD' in os.environ else []
         print('NOTE: Entering nix-shell etc/shell.nix')
         try:
             # sys argv already contains the ./mach part, so we just need to pass it as-is
-            result = subprocess.run(['nix-shell', mach_dir + '/etc/shell.nix', '--run', ' '.join(map(quote, sys.argv))])
+            result = subprocess.run(['nix-shell', mach_dir + '/etc/shell.nix'] + build_android_args + ['--run', ' '.join(map(quote, sys.argv))])
             sys.exit(result.returncode)
         except KeyboardInterrupt:
             sys.exit(0)

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -537,6 +537,9 @@ class CommandBase(object):
             if os.path.isdir(default):
                 env.setdefault(f"ANDROID_{kind.upper()}_ROOT", default)
 
+        if "IN_NIX_SHELL" in env and ("ANDROID_NDK_ROOT" not in env or "ANDROID_SDK_ROOT" not in env):
+            print("Please set SERVO_ANDROID_BUILD=1 when starting the Nix shell to include the Android SDK/NDK.")
+            sys.exit(1)
         if "ANDROID_NDK_ROOT" not in env:
             print("Please set the ANDROID_NDK_ROOT environment variable.")
             sys.exit(1)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I want to build Servo on NixOS, without installing the non-free Android SDK. This PR makes it so Android support is only built if the `buildAndroid` argument is true (e.g. by running `nix-shell --arg buildAndroid true etc/shell.nix`)

I've verified that you can still build/run non-Android Servo with this change, but I haven't tested on Android (it should still work though, since the derivation is unaffected by this change when `buildAndroid` is true).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors - it reports a diff in `components/config/prefs.rs`, which this PR didn't change (I think #31223 caused this by adding a trailing space?)
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the Nix configuration doesn't have tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
