### PR TITLE
Include border-spacing gutters in compute_inline_content_sizes

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1185,6 +1185,9 @@ impl Table {
             inline_content_sizes.push(row_inline_content_sizes);
             total_size += max_content_sizes_in_column;
         }
+        let gutters = self.border_spacing().inline * (self.size.width as i32 + 1);
+        total_size.min_content += gutters;
+        total_size.max_content += gutters;
         (total_size, inline_content_sizes)
     }
 

--- a/tests/wpt/meta/css/css-tables/absolute-tables-005.html.ini
+++ b/tests/wpt/meta/css/css-tables/absolute-tables-005.html.ini
@@ -4,9 +4,3 @@
 
   [.table 2]
     expected: FAIL
-
-  [.table 3]
-    expected: FAIL
-
-  [.table 4]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-minmax.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-minmax.html.ini
@@ -2,12 +2,6 @@
   [table 2]
     expected: FAIL
 
-  [table 3]
-    expected: FAIL
-
-  [table 4]
-    expected: FAIL
-
   [table 5]
     expected: FAIL
 


### PR DESCRIPTION
This way, if the table is inside an intrinsically sized container, like a float or inline-block, the table won't overflow it (in basic cases).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
