### PR TITLE
Do not adjust margins in over-constrained cases

### DIFF
--- a/tests/wpt/meta/css/CSS2/normal-flow/auto-margins-used-values-with-floats.tentative.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/auto-margins-used-values-with-floats.tentative.html.ini
@@ -1,6 +1,0 @@
-[auto-margins-used-values-with-floats.tentative.html]
-  [.box 2]
-    expected: FAIL
-
-  [.box 5]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-logical/inheritance.html.ini
+++ b/tests/wpt/meta/css/css-logical/inheritance.html.ini
@@ -1,7 +1,4 @@
 [inheritance.html]
-  [Property margin-inline-end does not inherit]
-    expected: FAIL
-
   [Property min-block-size has initial value 0px]
     expected: FAIL
 

--- a/tests/wpt/meta/html/rendering/pixel-length-attributes.html.ini
+++ b/tests/wpt/meta/html/rendering/pixel-length-attributes.html.ini
@@ -96,21 +96,6 @@
   [<iframe marginwidth="200.25%"> mapping to marginRight]
     expected: FAIL
 
-  [<iframe marginwidth="-200"> mapping to marginRight]
-    expected: FAIL
-
-  [<iframe marginwidth="-200px"> mapping to marginRight]
-    expected: FAIL
-
-  [<iframe marginwidth="   -200"> mapping to marginRight]
-    expected: FAIL
-
-  [<iframe marginwidth="+-200"> mapping to marginRight]
-    expected: FAIL
-
-  [<iframe marginwidth="-+200"> mapping to marginRight]
-    expected: FAIL
-
   [<iframe marginheight="200"> mapping to marginTop]
     expected: FAIL
 


### PR DESCRIPTION
This deviates from css2, but it's mandated by css-align, and matches what other browsers do when no margin is 'auto'.

When some margin is 'auto', this should keep the proper round-tripping behavior that Gecko and WebKit lack, and Blink recently adopted.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
