### PR TITLE
Remove duplicate pkg in `APT_PKGS`

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -27,7 +27,6 @@ APT_PKGS = [
     'build-essential', 'ccache', 'clang', 'cmake', 'curl', 'g++', 'git',
     'gperf', 'libdbus-1-dev', 'libfreetype6-dev', 'libgl1-mesa-dri',
     'libgles2-mesa-dev', 'libglib2.0-dev',
-    'libgstreamer-plugins-base1.0-dev',
     'gstreamer1.0-plugins-good', 'libgstreamer-plugins-good1.0-dev',
     'gstreamer1.0-plugins-bad', 'libgstreamer-plugins-bad1.0-dev',
     'gstreamer1.0-plugins-ugly',


### PR DESCRIPTION
We have `libgstreamer-plugins-base1.0-dev` twice in `APT_PKGS`; it looks like a duplicate. This PR removes the duplicated package.

The change was tested on `Debian Bullseye`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors