### PR TITLE
Update truetype in components/gfx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6270,9 +6270,9 @@ checksum = "ce607aae8ab0ab3abf3a2723a9ab6f09bb8639ed83fdd888d857b8e556c868d8"
 
 [[package]]
 name = "truetype"
-version = "0.40.1"
+version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded349527e54edfdbfb6db194f6da69b15a5fa811dd3fdfd691882290cb45d17"
+checksum = "cef21dc120b50cec529152c8862800f7f5fa13a2ec8d174cc643aed7af4d2417"
 dependencies = [
  "typeface",
 ]
@@ -6317,9 +6317,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typeface"
-version = "0.2.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf610e8cc23b65075cc984c5b3dd40ea77849189f395b2604e059c00558b719b"
+checksum = "3a51fd676d85b67be6a48da89094f5d8e24939c05694976379935517ba958c16"
 
 [[package]]
 name = "typenum"

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -59,4 +59,4 @@ xml-rs = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.11"
-truetype = { version = "0.40.0", features = ["ignore-invalid-language-ids"] }
+truetype = { version = "0.47.3", features = ["ignore-invalid-language-ids"] }


### PR DESCRIPTION
Hello, I am the author of the crate, and in this PR, I would like to update its usage to the last version.

```
Ivan@Ivan servo [truetype] $ ./mach build -d
    Updating crates.io index
    Updating git repository `https://github.com/servo/media`
dyld[43087]: missing symbol called
error: failed to get `servo-media` as a dependency of package `servoshell v0.0.1 (/Users/Ivan/Downloads/servo/ports/servoshell)`

Caused by:
  failed to load source for dependency `servo-media`

Caused by:
  Unable to update https://github.com/servo/media#a77995f1

Caused by:
  failed to fetch into: /Users/Ivan/.cargo/git/db/media-c23a3cd5aa97076a

Caused by:
  process didn't exit successfully: `git fetch --force --update-head-ok 'https://github.com/servo/media' '+a77995f1c8fe7d221ce3afef8bd8b92342e42321:refs/commit/a77995f1c8fe7d221ce3afef8bd8b92342e42321'` (signal: 6, SIGABRT: process abort signal)
Failed in 0:00:00
```

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes