### PR TITLE
style: Remove dependency on servo_url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,6 +3107,7 @@ dependencies = [
  "style",
  "style_traits",
  "time 0.1.45",
+ "url",
  "webrender_api",
 ]
 
@@ -3143,6 +3144,7 @@ dependencies = [
  "servo_url",
  "style",
  "style_traits",
+ "url",
  "webrender_api",
 ]
 
@@ -5374,6 +5376,7 @@ dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
  "serde",
+ "servo_arc",
  "servo_rand",
  "to_shmem",
  "url",
@@ -5707,7 +5710,6 @@ dependencies = [
  "servo_arc",
  "servo_atoms",
  "servo_config",
- "servo_url",
  "smallbitvec",
  "smallvec",
  "static_assertions",
@@ -5723,6 +5725,7 @@ dependencies = [
  "uluru",
  "unicode-bidi",
  "unicode-segmentation",
+ "url",
  "void",
  "walkdir",
 ]
@@ -5753,9 +5756,9 @@ dependencies = [
  "servo_arc",
  "servo_atoms",
  "servo_config",
- "servo_url",
  "style",
  "style_traits",
+ "url",
 ]
 
 [[package]]
@@ -5773,10 +5776,10 @@ dependencies = [
  "serde",
  "servo_arc",
  "servo_atoms",
- "servo_url",
  "size_of_test",
  "to_shmem",
  "to_shmem_derive",
+ "url",
  "webrender_api",
 ]
 

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -276,7 +276,7 @@ impl FontCache {
 
                 // FIXME:
                 // This shouldn't use NoReferrer, but the current documents url
-                let request = RequestBuilder::new(url.clone(), Referrer::NoReferrer)
+                let request = RequestBuilder::new(url.clone().into(), Referrer::NoReferrer)
                     .destination(Destination::Font);
 
                 let channel_to_self = self.channel_to_self.clone();
@@ -334,7 +334,7 @@ impl FontCache {
                             };
                             let command = Command::AddDownloadedWebFont(
                                 family_name.clone(),
-                                url.clone(),
+                                url.clone().into(),
                                 bytes,
                                 sender.clone(),
                             );

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -160,7 +160,6 @@ impl FontTemplateData {
                 .to_string(),
         )
         .expect("Couldn't parse Core Text font URL!")
-        .as_url()
         .to_file_path()
         .expect("Core Text font didn't name a path!");
         let mut bytes = Vec::new();

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1512,7 +1512,7 @@ where
         let marker_fragments = match node.style(self.style_context()).get_list().list_style_image {
             Image::Url(ref url_value) => {
                 let image_info = Box::new(ImageFragmentInfo::new(
-                    url_value.url().cloned(),
+                    url_value.url().cloned().map(Into::into),
                     None,
                     node,
                     self.layout_context,

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -734,7 +734,7 @@ impl Fragment {
                     if let Some(url) = image_url.url() {
                         let webrender_image = state.layout_context.get_webrender_image_for_url(
                             self.node,
-                            url.clone(),
+                            url.clone().into(),
                             UsePlaceholder::No,
                         );
                         if let Some(webrender_image) = webrender_image {
@@ -1205,7 +1205,7 @@ impl Fragment {
                 let url = image_url.url()?;
                 let image = state.layout_context.get_webrender_image_for_url(
                     self.node,
-                    url.clone(),
+                    url.clone().into(),
                     UsePlaceholder::No,
                 )?;
                 width = image.width;

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -37,7 +37,7 @@ use style::properties::{
 };
 use style::selector_parser::PseudoElement;
 use style::shared_lock::SharedRwLock;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::{CSSPixel, ParsingMode, ToCss};
 use webrender_api::ExternalScrollId;
 
@@ -798,7 +798,7 @@ fn create_font_declaration(
         property.clone(),
         value,
         Origin::Author,
-        url_data,
+        &UrlExtraData(url_data.get_arc()),
         None,
         ParsingMode::DEFAULT,
         quirks_mode,

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -608,7 +608,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                     };
                     let (width, height, key) = match builder.context.get_webrender_image_for_url(
                         node,
-                        image_url,
+                        image_url.into(),
                         UsePlaceholder::No,
                     ) {
                         Some(WebRenderImageInfo {

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -177,7 +177,7 @@ impl ReplacedContent {
         if let ComputedUrl::Valid(image_url) = image_url {
             let (image, width, height) = match context.get_or_request_image_or_meta(
                 element.opaque(),
-                image_url.clone(),
+                image_url.clone().into(),
                 UsePlaceholder::No,
             ) {
                 Some(ImageOrMetadataAvailable::ImageAvailable { image, .. }) => {

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -44,4 +44,5 @@ servo_url = { path = "../url" }
 style = { path = "../style" }
 style_traits = { workspace = true }
 time = { workspace = true }
+url = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -40,4 +40,5 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 style = { path = "../style" }
 style_traits = { workspace = true }
+url = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -32,6 +32,7 @@ use style::values::computed::font::FontStyle;
 use style::values::specified::color::Color;
 use style_traits::values::ToCss;
 use style_traits::ParsingMode;
+use url::Url;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
@@ -1681,7 +1682,7 @@ impl CanvasState {
 pub fn parse_color(canvas: Option<&HTMLCanvasElement>, string: &str) -> Result<RGBA, ()> {
     let mut input = ParserInput::new(string);
     let mut parser = Parser::new(&mut input);
-    let url = ServoUrl::parse("about:blank").unwrap();
+    let url = Url::parse("about:blank").unwrap().into();
     let context = ParserContext::new(
         Origin::Author,
         &url,

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -7,7 +7,7 @@ use dom_struct::dom_struct;
 use style::context::QuirksMode;
 use style::parser::ParserContext;
 use style::stylesheets::supports_rule::{parse_condition_or_declaration, Declaration};
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::ParsingMode;
 
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -39,10 +39,10 @@ impl CSS {
         decl.push_str(": ");
         decl.push_str(&value);
         let decl = Declaration(decl);
-        let url = win.Document().url();
+        let url_data = UrlExtraData(win.Document().url().get_arc());
         let context = ParserContext::new(
             Origin::Author,
-            &url,
+            &url_data,
             Some(CssRuleType::Style),
             ParsingMode::DEFAULT,
             QuirksMode::NoQuirks,
@@ -62,10 +62,10 @@ impl CSS {
             Err(..) => return false,
         };
 
-        let url = win.Document().url();
+        let url_data = UrlExtraData(win.Document().url().get_arc());
         let context = ParserContext::new(
             Origin::Author,
-            &url,
+            &url_data,
             Some(CssRuleType::Style),
             ParsingMode::DEFAULT,
             QuirksMode::NoQuirks,

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -13,7 +13,7 @@ use style::properties::{
 };
 use style::selector_parser::PseudoElement;
 use style::shared_lock::Locked;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::ParsingMode;
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
@@ -160,12 +160,15 @@ impl CSSStyleOwner {
     fn base_url(&self) -> ServoUrl {
         match *self {
             CSSStyleOwner::Element(ref el) => window_from_node(&**el).Document().base_url(),
-            CSSStyleOwner::CSSRule(ref rule, _) => (*rule
-                .parent_stylesheet()
-                .style_stylesheet()
-                .contents
-                .url_data
-                .read())
+            CSSStyleOwner::CSSRule(ref rule, _) => ServoUrl::from(
+                rule.parent_stylesheet()
+                    .style_stylesheet()
+                    .contents
+                    .url_data
+                    .read()
+                    .0
+                    .clone(),
+            )
             .clone(),
         }
     }
@@ -307,7 +310,7 @@ impl CSSStyleDeclaration {
                 id,
                 &value,
                 Origin::Author,
-                &self.owner.base_url(),
+                &UrlExtraData(self.owner.base_url().get_arc()),
                 window.css_error_reporter(),
                 ParsingMode::DEFAULT,
                 quirks_mode,
@@ -458,7 +461,7 @@ impl CSSStyleDeclarationMethods for CSSStyleDeclaration {
             // Step 3
             *pdb = parse_style_attribute(
                 &value,
-                &self.owner.base_url(),
+                &UrlExtraData(self.owner.base_url().get_arc()),
                 window.css_error_reporter(),
                 quirks_mode,
                 CssRuleType::Style,

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -13,6 +13,7 @@ use js::jsapi::JSObject;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
 use js::typedarray::{Float32Array, Float64Array};
 use style::parser::ParserContext;
+use url::Url;
 
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::DOMMatrixBinding::{DOMMatrixInit, DOMMatrixMethods};
@@ -830,10 +831,10 @@ pub fn transform_to_matrix(value: String) -> Fallible<(bool, Transform3D<f64>)> 
 
     let mut input = ParserInput::new(&value);
     let mut parser = Parser::new(&mut input);
-    let url = ::servo_url::ServoUrl::parse("about:blank").unwrap();
+    let url_data = Url::parse("about:blank").unwrap().into();
     let context = ParserContext::new(
         ::style::stylesheets::Origin::Author,
-        &url,
+        &url_data,
         Some(::style::stylesheets::CssRuleType::Style),
         ::style_traits::ParsingMode::DEFAULT,
         ::style::context::QuirksMode::NoQuirks,

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -87,8 +87,10 @@ impl HTMLBodyElementMethods for HTMLBodyElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-body-background
     fn SetBackground(&self, input: DOMString) {
-        let value =
-            AttrValue::from_resolved_url(&document_from_node(self).base_url(), input.into());
+        let value = AttrValue::from_resolved_url(
+            &document_from_node(self).base_url().get_arc(),
+            input.into(),
+        );
         self.upcast::<Element>()
             .set_attribute(&local_name!("background"), value);
     }
@@ -123,6 +125,7 @@ impl HTMLBodyElementLayoutHelpers for LayoutDom<'_, HTMLBodyElement> {
             .get_attr_for_layout(&ns!(), &local_name!("background"))
             .and_then(AttrValue::as_resolved_url)
             .cloned()
+            .map(Into::into)
     }
 }
 
@@ -164,9 +167,10 @@ impl VirtualMethods for HTMLBodyElement {
             local_name!("bgcolor") | local_name!("text") => {
                 AttrValue::from_legacy_color(value.into())
             },
-            local_name!("background") => {
-                AttrValue::from_resolved_url(&document_from_node(self).base_url(), value.into())
-            },
+            local_name!("background") => AttrValue::from_resolved_url(
+                &document_from_node(self).base_url().get_arc(),
+                value.into(),
+            ),
             _ => self
                 .super_type()
                 .unwrap()

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -40,11 +40,12 @@ use style::context::QuirksMode;
 use style::media_queries::MediaList;
 use style::parser::ParserContext;
 use style::str::is_ascii_digit;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style::values::specified::length::{Length, NoCalcLength};
 use style::values::specified::source_size_list::SourceSizeList;
 use style::values::specified::AbsoluteLength;
 use style_traits::ParsingMode;
+use url::Url;
 
 use crate::document_loader::{LoadBlocker, LoadType};
 use crate::dom::activation::Activatable;
@@ -678,7 +679,7 @@ impl HTMLImageElement {
     fn matches_environment(&self, media_query: String) -> bool {
         let document = document_from_node(self);
         let quirks_mode = document.quirks_mode();
-        let document_url = &document.url();
+        let document_url_data = UrlExtraData(document.url().get_arc());
         // FIXME(emilio): This should do the same that we do for other media
         // lists regarding the rule type and such, though it doesn't really
         // matter right now...
@@ -686,7 +687,7 @@ impl HTMLImageElement {
         // Also, ParsingMode::all() is wrong, and should be DEFAULT.
         let context = ParserContext::new(
             Origin::Author,
-            document_url,
+            &document_url_data,
             Some(CssRuleType::Style),
             ParsingMode::all(),
             quirks_mode,
@@ -1434,10 +1435,10 @@ impl LayoutHTMLImageElementHelpers for LayoutDom<'_, HTMLImageElement> {
 pub fn parse_a_sizes_attribute(value: DOMString) -> SourceSizeList {
     let mut input = ParserInput::new(&value);
     let mut parser = Parser::new(&mut input);
-    let url = ServoUrl::parse("about:blank").unwrap();
+    let url_data = Url::parse("about:blank").unwrap().into();
     let context = ParserContext::new(
         Origin::Author,
-        &url,
+        &url_data,
         Some(CssRuleType::Style),
         // FIXME(emilio): why ::empty() instead of ::DEFAULT? Also, what do
         // browsers do regarding quirks-mode in a media list?

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -18,7 +18,7 @@ use style::attr::AttrValue;
 use style::media_queries::MediaList;
 use style::parser::ParserContext as CssParserContext;
 use style::str::HTML_SPACE_CHARACTERS;
-use style::stylesheets::{CssRuleType, Origin, Stylesheet};
+use style::stylesheets::{CssRuleType, Origin, Stylesheet, UrlExtraData};
 use style_traits::ParsingMode;
 
 use crate::dom::attr::Attr;
@@ -310,14 +310,14 @@ impl HTMLLinkElement {
 
         let mut input = ParserInput::new(&mq_str);
         let mut css_parser = CssParser::new(&mut input);
-        let doc_url = document.url();
+        let document_url_data = &UrlExtraData(document.url().get_arc());
         let window = document.window();
         // FIXME(emilio): This looks somewhat fishy, since we use the context
         // only to parse the media query list, CssRuleType::Media doesn't make
         // much sense.
         let context = CssParserContext::new(
             Origin::Author,
-            &doc_url,
+            &document_url_data,
             Some(CssRuleType::Media),
             ParsingMode::DEFAULT,
             document.quirks_mode(),

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1117,7 +1117,7 @@ impl HTMLScriptElement {
             if let Some(record) = record {
                 rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
                 let evaluated =
-                    module_tree.execute_module(global, record, rval.handle_mut().into());
+                    module_tree.execute_module(&global, record, rval.handle_mut().into());
 
                 if let Err(exception) = evaluated {
                     module_tree.set_rethrow_error(exception);

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -12,7 +12,7 @@ use net_traits::ReferrerPolicy;
 use servo_arc::Arc;
 use style::media_queries::MediaList;
 use style::parser::ParserContext as CssParserContext;
-use style::stylesheets::{AllowImportRules, CssRuleType, Origin, Stylesheet};
+use style::stylesheets::{AllowImportRules, CssRuleType, Origin, Stylesheet, UrlExtraData};
 use style_traits::ParsingMode;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -100,11 +100,11 @@ impl HTMLStyleElement {
         let data = node
             .GetTextContent()
             .expect("Element.textContent must be a string");
-        let url = window.get_url();
+        let url_data = UrlExtraData(window.get_url().get_arc());
         let css_error_reporter = window.css_error_reporter();
         let context = CssParserContext::new(
             Origin::Author,
-            &url,
+            &url_data,
             Some(CssRuleType::Media),
             ParsingMode::DEFAULT,
             doc.quirks_mode(),
@@ -119,7 +119,7 @@ impl HTMLStyleElement {
         let loader = StylesheetLoader::for_element(self.upcast());
         let sheet = Stylesheet::from_str(
             &data,
-            window.get_url(),
+            UrlExtraData(window.get_url().get_arc()),
             Origin::Author,
             mq,
             shared_lock,

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -8,7 +8,7 @@ use servo_arc::Arc;
 use style::media_queries::{MediaList as StyleMediaList, MediaQuery};
 use style::parser::ParserContext;
 use style::shared_lock::{Locked, SharedRwLock};
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::{ParsingMode, ToCss};
 
 use crate::dom::bindings::codegen::Bindings::MediaListBinding::MediaListMethods;
@@ -80,11 +80,11 @@ impl MediaListMethods for MediaList {
         let mut parser = Parser::new(&mut input);
         let global = self.global();
         let window = global.as_window();
-        let url = window.get_url();
+        let url_data = UrlExtraData(window.get_url().get_arc());
         let quirks_mode = window.Document().quirks_mode();
         let context = ParserContext::new(
             Origin::Author,
-            &url,
+            &url_data,
             Some(CssRuleType::Media),
             ParsingMode::DEFAULT,
             quirks_mode,
@@ -123,11 +123,11 @@ impl MediaListMethods for MediaList {
         let mut parser = Parser::new(&mut input);
         let global = self.global();
         let win = global.as_window();
-        let url = win.get_url();
+        let url_data = UrlExtraData(win.get_url().get_arc());
         let quirks_mode = win.Document().quirks_mode();
         let context = ParserContext::new(
             Origin::Author,
-            &url,
+            &url_data,
             Some(CssRuleType::Media),
             ParsingMode::DEFAULT,
             quirks_mode,
@@ -162,11 +162,11 @@ impl MediaListMethods for MediaList {
         let mut parser = Parser::new(&mut input);
         let global = self.global();
         let win = global.as_window();
-        let url = win.get_url();
+        let url_data = UrlExtraData(win.get_url().get_arc());
         let quirks_mode = win.Document().quirks_mode();
         let context = ParserContext::new(
             Origin::Author,
-            &url,
+            &url_data,
             Some(CssRuleType::Media),
             ParsingMode::DEFAULT,
             quirks_mode,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -41,7 +41,7 @@ use style::context::QuirksMode;
 use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::selector_parser::{SelectorImpl, SelectorParser};
-use style::stylesheets::Stylesheet;
+use style::stylesheets::{Stylesheet, UrlExtraData};
 use uuid::Uuid;
 
 use crate::document_loader::DocumentLoader;
@@ -961,7 +961,10 @@ impl Node {
     pub fn query_selector(&self, selectors: DOMString) -> Fallible<Option<DomRoot<Element>>> {
         // Step 1.
         let doc = self.owner_doc();
-        match SelectorParser::parse_author_origin_no_namespace(&selectors, &doc.url()) {
+        match SelectorParser::parse_author_origin_no_namespace(
+            &selectors,
+            &UrlExtraData(doc.url().get_arc()),
+        ) {
             // Step 2.
             Err(_) => Err(Error::Syntax),
             // Step 3.
@@ -989,7 +992,10 @@ impl Node {
     pub fn query_selector_iter(&self, selectors: DOMString) -> Fallible<QuerySelectorIterator> {
         // Step 1.
         let url = self.owner_doc().url();
-        match SelectorParser::parse_author_origin_no_namespace(&selectors, &url) {
+        match SelectorParser::parse_author_origin_no_namespace(
+            &selectors,
+            &UrlExtraData(url.get_arc()),
+        ) {
             // Step 2.
             Err(_) => Err(Error::Syntax),
             // Step 3.

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -25,7 +25,7 @@ use style::shared_lock::{Locked, SharedRwLock};
 use style::stylesheets::import_rule::{ImportLayer, ImportSheet, ImportSupportsCondition};
 use style::stylesheets::{
     CssRules, ImportRule, Origin, Stylesheet, StylesheetContents,
-    StylesheetLoader as StyleStylesheetLoader,
+    StylesheetLoader as StyleStylesheetLoader, UrlExtraData,
 };
 use style::values::CssUrl;
 
@@ -159,7 +159,7 @@ impl FetchResponseListener for StylesheetContext {
                         let shared_lock = document.style_shared_lock().clone();
                         let sheet = Arc::new(Stylesheet::from_bytes(
                             &data,
-                            final_url,
+                            UrlExtraData(final_url.get_arc()),
                             protocol_encoding_label,
                             Some(environment_encoding),
                             Origin::Author,
@@ -183,7 +183,7 @@ impl FetchResponseListener for StylesheetContext {
                         &data,
                         protocol_encoding_label,
                         Some(environment_encoding),
-                        final_url,
+                        UrlExtraData(final_url.get_arc()),
                         Some(&loader),
                         win.css_error_reporter(),
                     );
@@ -404,7 +404,7 @@ impl<'a> StyleStylesheetLoader for StylesheetLoader<'a> {
         // TODO (mrnayak) : Whether we should use the original loader's CORS
         // setting? Fix this when spec has more details.
         let source = StylesheetContextSource::Import(sheet.clone());
-        self.load(source, url, None, "".to_owned());
+        self.load(source, url.into(), None, "".to_owned());
 
         Arc::new(lock.wrap(import))
     }

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -27,10 +27,10 @@ servo = [
     "cssparser/serde",
     "encoding_rs",
     "malloc_size_of/servo",
-    "servo_url",
     "string_cache",
     "to_shmem/servo",
     "servo_arc/servo",
+    "url",
 ]
 gecko_debug = []
 gecko_refcount_logging = []
@@ -69,7 +69,6 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms", optional = true }
 servo_config = { path = "../config", optional = true }
-servo_url = { path = "../url", optional = true }
 smallbitvec = "2.3.0"
 smallvec = "1.0"
 static_assertions = "1.1"
@@ -81,6 +80,7 @@ time = "0.1"
 thin-vec = { workspace = true }
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }
+url = { workspace = true, optional = true, features = ["serde"] }
 uluru = "3.0"
 unicode-bidi = "0.3"
 unicode-segmentation = "1.0"

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -20,7 +20,6 @@ use euclid::num::Zero;
 use num_traits::ToPrimitive;
 use selectors::attr::AttrSelectorOperation;
 use servo_arc::Arc;
-use servo_url::ServoUrl;
 use std::str::FromStr;
 
 // Duplicated from script::dom::values.
@@ -51,7 +50,10 @@ pub enum AttrValue {
     ///
     /// The URL is resolved at setting-time, so this kind of attribute value is
     /// not actually suitable for most URL-reflecting IDL attributes.
-    ResolvedUrl(String, Option<ServoUrl>),
+    ResolvedUrl(
+        String,
+        #[ignore_malloc_size_of = "Arc"] Option<Arc<url::Url>>
+    ),
 
     /// Note that this variant is only used transitively as a fast path to set
     /// the property declaration block relevant to the style of an element when
@@ -243,8 +245,8 @@ impl AttrValue {
         AttrValue::Atom(value)
     }
 
-    pub fn from_resolved_url(base: &ServoUrl, url: String) -> AttrValue {
-        let joined = base.join(&url).ok();
+    pub fn from_resolved_url(base: &Arc<::url::Url>, url: String) -> AttrValue {
+        let joined = base.join(&url).ok().map(Arc::new);
         AttrValue::ResolvedUrl(url, joined)
     }
 
@@ -316,7 +318,7 @@ impl AttrValue {
     /// ## Panics
     ///
     /// Panics if the `AttrValue` is not a `ResolvedUrl`
-    pub fn as_resolved_url(&self) -> Option<&ServoUrl> {
+    pub fn as_resolved_url(&self) -> Option<&Arc<::url::Url>> {
         match *self {
             AttrValue::ResolvedUrl(_, ref url) => url.as_ref(),
             _ => panic!("Url not found"),

--- a/components/style/servo/url.rs
+++ b/components/style/servo/url.rs
@@ -9,9 +9,10 @@ use crate::stylesheets::CorsMode;
 use crate::values::computed::{Context, ToComputedValue};
 use cssparser::Parser;
 use servo_arc::Arc;
-use servo_url::ServoUrl;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
+use to_shmem::{SharedMemoryBuilder, ToShmem};
+use url::Url;
 
 /// A CSS url() value for servo.
 ///
@@ -24,7 +25,7 @@ use style_traits::{CssWriter, ParseError, ToCss};
 ///
 /// TODO(emilio): This should be shrunk by making CssUrl a wrapper type of an
 /// arc, and keep the serialization in that Arc. See gecko/url.rs for example.
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize, SpecifiedValueInfo, ToShmem)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize, SpecifiedValueInfo)]
 pub struct CssUrl {
     /// The original URI. This might be optional since we may insert computed
     /// values of images into the cascade directly, and we don't bother to
@@ -36,7 +37,14 @@ pub struct CssUrl {
     original: Option<Arc<String>>,
 
     /// The resolved value for the url, if valid.
-    resolved: Option<ServoUrl>,
+    #[ignore_malloc_size_of = "Arc"]
+    resolved: Option<Arc<Url>>,
+}
+
+impl ToShmem for CssUrl {
+    fn to_shmem(&self, _builder: &mut SharedMemoryBuilder) -> to_shmem::Result<Self> {
+        unimplemented!("If servo wants to share stylesheets across processes, ToShmem for Url must be implemented");
+    }
 }
 
 impl CssUrl {
@@ -46,7 +54,7 @@ impl CssUrl {
     /// FIXME(emilio): Should honor CorsMode.
     pub fn parse_from_string(url: String, context: &ParserContext, _: CorsMode) -> Self {
         let serialization = Arc::new(url);
-        let resolved = context.url_data.join(&serialization).ok();
+        let resolved = context.url_data.0.join(&serialization).ok().map(Arc::new);
         CssUrl {
             original: Some(serialization),
             resolved: resolved,
@@ -71,7 +79,7 @@ impl CssUrl {
     }
 
     /// Returns the resolved url if it was valid.
-    pub fn url(&self) -> Option<&ServoUrl> {
+    pub fn url(&self) -> Option<&Arc<Url>> {
         self.resolved.as_ref()
     }
 
@@ -87,7 +95,7 @@ impl CssUrl {
 
     /// Creates an already specified url value from an already resolved URL
     /// for insertion in the cascade.
-    pub fn for_cascade(url: ServoUrl) -> Self {
+    pub fn for_cascade(url: Arc<::url::Url>) -> Self {
         CssUrl {
             original: None,
             resolved: Some(url),
@@ -98,7 +106,7 @@ impl CssUrl {
     pub fn new_for_testing(url: &str) -> Self {
         CssUrl {
             original: Some(Arc::new(url.into())),
-            resolved: ServoUrl::parse(url).ok(),
+            resolved: ::url::Url::parse(url).ok().map(Arc::new),
         }
     }
 
@@ -205,12 +213,12 @@ pub enum ComputedUrl {
     /// The `url()` was invalid or it wasn't specified by the user.
     Invalid(#[ignore_malloc_size_of = "Arc"] Arc<String>),
     /// The resolved `url()` relative to the stylesheet URL.
-    Valid(ServoUrl),
+    Valid(#[ignore_malloc_size_of = "Arc"] Arc<Url>),
 }
 
 impl ComputedUrl {
     /// Returns the resolved url if it was valid.
-    pub fn url(&self) -> Option<&ServoUrl> {
+    pub fn url(&self) -> Option<&Arc<Url>> {
         match *self {
             ComputedUrl::Valid(ref url) => Some(url),
             _ => None,

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -27,8 +27,6 @@ use crate::values::specified::{Number, NumberOrPercentage, Percentage};
 use crate::Atom;
 use cssparser::{Delimiter, Parser, Token};
 use selectors::parser::SelectorParseErrorKind;
-#[cfg(feature = "servo")]
-use servo_url::ServoUrl;
 use std::cmp::Ordering;
 use std::fmt::{self, Write};
 use style_traits::{CssType, CssWriter, KeywordsCollectFn, ParseError};
@@ -260,7 +258,7 @@ impl Image {
     /// Creates an already specified image value from an already resolved URL
     /// for insertion in the cascade.
     #[cfg(feature = "servo")]
-    pub fn for_cascade(url: ServoUrl) -> Self {
+    pub fn for_cascade(url: ::servo_arc::Arc<::url::Url>) -> Self {
         use crate::values::CssUrl;
         generic::Image::Url(CssUrl::for_cascade(url))
     }

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -11,7 +11,7 @@ name = "style_traits"
 path = "lib.rs"
 
 [features]
-servo = ["servo_atoms", "cssparser/serde", "webrender_api", "servo_url", "euclid/serde"]
+servo = ["servo_atoms", "cssparser/serde", "webrender_api", "url", "euclid/serde"]
 gecko = []
 
 [dependencies]
@@ -26,8 +26,8 @@ selectors = { path = "../selectors", features = ["shmem"] }
 serde = "1.0"
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms", optional = true }
-servo_url = { path = "../url", optional = true }
 size_of_test = { path = "../size_of_test" }
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }
+url = { workspace = true, optional = true }
 webrender_api = { workspace = true, optional = true }

--- a/components/style_traits/specified_value_info.rs
+++ b/components/style_traits/specified_value_info.rs
@@ -92,7 +92,7 @@ impl SpecifiedValueInfo for crate::owned_str::OwnedStr {}
 #[cfg(feature = "servo")]
 impl SpecifiedValueInfo for ::servo_atoms::Atom {}
 #[cfg(feature = "servo")]
-impl SpecifiedValueInfo for ::servo_url::ServoUrl {}
+impl SpecifiedValueInfo for ::url::Url {}
 
 impl<T: SpecifiedValueInfo + ?Sized> SpecifiedValueInfo for Box<T> {
     const SUPPORTED_TYPES: u8 = T::SUPPORTED_TYPES;

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 malloc_size_of = { path = "../malloc_size_of", features = ["servo"] }
 malloc_size_of_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+servo_arc = { path = "../servo_arc" }
 servo_rand = { path = "../rand" }
 to_shmem = { path = "../to_shmem" }
 url = { workspace = true, features = ["serde"] }

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -20,6 +20,6 @@ selectors = {path = "../../../components/selectors", features = ["shmem"] }
 servo_arc = {path = "../../../components/servo_arc"}
 servo_atoms = {path = "../../../components/atoms"}
 servo_config = {path = "../../../components/config"}
-servo_url = {path = "../../../components/url"}
 style = {path = "../../../components/style", features = ["servo"]}
 style_traits = {path = "../../../components/style_traits"}
+url = { workspace = true }

--- a/tests/unit/style/lib.rs
+++ b/tests/unit/style/lib.rs
@@ -15,10 +15,10 @@ extern crate selectors;
 extern crate serde_json;
 extern crate servo_arc;
 extern crate servo_atoms;
-extern crate servo_url;
 extern crate style;
 extern crate style_traits;
 extern crate test;
+extern crate url;
 
 mod animated_properties;
 mod attr;

--- a/tests/unit/style/parsing/mod.rs
+++ b/tests/unit/style/parsing/mod.rs
@@ -9,6 +9,7 @@ use style::context::QuirksMode;
 use style::parser::ParserContext;
 use style::stylesheets::{CssRuleType, Origin};
 use style_traits::{ParseError, ParsingMode};
+use url::Url;
 
 fn parse<T, F>(f: F, s: &'static str) -> Result<T, ParseError<'static>>
 where
@@ -22,10 +23,10 @@ fn parse_input<'i: 't, 't, T, F>(f: F, input: &'t mut ParserInput<'i>) -> Result
 where
     F: Fn(&ParserContext, &mut Parser<'i, 't>) -> Result<T, ParseError<'i>>,
 {
-    let url = ::servo_url::ServoUrl::parse("http://localhost").unwrap();
+    let url_data = Url::parse("http://localhost").unwrap().into();
     let context = ParserContext::new(
         Origin::Author,
-        &url,
+        &url_data,
         Some(CssRuleType::Style),
         ParsingMode::DEFAULT,
         QuirksMode::NoQuirks,

--- a/tests/unit/style/parsing/selectors.rs
+++ b/tests/unit/style/parsing/selectors.rs
@@ -4,10 +4,10 @@
 
 use cssparser::{Parser, ParserInput, ToCss};
 use selectors::parser::SelectorList;
-use servo_url::ServoUrl;
 use style::selector_parser::{SelectorImpl, SelectorParser};
 use style::stylesheets::{Namespaces, Origin};
 use style_traits::ParseError;
+use url::Url;
 
 fn parse_selector<'i, 't>(
     input: &mut Parser<'i, 't>,
@@ -15,11 +15,11 @@ fn parse_selector<'i, 't>(
     let mut ns = Namespaces::default();
     ns.prefixes
         .insert("svg".into(), style::Namespace::new(ns!(svg)));
-    let dummy_url = ServoUrl::parse("about:blank").unwrap();
+    let dummy_url_data = Url::parse("about:blank").unwrap().into();
     let parser = SelectorParser {
         stylesheet_origin: Origin::UserAgent,
         namespaces: &ns,
-        url_data: &dummy_url,
+        url_data: &dummy_url_data,
         for_supports_rule: false,
     };
     SelectorList::parse(&parser, input)

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -7,7 +7,6 @@ use euclid::{Scale, Size2D};
 use selectors::parser::{AncestorHashes, Selector};
 use servo_arc::Arc;
 use servo_atoms::Atom;
-use servo_url::ServoUrl;
 use style::context::QuirksMode;
 use style::media_queries::{Device, MediaType};
 use style::properties::{longhands, Importance, PropertyDeclaration, PropertyDeclarationBlock};
@@ -19,11 +18,12 @@ use style::stylist::{
     needs_revalidation_for_testing, ContainerConditionId, LayerId, Rule, Stylist,
 };
 use style::thread_state::{self, ThreadState};
+use url::Url;
 
 /// Helper method to get some Rules from selector strings.
 /// Each sublist of the result contains the Rules for one StyleRule.
 fn get_mock_rules(css_selectors: &[&str]) -> (Vec<Vec<Rule>>, SharedRwLock) {
-    let dummy_url = &ServoUrl::parse("about:blank").unwrap();
+    let dummy_url_data = Url::parse("about:blank").unwrap().into();
     let shared_lock = SharedRwLock::new();
     (
         css_selectors
@@ -31,7 +31,8 @@ fn get_mock_rules(css_selectors: &[&str]) -> (Vec<Vec<Rule>>, SharedRwLock) {
             .enumerate()
             .map(|(i, selectors)| {
                 let selectors =
-                    SelectorParser::parse_author_origin_no_namespace(selectors, dummy_url).unwrap();
+                    SelectorParser::parse_author_origin_no_namespace(selectors, &dummy_url_data)
+                        .unwrap();
 
                 let locked = Arc::new(shared_lock.wrap(StyleRule {
                     selectors: selectors,
@@ -66,11 +67,11 @@ fn get_mock_rules(css_selectors: &[&str]) -> (Vec<Vec<Rule>>, SharedRwLock) {
 }
 
 fn parse_selectors(selectors: &[&str]) -> Vec<Selector<SelectorImpl>> {
-    let dummy_url = &ServoUrl::parse("about:blank").unwrap();
+    let dummy_url_data = Url::parse("about:blank").unwrap().into();
     selectors
         .iter()
         .map(|x| {
-            SelectorParser::parse_author_origin_no_namespace(x, dummy_url)
+            SelectorParser::parse_author_origin_no_namespace(x, &dummy_url_data)
                 .unwrap()
                 .0
                 .into_iter()


### PR DESCRIPTION
In order for stylo to be a separate crate, it needs to depend on less
things from Servo. This change makes it so that stylo no longer depends
on servo_url.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
