### PR TITLE
style: Reduce Servo's diff with upstream `to_shmem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6095,7 +6095,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "to_shmem"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "to_shmem_derive"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "darling",
  "derive_common",

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -31,8 +31,8 @@ precomputed-hash = "0.1"
 servo_arc = { version = "0.2", path = "../servo_arc" }
 size_of_test = { path = "../size_of_test" }
 smallvec = "1.0"
-to_shmem = { version = "0.0.0", path = "../to_shmem", optional = true }
-to_shmem_derive = { version = "0.0.0", path = "../to_shmem_derive", optional = true }
+to_shmem = { version = "0.0.1", path = "../to_shmem", optional = true }
+to_shmem_derive = { version = "0.0.1", path = "../to_shmem_derive", optional = true }
 
 [build-dependencies]
 phf_codegen = "0.10"

--- a/components/to_shmem/Cargo.toml
+++ b/components/to_shmem/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "to_shmem"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
-edition = "2018"
 publish = false
 
 [lib]

--- a/components/to_shmem/lib.rs
+++ b/components/to_shmem/lib.rs
@@ -12,13 +12,21 @@
 #![crate_name = "to_shmem"]
 #![crate_type = "rlib"]
 
+extern crate cssparser;
+extern crate servo_arc;
+extern crate smallbitvec;
+extern crate smallvec;
+#[cfg(feature = "string_cache")]
+extern crate string_cache;
 extern crate thin_vec;
 
+use servo_arc::{Arc, ThinArc};
+use smallbitvec::{InternalStorage, SmallBitVec};
+use smallvec::{Array, SmallVec};
 use std::alloc::Layout;
-#[cfg(debug_assertions)]
-use std::any::TypeId;
 use std::collections::HashSet;
 use std::ffi::CString;
+use std::isize;
 use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
 use std::num::Wrapping;
@@ -27,11 +35,8 @@ use std::os::raw::c_char;
 #[cfg(debug_assertions)]
 use std::os::raw::c_void;
 use std::ptr::{self, NonNull};
-use std::{isize, slice, str};
-
-use servo_arc::{Arc, ThinArc};
-use smallbitvec::{InternalStorage, SmallBitVec};
-use smallvec::{Array, SmallVec};
+use std::slice;
+use std::str;
 use thin_vec::ThinVec;
 
 /// Result type for ToShmem::to_shmem.
@@ -53,16 +58,12 @@ pub struct SharedMemoryBuilder {
     /// The current position in the buffer, where the next value will be written
     /// at.
     index: usize,
-    /// Pointers to every sharable value that we store in the shared memory
+    /// Pointers to every shareable value that we store in the shared memory
     /// buffer.  We use this to assert against encountering the same value
     /// twice, e.g. through another Arc reference, so that we don't
     /// inadvertently store duplicate copies of values.
     #[cfg(debug_assertions)]
     shared_values: HashSet<*const c_void>,
-    /// Types of values that we may duplicate in the shared memory buffer when
-    /// there are shared references to them, such as in Arcs.
-    #[cfg(debug_assertions)]
-    allowed_duplication_types: HashSet<TypeId>,
 }
 
 /// Amount of padding needed after `size` bytes to ensure that the following
@@ -85,17 +86,7 @@ impl SharedMemoryBuilder {
             index: 0,
             #[cfg(debug_assertions)]
             shared_values: HashSet::new(),
-            #[cfg(debug_assertions)]
-            allowed_duplication_types: HashSet::new(),
         }
-    }
-
-    /// Notes a type as being allowed for duplication when being copied to the
-    /// shared memory buffer, such as Arcs referencing the same value.
-    #[inline]
-    pub fn add_allowed_duplication_type<T: 'static>(&mut self) {
-        #[cfg(debug_assertions)]
-        self.allowed_duplication_types.insert(TypeId::of::<T>());
     }
 
     /// Returns the number of bytes currently used in the buffer.
@@ -440,23 +431,16 @@ where
     }
 }
 
-impl<T: 'static + ToShmem> ToShmem for Arc<T> {
+impl<T: ToShmem> ToShmem for Arc<T> {
     fn to_shmem(&self, builder: &mut SharedMemoryBuilder) -> Result<Self> {
         // Assert that we don't encounter any shared references to values we
-        // don't expect.  Those we expect are those noted by calling
-        // add_allowed_duplication_type, and should be types where we're fine
-        // with duplicating any shared references in the shared memory buffer.
-        //
-        // Unfortunately there's no good way to print out the exact type of T
-        // in the assertion message.
+        // don't expect.
         #[cfg(debug_assertions)]
         assert!(
-            !builder.shared_values.contains(&self.heap_ptr()) ||
-                builder
-                    .allowed_duplication_types
-                    .contains(&TypeId::of::<T>()),
-            "ToShmem failed for Arc<T>: encountered a value of type T with multiple references \
-             and which has not been explicitly allowed with an add_allowed_duplication_type call",
+            !builder.shared_values.contains(&self.heap_ptr()),
+            "ToShmem failed for Arc<{}>: encountered a value with multiple \
+            references.",
+            std::any::type_name::<T>()
         );
 
         // Make a clone of the Arc-owned value with all of its heap allocations
@@ -479,7 +463,7 @@ impl<T: 'static + ToShmem> ToShmem for Arc<T> {
     }
 }
 
-impl<H: 'static + ToShmem, T: 'static + ToShmem> ToShmem for ThinArc<H, T> {
+impl<H: ToShmem, T: ToShmem> ToShmem for ThinArc<H, T> {
     fn to_shmem(&self, builder: &mut SharedMemoryBuilder) -> Result<Self> {
         // We don't currently have any shared ThinArc values in stylesheets,
         // so don't support them for now.

--- a/components/to_shmem_derive/Cargo.toml
+++ b/components/to_shmem_derive/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "to_shmem_derive"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
-edition = "2018"
 publish = false
 
 [lib]

--- a/components/to_shmem_derive/lib.rs
+++ b/components/to_shmem_derive/lib.rs
@@ -4,6 +4,17 @@
 
 #![recursion_limit = "128"]
 
+#[macro_use]
+extern crate darling;
+extern crate derive_common;
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+extern crate synstructure;
+
 use proc_macro::TokenStream;
 
 mod to_shmem;

--- a/components/to_shmem_derive/to_shmem.rs
+++ b/components/to_shmem_derive/to_shmem.rs
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use darling::{FromDeriveInput, FromField};
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{self, parse_quote};
+use syn;
 use synstructure::{BindStyle, Structure};
 
 pub fn derive(mut input: syn::DeriveInput) -> TokenStream {


### PR DESCRIPTION
This is part of getting Servo using an version of style closer to
upstream. This change reverts some changes we made to `to_shmem` and
`to_shmem_derive` in order to reduce our diff with upstream stylo.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this does not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
