### PR TITLE
bootstrap: More resiliently install Debian-like platform dependencies

### DIFF
--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -55,9 +55,9 @@ class Base:
             return False
 
     def bootstrap(self, force: bool):
-        installed_something = self._platform_bootstrap(force)
-        installed_something |= self.install_taplo(force)
+        installed_something = self.install_taplo(force)
         installed_something |= self.install_crown(force)
+        installed_something |= self._platform_bootstrap(force)
         if not installed_something:
             print("Dependencies were already installed!")
 


### PR DESCRIPTION
1. First check to see if a package is available before trying to install
   it. This means that we always do our best to install everything, but
   don't fail if we cannot.
2. Install crown and taplo first. This means that if the
   platform-specific bits fail, we still install Servo-specific
   dependencies.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change bootstrap.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
