### PR TITLE
install libudev-dev required by gamepad API

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -77,6 +77,8 @@ stdenv.mkDerivation (androidEnvironment // rec {
     taplo
     llvmPackages.bintools # provides lld
 
+    udev # Needed by libudev-sys for GamePad API.
+
     # Build utilities
     cmake dbus gcc git pkg-config which llvm perl yasm m4
     (python3.withPackages (ps: with ps; [virtualenv pip dbus]))

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -35,7 +35,7 @@ APT_PKGS = [
     'libgstrtspserver-1.0-dev',
     'gstreamer1.0-tools',
     'libges-1.0-dev',
-    'libharfbuzz-dev', 'liblzma-dev', 'libunwind-dev', 'libunwind-dev',
+    'libharfbuzz-dev', 'liblzma-dev', 'libudev-dev', 'libunwind-dev',
     'libvulkan1', 'libx11-dev', 'libxcb-render0-dev', 'libxcb-shape0-dev',
     'libxcb-xfixes0-dev', 'libxmu-dev', 'libxmu6', 'libegl1-mesa-dev',
     'llvm-dev', 'm4', 'xorg-dev',


### PR DESCRIPTION
Ubuntu 20.04 does not have libudev-dev causing build failure when compiling libudev-sys, which is in-turn needed by gilrs-core. Similarly, nix build also needs the udev C library.

On Ubuntu 22.04, we don't see the build failures since the build dependency 'libgstreamer-plugins-base-1.0-dev' transitively pulls in libudev-dev.

Fixes #31373

Note: I'm not sure if other distros require similar fixes - this patch is just for Debian and Nix.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31373 partially 
- [x] These changes do not require tests because they fix build errors in CI job.
