### PR TITLE
Convert etc/profilicate.py to Python 3

### DIFF
--- a/etc/profilicate.py
+++ b/etc/profilicate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2018 The Servo Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution.
@@ -35,10 +35,10 @@ class StringTable:
         return self.table[s]
 
     def length(self):
-        return len(self.table.keys())
+        return len(list(self.table.keys()))
 
     def contents(self):
-        return sorted(self.table.keys(), key=self.table.__getitem__)
+        return sorted(list(self.table.keys()), key=self.table.__getitem__)
 
 
 with open(sys.argv[1]) as f:
@@ -63,7 +63,7 @@ for sample in samples:
 
 tid = 0
 threads = []
-for (name, raw_samples) in sorted(thread_data.iteritems(), key=lambda x: thread_order[x[0]]):
+for (name, raw_samples) in sorted(iter(thread_data.items()), key=lambda x: thread_order[x[0]]):
     string_table = StringTable()
     tid += 1
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Converts  `etc/profilicate.py` (a script for processing raw profiler samples) from Python 2 to Python 3, to make it easier to run on modern systems. I used `2to3`, then removed unnecessary double brackets and updated the shebang.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [X] These changes do not require tests because it is a testing script

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
