### PR TITLE
layout: Use `BoxFragment` border widths for display list generation

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -685,11 +685,15 @@ impl<'a> BuilderForBoxFragment<'a> {
 
     fn build_border(&mut self, builder: &mut DisplayListBuilder) {
         let border = self.fragment.style.get_border();
+        let border_widths = self
+            .fragment
+            .border
+            .to_physical(self.fragment.style.writing_mode);
         let widths = SideOffsets2D::new(
-            border.border_top_width.to_f32_px(),
-            border.border_right_width.to_f32_px(),
-            border.border_bottom_width.to_f32_px(),
-            border.border_left_width.to_f32_px(),
+            border_widths.top.px(),
+            border_widths.right.px(),
+            border_widths.bottom.px(),
+            border_widths.left.px(),
         );
         if widths == SideOffsets2D::zero() {
             return;

--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -302,11 +302,6 @@ impl InlineBoxLineItem {
             border.inline_start = Length::zero();
             margin.inline_start = Length::zero();
         }
-        if !self.is_last_fragment_of_ib_split {
-            padding.inline_end = Length::zero();
-            border.inline_end = Length::zero();
-            margin.inline_end = Length::zero();
-        }
         let pbm_sums = &(&padding + &border) + &margin;
         state.inline_position += pbm_sums.inline_start;
 

--- a/tests/wpt/meta/css/CSS2/box/ltr-basic.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/ltr-basic.xht.ini
@@ -1,2 +1,0 @@
-[ltr-basic.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/ltr-ib.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/ltr-ib.xht.ini
@@ -1,2 +1,0 @@
-[ltr-ib.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/ltr-span-only-ib.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/ltr-span-only-ib.xht.ini
@@ -1,2 +1,0 @@
-[ltr-span-only-ib.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box/ltr-span-only.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box/ltr-span-only.xht.ini
@@ -1,2 +1,0 @@
-[ltr-span-only.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c42-ibx-ht-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c42-ibx-ht-000.xht.ini
@@ -1,2 +1,0 @@
-[c42-ibx-ht-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/inline-box-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/inline-box-001.xht.ini
@@ -1,2 +1,0 @@
-[inline-box-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/inline-formatting-context-022.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/inline-formatting-context-022.xht.ini
@@ -1,2 +1,0 @@
-[inline-formatting-context-022.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-append-002-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-append-002-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-append-002-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-append-002-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-append-002-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-append-002-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-append-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-append-002.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-append-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-001-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-001-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-001-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-001-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-001-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-001-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-001a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-001a.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-001a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-002-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-002-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-002-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-002-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-002-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-002-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-002a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-002a.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-002a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-003-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-003-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-003-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-003-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-003-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-003-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-003.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-004-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-004-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-004-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-004-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-004-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-004-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-004.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-007-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-007-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-007-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-007-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-007-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-007-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-007.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-008-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-008-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-008-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-008-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-008-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-008-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-008a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-008a.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-008a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-009-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-009-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-009-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-009-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-009-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-009-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-009.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-010-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-010-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-010-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-010-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-010-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-010-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-010.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-010.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-011-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-011-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-011-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-011-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-011-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-011-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-011.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-011.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-011.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-012-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-012-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-012-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-012-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-012-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-012-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-012.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-013-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-013-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-013-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-013-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-013-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-013-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-013.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-014-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-014-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-014-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-014-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-014-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-014-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-014.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-015-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-015-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-015-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-015-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-015-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-015-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-015.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-016-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-016-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-016-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-016-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-016-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-016-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-016a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-016a.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-016a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-insert-017.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-insert-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-001-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-001-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-001-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-001-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-001-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-001-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-001.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-003-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-003-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-003-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-003-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-003-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-003-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-003.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-004-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-004-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-004-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-004-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-004-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-004-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-004.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-005-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-005-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-005-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-005-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-005-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-005-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-005.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-006-nosplit-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-006-nosplit-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-006-nosplit-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-006-ref.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-006-ref.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-006-ref.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-remove-006.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-remove-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-1-ref.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-1-ref.html.ini
@@ -1,2 +1,0 @@
-[remove-from-split-inline-1-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-3-ref.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-3-ref.html.ini
@@ -1,2 +1,0 @@
-[remove-from-split-inline-3-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-4-ref.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-4-ref.html.ini
@@ -1,2 +1,0 @@
-[remove-from-split-inline-4-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-5-ref.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-5-ref.html.ini
@@ -1,2 +1,0 @@
-[remove-from-split-inline-5-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-6-ref.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/remove-from-split-inline-6-ref.html.ini
@@ -1,2 +1,0 @@
-[remove-from-split-inline-6-ref.html]
-  expected: FAIL


### PR DESCRIPTION
Instead of using the border widths from the style, use the ones recorded by the `BoxFragment`. This is necessary because inline layout can override these border widths during fragmentation. For instance, when a box is split across two lines only one fragment should have an inline start border.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
