### PR TITLE
ci: Make `dispatch-workflow.yml` GitHub job names a bit friendlier

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   win:
     if: ${{ inputs.workflow == 'windows' }}
+    name: Windows
     uses: ./.github/workflows/windows.yml
     secrets: inherit
     with:
@@ -29,6 +30,7 @@ jobs:
 
   macos:
     if: ${{ inputs.workflow == 'macos' }}
+    name: MacOS
     uses: ./.github/workflows/mac.yml
     secrets: inherit
     with:
@@ -39,6 +41,7 @@ jobs:
 
   linux:
     if: ${{ inputs.workflow == 'linux' }}
+    name: Linux
     uses: ./.github/workflows/linux.yml
     secrets: inherit
     with:
@@ -49,6 +52,7 @@ jobs:
 
   android:
     if: ${{ inputs.workflow == 'android' }}
+    name: Android
     uses: ./.github/workflows/android.yml
     secrets: inherit
     with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -154,7 +154,7 @@ jobs:
 
   wpt-2020:
     if: ${{ inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
-    name: Linux WPT Tests 2020
+    name: Linux WPT
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
@@ -166,7 +166,7 @@ jobs:
 
   wpt-2013:
     if: ${{ inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
-    name: Linux WPT Tests 2013
+    name: Linux WPT (Legacy)
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,4 +1,4 @@
-name: Mac
+name: MacOS
 
 on:
   workflow_call:
@@ -58,7 +58,7 @@ env:
 
 jobs:
   build:
-    name: Mac Build
+    name: MacOS Build
     runs-on: macos-13
     steps:
       # XProtect can cause random failures if it decides that the DMG we create
@@ -150,7 +150,7 @@ jobs:
 
   wpt-2020:
     if: ${{ inputs.wpt-layout == '2020' || inputs.wpt-layout == 'all' }}
-    name: Mac WPT Tests 2020
+    name: MacOS WPT
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
     with:
@@ -161,7 +161,7 @@ jobs:
 
   wpt-2013:
     if: ${{ inputs.wpt-layout == '2013' || inputs.wpt-layout == 'all' }}
-    name: Mac WPT Tests 2013
+    name: MacOS WPT (Legacy)
     needs: ["build"]
     uses: ./.github/workflows/mac-wpt.yml
     with:


### PR DESCRIPTION
This makes the names match the ones used in the workflows themselves
and moves more toward the "legacy" terminology for layout 2013.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this is just an adjustment to the CI display.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
