### PR TITLE
layout: make `ContainingBlock` use `Au` for `inline_size` and `block_size`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -243,8 +243,8 @@ impl FlexContainer {
             ),
             // https://drafts.csswg.org/css-flexbox/#definite-sizes
             container_definite_inner_size: flex_axis.vec2_to_flex_relative(LogicalVec2 {
-                inline: Some(containing_block.inline_size),
-                block: containing_block.block_size.non_auto(),
+                inline: Some(containing_block.inline_size.into()),
+                block: containing_block.block_size.non_auto().map(|t| t.into()),
             }),
         };
 
@@ -273,9 +273,9 @@ impl FlexContainer {
         // https://drafts.csswg.org/css-flexbox/#algo-flex
         let flex_lines = collect_flex_lines(
             &mut flex_context,
-            container_main_size,
+            container_main_size.into(),
             &mut flex_items,
-            |flex_context, mut line| line.layout(flex_context, container_main_size),
+            |flex_context, mut line| line.layout(flex_context, container_main_size.into()),
         );
 
         let content_cross_size = flex_lines
@@ -343,7 +343,7 @@ impl FlexContainer {
                 // And we’ll need to change the signature of `IndependentFormattingContext::layout`
                 // to allow the inner formatting context to “negotiate” a used inline-size
                 // with the outer one somehow.
-                container_main_size
+                container_main_size.into()
             },
         };
 
@@ -1091,12 +1091,12 @@ impl<'a> FlexItem<'a> {
                     },
                     IndependentFormattingContext::NonReplaced(non_replaced) => {
                         let block_size = match used_cross_size_override {
-                            Some(s) => LengthOrAuto::LengthPercentage(s),
-                            None => self.content_box_size.cross,
+                            Some(s) => AuOrAuto::LengthPercentage(s.into()),
+                            None => self.content_box_size.cross.map(|t| t.into()),
                         };
 
                         let item_as_containing_block = ContainingBlock {
-                            inline_size: used_main_size,
+                            inline_size: used_main_size.into(),
                             block_size,
                             style: &non_replaced.style,
                         };

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -918,10 +918,10 @@ impl FloatBox {
 
                         let tentative_inline_size = box_size.inline.auto_is(|| {
                             let available_size =
-                                containing_block.inline_size - pbm_sums.inline_sum().into();
+                                containing_block.inline_size - pbm_sums.inline_sum();
                             non_replaced
                                 .inline_content_sizes(layout_context)
-                                .shrink_to_fit(available_size.into())
+                                .shrink_to_fit(available_size)
                                 .into()
                         });
                         let inline_size = tentative_inline_size
@@ -931,8 +931,8 @@ impl FloatBox {
                         // https://drafts.csswg.org/css2/#block-root-margin
                         // FIXME(pcwalton): Is a tree rank of zero correct here?
                         let containing_block_for_children = ContainingBlock {
-                            inline_size,
-                            block_size: box_size.block,
+                            inline_size: inline_size.into(),
+                            block_size: box_size.block.map(|t| t.into()),
                             style: &non_replaced.style,
                         };
                         let independent_layout = non_replaced.layout(

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -136,10 +136,10 @@ impl LogicalVec2<LengthPercentageOrAuto<'_>> {
         LogicalVec2 {
             inline: self
                 .inline
-                .percentage_relative_to(containing_block.inline_size),
-            block: self
-                .block
-                .maybe_percentage_relative_to(containing_block.block_size.non_auto()),
+                .percentage_relative_to(containing_block.inline_size.into()),
+            block: self.block.maybe_percentage_relative_to(
+                containing_block.block_size.map(|t| t.into()).non_auto(),
+            ),
         }
     }
 }
@@ -152,9 +152,11 @@ impl LogicalVec2<Option<&'_ LengthPercentage>> {
         LogicalVec2 {
             inline: self
                 .inline
-                .map(|lp| lp.percentage_relative_to(containing_block.inline_size)),
+                .map(|lp| lp.percentage_relative_to(containing_block.inline_size.into())),
             block: self.block.and_then(|lp| {
-                lp.maybe_percentage_relative_to(containing_block.block_size.non_auto())
+                lp.maybe_percentage_relative_to(
+                    containing_block.block_size.map(|t| t.into()).non_auto(),
+                )
             }),
         }
     }

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -28,14 +28,14 @@ pub mod traversal;
 use app_units::Au;
 pub use flow::BoxTree;
 pub use fragment_tree::FragmentTree;
+use geom::AuOrAuto;
 use style::properties::ComputedValues;
-use style::values::computed::{Length, LengthOrAuto};
 
 use crate::geom::LogicalVec2;
 
 pub struct ContainingBlock<'a> {
-    inline_size: Length,
-    block_size: LengthOrAuto,
+    inline_size: Au,
+    block_size: AuOrAuto,
     style: &'a ComputedValues,
 }
 
@@ -47,8 +47,8 @@ struct DefiniteContainingBlock<'a> {
 impl<'a> From<&'_ DefiniteContainingBlock<'a>> for ContainingBlock<'a> {
     fn from(definite: &DefiniteContainingBlock<'a>) -> Self {
         ContainingBlock {
-            inline_size: definite.size.inline.into(),
-            block_size: LengthOrAuto::LengthPercentage(definite.size.block.into()),
+            inline_size: definite.size.inline,
+            block_size: AuOrAuto::LengthPercentage(definite.size.block),
             style: definite.style,
         }
     }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -349,7 +349,7 @@ impl ComputedValuesExt for ComputedValues {
         let cbis = containing_block.inline_size;
         let padding = self
             .padding(containing_block.style.writing_mode)
-            .percentages_relative_to(cbis);
+            .percentages_relative_to(cbis.into());
         let border = self.border_width(containing_block.style.writing_mode);
         PaddingBorderMargin {
             padding_border_sums: LogicalVec2 {
@@ -360,7 +360,7 @@ impl ComputedValuesExt for ComputedValues {
             border: border.into(),
             margin: self
                 .margin(containing_block.style.writing_mode)
-                .percentages_relative_to(cbis),
+                .percentages_relative_to(cbis.into()),
         }
     }
 

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -9,7 +9,7 @@ use euclid::num::Zero;
 use log::warn;
 use style::computed_values::border_collapse::T as BorderCollapse;
 use style::logical_geometry::WritingMode;
-use style::values::computed::{CSSPixelLength, Length, LengthOrAuto, Percentage};
+use style::values::computed::{CSSPixelLength, Length, Percentage};
 use style::values::generics::box_::{GenericVerticalAlign as VerticalAlign, VerticalAlignKeyword};
 use style::values::generics::length::GenericLengthPercentageOrAuto::{Auto, LengthPercentage};
 
@@ -17,7 +17,7 @@ use super::{Table, TableSlot, TableSlotCell};
 use crate::context::LayoutContext;
 use crate::formatting_contexts::{Baselines, IndependentLayout};
 use crate::fragment_tree::{AnonymousFragment, BoxFragment, CollapsedBlockMargins, Fragment};
-use crate::geom::{LogicalRect, LogicalSides, LogicalVec2};
+use crate::geom::{AuOrAuto, LogicalRect, LogicalSides, LogicalVec2};
 use crate::positioned::{PositioningContext, PositioningContextLength};
 use crate::sizing::ContentSizes;
 use crate::style_ext::{Clamp, ComputedValuesExt, PaddingBorderMargin};
@@ -601,7 +601,7 @@ impl<'a> TableLayout<'a> {
             },
             Auto => grid_min_and_max
                 .max_content
-                .min(containing_block.inline_size.into())
+                .min(containing_block.inline_size)
                 .max(used_min_width_of_table),
         };
 
@@ -937,8 +937,8 @@ impl<'a> TableLayout<'a> {
                 total_width = total_width.max(Length::zero());
 
                 let containing_block_for_children = ContainingBlock {
-                    inline_size: total_width,
-                    block_size: LengthOrAuto::Auto,
+                    inline_size: total_width.into(),
+                    block_size: AuOrAuto::Auto,
                     style: &cell.style,
                 };
                 let collect_for_nearest_positioned_ancestor =


### PR DESCRIPTION
Make ContainingBlock use Au for inline_size and block_size

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)