### PR TITLE
mach: Make `./mach try` a little friendlier

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -128,8 +128,8 @@ class Config(object):
             else:
                 self.matrix.append(preset)
 
-    def to_json(self) -> str:
-        return json.dumps(self, cls=Encoder)
+    def to_json(self, **kwargs) -> str:
+        return json.dumps(self, cls=Encoder, **kwargs)
 
 
 def main():


### PR DESCRIPTION
1. Move `./mach try` to `testing_commands.py which is a bit more
   consistent.
2. Make `./mach try` print out the remote name always and properly
   form the URL for ssh repositories.
3. Print out the try configuration matrix to make it more obvious
   what is being triggered remotely.
4. Better error handling. Print and error and exit if the remote isn't
   on GitHub and also clean up properly if something fails after making
   the temporary commit.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change a build environment command.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
