### PR TITLE
Update fontsan to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,8 +1697,8 @@ dependencies = [
 
 [[package]]
 name = "fontsan"
-version = "0.4.0"
-source = "git+https://github.com/servo/fontsan#29e879c870348c4b3fd51086e42dbb6365171479"
+version = "0.5.0"
+source = "git+https://github.com/servo/fontsan#36de30730c14af97c5545b957b125a6ce94a4ea3"
 dependencies = [
  "cmake",
  "libc",

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/variations/slnt-backslant-variable.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/variations/slnt-backslant-variable.html.ini
@@ -1,2 +1,0 @@
-[slnt-backslant-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/variations/slnt-variable.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/variations/slnt-variable.html.ini
@@ -1,2 +1,0 @@
-[slnt-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/slnt-backslant-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/slnt-backslant-variable.html.ini
@@ -1,2 +1,0 @@
-[slnt-backslant-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/slnt-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/slnt-variable.html.ini
@@ -1,2 +1,0 @@
-[slnt-variable.html]
-  expected: FAIL


### PR DESCRIPTION
Updates the C font-sanitizer library `ots` and dependencies to the latest version. 
[Fontsan changelog](https://github.com/servo/fontsan/blob/main/CHANGELOG.md)

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28102 : The dependencies are vendored in `fontsan` now, so fetching submodules can't fail.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a dependency update, which hopefully already has tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
