### PR TITLE
script: implement navigator.hardwareConcurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,6 +4894,7 @@ dependencies = [
  "msg",
  "net_traits",
  "num-traits",
+ "num_cpus",
  "parking_lot",
  "percent-encoding",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ mime_guess = "2.0.3"
 mozangle = "0.5.0"
 msg = { path = "components/shared/msg" }
 net_traits = { path = "components/shared/net" }
+num_cpus = { workspace = true }
 num-traits = "0.2"
 parking_lot = "0.12"
 percent-encoding = "2.3"

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -16,7 +16,7 @@ euclid = { workspace = true }
 getopts = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-num_cpus = "1.1.0"
+num_cpus = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 servo_config_plugins = { path = "../config_plugins" }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -75,6 +75,7 @@ mime = { workspace = true }
 mime_guess = { workspace = true }
 msg = { workspace = true }
 net_traits = { workspace = true }
+num_cpus = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = { workspace = true }

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::convert::TryInto;
+
 use dom_struct::dom_struct;
 use js::jsval::JSVal;
+use lazy_static::lazy_static;
 
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
@@ -23,6 +26,13 @@ use crate::dom::serviceworkercontainer::ServiceWorkerContainer;
 use crate::dom::window::Window;
 use crate::dom::xrsystem::XRSystem;
 use crate::script_runtime::JSContext;
+
+pub(super) fn hardware_concurrency() -> u64 {
+    lazy_static! {
+        static ref CPUS: u64 = num_cpus::get().try_into().unwrap_or(1);
+    }
+    *CPUS
+}
 
 #[dom_struct]
 pub struct Navigator {
@@ -205,5 +215,10 @@ impl NavigatorMethods for Navigator {
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     fn Gpu(&self) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(&self.global()))
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>
+    fn HardwareConcurrency(&self) -> u64 {
+        hardware_concurrency()
     }
 }

--- a/components/script/dom/webidls/Navigator.webidl
+++ b/components/script/dom/webidls/Navigator.webidl
@@ -15,6 +15,7 @@ Navigator includes NavigatorLanguage;
 Navigator includes NavigatorPlugins;
 Navigator includes NavigatorCookies;
 Navigator includes NavigatorGPU;
+Navigator includes NavigatorConcurrentHardware;
 
 // https://html.spec.whatwg.org/multipage/#navigatorid
 [Exposed=(Window,Worker)]
@@ -69,4 +70,9 @@ partial interface Navigator {
 // https://w3c.github.io/gamepad/#navigator-interface-extension
 partial interface Navigator {
     [Pref="dom.gamepad.enabled"] GamepadList getGamepads();
+};
+
+// https://html.spec.whatwg.org/multipage/#navigatorconcurrenthardware
+interface mixin NavigatorConcurrentHardware {
+  readonly attribute unsigned long long hardwareConcurrency;
 };

--- a/components/script/dom/webidls/WorkerNavigator.webidl
+++ b/components/script/dom/webidls/WorkerNavigator.webidl
@@ -8,6 +8,7 @@ interface WorkerNavigator {};
 WorkerNavigator includes NavigatorID;
 WorkerNavigator includes NavigatorLanguage;
 //WorkerNavigator includes NavigatorOnLine;
+WorkerNavigator includes NavigatorConcurrentHardware;
 
 // https://w3c.github.io/permissions/#navigator-and-workernavigator-extension
 

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::gpu::GPU;
+use crate::dom::navigator::hardware_concurrency;
 use crate::dom::navigatorinfo;
 use crate::dom::permissions::Permissions;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
@@ -109,5 +110,10 @@ impl WorkerNavigatorMethods for WorkerNavigator {
     // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
     fn Gpu(&self) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(&self.global()))
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>
+    fn HardwareConcurrency(&self) -> u64 {
+        hardware_concurrency()
     }
 }

--- a/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
@@ -143,9 +143,6 @@
   [ApplicationCache interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
-  [Navigator interface: attribute hardwareConcurrency]
-    expected: FAIL
-
   [OffscreenCanvasRenderingContext2D interface: operation restore()]
     expected: FAIL
 
@@ -810,9 +807,6 @@
     expected: FAIL
 
   [DragEvent interface: existence and properties of interface object]
-    expected: FAIL
-
-  [Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type]
     expected: FAIL
 
   [ApplicationCache interface: operation update()]

--- a/tests/wpt/meta-legacy-layout/html/dom/idlharness.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/idlharness.worker.js.ini
@@ -266,9 +266,6 @@
   [OffscreenCanvasRenderingContext2D interface: attribute lineDashOffset]
     expected: FAIL
 
-  [WorkerNavigator interface: self.navigator must inherit property "hardwareConcurrency" with the proper type]
-    expected: FAIL
-
   [ImageBitmapRenderingContext interface object name]
     expected: FAIL
 
@@ -384,9 +381,6 @@
     expected: FAIL
 
   [OffscreenCanvas interface: operation transferToImageBitmap()]
-    expected: FAIL
-
-  [WorkerNavigator interface: attribute hardwareConcurrency]
     expected: FAIL
 
   [OffscreenCanvasRenderingContext2D interface: operation arcTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)]

--- a/tests/wpt/meta-legacy-layout/workers/WorkerNavigator-hardware-concurrency.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/workers/WorkerNavigator-hardware-concurrency.any.js.ini
@@ -1,16 +1,5 @@
 [WorkerNavigator-hardware-concurrency.any.sharedworker.html]
   expected: ERROR
-  [WorkerNavigator-hardware-concurrency]
-    expected: FAIL
-
-
-[WorkerNavigator-hardware-concurrency.any.worker.html]
-  [Test worker navigator hardware concurrency.]
-    expected: FAIL
-
 
 [WorkerNavigator-hardware-concurrency.any.serviceworker.html]
   expected: ERROR
-  [WorkerNavigator-hardware-concurrency]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -443,9 +443,6 @@
   [CanvasRenderingContext2D interface: calling isPointInStroke(Path2D, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Navigator interface: attribute hardwareConcurrency]
-    expected: FAIL
-
   [ApplicationCache interface: constant CHECKING on interface object]
     expected: FAIL
 
@@ -807,9 +804,6 @@
     expected: FAIL
 
   [DragEvent interface: existence and properties of interface object]
-    expected: FAIL
-
-  [Navigator interface: window.navigator must inherit property "hardwareConcurrency" with the proper type]
     expected: FAIL
 
   [ElementInternals interface: existence and properties of interface prototype object's @@unscopables property]

--- a/tests/wpt/meta/html/dom/idlharness.worker.js.ini
+++ b/tests/wpt/meta/html/dom/idlharness.worker.js.ini
@@ -266,9 +266,6 @@
   [OffscreenCanvasRenderingContext2D interface: attribute lineDashOffset]
     expected: FAIL
 
-  [WorkerNavigator interface: self.navigator must inherit property "hardwareConcurrency" with the proper type]
-    expected: FAIL
-
   [ImageBitmapRenderingContext interface object name]
     expected: FAIL
 
@@ -396,9 +393,6 @@
     expected: FAIL
 
   [OffscreenCanvas interface: operation transferToImageBitmap()]
-    expected: FAIL
-
-  [WorkerNavigator interface: attribute hardwareConcurrency]
     expected: FAIL
 
   [OffscreenCanvasRenderingContext2D interface: operation arcTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)]

--- a/tests/wpt/meta/workers/WorkerNavigator-hardware-concurrency.any.js.ini
+++ b/tests/wpt/meta/workers/WorkerNavigator-hardware-concurrency.any.js.ini
@@ -3,7 +3,3 @@
 
 [WorkerNavigator-hardware-concurrency.any.serviceworker.html]
   expected: ERROR
-
-[WorkerNavigator-hardware-concurrency.any.worker.html]
-  [Test worker navigator hardware concurrency.]
-    expected: FAIL


### PR DESCRIPTION
Implements [`navigator.hardwareConcurrency`](https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency), which returns the number of logical processors available.

I used the `num_cpus` library (which is already used by Servo in other places), and cache the result since it can be slow to query that information on some operating systems.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
