### PR TITLE
ci: Merge similar try jobs when possible

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -233,7 +233,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
-        b = JobConfig("Linux", Workflow.MACOS, unit_tests=True)
+        b = JobConfig("Mac", Workflow.MACOS, unit_tests=True)
         self.assertFalse(a.merge(b), "Should not merge jobs with different workflows.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -242,7 +242,6 @@ class TestParser(unittest.TestCase):
         self.assertFalse(a.merge(b), "Should not merge jobs with different profiles.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
-        # Ditto.
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
         b = JobConfig("Linux", Workflow.LINUX, unit_tests=True, wpt_tests_to_run="/css")
         self.assertFalse(a.merge(b), "Should not merge jobs that run different WPT tests.")

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -227,28 +227,25 @@ class TestParser(unittest.TestCase):
                               }]
                               })
 
-        # These two jobs should not be merged to one that turns on unit tests.
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
         b = JobConfig("Linux", Workflow.LINUX, unit_tests=False)
-        self.assertTrue(a.merge(b))
+        self.assertTrue(a.merge(b), "Should not merge jobs that have different unit test configurations.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
-        # These two jobs should not be mergable to one that turns on unit tests.
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
         b = JobConfig("Linux", Workflow.MACOS, unit_tests=True)
-        self.assertFalse(a.merge(b))
+        self.assertFalse(a.merge(b), "Should not merge jobs with different workflows.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
-        # Ditto.
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
         b = JobConfig("Linux", Workflow.LINUX, unit_tests=True, profile="production")
-        self.assertFalse(a.merge(b))
+        self.assertFalse(a.merge(b), "Should not merge jobs with different profiles.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
         # Ditto.
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
         b = JobConfig("Linux", Workflow.LINUX, unit_tests=True, wpt_tests_to_run="/css")
-        self.assertFalse(a.merge(b))
+        self.assertFalse(a.merge(b), "Should not merge jobs that run different WPT tests.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
     def test_full(self):

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -9,6 +9,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from __future__ import annotations
+
 import json
 import sys
 from typing import Optional
@@ -40,10 +42,10 @@ class Layout(Flag):
 
 
 class Workflow(str, Enum):
-    LINUX = 'linux'
-    MACOS = 'macos'
-    WINDOWS = 'windows'
-    ANDROID = 'android'
+    LINUX = "linux"
+    MACOS = "macos"
+    WINDOWS = "windows"
+    ANDROID = "android"
 
 
 @dataclass
@@ -54,6 +56,16 @@ class JobConfig(object):
     profile: str = "release"
     unit_tests: bool = False
     wpt_tests_to_run: str = ""
+
+    def merge(self, other: JobConfig) -> bool:
+        """Try to merge another job with this job. Returns True if merging is successful
+           or False if not. If merging is successful this job will be modified."""
+        if self.workflow != other.workflow or self.profile != other.profile or \
+                self.wpt_tests_to_run != other.wpt_tests_to_run:
+            return False
+        self.wpt_layout |= other.wpt_layout
+        self.unit_tests |= other.unit_tests
+        return True
 
 
 def handle_preset(s: str) -> Optional[JobConfig]:
@@ -68,15 +80,15 @@ def handle_preset(s: str) -> Optional[JobConfig]:
     elif s in ["wpt", "linux-wpt"]:
         return JobConfig("Linux WPT", Workflow.LINUX, unit_tests=True, wpt_layout=Layout.all())
     elif s in ["wpt-2013", "linux-wpt-2013"]:
-        return JobConfig("Linux WPT legacy-layout", Workflow.LINUX, wpt_layout=Layout.layout2013)
+        return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.layout2013)
     elif s in ["wpt-2020", "linux-wpt-2020"]:
-        return JobConfig("Linux WPT layout-2020", Workflow.LINUX, wpt_layout=Layout.layout2020)
+        return JobConfig("Linux WPT", Workflow.LINUX, wpt_layout=Layout.layout2020)
     elif s in ["mac-wpt", "wpt-mac"]:
         return JobConfig("MacOS WPT", Workflow.MACOS, wpt_layout=Layout.all())
     elif s == "mac-wpt-2013":
-        return JobConfig("MacOS WPT legacy-layout", Workflow.MACOS, wpt_layout=Layout.layout2013)
+        return JobConfig("MacOS WPT", Workflow.MACOS, wpt_layout=Layout.layout2013)
     elif s == "mac-wpt-2020":
-        return JobConfig("MacOS WPT layout-2020", Workflow.MACOS, wpt_layout=Layout.layout2020)
+        return JobConfig("MacOS WPT", Workflow.MACOS, wpt_layout=Layout.layout2020)
     elif s == "android":
         return JobConfig("Android", Workflow.ANDROID)
     elif s == "webgpu":
@@ -122,11 +134,17 @@ class Config(object):
                 words.extend(["linux-wpt", "macos", "windows", "android"])
                 continue  # skip over keyword
 
-            preset = handle_preset(word)
-            if preset is None:
+            job = handle_preset(word)
+            if job is None:
                 print(f"Ignoring unknown preset {word}")
             else:
-                self.matrix.append(preset)
+                self.add_or_merge_job_to_matrix(job)
+
+    def add_or_merge_job_to_matrix(self, job: JobConfig):
+        for existing_job in self.matrix:
+            if existing_job.merge(job):
+                return
+        self.matrix.append(job)
 
     def to_json(self, **kwargs) -> str:
         return json.dumps(self, cls=Encoder, **kwargs)
@@ -191,6 +209,19 @@ class TestParser(unittest.TestCase):
                                   "wpt_tests_to_run": ""
                               }
                               ]})
+
+    def test_job_merging(self):
+        self.assertDictEqual(json.loads(Config("wpt-2020 wpt-2013").to_json()),
+                             {'fail_fast': False,
+                              'matrix': [{
+                                  'name': 'Linux WPT',
+                                  'profile': 'release',
+                                  'unit_tests': False,
+                                  'workflow': 'linux',
+                                  'wpt_layout': 'all',
+                                  'wpt_tests_to_run': ''
+                              }]
+                              })
 
     def test_full(self):
         self.assertDictEqual(json.loads(Config("linux-wpt macos windows android").to_json()),


### PR DESCRIPTION
This comes up a lot when triggering wpt-2013 and wpt-2020. Instead of
merging the jobs and triggering both layouts, the try parser will
trigger two separate jobs. Running two of the same builds at once seems
to cause the CI to fail one of them [1]. This fixes that issue.

1. An example of this: https://github.com/servo/servo/actions/runs/7892269495

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
