### PR TITLE
layout: Implement support for font fallback

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -106,7 +106,7 @@ pub trait FontTableMethods {
     fn buffer(&self) -> &[u8];
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct FontMetrics {
     pub underline_size: Au,
     pub underline_offset: Au,

--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -148,12 +148,13 @@ where
             .into_par_iter()
             .map(|job| match job {
                 FlexLevelJob::TextRuns(runs) => ArcRefCell::new(FlexLevelBox::FlexItem({
-                    let runs = runs.into_iter().map(|run| crate::flow::text_run::TextRun {
-                        base_fragment_info: (&run.info).into(),
-                        text: run.text.into(),
-                        parent_style: run.info.style,
-                        has_uncollapsible_content: false,
-                        shaped_text: None,
+                    let runs = runs.into_iter().map(|run| {
+                        crate::flow::text_run::TextRun::new(
+                            (&run.info).into(),
+                            run.info.style,
+                            run.text.into(),
+                            false, /* has_uncollapsible_content */
+                        )
                     });
                     let bfc = BlockFormattingContext::construct_for_text_runs(
                         runs,

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -67,6 +67,7 @@ impl BlockFormattingContext {
 
         let ifc = InlineFormattingContext {
             inline_level_boxes,
+            font_metrics: Vec::new(),
             text_decoration_line,
             has_first_formatted_line: true,
             contains_floats: false,
@@ -433,13 +434,12 @@ where
             _ => {},
         }
 
-        inlines.push(ArcRefCell::new(InlineLevelBox::TextRun(TextRun {
-            base_fragment_info: info.into(),
-            parent_style: Arc::clone(&info.style),
-            text: output,
+        inlines.push(ArcRefCell::new(InlineLevelBox::TextRun(TextRun::new(
+            info.into(),
+            Arc::clone(&info.style),
+            output,
             has_uncollapsible_content,
-            shaped_text: None,
-        })));
+        ))));
     }
 }
 
@@ -606,6 +606,7 @@ where
                 is_first_fragment: true,
                 is_last_fragment: false,
                 children: vec![],
+                default_font_index: None,
             });
 
             if is_list_item {
@@ -670,6 +671,7 @@ where
                         // are obviously not the last fragment.
                         is_last_fragment: false,
                         children: std::mem::take(&mut ongoing.children),
+                        default_font_index: None,
                     };
                     ongoing.is_first_fragment = false;
                     fragmented

--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -5,21 +5,29 @@
 use std::mem;
 
 use app_units::Au;
-use gfx::font::FontMetrics;
+use gfx::font::{FontRef, ShapingFlags, ShapingOptions};
+use gfx::font_cache_thread::FontCacheThread;
+use gfx::font_context::FontContext;
 use gfx::text::text_run::GlyphRun;
+use gfx_traits::ByteIndex;
+use log::warn;
+use range::Range;
 use serde::Serialize;
 use servo_arc::Arc;
+use style::computed_values::text_rendering::T as TextRendering;
+use style::computed_values::word_break::T as WordBreak;
 use style::properties::ComputedValues;
-use webrender_api::FontInstanceKey;
+use unicode_script::Script;
 use xi_unicode::{linebreak_property, LineBreakLeafIter};
 
-use super::inline::InlineFormattingContextState;
-use crate::context::LayoutContext;
+use super::inline::{FontKeyAndMetrics, InlineFormattingContextState};
 use crate::fragment_tree::BaseFragmentInfo;
 
 // These constants are the xi-unicode line breaking classes that are defined in
 // `table.rs`. Unfortunately, they are only identified by number.
+const XI_LINE_BREAKING_CLASS_CM: u8 = 9;
 const XI_LINE_BREAKING_CLASS_GL: u8 = 12;
+const XI_LINE_BREAKING_CLASS_ZW: u8 = 28;
 const XI_LINE_BREAKING_CLASS_WJ: u8 = 30;
 const XI_LINE_BREAKING_CLASS_ZWJ: u8 = 40;
 
@@ -30,30 +38,163 @@ pub(crate) struct TextRun {
     #[serde(skip_serializing)]
     pub parent_style: Arc<ComputedValues>,
     pub text: String,
+
+    /// The text of this [`TextRun`] with a font selected, broken into unbreakable
+    /// segments, and shaped.
+    pub shaped_text: Vec<TextRunSegment>,
+
+    /// Whether or not this [`TextRun`] has uncollapsible content. This is used
+    /// to determine if an [`super::InlineFormattingContext`] is considered empty or not.
     pub has_uncollapsible_content: bool,
-    pub shaped_text: Option<BreakAndShapeResult>,
+
+    /// Whether or not to prevent a soft wrap opportunity at the start of this [`TextRun`].
+    /// This depends on the whether the first character in the run prevents a soft wrap
+    /// opportunity.
+    prevent_soft_wrap_opportunity_at_start: bool,
+
+    /// Whether or not to prevent a soft wrap opportunity at the end of this [`TextRun`].
+    /// This depends on the whether the last character in the run prevents a soft wrap
+    /// opportunity.
+    prevent_soft_wrap_opportunity_at_end: bool,
+}
+
+// There are two reasons why we might want to break at the start:
+//
+//  1. The line breaker told us that a break was necessary between two separate
+//     instances of sending text to it.
+//  2. We are following replaced content ie `have_deferred_soft_wrap_opportunity`.
+//
+// In both cases, we don't want to do this if the first character prevents a
+// soft wrap opportunity.
+#[derive(PartialEq)]
+enum SegmentStartSoftWrapPolicy {
+    Force,
+    Prevent,
+    FollowLinebreaker,
 }
 
 #[derive(Debug, Serialize)]
-pub(crate) struct BreakAndShapeResult {
-    pub font_metrics: FontMetrics,
-    pub font_key: FontInstanceKey,
-    pub runs: Vec<GlyphRun>,
+pub(crate) struct TextRunSegment {
+    /// The index of this font in the parent [`InlineFormattingContext`]'s collection of font
+    /// information.
+    pub font_index: usize,
+
+    /// The [`Script`] of this segment.
+    #[serde(skip_serializing)]
+    pub script: Script,
+
+    /// The range of bytes in the [`TextRun`]'s text that this segment covers.
+    pub range: Range<ByteIndex>,
+
+    /// Whether or not the linebreaker said that we should allow a line break at the start of this
+    /// segment.
     pub break_at_start: bool,
+
+    /// The shaped runs within this segment.
+    pub runs: Vec<GlyphRun>,
+}
+
+impl TextRunSegment {
+    fn new(font_index: usize, script: Script, byte_index: ByteIndex) -> Self {
+        Self {
+            script,
+            font_index,
+            range: Range::new(byte_index, ByteIndex(0)),
+            runs: Vec::new(),
+            break_at_start: false,
+        }
+    }
+
+    /// Update this segment if the Font and Script are compatible. The update will only
+    /// ever make the Script specific. Returns true if the new Font and Script are
+    /// compatible with this segment or false otherwise.
+    fn update_if_compatible(
+        &mut self,
+        font: &FontRef,
+        script: Script,
+        fonts: &[FontKeyAndMetrics],
+    ) -> bool {
+        fn is_specific(script: Script) -> bool {
+            script != Script::Common && script != Script::Inherited
+        }
+
+        let current_font_key_and_metrics = &fonts[self.font_index];
+        let new_font = font.borrow();
+        if new_font.font_key != current_font_key_and_metrics.key ||
+            new_font.actual_pt_size != current_font_key_and_metrics.actual_pt_size
+        {
+            return false;
+        }
+
+        if !is_specific(self.script) && is_specific(script) {
+            self.script = script;
+        }
+        script == self.script || !is_specific(script)
+    }
+
+    fn layout_into_line_items(
+        &self,
+        text_run: &TextRun,
+        mut soft_wrap_policy: SegmentStartSoftWrapPolicy,
+        ifc: &mut InlineFormattingContextState,
+    ) {
+        if self.break_at_start && soft_wrap_policy == SegmentStartSoftWrapPolicy::FollowLinebreaker
+        {
+            soft_wrap_policy = SegmentStartSoftWrapPolicy::Force;
+        }
+
+        for (run_index, run) in self.runs.iter().enumerate() {
+            ifc.possibly_flush_deferred_forced_line_break();
+
+            // If this whitespace forces a line break, queue up a hard line break the next time we
+            // see any content. We don't line break immediately, because we'd like to finish processing
+            // any ongoing inline boxes before ending the line.
+            if text_run.glyph_run_is_whitespace_ending_with_preserved_newline(run) {
+                ifc.defer_forced_line_break();
+                continue;
+            }
+
+            // Break before each unbreakable run in this TextRun, except the first unless the
+            // linebreaker was set to break before the first run.
+            if run_index != 0 || soft_wrap_policy == SegmentStartSoftWrapPolicy::Force {
+                ifc.process_soft_wrap_opportunity();
+            }
+
+            ifc.push_glyph_store_to_unbreakable_segment(
+                run.glyph_store.clone(),
+                text_run,
+                self.font_index,
+            );
+        }
+    }
 }
 
 impl TextRun {
+    pub(crate) fn new(
+        base_fragment_info: BaseFragmentInfo,
+        parent_style: Arc<ComputedValues>,
+        text: String,
+        has_uncollapsible_content: bool,
+    ) -> Self {
+        Self {
+            base_fragment_info,
+            parent_style,
+            text,
+            has_uncollapsible_content,
+            shaped_text: Vec::new(),
+            prevent_soft_wrap_opportunity_at_start: false,
+            prevent_soft_wrap_opportunity_at_end: false,
+        }
+    }
+
     pub(super) fn break_and_shape(
         &mut self,
-        layout_context: &LayoutContext,
+        font_context: &mut FontContext<FontCacheThread>,
         linebreaker: &mut Option<LineBreakLeafIter>,
+        font_cache: &mut Vec<FontKeyAndMetrics>,
     ) {
-        use gfx::font::ShapingFlags;
-        use style::computed_values::text_rendering::T as TextRendering;
-        use style::computed_values::word_break::T as WordBreak;
-
-        let font_style = self.parent_style.clone_font();
-        let inherited_text_style = self.parent_style.get_inherited_text();
+        let segment_results = self.segment_text(font_context, font_cache);
+        let inherited_text_style = self.parent_style.get_inherited_text().clone();
         let letter_spacing = if inherited_text_style.letter_spacing.0.px() != 0. {
             Some(app_units::Au::from(inherited_text_style.letter_spacing.0))
         } else {
@@ -72,50 +213,145 @@ impl TextRun {
             flags.insert(ShapingFlags::KEEP_ALL_FLAG);
         }
 
-        self.shaped_text =
-            crate::context::with_thread_local_font_context(layout_context, |font_context| {
-                let font_group = font_context.font_group(font_style);
-                let font = match font_group.borrow_mut().first(font_context) {
-                    Some(font) => font,
-                    None => return Err("Could not find find for TextRun."),
-                };
+        let specified_word_spacing = &inherited_text_style.word_spacing;
+        let style_word_spacing: Option<Au> = specified_word_spacing.to_length().map(|l| l.into());
+        let segments = segment_results
+            .into_iter()
+            .map(|(mut segment, font)| {
                 let mut font = font.borrow_mut();
-
-                let word_spacing = &inherited_text_style.word_spacing;
-                let word_spacing =
-                    word_spacing
-                        .to_length()
-                        .map(|l| l.into())
-                        .unwrap_or_else(|| {
-                            let space_width = font
-                                .glyph_index(' ')
-                                .map(|glyph_id| font.glyph_h_advance(glyph_id))
-                                .unwrap_or(gfx::font::LAST_RESORT_GLYPH_ADVANCE);
-                            word_spacing.to_used_value(Au::from_f64_px(space_width))
-                        });
-
-                let shaping_options = gfx::font::ShapingOptions {
+                let word_spacing = style_word_spacing.unwrap_or_else(|| {
+                    let space_width = font
+                        .glyph_index(' ')
+                        .map(|glyph_id| font.glyph_h_advance(glyph_id))
+                        .unwrap_or(gfx::font::LAST_RESORT_GLYPH_ADVANCE);
+                    specified_word_spacing.to_used_value(Au::from_f64_px(space_width))
+                });
+                let shaping_options = ShapingOptions {
                     letter_spacing,
                     word_spacing,
-                    script: unicode_script::Script::Common,
+                    script: segment.script,
                     flags,
                 };
+                (segment.runs, segment.break_at_start) =
+                    gfx::text::text_run::TextRun::break_and_shape(
+                        &mut font,
+                        &self.text
+                            [segment.range.begin().0 as usize..segment.range.end().0 as usize],
+                        &shaping_options,
+                        linebreaker,
+                    );
 
-                let (runs, break_at_start) = gfx::text::text_run::TextRun::break_and_shape(
-                    &mut font,
-                    &self.text,
-                    &shaping_options,
-                    linebreaker,
-                );
-
-                Ok(BreakAndShapeResult {
-                    font_metrics: font.metrics.clone(),
-                    font_key: font.font_key,
-                    runs,
-                    break_at_start,
-                })
+                segment
             })
-            .ok();
+            .collect();
+
+        let _ = std::mem::replace(&mut self.shaped_text, segments);
+    }
+
+    /// Take the [`TextRun`]'s text and turn it into [`TextRunSegment`]s. Each segment has a matched
+    /// font and script. Fonts may differ when glyphs are found in fallback fonts. Fonts are stored
+    /// in the `font_cache` which is a cache of all font keys and metrics used in this
+    /// [`super::InlineFormattingContext`].
+    fn segment_text(
+        &mut self,
+        font_context: &mut FontContext<FontCacheThread>,
+        font_cache: &mut Vec<FontKeyAndMetrics>,
+    ) -> Vec<(TextRunSegment, FontRef)> {
+        let font_group = font_context.font_group(self.parent_style.clone_font());
+        let mut current: Option<(TextRunSegment, FontRef)> = None;
+        let mut results = Vec::new();
+
+        for (byte_index, character) in self.text.char_indices() {
+            let prevents_soft_wrap_opportunity =
+                char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character);
+            if byte_index == 0 && prevents_soft_wrap_opportunity {
+                self.prevent_soft_wrap_opportunity_at_start = true;
+            }
+            self.prevent_soft_wrap_opportunity_at_end = prevents_soft_wrap_opportunity;
+
+            if char_does_not_change_font(character) {
+                continue;
+            }
+
+            let font = match font_group
+                .borrow_mut()
+                .find_by_codepoint(font_context, character)
+            {
+                Some(font) => font,
+                None => continue,
+            };
+
+            // If the existing segment is compatible with the character, keep going.
+            let script = Script::from(character);
+            if let Some(current) = current.as_mut() {
+                if current.0.update_if_compatible(&font, script, font_cache) {
+                    continue;
+                }
+            }
+
+            let font_index = add_or_get_font(&font, font_cache);
+
+            // Add the new segment and finish the existing one, if we had one. If the first
+            // characters in the run were control characters we may be creating the first
+            // segment in the middle of the run (ie the start should be 0).
+            let byte_index = match current {
+                Some(_) => ByteIndex(byte_index as isize),
+                None => ByteIndex(0 as isize),
+            };
+            let new = (TextRunSegment::new(font_index, script, byte_index), font);
+            if let Some(mut finished) = current.replace(new) {
+                finished.0.range.extend_to(byte_index);
+                results.push(finished);
+            }
+        }
+
+        // Either we have a current segment or we only had control character and whitespace. In both
+        // of those cases, just use the first font.
+        if current.is_none() {
+            current = font_group.borrow_mut().first(font_context).map(|font| {
+                let font_index = add_or_get_font(&font, font_cache);
+                (
+                    TextRunSegment::new(font_index, Script::Common, ByteIndex(0)),
+                    font,
+                )
+            })
+        }
+
+        // Extend the last segment to the end of the string and add it to the results.
+        if let Some(mut last_segment) = current.take() {
+            last_segment
+                .0
+                .range
+                .extend_to(ByteIndex(self.text.len() as isize));
+            results.push(last_segment);
+        }
+
+        results
+    }
+
+    pub(super) fn layout_into_line_items(&self, ifc: &mut InlineFormattingContextState) {
+        if self.text.is_empty() {
+            return;
+        }
+
+        // If we are following replaced content, we should have a soft wrap opportunity, unless the
+        // first character of this `TextRun` prevents that soft wrap opportunity. If we see such a
+        // character it should also override the LineBreaker's indication to break at the start.
+        let have_deferred_soft_wrap_opportunity =
+            mem::replace(&mut ifc.have_deferred_soft_wrap_opportunity, false);
+        let mut soft_wrap_policy = match self.prevent_soft_wrap_opportunity_at_start {
+            true => SegmentStartSoftWrapPolicy::Prevent,
+            false if have_deferred_soft_wrap_opportunity => SegmentStartSoftWrapPolicy::Force,
+            false => SegmentStartSoftWrapPolicy::FollowLinebreaker,
+        };
+
+        for segment in self.shaped_text.iter() {
+            segment.layout_into_line_items(self, soft_wrap_policy, ifc);
+            soft_wrap_policy = SegmentStartSoftWrapPolicy::FollowLinebreaker;
+        }
+
+        ifc.prevent_soft_wrap_opportunity_before_next_atomic =
+            self.prevent_soft_wrap_opportunity_at_end;
     }
 
     pub(super) fn glyph_run_is_whitespace_ending_with_preserved_newline(
@@ -137,61 +373,9 @@ impl TextRun {
         let last_byte = self.text.as_bytes().get(run.range.end().to_usize() - 1);
         last_byte == Some(&b'\n')
     }
-
-    pub(super) fn layout_into_line_items(&self, ifc: &mut InlineFormattingContextState) {
-        let broken = match self.shaped_text.as_ref() {
-            Some(broken) => broken,
-            None => return,
-        };
-
-        // We either have a soft wrap opportunity if specified by the breaker or if we are
-        // following replaced content.
-        let have_deferred_soft_wrap_opportunity =
-            mem::replace(&mut ifc.have_deferred_soft_wrap_opportunity, false);
-        let mut break_at_start = broken.break_at_start || have_deferred_soft_wrap_opportunity;
-
-        if have_deferred_soft_wrap_opportunity {
-            if let Some(first_character) = self.text.chars().nth(0) {
-                break_at_start = break_at_start &&
-                    !char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(
-                        first_character,
-                    )
-            }
-        }
-
-        if let Some(last_character) = self.text.chars().last() {
-            ifc.prevent_soft_wrap_opportunity_before_next_atomic =
-                char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(last_character);
-        }
-
-        for (run_index, run) in broken.runs.iter().enumerate() {
-            ifc.possibly_flush_deferred_forced_line_break();
-
-            // If this whitespace forces a line break, queue up a hard line break the next time we
-            // see any content. We don't line break immediately, because we'd like to finish processing
-            // any ongoing inline boxes before ending the line.
-            if self.glyph_run_is_whitespace_ending_with_preserved_newline(run) {
-                ifc.defer_forced_line_break();
-                continue;
-            }
-
-            // Break before each unbrekable run in this TextRun, except the first unless the
-            // linebreaker was set to break before the first run.
-            if run_index != 0 || break_at_start {
-                ifc.process_soft_wrap_opportunity();
-            }
-
-            ifc.push_glyph_store_to_unbreakable_segment(
-                run.glyph_store.clone(),
-                self.base_fragment_info,
-                &self.parent_style,
-                &broken.font_metrics,
-                broken.font_key,
-            );
-        }
-    }
 }
 
+/// Whether or not this character will rpevent a soft wrap opportunity when it
 /// comes before or after an atomic inline element.
 ///
 /// From https://www.w3.org/TR/css-text-3/#line-break-details:
@@ -210,4 +394,52 @@ fn char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character: ch
     class == XI_LINE_BREAKING_CLASS_GL ||
         class == XI_LINE_BREAKING_CLASS_WJ ||
         class == XI_LINE_BREAKING_CLASS_ZWJ
+}
+
+/// Whether or not this character should be able to change the font during segmentation.  Certain
+/// character are not rendered at all, so it doesn't matter what font we use to render them. They
+/// should just be added to the current segment.
+fn char_does_not_change_font(character: char) -> bool {
+    if character.is_whitespace() || character.is_control() {
+        return true;
+    }
+    if character == '\u{00A0}' {
+        return true;
+    }
+    let class = linebreak_property(character);
+    class == XI_LINE_BREAKING_CLASS_CM ||
+        class == XI_LINE_BREAKING_CLASS_GL ||
+        class == XI_LINE_BREAKING_CLASS_ZW ||
+        class == XI_LINE_BREAKING_CLASS_WJ ||
+        class == XI_LINE_BREAKING_CLASS_ZWJ
+}
+
+pub(super) fn add_or_get_font(font: &FontRef, ifc_fonts: &mut Vec<FontKeyAndMetrics>) -> usize {
+    let font = font.borrow();
+    for (index, ifc_font_info) in ifc_fonts.iter().enumerate() {
+        if ifc_font_info.key == font.font_key && ifc_font_info.actual_pt_size == font.actual_pt_size
+        {
+            return index;
+        }
+    }
+    ifc_fonts.push(FontKeyAndMetrics {
+        metrics: font.metrics.clone(),
+        key: font.font_key,
+        actual_pt_size: font.actual_pt_size,
+    });
+    ifc_fonts.len() - 1
+}
+
+pub(super) fn get_font_for_first_font_for_style(
+    style: &ComputedValues,
+    font_context: &mut FontContext<FontCacheThread>,
+) -> Option<FontRef> {
+    let font = font_context
+        .font_group(style.clone_font())
+        .borrow_mut()
+        .first(font_context);
+    if font.is_none() {
+        warn!("Could not find font for style: {:?}", style.clone_font());
+    }
+    font
 }

--- a/tests/wpt/meta/css/CSS2/fonts/font-family-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-family-013.xht.ini
@@ -1,2 +1,0 @@
-[font-family-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/fonts-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/fonts-012.xht.ini
@@ -1,2 +1,2 @@
-[fonts-013.xht]
+[fonts-012.xht]
   expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-009.xht.ini
@@ -1,0 +1,2 @@
+[text-transform-bicameral-009.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-010.xht.ini
@@ -1,0 +1,2 @@
+[text-transform-bicameral-010.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-variant-ligatures-11.optional.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variant-ligatures-11.optional.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-11.optional.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/bidi/bidi-lines-001.html.ini
+++ b/tests/wpt/meta/css/css-text/bidi/bidi-lines-001.html.ini
@@ -1,0 +1,2 @@
+[bidi-lines-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-010.html.ini
+++ b/tests/wpt/meta/css/css-text/boundary-shaping/boundary-shaping-010.html.ini
@@ -1,0 +1,2 @@
+[boundary-shaping-010.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/hyphens/hyphens-shaping-001.html.ini
+++ b/tests/wpt/meta/css/css-text/hyphens/hyphens-shaping-001.html.ini
@@ -1,0 +1,2 @@
+[hyphens-shaping-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-ligatures-002.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-ligatures-002.html.ini
@@ -1,0 +1,2 @@
+[letter-spacing-ligatures-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-000-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-000-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-000-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-012-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-012-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-012-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-000.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-000.html.ini
@@ -1,0 +1,2 @@
+[shaping-000.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-004.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-004.html.ini
@@ -1,0 +1,2 @@
+[shaping-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-005.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-005.html.ini
@@ -1,0 +1,2 @@
+[shaping-005.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-006.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-006.html.ini
@@ -1,0 +1,2 @@
+[shaping-006.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-007.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-007.html.ini
@@ -1,0 +1,2 @@
+[shaping-007.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping_lig-000.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping_lig-000.html.ini
@@ -1,0 +1,2 @@
+[shaping_lig-000.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-encoding/shaping-join-001.html.ini
+++ b/tests/wpt/meta/css/css-text/text-encoding/shaping-join-001.html.ini
@@ -1,0 +1,2 @@
+[shaping-join-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-encoding/shaping-join-003.html.ini
+++ b/tests/wpt/meta/css/css-text/text-encoding/shaping-join-003.html.ini
@@ -1,0 +1,2 @@
+[shaping-join-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-encoding/shaping-no-join-001.html.ini
+++ b/tests/wpt/meta/css/css-text/text-encoding/shaping-no-join-001.html.ini
@@ -1,0 +1,2 @@
+[shaping-no-join-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-encoding/shaping-no-join-003.html.ini
+++ b/tests/wpt/meta/css/css-text/text-encoding/shaping-no-join-003.html.ini
@@ -1,0 +1,2 @@
+[shaping-no-join-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-encoding/shaping-tatweel-001.html.ini
+++ b/tests/wpt/meta/css/css-text/text-encoding/shaping-tatweel-001.html.ini
@@ -1,0 +1,2 @@
+[shaping-tatweel-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-encoding/shaping-tatweel-003.html.ini
+++ b/tests/wpt/meta/css/css-text/text-encoding/shaping-tatweel-003.html.ini
@@ -1,0 +1,2 @@
+[shaping-tatweel-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-103.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-103.html.ini
@@ -1,0 +1,2 @@
+[text-transform-upperlower-103.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-104.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-104.html.ini
@@ -1,0 +1,2 @@
+[text-transform-upperlower-104.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-normal-ar-000.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-normal-ar-000.html.ini
@@ -1,2 +1,0 @@
-[word-break-normal-ar-000.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/font_fallback_03.html.ini
+++ b/tests/wpt/mozilla/meta/css/font_fallback_03.html.ini
@@ -1,2 +1,0 @@
-[font_fallback_03.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/per_glyph_font_fallback_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/per_glyph_font_fallback_a.html.ini
@@ -1,2 +1,0 @@
-[per_glyph_font_fallback_a.html]
-  expected: FAIL


### PR DESCRIPTION
This adds an initial implementation of font fallback, on part with the
one used in legacy layout. This causes more tests to fail than pass, but
is a progression. There are several reasons for this.

1. Font matching is done per unicode character rather than per-grapheme.
     We should eventually do per-grapheme fallback or take the approach of
     Chromium, which is to try to shape everything and then fall back when
     there are missing glyphs.
3. Shaping is not done across element boundaries. This is step 2 of proper
     font fallback and shaping, but it causes many tests to fail.
2. Now that fall back is happening, we detect more failures, in particular with 
    white space collapse and Arabic / Persian handling.

The idea is that these changes can be made in a followup.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
