### PR TITLE
layout: Start work on table row height and vertical-align

### DIFF
--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -61,7 +61,7 @@ pub(crate) enum NonReplacedFormattingContextContents {
 
 /// The baselines of a layout or a [`BoxFragment`]. Some layout uses the first and some layout uses
 /// the last.
-#[derive(Default, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub(crate) struct Baselines {
     pub first: Option<Au>,
     pub last: Option<Au>,

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -202,6 +202,7 @@ impl BoxFragment {
                 \nmargin={:?}\
                 \nclearance={:?}\
                 \nscrollable_overflow={:?}\
+                \nbaselines={:?}\
                 \noverflow={:?} / {:?}",
             self.base,
             self.content_rect,
@@ -210,6 +211,7 @@ impl BoxFragment {
             self.margin,
             self.clearance,
             self.scrollable_overflow(&PhysicalRect::zero()),
+            self.baselines,
             self.style.get_box().overflow_x,
             self.style.get_box().overflow_y,
         ));

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -37,6 +37,9 @@ pub struct Table {
 
     /// The size of this table.
     pub size: TableSize,
+
+    /// Whether or not this Table is anonymous.
+    anonymous: bool,
 }
 
 impl Table {
@@ -45,6 +48,7 @@ impl Table {
             style,
             slots: Vec::new(),
             size: TableSize::zero(),
+            anonymous: false,
         }
     }
 

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-002.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-003.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-008.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-clear-009.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-clear-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-001.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-002.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-003.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-004.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-005.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-006.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-vertical-align-baseline-007.xht.ini
@@ -1,2 +1,0 @@
-[table-vertical-align-baseline-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-3.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-3.html.ini
@@ -5,9 +5,6 @@
   [Anonymous consecutive columns spanned by the same set of cells are merged]
     expected: FAIL
 
-  [Anonymous consecutive rows spanned by the same set of cells are merged]
-    expected: FAIL
-
   [Explicitely-defined consecutive columns spanned by the same set of cells are not merged]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/baseline-table.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/baseline-table.html.ini
@@ -1,16 +1,4 @@
 [baseline-table.html]
-  [.container 3]
-    expected: FAIL
-
-  [.container 4]
-    expected: FAIL
-
-  [.container 5]
-    expected: FAIL
-
-  [.container 6]
-    expected: FAIL
-
   [.container 11]
     expected: FAIL
 
@@ -18,7 +6,4 @@
     expected: FAIL
 
   [.container 13]
-    expected: FAIL
-
-  [.container 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed-padding.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed-padding.html.ini
@@ -17,9 +17,6 @@
   [table 7]
     expected: FAIL
 
-  [table 8]
-    expected: FAIL
-
   [table 9]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
@@ -29,9 +29,6 @@
   [table 12]
     expected: FAIL
 
-  [table 13]
-    expected: FAIL
-
   [table 14]
     expected: FAIL
 


### PR DESCRIPTION
layout: Start work on table row height and vertical-align

This implements a very naive row height allocation approach. It has just
enough to implement `vertical-align` in table cells. Rowspanned cells
get enough space for their content, with the extra space necessary being
allocated to the last row. There's still a lot missing here, including
proper distribution of row height to rowspanned cells.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
