### PR TITLE
Cargo.toml: explictly specify num_cpus version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ mime_guess = "2.0.3"
 mozangle = "0.5.1"
 msg = { path = "components/shared/msg" }
 net_traits = { path = "components/shared/net" }
-num_cpus = { workspace = true }
+num_cpus = "1.1.0"
 num-traits = "0.2"
 parking_lot = "0.12"
 percent-encoding = "2.3"


### PR DESCRIPTION
This fixes a warning from Cargo about relying on deprecated behavior:
```
warning: /home/loops/src/servo/servo/components/script/Cargo.toml: dependency (num_cpus) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
warning: /home/loops/src/servo/servo/components/config/Cargo.toml: dependency (num_cpus) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there isn't a way to test this, since Cargo doesn't support promoting warnings from Cargo itself into errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
