### PR TITLE
canvas2d: Implement `.reset()`

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -1054,7 +1054,8 @@ impl<'a> CanvasData<'a> {
         self.backend.set_global_composition(op, &mut self.state);
     }
 
-    pub fn recreate(&mut self, size: Size2D<u64>) {
+    pub fn recreate(&mut self, size: Option<Size2D<u64>>) {
+        let size = size.unwrap_or_else(|| self.drawtarget.get_size().to_u64());
         self.drawtarget = self
             .backend
             .create_drawtarget(Size2D::new(size.width, size.height));

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -216,7 +216,14 @@ impl CanvasState {
     pub fn set_bitmap_dimensions(&self, size: Size2D<u64>) {
         self.reset_to_initial_state();
         self.ipc_renderer
-            .send(CanvasMsg::Recreate(size, self.get_canvas_id()))
+            .send(CanvasMsg::Recreate(Some(size), self.get_canvas_id()))
+            .unwrap();
+    }
+
+    pub fn reset(&self) {
+        self.reset_to_initial_state();
+        self.ipc_renderer
+            .send(CanvasMsg::Recreate(None, self.get_canvas_id()))
             .unwrap();
     }
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -181,7 +181,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
         self.canvas_state.restore()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-reset
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-reset>
     fn Reset(&self) {
         self.canvas_state.reset()
     }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -74,7 +74,7 @@ impl CanvasRenderingContext2D {
         self.canvas_state
             .get_ipc_renderer()
             .send(CanvasMsg::Recreate(
-                size.to_u64(),
+                Some(size.to_u64()),
                 self.canvas_state.get_canvas_id(),
             ))
             .unwrap();
@@ -179,6 +179,11 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-restore
     fn Restore(&self) {
         self.canvas_state.restore()
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-reset
+    fn Reset(&self) {
+        self.canvas_state.reset()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-scale

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -213,7 +213,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         self.canvas_state.restore()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-reset
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-reset>
     fn Reset(&self) {
         self.canvas_state.reset()
     }

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -213,6 +213,11 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         self.canvas_state.restore()
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-reset
+    fn Reset(&self) {
+        self.canvas_state.reset()
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalalpha
     fn GlobalAlpha(&self) -> f64 {
         self.canvas_state.global_alpha()

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -95,6 +95,11 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
         self.context.Restore()
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-reset
+    fn Reset(&self) {
+        self.context.Reset()
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-scale
     fn Scale(&self, x: f64, y: f64) {
         self.context.Scale(x, y)

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -95,7 +95,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
         self.context.Restore()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-reset
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-reset>
     fn Reset(&self) {
         self.context.Reset()
     }

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -44,6 +44,7 @@ interface mixin CanvasState {
   // state
   undefined save(); // push state on state stack
   undefined restore(); // pop state stack and restore state
+  undefined reset();
 };
 
 interface mixin CanvasTransform {

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -28,7 +28,7 @@ pub enum CanvasMsg {
     Canvas2d(Canvas2dMsg, CanvasId),
     FromLayout(FromLayoutMsg, CanvasId),
     FromScript(FromScriptMsg, CanvasId),
-    Recreate(Size2D<u64>, CanvasId),
+    Recreate(Option<Size2D<u64>>, CanvasId),
     Close(CanvasId),
 }
 

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/canvas-reset.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/hidpi/canvas-reset.https.html.ini
@@ -1,2 +1,0 @@
-[canvas-reset.https.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-reset.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-paint-api/paint2d-reset.https.html.ini
@@ -1,2 +1,0 @@
-[paint2d-reset.https.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.valid-calls.save_reset_restore.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/layers/2d.layer.valid-calls.save_reset_restore.html.ini
@@ -1,3 +1,0 @@
-[2d.layer.valid-calls.save_reset_restore.html]
-  [No exception raised on save() + reset() + restore().]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.basic.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.basic.html.ini
@@ -1,4 +1,0 @@
-[2d.reset.basic.html]
-  [reset clears to transparent black]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.drop_shadow.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.drop_shadow.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.drop_shadow.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.global_composite_operation.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.global_composite_operation.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.global_composite_operation.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.misc.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.misc.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.misc.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.miter_limit.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.miter_limit.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.miter_limit.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.text.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.render.text.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.text.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.clip.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.clip.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.state.clip.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.direction.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.direction.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.direction.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.fill_style.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.fill_style.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.fill_style.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.font.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.font.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.font.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.global_alpha.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.global_alpha.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_alpha.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.global_composite_operation.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.global_composite_operation.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_composite_operation.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.image_smoothing_enabled.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.line_cap.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.line_cap.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_cap.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.line_join.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.line_join.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_join.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.line_width.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.line_width.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_width.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.miter_limit.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.miter_limit.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.miter_limit.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_blur.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_blur.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_blur.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_color.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_color.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_color.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_offset_x.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_offset_x.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_x.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_offset_y.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.shadow_offset_y.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_y.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.stroke_style.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.stroke_style.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.stroke_style.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.text_align.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.text_align.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_align.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.text_baseline.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.text_baseline.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_baseline.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.transformation_matrix.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/element/reset/2d.reset.state.transformation_matrix.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.transformation_matrix.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.valid-calls.save_reset_restore.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.valid-calls.save_reset_restore.html.ini
@@ -1,3 +1,0 @@
-[2d.layer.valid-calls.save_reset_restore.html]
-  [No exception raised on save() + reset() + restore().]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.valid-calls.save_reset_restore.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/layers/2d.layer.valid-calls.save_reset_restore.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.layer.valid-calls.save_reset_restore.worker.html]
-  [No exception raised on save() + reset() + restore().]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.basic.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.basic.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.basic.html]
-  [reset clears to transparent black]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.basic.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.basic.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.basic.worker.html]
-  [reset clears to transparent black]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.drop_shadow.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.drop_shadow.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.drop_shadow.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.global_composite_operation.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.global_composite_operation.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.global_composite_operation.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.misc.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.misc.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.misc.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.miter_limit.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.miter_limit.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.miter_limit.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.text.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.render.text.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.text.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.clip.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.clip.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.state.clip.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.direction.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.direction.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.direction.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.direction.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.direction.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.direction.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.fill_style.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.fill_style.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.fill_style.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.fill_style.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.fill_style.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.fill_style.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_alpha.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_alpha.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_alpha.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_alpha.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_alpha.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_alpha.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_composite_operation.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_composite_operation.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.image_smoothing_enabled.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.image_smoothing_enabled.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_cap.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_cap.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_cap.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_cap.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_cap.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_cap.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_join.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_join.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_join.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_join.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_join.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_join.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_width.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_width.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_width.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_width.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.line_width.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_width.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.miter_limit.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.miter_limit.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.miter_limit.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.miter_limit.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.miter_limit.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.miter_limit.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_blur.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_blur.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_color.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_color.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_color.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_color.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_color.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_color.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_x.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_x.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_y.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_y.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.stroke_style.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.stroke_style.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.stroke_style.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.stroke_style.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.stroke_style.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.stroke_style.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_align.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_align.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_align.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_align.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_align.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_align.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_baseline.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_baseline.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_baseline.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_baseline.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.text_baseline.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_baseline.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.transformation_matrix.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.transformation_matrix.worker.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
@@ -1379,9 +1379,6 @@
   [Worklet interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation reset()]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation createConicGradient(double, double, double)]
     expected: FAIL
 
@@ -1401,9 +1398,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: attribute textRendering]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "reset()" with the proper type]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "createConicGradient(double, double, double)" with the proper type]

--- a/tests/wpt/meta/html/canvas/element/layers/2d.layer.valid-calls.save_reset_restore.html.ini
+++ b/tests/wpt/meta/html/canvas/element/layers/2d.layer.valid-calls.save_reset_restore.html.ini
@@ -1,3 +1,0 @@
-[2d.layer.valid-calls.save_reset_restore.html]
-  [No exception raised on save() + reset() + restore().]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.basic.html.ini
@@ -1,4 +1,0 @@
-[2d.reset.basic.html]
-  [reset clears to transparent black]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.drop_shadow.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.drop_shadow.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.drop_shadow.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.global_composite_operation.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.global_composite_operation.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.global_composite_operation.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.misc.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.misc.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.misc.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.miter_limit.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.miter_limit.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.miter_limit.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.text.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.render.text.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.render.text.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.clip.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.clip.html.ini
@@ -1,2 +1,0 @@
-[2d.reset.state.clip.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.direction.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.direction.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.direction.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.fill_style.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.fill_style.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.fill_style.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.global_alpha.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.global_alpha.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_alpha.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.global_composite_operation.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.global_composite_operation.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.global_composite_operation.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.image_smoothing_enabled.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.line_cap.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.line_cap.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_cap.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.line_join.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.line_join.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_join.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.line_width.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.line_width.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.line_width.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.miter_limit.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.miter_limit.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.miter_limit.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_blur.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_blur.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_blur.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_color.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_color.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_color.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_offset_x.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_offset_x.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_x.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_offset_y.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.shadow_offset_y.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.shadow_offset_y.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.stroke_style.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.stroke_style.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.stroke_style.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.text_align.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.text_align.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_align.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.text_baseline.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.text_baseline.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.text_baseline.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.transformation_matrix.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.transformation_matrix.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.transformation_matrix.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -1241,9 +1241,6 @@
   [Worklet interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation reset()]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation createConicGradient(double, double, double)]
     expected: FAIL
 
@@ -1263,9 +1260,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: attribute textRendering]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "reset()" with the proper type]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "createConicGradient(double, double, double)" with the proper type]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implements [`.reset()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/reset) for `CanvasRenderingContext2D`, which resets the rendering context to its default state. There is already logic for resetting the rendering context for when the width/height is changed, so the implementation is similar.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (already in WPT)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
