### PR TITLE
style: Reduce diff with upstream derive_common and malloc_size_of

### DIFF
--- a/components/derive_common/Cargo.toml
+++ b/components/derive_common/Cargo.toml
@@ -3,7 +3,6 @@ name = "derive_common"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
-edition = "2018"
 publish = false
 
 [lib]

--- a/components/derive_common/cg.rs
+++ b/components/derive_common/cg.rs
@@ -4,11 +4,11 @@
 
 use darling::{FromDeriveInput, FromField, FromVariant};
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, TokenStreamExt};
+use quote::TokenStreamExt;
 use syn::{
-    self, parse_quote, AngleBracketedGenericArguments, AssocType, DeriveInput, Field,
-    GenericArgument, GenericParam, Ident, Path, PathArguments, PathSegment, QSelf, Type, TypeArray,
-    TypeGroup, TypeParam, TypeParen, TypePath, TypeSlice, TypeTuple, Variant, WherePredicate,
+    self, AngleBracketedGenericArguments, AssocType, DeriveInput, Field, GenericArgument,
+    GenericParam, Ident, Path, PathArguments, PathSegment, QSelf, Type, TypeArray, TypeGroup,
+    TypeParam, TypeParen, TypePath, TypeSlice, TypeTuple, Variant, WherePredicate,
 };
 use synstructure::{self, BindStyle, BindingInfo, VariantAst, VariantInfo};
 

--- a/components/derive_common/lib.rs
+++ b/components/derive_common/lib.rs
@@ -2,4 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+extern crate darling;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+extern crate synstructure;
+
 pub mod cg;

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -3,7 +3,6 @@ name = "malloc_size_of"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
 publish = false
 
 [lib]

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -46,6 +46,41 @@
 //!   Note: WebRender has a reduced fork of this crate, so that we can avoid
 //!   publishing this crate on crates.io.
 
+#[cfg(feature = "servo")]
+extern crate accountable_refcell;
+extern crate app_units;
+#[cfg(feature = "servo")]
+extern crate content_security_policy;
+#[cfg(feature = "servo")]
+extern crate crossbeam_channel;
+extern crate cssparser;
+extern crate euclid;
+#[cfg(feature = "servo")]
+extern crate http;
+#[cfg(feature = "servo")]
+extern crate keyboard_types;
+extern crate selectors;
+#[cfg(feature = "servo")]
+extern crate serde;
+#[cfg(feature = "servo")]
+extern crate serde_bytes;
+extern crate servo_arc;
+extern crate smallbitvec;
+extern crate smallvec;
+#[cfg(feature = "servo")]
+extern crate string_cache;
+#[cfg(feature = "servo")]
+extern crate time;
+#[cfg(feature = "url")]
+extern crate url;
+#[cfg(feature = "servo")]
+extern crate uuid;
+extern crate void;
+#[cfg(feature = "webrender_api")]
+extern crate webrender_api;
+#[cfg(feature = "servo")]
+extern crate xml5ever;
+
 use std::hash::{BuildHasher, Hash};
 use std::mem::size_of;
 use std::ops::{Deref, DerefMut, Range};


### PR DESCRIPTION
This patch brings Servo’s fork of Stylo closer to upstream to help prepare Servo for the [external Stylo fork](https://github.com/servo/stylo), by reverting the edition bumps from Rust 2015 to Rust 2018 (#<!---->29380) in derive_common and malloc_size_of.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because there are no functional changes