### PR TITLE
selectors: Revert as many changes from upstream as possible

### DIFF
--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -9,7 +9,6 @@ readme = "README.md"
 keywords = ["css", "selectors"]
 license = "MPL-2.0"
 build = "build.rs"
-edition = "2018"
 
 [lib]
 name = "selectors"

--- a/components/selectors/README.md
+++ b/components/selectors/README.md
@@ -1,11 +1,13 @@
 rust-selectors
 ==============
 
-* [Documentation](https://docs.rs/selectors)
+* [![Build Status](https://travis-ci.com/servo/rust-selectors.svg?branch=master)](
+  https://travis-ci.com/servo/rust-selectors)
+* [Documentation](https://docs.rs/selectors/)
 * [crates.io](https://crates.io/crates/selectors)
 
 CSS Selectors library for Rust.
-Includes parsing and serialization of selectors,
+Includes parsing and serilization of selectors,
 as well as matching against a generic tree of elements.
 Pseudo-elements and most pseudo-classes are generic as well.
 

--- a/components/selectors/attr.rs
+++ b/components/selectors/attr.rs
@@ -5,19 +5,16 @@
 use crate::parser::SelectorImpl;
 use cssparser::ToCss;
 use std::fmt;
-#[cfg(feature = "shmem")]
-use to_shmem_derive::ToShmem;
 
-#[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "shmem", derive(ToShmem))]
-#[cfg_attr(feature = "shmem", shmem(no_bounds))]
+#[derive(Clone, Eq, PartialEq, ToShmem)]
+#[shmem(no_bounds)]
 pub struct AttrSelectorWithOptionalNamespace<Impl: SelectorImpl> {
-    #[cfg_attr(feature = "shmem", shmem(field_bound))]
+    #[shmem(field_bound)]
     pub namespace: Option<NamespaceConstraint<(Impl::NamespacePrefix, Impl::NamespaceUrl)>>,
-    #[cfg_attr(feature = "shmem", shmem(field_bound))]
+    #[shmem(field_bound)]
     pub local_name: Impl::LocalName,
     pub local_name_lower: Impl::LocalName,
-    #[cfg_attr(feature = "shmem", shmem(field_bound))]
+    #[shmem(field_bound)]
     pub operation: ParsedAttrSelectorOperation<Impl::AttrValue>,
 }
 
@@ -30,8 +27,7 @@ impl<Impl: SelectorImpl> AttrSelectorWithOptionalNamespace<Impl> {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[derive(Clone, Eq, PartialEq, ToShmem)]
 pub enum NamespaceConstraint<NamespaceUrl> {
     Any,
 
@@ -39,8 +35,7 @@ pub enum NamespaceConstraint<NamespaceUrl> {
     Specific(NamespaceUrl),
 }
 
-#[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[derive(Clone, Eq, PartialEq, ToShmem)]
 pub enum ParsedAttrSelectorOperation<AttrValue> {
     Exists,
     WithValue {
@@ -80,8 +75,7 @@ impl<AttrValue> AttrSelectorOperation<AttrValue> {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[derive(Clone, Copy, Eq, PartialEq, ToShmem)]
 pub enum AttrSelectorOperator {
     Equal,
     Includes,
@@ -146,8 +140,7 @@ impl AttrSelectorOperator {
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r', '\x0C'];
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ToShmem)]
 pub enum ParsedCaseSensitivity {
     /// 's' was specified.
     ExplicitCaseSensitive,

--- a/components/selectors/build.rs
+++ b/components/selectors/build.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+extern crate phf_codegen;
+
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -19,16 +19,12 @@
 
 use crate::parser::{Combinator, Component, RelativeSelector, Selector, SelectorImpl};
 use crate::sink::Push;
-use bitflags::bitflags;
-use derive_more::{Add, AddAssign};
 use servo_arc::{Arc, HeaderWithLength, ThinArc};
 use smallvec::{self, SmallVec};
 use std::cmp;
 use std::iter;
 use std::ptr;
 use std::slice;
-#[cfg(feature = "shmem")]
-use to_shmem_derive::ToShmem;
 
 /// Top-level SelectorBuilder struct. This should be stack-allocated by the
 /// consumer and never moved (because it contains a lot of inline data that
@@ -182,8 +178,7 @@ fn split_from_end<T>(s: &[T], at: usize) -> (&[T], &[T]) {
 
 bitflags! {
     /// Flags that indicate at which point of parsing a selector are we.
-    #[derive(Default)]
-    #[cfg_attr(feature = "shmem", derive(ToShmem))]
+    #[derive(Default, ToShmem)]
     pub (crate) struct SelectorFlags : u8 {
         const HAS_PSEUDO = 1 << 0;
         const HAS_SLOTTED = 1 << 1;
@@ -192,8 +187,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ToShmem)]
 pub struct SpecificityAndFlags {
     /// There are two free bits here, since we use ten bits for each specificity
     /// kind (id, class, element).

--- a/components/selectors/lib.rs
+++ b/components/selectors/lib.rs
@@ -5,6 +5,25 @@
 // Make |cargo bench| work.
 #![cfg_attr(feature = "bench", feature(test))]
 
+#[macro_use]
+extern crate bitflags;
+#[macro_use]
+extern crate cssparser;
+#[macro_use]
+extern crate debug_unreachable;
+#[macro_use]
+extern crate derive_more;
+extern crate fxhash;
+#[macro_use]
+extern crate log;
+extern crate phf;
+extern crate precomputed_hash;
+extern crate servo_arc;
+extern crate smallvec;
+extern crate to_shmem;
+#[macro_use]
+extern crate to_shmem_derive;
+
 pub mod attr;
 pub mod bloom;
 mod builder;

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -15,8 +15,6 @@ use crate::parser::{
 };
 use crate::tree::Element;
 use bitflags::bitflags;
-use debug_unreachable::debug_unreachable;
-use log::debug;
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 use std::iter;

--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -8,7 +8,6 @@
 
 use crate::attr::NamespaceConstraint;
 use crate::parser::{Combinator, Component, Selector, SelectorImpl};
-use bitflags::bitflags;
 
 /// A trait to visit selector properties.
 ///


### PR DESCRIPTION
This is part of the preparation for splitting stylo into a separate
crate. We have made various changes to selectors includings:

 1. Bumping the rust edition
 2. Fixing typos and updating links

In addition to reverting those changes, this PR pulls in some changes to
selectors we seem to have missed in the process of updates.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
