### PR TITLE
Fix list-style serialization

### DIFF
--- a/components/style/properties/shorthands/list.mako.rs
+++ b/components/style/properties/shorthands/list.mako.rs
@@ -113,14 +113,14 @@
             #[cfg(feature = "gecko")]
             let position_is_initial = self.list_style_position == &ListStylePosition::Outside;
             #[cfg(feature = "servo")]
-            let position_is_initial = self.list_style_position == Some(&ListStylePosition::Outside);
+            let position_is_initial = matches!(self.list_style_position, None | Some(&ListStylePosition::Outside));
             if !position_is_initial {
                 self.list_style_position.to_css(dest)?;
                 have_one_non_initial_value = true;
             }
             if self.list_style_image != &ListStyleImage::None {
                 if have_one_non_initial_value {
-                   dest.write_char(' ')?;
+                    dest.write_char(' ')?;
                 }
                 self.list_style_image.to_css(dest)?;
                 have_one_non_initial_value = true;
@@ -137,7 +137,14 @@
                 have_one_non_initial_value = true;
             }
             if !have_one_non_initial_value {
+                #[cfg(feature = "gecko")]
                 self.list_style_position.to_css(dest)?;
+                #[cfg(feature = "servo")]
+                if let Some(position) = self.list_style_position {
+                    position.to_css(dest)?;
+                } else {
+                    self.list_style_type.to_css(dest)?;
+                }
             }
             Ok(())
         }

--- a/tests/wpt/meta/css/cssom/cssom-getPropertyValue-common-checks.html.ini
+++ b/tests/wpt/meta/css/cssom/cssom-getPropertyValue-common-checks.html.ini
@@ -1,6 +1,0 @@
-[cssom-getPropertyValue-common-checks.html]
-  [All properties (except 'all') can serialize their initial value (computed)]
-    expected: FAIL
-
-  [All shorthands (except 'all') can serialize their longhands set to their initial value]
-    expected: FAIL


### PR DESCRIPTION
In layout2020, `list-style-position` is disabled behind a pref, so the list_style_position field is an Option.

The serialization of the `list-style` shorthand wasn't correctly handling the case of it being None.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31307

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
