### PR TITLE
style: Add a `static_prefs` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,6 +5626,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_prefs"
+version = "0.1.0"
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5707,6 +5711,7 @@ dependencies = [
  "smallbitvec",
  "smallvec",
  "static_assertions",
+ "static_prefs",
  "string_cache",
  "style_derive",
  "style_traits",

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -73,6 +73,7 @@ servo_url = { path = "../url", optional = true }
 smallbitvec = "2.3.0"
 smallvec = "1.0"
 static_assertions = "1.1"
+static_prefs = { path = "../style_static_prefs" }
 string_cache = { version = "0.8", optional = true }
 style_derive = { path = "../style_derive" }
 style_traits = { workspace = true }

--- a/components/style/driver.rs
+++ b/components/style/driver.rs
@@ -63,10 +63,7 @@ fn with_pool_in_place_scope<'scope, R>(
 
 /// See documentation of the pref for performance characteristics.
 fn work_unit_max() -> usize {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.stylo-work-unit-size") as usize;
-    #[cfg(feature = "servo")]
-    return 16;
+    static_prefs::pref!("layout.css.stylo-work-unit-size") as usize
 }
 
 /// Do a DOM traversal for top-down and (optionally) bottom-up processing, generic over `D`.
@@ -127,12 +124,7 @@ where
             discovered,
             root.as_node().opaque(),
             work_unit_max,
-            (|| {
-                #[cfg(feature = "gecko")]
-                return static_prefs::pref!("layout.css.stylo-local-work-queue.in-main-thread") as usize;
-                #[cfg(feature = "servo")]
-                return 32;
-            })(),
+            static_prefs::pref!("layout.css.stylo-local-work-queue.in-main-thread") as usize,
             PerLevelTraversalData { current_dom_depth: root.depth() },
             maybe_scope,
             traversal,

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -577,13 +577,6 @@ impl<'a, 'b, 'i> RuleBodyItemParser<'i, (), StyleParseErrorKind<'i>>
     }
 }
 
-fn font_tech_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.font-tech.enabled");
-    #[cfg(feature = "servo")]
-    return false;
-}
-
 impl Parse for Source {
     fn parse<'i, 't>(
         context: &ParserContext,
@@ -618,9 +611,10 @@ impl Parse for Source {
         };
 
         // Parse optional tech()
-        let tech_flags = if font_tech_enabled() && input
-            .try_parse(|input| input.expect_function_matching("tech"))
-            .is_ok()
+        let tech_flags = if static_prefs::pref!("layout.css.font-tech.enabled") &&
+            input
+                .try_parse(|input| input.expect_function_matching("tech"))
+                .is_ok()
         {
             input.parse_nested_block(|input| FontFaceSourceTechFlags::parse(context, input))?
         } else {

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -93,12 +93,7 @@ fn distribute_one_chunk<'a, 'scope, E, D>(
             items,
             traversal_root,
             work_unit_max,
-            (|| {
-                #[cfg(feature = "gecko")]
-                return static_prefs::pref!("layout.css.stylo-local-work-queue.in-worker") as usize;
-                #[cfg(feature = "servo")]
-                return 0;
-            })(),
+            static_prefs::pref!("layout.css.stylo-local-work-queue.in-worker") as usize,
             traversal_data,
             Some(scope),
             traversal,

--- a/components/style/properties/shorthands/ui.mako.rs
+++ b/components/style/properties/shorthands/ui.mako.rs
@@ -190,13 +190,6 @@ macro_rules! try_parse_one {
             % endfor
         }
 
-        fn scroll_driven_animations_enabled() -> bool {
-            #[cfg(feature = "gecko")]
-            return static_prefs::pref!("layout.css.scroll-driven-animations.enabled");
-            #[cfg(feature = "servo")]
-            return false;
-        }
-
         fn parse_one_animation<'i, 't>(
             context: &ParserContext,
             input: &mut Parser<'i, 't>,
@@ -221,7 +214,7 @@ macro_rules! try_parse_one {
                 try_parse_one!(context, input, fill_mode, animation_fill_mode);
                 try_parse_one!(context, input, play_state, animation_play_state);
                 try_parse_one!(context, input, name, animation_name);
-                if scroll_driven_animations_enabled() {
+                if static_prefs::pref!("layout.css.scroll-driven-animations.enabled") {
                     try_parse_one!(context, input, timeline, animation_timeline);
                 }
 

--- a/components/style/selector_map.rs
+++ b/components/style/selector_map.rs
@@ -153,10 +153,7 @@ impl<T> SelectorMap<T> {
             namespace_hash: HashMap::default(),
             rare_pseudo_classes: SmallVec::new(),
             other: SmallVec::new(),
-            #[cfg(feature = "gecko")]
             bucket_attributes: static_prefs::pref!("layout.css.bucket-attribute-names.enabled"),
-            #[cfg(feature = "servo")]
-            bucket_attributes: false,
             count: 0,
         }
     }

--- a/components/style/stylesheets/import_rule.rs
+++ b/components/style/stylesheets/import_rule.rs
@@ -262,12 +262,7 @@ impl ImportRule {
                 .unwrap_or(ImportLayer::None)
         };
 
-        #[cfg(feature = "gecko")]
-        let supports_enabled = static_prefs::pref!("layout.css.import-supports.enabled");
-        #[cfg(feature = "servo")]
-        let supports_enabled = false;
-
-        let supports = if !supports_enabled {
+        let supports = if !static_prefs::pref!("layout.css.import-supports.enabled") {
             None
         } else {
             input

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -170,12 +170,10 @@ impl SupportsCondition {
                     input.slice_from(pos).to_owned()
                 )))
             },
-            #[cfg(feature = "gecko")]
             "font-format" if static_prefs::pref!("layout.css.font-tech.enabled") => {
                 let kw = FontFaceSourceFormatKeyword::parse(input)?;
                 Ok(SupportsCondition::FontFormat(kw))
             },
-            #[cfg(feature = "gecko")]
             "font-tech" if static_prefs::pref!("layout.css.font-tech.enabled") => {
                 let flag = FontFaceSourceTechFlags::parse_one(input)?;
                 Ok(SupportsCondition::FontTech(flag))

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -517,10 +517,7 @@ pub enum SingleFontFamily {
 }
 
 fn system_ui_enabled(_: &ParserContext) -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.system-ui.enabled");
-    #[cfg(feature = "servo")]
-    return false;
+    static_prefs::pref!("layout.css.system-ui.enabled")
 }
 
 /// A generic font-family name.

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -93,10 +93,7 @@ where
 }
 
 fn nan_inf_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.nan-inf.enabled");
-    #[cfg(feature = "servo")]
-    return false;
+    static_prefs::pref!("layout.css.nan-inf.enabled")
 }
 
 /// Serialize a number with calc, and NaN/infinity handling (if enabled)

--- a/components/style/values/resolved/counters.rs
+++ b/components/style/values/resolved/counters.rs
@@ -7,14 +7,6 @@
 use super::{Context, ToResolvedValue};
 use crate::values::computed;
 
-#[inline]
-fn allow_element_content_none() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.element-content-none.enabled");
-    #[cfg(feature = "servo")]
-    return false;
-}
-
 /// https://drafts.csswg.org/css-content/#content-property
 ///
 /// We implement this at resolved value time because otherwise it causes us to
@@ -43,7 +35,8 @@ impl ToResolvedValue for computed::Content {
             // Ditto for non-pseudo elements if the pref is disabled.
             Self::None
                 if (is_pseudo && !is_before_or_after && !is_marker) ||
-                    (!is_pseudo && !allow_element_content_none()) =>
+                    (!is_pseudo &&
+                        !static_prefs::pref!("layout.css.element-content-none.enabled")) =>
             {
                 Self::Normal
             },

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -1832,7 +1832,6 @@ impl Parse for Overflow {
             "-moz-hidden-unscrollable" if static_prefs::pref!("layout.css.overflow-moz-hidden-unscrollable.enabled") => {
                 Overflow::Clip
             },
-            #[cfg(feature = "gecko")]
             "overlay" if static_prefs::pref!("layout.css.overflow-overlay.enabled") => {
                 Overflow::Auto
             },

--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -21,38 +21,11 @@ use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, StyleParseErrorKind, ToCss};
 
 fn trig_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.trig.enabled");
-    #[cfg(feature = "servo")]
-    return false;
+    static_prefs::pref!("layout.css.trig.enabled")
 }
 
 fn nan_inf_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.nan-inf.enabled");
-    #[cfg(feature = "servo")]
-    return false;
-}
-
-fn round_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.round.enabled");
-    #[cfg(feature = "servo")]
-    return false;
-}
-
-fn mod_rem_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.mod-rem.enabled");
-    #[cfg(feature = "servo")]
-    return false;
-}
-
-fn exp_enabled() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.exp.enabled");
-    #[cfg(feature = "servo")]
-    return false;
+    static_prefs::pref!("layout.css.nan-inf.enabled")
 }
 
 /// The name of the mathematical function that we're parsing.
@@ -929,11 +902,11 @@ impl CalcNode {
         } else if matches!(function, Sin | Cos | Tan | Asin | Acos | Atan | Atan2) {
             trig_enabled()
         } else if matches!(function, Round) {
-            round_enabled()
+            static_prefs::pref!("layout.css.round.enabled")
         } else if matches!(function, Mod | Rem) {
-            mod_rem_enabled()
+            static_prefs::pref!("layout.css.mod-rem.enabled")
         } else if matches!(function, Pow | Sqrt | Hypot | Log | Exp) {
-            exp_enabled()
+            static_prefs::pref!("layout.css.exp.enabled")
         } else {
             true
         };

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -25,22 +25,6 @@ use style_traits::{SpecifiedValueInfo, ToCss, ValueParseErrorKind};
 /// A specified color-mix().
 pub type ColorMix = GenericColorMix<Color, Percentage>;
 
-#[inline]
-fn allow_color_mix() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.color-mix.enabled");
-    #[cfg(feature = "servo")]
-    return true;
-}
-
-#[inline]
-fn allow_more_color_4() -> bool {
-    #[cfg(feature = "gecko")]
-    return static_prefs::pref!("layout.css.more_color_4.enabled");
-    #[cfg(feature = "servo")]
-    return true;
-}
-
 impl ColorMix {
     fn parse<'i, 't>(
         context: &ParserContext,
@@ -48,7 +32,7 @@ impl ColorMix {
         preserve_authored: PreserveAuthored,
     ) -> Result<Self, ParseError<'i>> {
         let enabled =
-            context.chrome_rules_enabled() || allow_color_mix();
+            context.chrome_rules_enabled() || static_prefs::pref!("layout.css.color-mix.enabled");
 
         if !enabled {
             return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
@@ -639,7 +623,7 @@ impl Color {
                         );
                         let is_color_function =
                             absolute.color.flags.contains(ColorFlags::AS_COLOR_FUNCTION);
-                        let pref_enabled = allow_more_color_4();
+                        let pref_enabled = static_prefs::pref!("layout.css.more_color_4.enabled");
 
                         (is_legacy_color && !is_color_function) || pref_enabled
                     };
@@ -971,10 +955,10 @@ impl SpecifiedValueInfo for Color {
             "currentColor",
             "transparent",
         ]);
-        if allow_color_mix() {
+        if static_prefs::pref!("layout.css.color-mix.enabled") {
             f(&["color-mix"]);
         }
-        if allow_more_color_4() {
+        if static_prefs::pref!("layout.css.more_color_4.enabled") {
             f(&["color", "lab", "lch", "oklab", "oklch"]);
         }
     }

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -720,10 +720,7 @@ impl Parse for FontSizeAdjust {
     ) -> Result<Self, ParseError<'i>> {
         let location = input.current_source_location();
         if let Ok(ident) = input.try_parse(|i| i.expect_ident_cloned()) {
-            #[cfg(feature = "gecko")]
             let basis_enabled = static_prefs::pref!("layout.css.font-size-adjust.basis.enabled");
-            #[cfg(feature = "servo")]
-            let basis_enabled = false;
             let basis = match_ignore_ascii_case! { &ident,
                 "none" => return Ok(Self::None),
                 // Check for size adjustment basis keywords if enabled.

--- a/components/style/values/specified/motion.rs
+++ b/components/style/values/specified/motion.rs
@@ -23,15 +23,6 @@ pub type OffsetPath = generics::GenericOffsetPath<RayFunction>;
 /// The specified value of `offset-position`.
 pub type OffsetPosition = generics::GenericOffsetPosition<HorizontalPosition, VerticalPosition>;
 
-#[cfg(feature = "gecko")]
-fn is_ray_enabled() -> bool {
-    static_prefs::pref!("layout.css.motion-path-ray.enabled")
-}
-#[cfg(feature = "servo")]
-fn is_ray_enabled() -> bool {
-    false
-}
-
 impl Parse for RayFunction {
     fn parse<'i, 't>(
         context: &ParserContext,
@@ -39,7 +30,7 @@ impl Parse for RayFunction {
     ) -> Result<Self, ParseError<'i>> {
         use crate::values::specified::PositionOrAuto;
 
-        if !is_ray_enabled() {
+        if !static_prefs::pref!("layout.css.motion-path-ray.enabled") {
             return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 

--- a/components/style_static_prefs/Cargo.toml
+++ b/components/style_static_prefs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "static_prefs"
+version = "0.1.0"
+edition = "2021"
+authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
+publish = false

--- a/components/style_static_prefs/src/lib.rs
+++ b/components/style_static_prefs/src/lib.rs
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! A list of static preferences exposed to the style crate. These should
+//! be kept sync with the preferences used by the style.
+#[macro_export]
+macro_rules! pref {
+    ("browser.display.permit_backplate") => {
+        false
+    };
+    ("browser.display.use_document_fonts") => {
+        false
+    };
+    ("dom.customHighlightAPI.enabled") => {
+        false
+    };
+    ("dom.element.popover.enabled") => {
+        false
+    };
+    ("gfx.font_rendering.opentype_svg.enabled") => {
+        false
+    };
+    ("layout.css.color-mix.enabled") => {
+        true
+    };
+    ("layout.css.contain-intrinsic-size.enabled") => {
+        false
+    };
+    ("layout.css.container-queries.enabled") => {
+        false
+    };
+    ("layout.css.content-visibility.enabled") => {
+        false
+    };
+    ("layout.css.control-characters.visible") => {
+        false
+    };
+    ("layout.css.cross-fade.enabled") => {
+        false
+    };
+    ("layout.css.element-content-none.enabled") => {
+        false
+    };
+    ("layout.css.fit-content-function.enabled") => {
+        false
+    };
+    ("layout.css.font-palette.enabled") => {
+        false
+    };
+    ("layout.css.font-tech.enabled") => {
+        false
+    };
+    ("layout.css.font-variant-emoji.enabled") => {
+        false
+    };
+    ("layout.css.font-variations.enabled") => {
+        false
+    };
+    ("layout.css.forced-color-adjust.enabled") => {
+        false
+    };
+    ("layout.css.forced-colors.enabled") => {
+        false
+    };
+    ("layout.css.grid-template-masonry-value.enabled") => {
+        false
+    };
+    ("layout.css.has-selector.enabled") => {
+        false
+    };
+    ("layout.css.import-supports.enabled") => {
+        false
+    };
+    ("layout.css.inverted-colors.enabled") => {
+        false
+    };
+    ("layout.css.marker.restricted") => {
+        false
+    };
+    ("layout.css.math-depth.enabled") => {
+        false
+    };
+    ("layout.css.math-style.enabled") => {
+        false
+    };
+    ("layout.css.more_color_4.enabled") => {
+        true
+    };
+    ("layout.css.motion-path-offset-position.enabled") => {
+        false
+    };
+    ("layout.css.motion-path-ray.enabled") => {
+        false
+    };
+    ("layout.css.moz-control-character-visibility.enabled") => {
+        false
+    };
+    ("layout.css.nesting.enabled") => {
+        false
+    };
+    ("layout.css.overflow-moz-hidden-unscrollable.enabled") => {
+        false
+    };
+    ("layout.css.overflow-overlay.enabled") => {
+        false
+    };
+    ("layout.css.page-orientation.enabled") => {
+        false
+    };
+    ("layout.css.prefers-contrast.enabled") => {
+        false
+    };
+    ("layout.css.prefers-reduced-transparency.enabled") => {
+        false
+    };
+    ("layout.css.properties-and-values.enabled") => {
+        false
+    };
+    ("layout.css.scroll-driven-animations.enabled") => {
+        false
+    };
+    ("layout.css.size-adjust.enabled") => {
+        false
+    };
+    ("layout.css.stylo-local-work-queue.in-main-thread") => {
+        32
+    };
+    ("layout.css.stylo-local-work-queue.in-worker") => {
+        0
+    };
+    ("layout.css.stylo-threads") => {
+        false
+    };
+    ("layout.css.stylo-work-unit-size") => {
+        16
+    };
+    ("layout.css.system-ui.enabled") => {
+        false
+    };
+    ("layout.css.nan-inf.enabled") => {
+        false
+    };
+    ("layout.css.trig.enabled") => {
+        false
+    };
+    ("layout.css.round.enabled") => {
+        false
+    };
+    ("layout.css.mod-rem.enabled") => {
+        false
+    };
+    ("layout.css.exp.enabled") => {
+        false
+    };
+    ("layout.css.bucket-attribute-names.enabled") => {
+        false
+    };
+    ("layout.css.font-size-adjust.basis.enabled") => {
+        false
+    };
+}


### PR DESCRIPTION
This will eventually be part of the stylo crate and reduces the diff
between our verson of style and upstream's.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
