### PR TITLE
Fix rooting of external array buffer pointer

### DIFF
--- a/components/script/dom/bindings/typedarrays.rs
+++ b/components/script/dom/bindings/typedarrays.rs
@@ -183,16 +183,18 @@ where
         let mapping_slice_ptr =
             mapping.lock().unwrap().borrow_mut()[offset as usize..m_end as usize].as_mut_ptr();
 
-        let array_buffer = NewExternalArrayBuffer(
+        // rooted! is needed to ensure memory safety and prevent potential garbage collection issues.
+        // https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples/blob/esr78/docs/GC%20Rooting%20Guide.md#performance-tweaking
+        rooted!(in(*cx) let array_buffer = NewExternalArrayBuffer(
             *cx,
             range_size as usize,
             mapping_slice_ptr as _,
             Some(free_func),
             Arc::into_raw(mapping) as _,
-        );
+        ));
 
         HeapTypedArray {
-            internal: Heap::boxed(array_buffer),
+            internal: Heap::boxed(*array_buffer),
             phantom: PhantomData::default(),
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`rooted!` is needed to ensure memory safety and prevent potential garbage collection issues.
doc: https://github.com/mozilla-spidermonkey/spidermonkey-embedding-examples/blob/esr78/docs/GC%20Rooting%20Guide.md#performance-tweaking
 
Gecko example : https://searchfox.org/mozilla-central/rev/9bb5d5f55da6cc7163dd93825c25609b769822f9/dom/webgpu/Buffer.cpp#291

example:  

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31339

<!-- Either: -->
- [x] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
