### PR TITLE
layout: return None bounding box when no nodes found

### DIFF
--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -93,8 +93,9 @@ impl FragmentTree {
         });
     }
 
-    pub fn get_content_box_for_node(&self, requested_node: OpaqueNode) -> Rect<Au> {
+    pub fn get_content_box_for_node(&self, requested_node: OpaqueNode) -> Option<Rect<Au>> {
         let mut bounding_box = PhysicalRect::zero();
+        let mut found_any_nodes = false;
         let tag_to_find = Tag::new(requested_node);
         self.find(|fragment, _, containing_block| {
             if fragment.tag() != Some(tag_to_find) {
@@ -114,22 +115,27 @@ impl FragmentTree {
                 Fragment::Anonymous(_) => return None,
             };
 
+            found_any_nodes = true;
             bounding_box = fragment_relative_rect
                 .translate(containing_block.origin.to_vector())
                 .union(&bounding_box);
             None::<()>
         });
 
-        Rect::new(
-            Point2D::new(
-                Au::from_f32_px(bounding_box.origin.x.px()),
-                Au::from_f32_px(bounding_box.origin.y.px()),
-            ),
-            Size2D::new(
-                Au::from_f32_px(bounding_box.size.width.px()),
-                Au::from_f32_px(bounding_box.size.height.px()),
-            ),
-        )
+        if found_any_nodes {
+            Some(Rect::new(
+                Point2D::new(
+                    Au::from_f32_px(bounding_box.origin.x.px()),
+                    Au::from_f32_px(bounding_box.origin.y.px()),
+                ),
+                Size2D::new(
+                    Au::from_f32_px(bounding_box.size.width.px()),
+                    Au::from_f32_px(bounding_box.size.height.px()),
+                ),
+            ))
+        } else {
+            None
+        }
     }
 
     pub fn get_border_dimensions_for_node(&self, requested_node: OpaqueNode) -> Rect<i32> {

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -173,7 +173,7 @@ pub fn process_content_box_request(
     requested_node: OpaqueNode,
     fragment_tree: Option<Arc<FragmentTree>>,
 ) -> Option<Rect<Au>> {
-    Some(fragment_tree?.get_content_box_for_node(requested_node))
+    fragment_tree?.get_content_box_for_node(requested_node)
 }
 
 pub fn process_content_boxes_request(_requested_node: OpaqueNode) -> Vec<Rect<Au>> {

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/not-rendered-dimension-getter.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/not-rendered-dimension-getter.html.ini
@@ -1,3 +1,0 @@
-[not-rendered-dimension-getter.html]
-  [Image intrinsic dimensions are returned if the image isn't rendered]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html.ini
@@ -2,6 +2,3 @@
   expected: ERROR
   [WebGL test #2: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL
-
-  [WebGL test #0: img was loaded]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/origin-clean-conformance.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/origin-clean-conformance.html.ini
@@ -1,3 +1,0 @@
-[origin-clean-conformance.html]
-  [WebGL test #0: img was loaded]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html.ini
@@ -2,6 +2,3 @@
   expected: ERROR
   [WebGL test #2: Unable to fetch WebGL rendering context for Canvas]
     expected: FAIL
-
-  [WebGL test #0: img was loaded]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The `HTMLImageElement.prototype.width/height` attributes [should provide](https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-width) the rendered width/height of images that are being rendered, and the natural width/height of images that are not being rendered. In Servo, these attributes call `bounding_content_box` on the node, treating `None` as an indication that the element is not being rendered (and returning the natural width/height). But Layout 2020 returns a 0x0 bounding box for elements that are not being rendered, instead of `None`.

As a result:
```js
let image = new Image();
image.src = "...";
image.onload = () => {
    const [width, height] = [image.width, image.height];
    // use width/height
};
```
always gets 0/0 for the width/height (instead of the natural width/height) in Layout 2020.

This PR makes it so requests to Layout 2020 for the bounding box of a node that isn't being rendered return `None` instead of a 0x0 bounding box, which matches the Layout 2013 behavior.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (which already exist in WPT)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
