### PR TITLE
Fix `./mach bootstrap` failure in debian

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -154,9 +154,15 @@ class Linux(Base):
     def install_non_gstreamer_dependencies(self, force: bool) -> bool:
         install = False
         pkgs = []
-        if self.distro in ['Ubuntu', 'Debian GNU/Linux', 'Raspbian GNU/Linux']:
+        if self.distro in ['Ubuntu', 'Raspbian GNU/Linux']:
             command = ['apt-get', 'install']
             pkgs = APT_PKGS
+            if subprocess.call(['dpkg', '-s'] + pkgs, shell=True,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
+                install = True
+        elif self.distro == 'Debian GNU/Linux':
+            command = ['apt-get', 'install']
+            pkgs = [pkg for pkg in APT_PKGS if pkg != 'libgstreamer-plugins-good1.0-dev']
             if subprocess.call(['dpkg', '-s'] + pkgs, shell=True,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
                 install = True


### PR DESCRIPTION
Do not install `libgstreamer-plugins-good1.0-dev` on debian, install only on ubuntu.

I have tested this change on `Debian bullseye`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31220 
