### PR TITLE
<hr> elements are expected to have a default overflow:hidden

### DIFF
--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -266,7 +266,7 @@ input[type="submit"], select, button {
 
 input, textarea, select, button { display: inline-block; }
 
-hr { color: gray; border-style: inset; border-width: 1px; margin: 0.5em auto; }
+hr { color: gray; border-style: inset; border-width: 1px; margin: 0.5em auto; overflow: hidden; }
 
 
 fieldset {

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -266,7 +266,16 @@ input[type="submit"], select, button {
 
 input, textarea, select, button { display: inline-block; }
 
-hr { color: gray; border-style: inset; border-width: 1px; margin: 0.5em auto; overflow: hidden; }
+hr { 
+  color: gray;
+  border-style: inset;
+  border-width: 1px;
+  margin-block-start: 0.5em;
+  margin-inline-end: auto;
+  margin-block-end: 0.5em;
+  margin-inline-start: auto;
+  overflow: hidden;
+}
 
 
 fieldset {

--- a/tests/wpt/meta-legacy-layout/html/rendering/non-replaced-elements/the-hr-element-0/setting-overflow-visible.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/rendering/non-replaced-elements/the-hr-element-0/setting-overflow-visible.html.ini
@@ -1,8 +1,5 @@
 [setting-overflow-visible.html]
   type: testharness
-  [control]
-    expected: FAIL
 
   [overflow: visible]
     expected: FAIL
-

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/the-hr-element-0/setting-overflow-visible.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/the-hr-element-0/setting-overflow-visible.html.ini
@@ -1,3 +1,0 @@
-[setting-overflow-visible.html]
-  [control]
-    expected: FAIL


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/2724

This adds the required styling to the UA stylesheet. 

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

I'm not sure why the WPT test /html/rendering/non-replaced-elements/the-hr-element-0/hr.html currently passes, but while fixing #22838 the test started failing. Once both these land the test should be passing again.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
