### PR TITLE
Don't escape property name in CSSStyleDeclaration's item()

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use cssparser::CssStringWriter;
 use dom_struct::dom_struct;
 use html5ever::local_name;
 use servo_arc::Arc;
@@ -15,7 +14,7 @@ use style::properties::{
 use style::selector_parser::PseudoElement;
 use style::shared_lock::Locked;
 use style::stylesheets::{CssRuleType, Origin};
-use style_traits::{CssWriter, ParsingMode, ToCss};
+use style_traits::ParsingMode;
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
@@ -432,11 +431,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
     fn IndexedGetter(&self, index: u32) -> Option<DOMString> {
         self.owner.with_block(|pdb| {
             let declaration = pdb.declarations().get(index as usize)?;
-            let mut dest = String::new();
-            let mut writer = CssStringWriter::new(&mut dest);
-            let mut writer = CssWriter::new(&mut writer);
-            declaration.id().to_css(&mut writer).ok()?;
-            Some(DOMString::from(dest))
+            Some(DOMString::from(declaration.id().name()))
         })
     }
 

--- a/tests/wpt/meta-legacy-layout/css/cssom/variable-names.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/cssom/variable-names.html.ini
@@ -1,6 +1,0 @@
-[variable-names.html]
-  [custom property '--a;b']
-    expected: FAIL
-
-  [custom property '--\\']
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/variable-names.html.ini
+++ b/tests/wpt/meta/css/cssom/variable-names.html.ini
@@ -1,6 +1,0 @@
-[variable-names.html]
-  [custom property '--a;b']
-    expected: FAIL
-
-  [custom property '--\\']
-    expected: FAIL


### PR DESCRIPTION
Just return the raw name. This is only relevant for custom properties.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
