### PR TITLE
mach: fix shell.nix to actually include android pkgs

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -53,8 +53,14 @@ let
       ];
   };
   androidSdk = androidComposition.androidsdk;
+  # Required by ./mach build --android
+  androidEnvironment = lib.optionalAttrs buildAndroid rec {
+    ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
+    ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
+    GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${buildToolsVersion}/aapt2";
+  };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (androidEnvironment // rec {
   name = "servo-env";
 
   buildInputs = [
@@ -214,9 +220,4 @@ stdenv.mkDerivation rec {
       export RUSTUP_HOME=$repo_root/.rustup
     fi
   '';
-} // lib.optionalAttrs buildAndroid {
-  # Required by ./mach build --android
-  ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
-  ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
-  GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${buildToolsVersion}/aapt2";
-}
+})


### PR DESCRIPTION
Fix issue with precedence due to which the android environment variables were being added to the output of mkDerivation instead of the input attribute set.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only fix change the nix shell definition.
