### PR TITLE
Make `size` of `DefiniteContainingBlock` use app units

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -681,7 +681,7 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
             let pbm_end = Length::from(
                 inline_box_state.pbm.padding.inline_end + inline_box_state.pbm.border.inline_end,
             ) + inline_box_state.pbm.margin.inline_end.auto_is(Length::zero);
-            self.current_line_segment.inline_size += pbm_end.into();
+            self.current_line_segment.inline_size += pbm_end;
         }
     }
 

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -274,8 +274,8 @@ impl BoxTree {
         );
         let initial_containing_block = DefiniteContainingBlock {
             size: LogicalVec2 {
-                inline: physical_containing_block.size.width,
-                block: physical_containing_block.size.height,
+                inline: physical_containing_block.size.width.into(),
+                block: physical_containing_block.size.height.into(),
             },
             style,
         };

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -25,6 +25,7 @@ mod style_ext;
 pub mod table;
 pub mod traversal;
 
+use app_units::Au;
 pub use flow::BoxTree;
 pub use fragment_tree::FragmentTree;
 use style::properties::ComputedValues;
@@ -39,15 +40,15 @@ pub struct ContainingBlock<'a> {
 }
 
 struct DefiniteContainingBlock<'a> {
-    size: LogicalVec2<Length>,
+    size: LogicalVec2<Au>,
     style: &'a ComputedValues,
 }
 
 impl<'a> From<&'_ DefiniteContainingBlock<'a>> for ContainingBlock<'a> {
     fn from(definite: &DefiniteContainingBlock<'a>) -> Self {
         ContainingBlock {
-            inline_size: definite.size.inline,
-            block_size: LengthOrAuto::LengthPercentage(definite.size.block),
+            inline_size: definite.size.inline.into(),
+            block_size: LengthOrAuto::LengthPercentage(definite.size.block.into()),
             style: definite.style,
         }
     }


### PR DESCRIPTION
Make `size` of `DefiniteContainingBlock` use app units

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
