### PR TITLE
layout: Properly size `inline-table` elements

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -1884,8 +1884,13 @@ impl IndependentFormattingContext {
                 // https://drafts.csswg.org/css2/visudet.html#min-max-widths
                 // In this case “applying the rules above again” with a non-auto inline-size
                 // always results in that size.
+                let min_inline_size = min_box_size.inline.max(
+                    non_replaced
+                        .intrinsic_min_inline_size(layout_context)
+                        .into(),
+                );
                 let inline_size = tentative_inline_size
-                    .clamp_between_extremums(min_box_size.inline, max_box_size.inline);
+                    .clamp_between_extremums(min_inline_size, max_box_size.inline);
 
                 let containing_block_for_children = ContainingBlock {
                     inline_size,
@@ -1918,8 +1923,12 @@ impl IndependentFormattingContext {
                 // https://drafts.csswg.org/css2/visudet.html#min-max-heights
                 // In this case “applying the rules above again” with a non-auto block-size
                 // always results in that size.
+                let mut min_block_size = min_box_size.block;
+                if non_replaced.use_content_block_size_as_min_block_size() {
+                    min_block_size = independent_layout.content_block_size.into();
+                }
                 let block_size = tentative_block_size
-                    .clamp_between_extremums(min_box_size.block, max_box_size.block);
+                    .clamp_between_extremums(min_block_size, max_box_size.block);
 
                 let content_rect = LogicalRect {
                     start_corner: pbm_sums.start_offset(),

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -275,7 +275,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
             BlockLevelBox::SameFormattingContextBlock {
                 style, contents, ..
             } => {
-                let size = sizing::outer_inline(style, writing_mode, || {
+                let size = sizing::outer_inline(style, writing_mode, Au::zero(), || {
                     contents.inline_content_sizes(layout_context, style.writing_mode)
                 })
                 .max(ContentSizes::zero());

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -84,6 +84,7 @@ impl ContentSizes {
 pub(crate) fn outer_inline(
     style: &ComputedValues,
     containing_block_writing_mode: WritingMode,
+    intrinsic_min_inline_size: Au,
     get_content_size: impl FnOnce() -> ContentSizes,
 ) -> ContentSizes {
     let padding = style.padding(containing_block_writing_mode);
@@ -118,7 +119,8 @@ pub(crate) fn outer_inline(
         // Percentages for 'min-width' are treated as zero
         .percentage_relative_to(zero)
         // FIXME: 'auto' is not zero in Flexbox
-        .auto_is(Length::zero);
+        .auto_is(Length::zero)
+        .max(intrinsic_min_inline_size.into());
     let max_inline_size = style
         .max_box_size(containing_block_writing_mode)
         .inline


### PR DESCRIPTION
`width` and `min-width` as well as `height` and `min-height` work
differently for tables. Tables don't shrink beyond their content sizes.
This change fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
