### PR TITLE
Bury failed nightly releases as prereleases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,21 +41,32 @@ jobs:
 
   publish-nightly-release:
     # This job is only useful when run on upstream servo.
-    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    if: always() && (github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch')
     name: Publish GH Release for nightly
     runs-on: ubuntu-20.04
     steps:
-      - run: |
+      - name: Publish as latest (success)
+        if: success()
+        run: |
           gh api \
             --method PATCH \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${NIGHTLY_REPO}/releases/${RELEASE_ID} \
             -F draft=false
-        env:
-          GITHUB_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
-          RELEASE_ID: ${{ needs.create-draft-release.outputs.release-id }}
+      - name: Publish as latest (failure)
+        if: failure()
+        run: |
+          gh api \
+            --method PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${NIGHTLY_REPO}/releases/${RELEASE_ID} \
+            -F prerelease=true -F draft=false
+    env:
+      GITHUB_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+      NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+      RELEASE_ID: ${{ needs.create-draft-release.outputs.release-id }}
     needs:
       - create-draft-release
       - upload-linux


### PR DESCRIPTION
On our [nightly builds page](https://github.com/servo/servo-nightly-builds/releases), GitHub lists drafts before normal releases, and normal releases before prereleases. But when our release build fails, we leave the release for that day as a draft, which clogs up the list for anyone who can see drafts.

This patch makes the build publish the release as a prerelease on failure, which buries them under successful releases while preserving the downloads for any platforms that succeeded.

I’ve also [added a script](https://github.com/servo/servo-nightly-builds/commit/5044258532f9113d02a3b38ec64c5a975ee445e8) to the nightly builds repo that cleans up existing failed releases:

```
$ tools/bury-old-drafts.sh
Warning: ignoring release 141927042, which is only 691 seconds old
Page 1 has 100 releases; found 56 drafts so far
Page 2 has 100 releases; found 56 drafts so far
Page 3 has 100 releases; found 56 drafts so far
Page 4 has 14 releases; found 56 drafts so far
PATCH /repos/servo/servo-nightly-builds/releases/140026516 -F prerelease=true -F draft=false
PATCH /repos/servo/servo-nightly-builds/releases/136085696 -F prerelease=true -F draft=false
PATCH /repos/servo/servo-nightly-builds/releases/136047173 -F prerelease=true -F draft=false
[...]
PATCH /repos/servo/servo-nightly-builds/releases/135079699 -F prerelease=true -F draft=false
gh: Validation Failed (HTTP 422)
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "Release",
      "code": "already_exists",
      "field": "tag_name"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/releases/releases#update-a-release"
}
Delete release? [y/N] y
DELETE /repos/servo/servo-nightly-builds/releases/135079699
[...]
```

<details><summary>Screenshot of releases page sorting behaviour</summary>

![image](https://github.com/servo/servo/assets/465303/ec8eaeef-7338-499f-be25-5ea5e2eb0acf)</details>

<details><summary>Screenshot of nightly builds page before cleanup</summary>

![image](https://github.com/servo/servo/assets/465303/53344ab6-4445-495e-b1cc-7ca0e17ec3a6)</details>

<details><summary>Screenshot of nightly builds page after cleanup</summary>

(I have no idea why there are three old builds at the top when logged in)

![image](https://github.com/servo/servo/assets/465303/9c62e06f-439e-4f73-8fda-00d6f1ce88d4)</details>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect the nightly release build on CI