### PR TITLE
Fix crash on console logging large array

### DIFF
--- a/tests/wpt/meta-legacy-layout/console/console-log-large-array.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/console/console-log-large-array.any.js.ini
@@ -1,0 +1,6 @@
+[console-log-large-array.any.html]
+
+[console-log-large-array.any.worker.html]
+
+[console-log-large-array.any.shadowrealm.html]
+  expected: ERROR

--- a/tests/wpt/meta/console/console-log-large-array.any.js.ini
+++ b/tests/wpt/meta/console/console-log-large-array.any.js.ini
@@ -1,0 +1,6 @@
+[console-log-large-array.any.worker.html]
+
+[console-log-large-array.any.shadowrealm.html]
+  expected: ERROR
+
+[console-log-large-array.any.html]

--- a/tests/wpt/tests/console/console-log-large-array.any.js
+++ b/tests/wpt/tests/console/console-log-large-array.any.js
@@ -1,0 +1,8 @@
+// META: global=window,dedicatedworker,shadowrealm
+"use strict";
+// https://console.spec.whatwg.org/
+
+test(() => {
+    console.log(new Array(10000000).fill("x"));
+    console.log(new Uint8Array(10000000));
+}, "Logging large arrays works");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I checked for very deep objects in when adding object logging support in #31241, but didn't check for objects with many elements (usually large arrays). This caused crashes with code like `console.log(new Array(10000000).fill("x"))`.

This PR fixes that by only logging the first 15 elements of objects.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
