### PR TITLE
Fix bugs in `mach test-tidy`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -473,7 +473,7 @@ mod gen {
                     enabled: bool,
                 },
                 testing: {
-                    /// Enable a non-standard event handler for verifying behavior of media elements during tests. 
+                    /// Enable a non-standard event handler for verifying behavior of media elements during tests.
                     enabled: bool,
                 }
             },

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -10,9 +10,7 @@
 import os
 import shutil
 import subprocess
-from typing import Dict, Optional
-
-from .. import util
+from typing import Optional
 
 
 class Base:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -218,7 +218,7 @@ class MachCommands(CommandBase):
         else:
             print("\r ✅ test-tidy reported no errors.")
 
-        tidy_failed
+        return tidy_failed
 
     @Command('test-scripts',
              description='Run tests for all build and support scripts.',

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -822,7 +822,7 @@ def check_spec(file_name, lines):
     macro_patt = re.compile(r"^\s*\S+!(.*)$")
 
     # Pattern representing a line with comment containing a spec link
-    link_patt = re.compile(r"^\s*///? (<https://.+>|https://.+)$")
+    link_patt = re.compile(r"^\s*///? (<https://.+>.*|https://.+)$")
 
     # Pattern representing a line with comment or attribute
     comment_patt = re.compile(r"^\s*(///?.+|#\[.+\])$")


### PR DESCRIPTION
A bug was introduced in PR #30941 which meant
`./mach test-tidy` did not fail when there are lint errors.

This in turn meant that subsequent changes were able
to land in master even though they had violations.

The first commit in this PR fixes ./mach test-tidy to correctly
fail when it detects errors. The second commit address
violations introduced in PR #31223 and PR #31078

The third commit addresses an issue in PR #31147. 
Currently test-tidy's check for spec links in doc
comments allows trailing test for links NOT wrapped
in `<` `>`. Links that are wrapped in `<` `>` cannot have
trailing text. This seems like an unintentional rule
due to the way regex is defined. I've modified the regex
to allow trailing text even for links within `<>`. 

Let me know if that should not be allowed and we should just
reformat the comment instead so that the links are on their
own lines and don't have trailing text.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31233

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix tidy errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
