### PR TITLE
ci: Switch to version 4 of GitHub artifact actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,20 +70,19 @@ jobs:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           python3 ./mach build --android --target ${{ matrix.arch }} --${{ inputs.profile }}
+          cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.arch }}
       # TODO: This is disabled since APK crashes during startup.
       # See https://github.com/servo/servo/issues/31134
       # - name: Script tests
       #   run: ./mach test-android-startup
-      - name: Rename build timing
-        run: cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.arch }}
       - name: Archive build timing
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings
+          name: cargo-timings-android-${{ matrix.arch }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload APK artifact for mach package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: android-${{ matrix.arch }}-${{ inputs.profile }}
+          name: ${{ inputs.profile }}-binary-android-${{ matrix.arch }}
           path: target/android/${{ matrix.arch }}/${{ inputs.profile }}/servoapp.apk

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -80,11 +80,13 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Archive results (filtered)
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
       - name: Archive results (full)
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
           path: wpt-full-logs/*/

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -20,8 +20,10 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  WPT_COMMAND_LINE_ARG: "${{ inputs.wpt-layout == 'layout-2013' && '--legacy-layout' || '' }}"
   GST_PLUGIN_FEATURE_RANK: pulsesink:NONE,alsasink:NONE,jacksink:NONE,fakesink:MAX
+  INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ !inputs.wpt-sync-from-upstream && secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET || '' }}
+  WPT_LAYOUT_ARG: "${{ inputs.wpt-layout == 'layout-2013' && '--legacy-layout' || '' }}"
+  WPT_ALWAYS_SUCCEED_ARG: "${{ inputs.wpt-sync-from-upstream && '--always-succeed' || '' }}"
 
 jobs:
   linux-wpt:
@@ -45,12 +47,12 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: release-binary
-          path: release-binary
+          name: ${{ inputs.profile }}-binary-linux
+          path: ${{ inputs.profile }}-binary-linux
       - name: unPackage binary
-        run: tar -xzf release-binary/target.tar.gz
+        run: tar -xzf ${{ inputs.profile }}-binary-linux/target.tar.gz
       - name: Bootstrap dependencies
         run: |
           python3 -m pip install --upgrade pip
@@ -62,75 +64,64 @@ jobs:
         run: |
           ./mach update-wpt --sync --patch
       - name: Run tests
-        if: ${{ !inputs.wpt-sync-from-upstream }}
         run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${{ inputs.wpt-tests-to-run }} \
+          mkdir -p wpt-filtered-logs/linux-${{ inputs.wpt-layout }}
+          mkdir -p wpt-full-logs/linux-${{ inputs.wpt-layout }}
+          python3 ./mach test-wpt \
+            $WPT_LAYOUT_ARG \
+            $WPT_ALWAYS_SUCCEED_ARG \
+            ${{ inputs.wpt-tests-to-run }} \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-            --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
-            --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
+            --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
+            --log-raw-unexpected wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
+            --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-          INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
-      - name: Run tests (sync)
-        if: ${{ inputs.wpt-sync-from-upstream }}
-        run: |
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
-            --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
-            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-            --always-succeed
-      - name: Archive filtered results
-        uses: actions/upload-artifact@v3
-        if: ${{ always() && !inputs.wpt-sync-from-upstream }}
+      - name: Archive results (filtered)
+        uses: actions/upload-artifact@v4
         with:
-          name: wpt-filtered-results-linux-${{ inputs.wpt-layout }}
-          path: |
-            filtered-test-wpt.${{ matrix.chunk_id }}.json
-            unexpected-test-wpt.${{ matrix.chunk_id }}.log
-      - name: Archive logs
-        uses: actions/upload-artifact@v3
-        if: ${{ failure() && !inputs.wpt-sync-from-upstream }}
+          name: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
+          path: wpt-filtered-logs/*/
+      - name: Archive results (full)
+        uses: actions/upload-artifact@v4
         with:
-          name: wpt-logs-linux-${{ inputs.wpt-layout }}
-          path: |
-            test-wpt.${{ matrix.chunk_id }}.log
-      - name: Archive logs
-        uses: actions/upload-artifact@v3
-        if: ${{ inputs.wpt-sync-from-upstream }}
-        with:
-          name: wpt-logs-linux-${{ inputs.wpt-layout }}
-          path: |
-            test-wpt.${{ matrix.chunk_id }}.log
-            wpt-jsonsummary.${{ matrix.chunk_id }}.log
+          name: wpt-full-logs-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
+          path: wpt-full-logs/*/
 
   report-test-results:
-    name: Report WPT Results
+    name: Process WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && !inputs.wpt-sync-from-upstream }}
-    needs:
-      - "linux-wpt"
+    if: ${{ always() }}
+    needs: linux-wpt
     steps:
+      - name: Merge logs (filtered)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}
+          pattern: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}-*
+          delete-merged: true
+      - name: Merge logs (full)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wpt-full-logs-linux-${{ inputs.wpt-layout }}
+          pattern: wpt-full-logs-linux-${{ inputs.wpt-layout }}-*
+          delete-merged: true
       - uses: actions/checkout@v3
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         with:
-          name: wpt-filtered-results-linux-${{ inputs.wpt-layout }}
-          path: wpt-filtered-results-linux
-      - name: Create aggregated unexpected results
+          name: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}
+          path: results
+      - name: Report results
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         run: |
-          cat wpt-filtered-results-linux/*.log > unexpected-test-wpt-${{ inputs.wpt-layout }}.log
-      - name: Archive aggregate results
-        uses: actions/upload-artifact@v3
-        with:
-          name: wpt-filtered-results-linux
-          path: |
-            unexpected-test-wpt-${{ inputs.wpt-layout }}.log
-      - name: Comment on PR with results
-        run: |
-          etc/ci/report_aggregated_expected_results.py --tag="linux-wpt-${{ inputs.wpt-layout }}" wpt-filtered-results-linux/*.json
+          etc/ci/report_aggregated_expected_results.py \
+            --tag="linux-wpt-${{ inputs.wpt-layout }}" \
+            results/linux-${{ inputs.wpt-layout }}/*.json
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -105,7 +105,9 @@ jobs:
       - name: Tidy
         run: python3 ./mach test-tidy --no-progress --all
       - name: Build (${{ inputs.profile }})
-        run: python3 ./mach build --${{ inputs.profile }}
+        run: |
+          python3 ./mach build --${{ inputs.profile }}
+          cp -r target/cargo-timings target/cargo-timings-linux
       - name: Smoketest
         run: xvfb-run python3 ./mach smoketest --${{ inputs.profile  }}
       - name: Script tests
@@ -117,12 +119,10 @@ jobs:
           timeout_minutes: 20
           max_attempts: 2 # https://github.com/servo/servo/issues/30683
           command: python ./mach test-unit --${{ inputs.profile }}
-      - name: Rename build timing
-        run: cp -r target/cargo-timings target/cargo-timings-linux
       - name: Archive build timing
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings
+          name: cargo-timings-linux
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Lockfile check
@@ -130,7 +130,7 @@ jobs:
       - name: Build mach package
         run: python3 ./mach package --${{ inputs.profile }}
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux
           path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
@@ -147,9 +147,9 @@ jobs:
       - name: Build package for target
         run: tar -czf target.tar.gz target/${{ inputs.profile }}/servo resources
       - name: Upload artifact for target
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: release-binary
+          name: ${{ inputs.profile }}-binary-linux
           path: target.tar.gz
 
   wpt-2020:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: release-binary-macos
+          name: ${{ inputs.profile }}-binary-macos
       - name: Prep test environment
         run: |
           gtar -xzf target.tar.gz
@@ -53,53 +53,58 @@ jobs:
         run: python3 ./mach smoketest --${{ inputs.profile }}
       - name: Run tests
         run: |
+          mkdir -p wpt-filtered-logs/macos-${{ inputs.wpt-layout }}
+          mkdir -p wpt-full-logs/macos-${{ inputs.wpt-layout }}
           python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${{ inputs.wpt-tests-to-run }} \
             --${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-            --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
-            --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
-      - name: Archive filtered results
-        uses: actions/upload-artifact@v3
-        if: always()
+            --log-raw wpt-full-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
+            --log-raw-unexpected wpt-filtered-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
+            --filter-intermittents wpt-filtered-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
+      - name: Archive results (filtered)
+        uses: actions/upload-artifact@v4
         with:
-          name: wpt-filtered-results-mac-${{ inputs.wpt-layout }}
-          path: |
-            filtered-test-wpt.${{ matrix.chunk_id }}.json
-            unexpected-test-wpt.${{ matrix.chunk_id }}.log
-      - name: Archive logs
-        uses: actions/upload-artifact@v3
-        if: failure()
+          name: wpt-filtered-logs-macos-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
+          path: wpt-filtered-logs/*/
+      - name: Archive results (full)
+        uses: actions/upload-artifact@v4
         with:
-          name: wpt-logs-mac-${{ inputs.wpt-layout }}
-          path: |
-            test-wpt.${{ matrix.chunk_id }}.log
-            filtered-wpt-results.${{ matrix.chunk_id }}.json
+          name: wpt-full-logs-macos-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
+          path: wpt-full-logs/*/
 
   report-test-results:
-    name: Reporting test results
+    name: Process WPT Results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() }}
-    needs: [ mac-wpt ]
+    if: ${{ always() }}
+    needs: mac-wpt
     steps:
+      - name: Merge logs (filtered)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wpt-filtered-logs-macos-${{ inputs.wpt-layout }}
+          pattern: wpt-filtered-logs-macos-${{ inputs.wpt-layout }}-*
+          delete-merged: true
+      - name: Merge logs (full)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wpt-full-logs-macos-${{ inputs.wpt-layout }}
+          pattern: wpt-full-logs-macos-${{ inputs.wpt-layout }}-*
+          delete-merged: true
       - uses: actions/checkout@v3
+        if: ${{ !cancelled() }}
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        if: ${{ !cancelled() }}
         with:
-          name: wpt-filtered-results-mac-${{ inputs.wpt-layout }}
-          path: wpt-filtered-results-mac
-      - name: Create aggregated unexpected results
-        run: cat wpt-filtered-results-mac/*.log > unexpected-test-wpt.log
-      - name: Archive aggregate results
-        uses: actions/upload-artifact@v3
-        with:
-          name: wpt-filtered-results-mac-${{ inputs.wpt-layout }}
-          path: |
-            unexpected-test-wpt.log
-      - name: Comment on PR with results
-        run: etc/ci/report_aggregated_expected_results.py --tag="mac-wpt-${{ inputs.wpt-layout }}"
-          wpt-filtered-results-mac/*.json
+          name: wpt-filtered-logs-macos-${{ inputs.wpt-layout }}
+          path: results
+      - name: Report results
+        if: ${{ !cancelled() }}
+        run: |
+          etc/ci/report_aggregated_expected_results.py \
+            --tag="macos-wpt-${{ inputs.wpt-layout }}" \
+            results/macos-${{ inputs.wpt-layout }}/*.json
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -63,11 +63,13 @@ jobs:
             --filter-intermittents wpt-filtered-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
       - name: Archive results (filtered)
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: wpt-filtered-logs-macos-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
       - name: Archive results (full)
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: wpt-full-logs-macos-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
           path: wpt-full-logs/*/

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Build (${{ inputs.profile }})
         run: |
           python3 ./mach build --${{ inputs.profile }}
+          cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
         uses: nick-fields/retry@v2
         with: # See https://github.com/servo/servo/issues/30757
@@ -117,16 +118,14 @@ jobs:
           timeout_minutes: 5
           max_attempts: 2
           command: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
-      - name: Rename build timing
-        run: cp -r target/cargo-timings target/cargo-timings-macos
       - name: Archive build timing
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings
+          name: cargo-timings-macos
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mac
           path: target/${{ inputs.profile }}/servo-tech-demo.dmg
@@ -143,9 +142,9 @@ jobs:
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: release-binary-macos
+          name: ${{ inputs.profile }}-binary-macos
           path: target.tar.gz
 
   wpt-2020:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,22 @@ jobs:
       profile: "release"
     secrets: inherit
 
+  merge-build-timings:
+    name: Merge Build Timings
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - "build-win"
+      - "build-mac"
+      - "build-linux"
+      - "build-android"
+    steps:
+      - name: Merge
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cargo-timings
+          pattern: cargo-timings-*
+
   build-result:
     name: Result
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,22 +46,6 @@ jobs:
       profile: "release"
     secrets: inherit
 
-  merge-build-timings:
-    name: Merge Build Timings
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs:
-      - "build-win"
-      - "build-mac"
-      - "build-linux"
-      - "build-android"
-    steps:
-      - name: Merge
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: cargo-timings
-          pattern: cargo-timings-*
-
   build-result:
     name: Result
     runs-on: ubuntu-latest
@@ -73,9 +57,15 @@ jobs:
       - "build-linux"
       - "build-android"
     steps:
-      - name: Mark the job as successful
+      - name: Merge build timings
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cargo-timings
+          pattern: cargo-timings-*
+          delete-merged: true
+      - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0
-      - name: Mark the job as unsuccessful
+      - name: Failure
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -31,8 +31,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      # Download all artifacts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
+        name: wpt-full-logs-linux-layout-2013
+      - uses: actions/download-artifact@v4
+        name: wpt-full-logs-linux-layout-2020
       - name: Prep environment
         run: |
           python3 -m pip install --upgrade pip
@@ -52,8 +54,8 @@ jobs:
           export CURRENT_DATE=$(date +"%d-%m-%Y")
           echo $CURRENT_DATE
           echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
-          ./mach update-wpt --legacy-layout wpt-logs-linux-layout-2013/test-wpt.*.log
-          ./mach update-wpt wpt-logs-linux-layout-2020/test-wpt.*.log
+          ./mach update-wpt wpt-full-logs-linux-layout-2013/test-wpt.*.log --legacy-layout
+          ./mach update-wpt wpt-full-logs-linux-layout-2020/test-wpt.*.log
           git add tests/wpt/meta tests/wpt/meta-legacy-layout
           git commit -a --amend --no-edit
       - name: Push changes

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -32,9 +32,11 @@ jobs:
         with:
           fetch-depth: 2
       - uses: actions/download-artifact@v4
-        name: wpt-full-logs-linux-layout-2013
+        with:
+          name: wpt-full-logs-linux-layout-2013
       - uses: actions/download-artifact@v4
-        name: wpt-full-logs-linux-layout-2020
+        with:
+          name: wpt-full-logs-linux-layout-2020
       - name: Prep environment
         run: |
           python3 -m pip install --upgrade pip
@@ -54,8 +56,8 @@ jobs:
           export CURRENT_DATE=$(date +"%d-%m-%Y")
           echo $CURRENT_DATE
           echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
-          ./mach update-wpt wpt-full-logs-linux-layout-2013/test-wpt.*.log --legacy-layout
-          ./mach update-wpt wpt-full-logs-linux-layout-2020/test-wpt.*.log
+          ./mach update-wpt linux-layout-2013/*.log --legacy-layout
+          ./mach update-wpt linux-layout-2020/*.log
           git add tests/wpt/meta tests/wpt/meta-legacy-layout
           git commit -a --amend --no-edit
       - name: Push changes

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -105,31 +105,22 @@ jobs:
       unit-tests: ${{ matrix.unit_tests }}
       wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
 
-  merge-build-timings:
-    name: Merge Build Timings
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: ["decision", "build"]
-    steps:
-      - name: Merge
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: cargo-timings
-          pattern: cargo-timings-*
-
   build-result:
     name: Result
     runs-on: ubuntu-latest
     if: always()
     # `needs: "build"` is necessary to detect cancellation.
-    needs:
-      - "decision"
-      - "build"
-
+    needs: [ "decision", "build" ]
     steps:
-      - name: Mark the job as successful
+      - name: Merge build timings
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cargo-timings
+          pattern: cargo-timings-*
+          delete-merged: true
+      - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: exit 0
-      - name: Mark the job as unsuccessful
+      - name: Failure
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -105,6 +105,18 @@ jobs:
       unit-tests: ${{ matrix.unit_tests }}
       wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
 
+  merge-build-timings:
+    name: Merge Build Timings
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: ["decision", "build"]
+    steps:
+      - name: Merge
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: cargo-timings
+          pattern: cargo-timings-*
+
   build-result:
     name: Result
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,7 +81,9 @@ jobs:
           python mach bootstrap-gstreamer
           cargo install --path support/crown
       - name: Build (${{ inputs.profile }})
-        run: python mach build --${{ inputs.profile }}
+        run: |
+          python mach build --${{ inputs.profile }}
+          cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Copy resources
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
@@ -93,18 +95,16 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: python mach test-unit --${{ inputs.profile }} -- -- --test-threads=1
-      - name: Rename build timing
-        run: cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Archive build timing
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings
+          name: cargo-timings-windows
           # Using a wildcard here ensures that the archive includes the path.
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
         run: python mach package --${{ inputs.profile }}
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: win
           # These files are available


### PR DESCRIPTION
This switches to version 4 of the GitHub artifact actions, which
requires producing a single artifact per job and adding merge steps. In
addition, the names of artifacts are standardized:

- Build: `<profile>-binary-<platform>`
- Full WPT results (only on failure): `wpt-full-logs-<platform>-<layout>`
- Filtered WPT results (only on failure): `wpt-filtered-logs-<platform>-<layout>`

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change the CI behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
