### PR TITLE
Revert changes to servo_arc, style_derive, and style_traits

### DIFF
--- a/components/servo_arc/Cargo.toml
+++ b/components/servo_arc/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/servo"
 description = "A fork of std::sync::Arc with some extra functionality and without weak references"
-edition = "2018"
 
 [lib]
 name = "servo_arc"

--- a/components/style_derive/Cargo.toml
+++ b/components/style_derive/Cargo.toml
@@ -3,7 +3,6 @@ name = "style_derive"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
-edition = "2018"
 publish = false
 
 [lib]

--- a/components/style_derive/animate.rs
+++ b/components/style_derive/animate.rs
@@ -3,14 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use darling::util::PathList;
-use darling::FromDeriveInput;
-use darling::FromField;
-use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
 use quote::TokenStreamExt;
-use syn::{parse_quote, DeriveInput, WhereClause};
+use syn::{DeriveInput, WhereClause};
 use synstructure::{Structure, VariantInfo};
 
 pub fn derive(mut input: DeriveInput) -> TokenStream {

--- a/components/style_derive/compute_squared_distance.rs
+++ b/components/style_derive/compute_squared_distance.rs
@@ -3,12 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
-use darling::FromField;
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
 use quote::TokenStreamExt;
-use syn::{parse_quote, DeriveInput, WhereClause};
+use syn::{DeriveInput, WhereClause};
 use synstructure;
 
 pub fn derive(mut input: DeriveInput) -> TokenStream {

--- a/components/style_derive/lib.rs
+++ b/components/style_derive/lib.rs
@@ -4,6 +4,17 @@
 
 #![recursion_limit = "128"]
 
+#[macro_use]
+extern crate darling;
+extern crate derive_common;
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+extern crate synstructure;
+
 use proc_macro::TokenStream;
 
 mod animate;

--- a/components/style_derive/parse.rs
+++ b/components/style_derive/parse.rs
@@ -3,12 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::to_css::{CssBitflagAttrs, CssVariantAttrs};
-use darling::FromField;
-use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, TokenStreamExt};
-use syn::parse_quote;
+use quote::TokenStreamExt;
 use syn::{self, DeriveInput, Ident, Path};
 use synstructure::{Structure, VariantInfo};
 
@@ -132,7 +129,7 @@ fn parse_non_keyword_variant(
         }
     } else {
         quote! {
-            if let Ok(v) = input.r#try(|i| <#ty as crate::parser::Parse>::parse(context, i)) {
+            if let Ok(v) = input.try(|i| <#ty as crate::parser::Parse>::parse(context, i)) {
                 return Ok(#name::#variant_name(v));
             }
         }

--- a/components/style_derive/specified_value_info.rs
+++ b/components/style_derive/specified_value_info.rs
@@ -4,14 +4,10 @@
 
 use crate::parse::ParseVariantAttrs;
 use crate::to_css::{CssFieldAttrs, CssInputAttrs, CssVariantAttrs};
-use darling::FromDeriveInput;
-use darling::FromField;
-use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
 use quote::TokenStreamExt;
-use syn::{parse_quote, Data, DeriveInput, Fields, Ident, Type};
+use syn::{Data, DeriveInput, Fields, Ident, Type};
 
 pub fn derive(mut input: DeriveInput) -> TokenStream {
     let css_attrs = cg::parse_input_attrs::<CssInputAttrs>(&input);

--- a/components/style_derive/to_animated_value.rs
+++ b/components/style_derive/to_animated_value.rs
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::to_computed_value;
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{parse_quote, DeriveInput};
+use syn::DeriveInput;
 use synstructure::BindStyle;
+use to_computed_value;
 
 pub fn derive(input: DeriveInput) -> TokenStream {
     let trait_impl = |from_body, to_body| {

--- a/components/style_derive/to_animated_zero.rs
+++ b/components/style_derive/to_animated_zero.rs
@@ -5,9 +5,8 @@
 use crate::animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
 use quote::TokenStreamExt;
-use syn::{self, parse_quote};
+use syn;
 use synstructure;
 
 pub fn derive(mut input: syn::DeriveInput) -> TokenStream {

--- a/components/style_derive/to_computed_value.rs
+++ b/components/style_derive/to_computed_value.rs
@@ -2,11 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use darling::FromField;
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::parse_quote;
 use syn::{DeriveInput, Ident, Path};
 use synstructure::{BindStyle, BindingInfo};
 

--- a/components/style_derive/to_css.rs
+++ b/components/style_derive/to_css.rs
@@ -3,15 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use darling::util::Override;
-use darling::FromDeriveInput;
-use darling::FromField;
-use darling::FromMeta;
-use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
 use quote::{ToTokens, TokenStreamExt};
-use syn::parse_quote;
 use syn::{self, Data, Ident, Path, WhereClause};
 use synstructure::{BindingInfo, Structure, VariantInfo};
 
@@ -209,7 +203,7 @@ fn derive_variant_fields_expr(
     let mut iter = bindings
         .iter()
         .filter_map(|binding| {
-            let attrs = cg::parse_field_attrs::<CssFieldAttrs>(binding.ast());
+            let attrs = cg::parse_field_attrs::<CssFieldAttrs>(&binding.ast());
             if attrs.skip {
                 return None;
             }

--- a/components/style_derive/to_resolved_value.rs
+++ b/components/style_derive/to_resolved_value.rs
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::to_computed_value;
-use darling::FromField;
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{parse_quote, DeriveInput};
+use syn::DeriveInput;
 use synstructure::BindStyle;
+use to_computed_value;
 
 pub fn derive(input: DeriveInput) -> TokenStream {
     let trait_impl = |from_body, to_body| {

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -3,7 +3,6 @@ name = "style_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
-edition = "2018"
 publish = false
 
 [lib]
@@ -22,7 +21,7 @@ euclid = "0.22"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
-selectors = { path = "../selectors", features = ["shmem"] }
+selectors = { path = "../selectors" }
 serde = "1.0"
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms", optional = true }

--- a/components/style_traits/arc_slice.rs
+++ b/components/style_traits/arc_slice.rs
@@ -4,16 +4,14 @@
 
 //! A thin atomically-reference-counted slice.
 
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use servo_arc::ThinArc;
 use std::ops::Deref;
 use std::ptr::NonNull;
 use std::{iter, mem};
 
-use lazy_static::lazy_static;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps, MallocUnconditionalSizeOf};
-use serde::de::{Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
-use servo_arc::ThinArc;
-use to_shmem_derive::ToShmem;
 
 /// A canary that we stash in ArcSlices.
 ///

--- a/components/style_traits/dom.rs
+++ b/components/style_traits/dom.rs
@@ -4,10 +4,7 @@
 
 //! Types used to access the DOM from style calculation.
 
-use bitflags::bitflags;
 use malloc_size_of::malloc_size_of_is_0;
-use malloc_size_of_derive::MallocSizeOf;
-use serde::{Deserialize, Serialize};
 
 /// An opaque handle to a node, which, unlike UnsafeNode, cannot be transformed
 /// back into a non-opaque representation. The only safe operation that can be

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -9,16 +9,36 @@
 #![crate_name = "style_traits"]
 #![crate_type = "rlib"]
 
-use bitflags::bitflags;
-use cssparser::{CowRcStr, Token};
-use malloc_size_of_derive::MallocSizeOf;
-use selectors::parser::SelectorParseErrorKind;
-use serde::{Deserialize, Serialize};
+extern crate app_units;
+#[macro_use]
+extern crate bitflags;
+extern crate cssparser;
+extern crate euclid;
+#[macro_use]
+extern crate lazy_static;
+extern crate malloc_size_of;
+#[macro_use]
+extern crate malloc_size_of_derive;
+extern crate selectors;
+#[macro_use]
+extern crate serde;
+extern crate servo_arc;
 #[cfg(feature = "servo")]
-use servo_atoms::Atom;
-use size_of_test::size_of_test;
+extern crate servo_atoms;
+extern crate to_shmem;
+#[macro_use]
+extern crate to_shmem_derive;
+#[cfg(feature = "servo")]
+extern crate webrender_api;
+#[cfg(feature = "servo")]
+extern crate url;
 #[cfg(feature = "servo")]
 pub use webrender_api::units::DevicePixel;
+
+use cssparser::{CowRcStr, Token};
+use selectors::parser::SelectorParseErrorKind;
+#[cfg(feature = "servo")]
+use servo_atoms::Atom;
 
 /// One hardware pixel.
 ///
@@ -78,11 +98,9 @@ pub use crate::values::{
 
 /// The error type for all CSS parsing routines.
 pub type ParseError<'i> = cssparser::ParseError<'i, StyleParseErrorKind<'i>>;
-size_of_test!(ParseError, 64);
 
 /// Error in property value parsing
 pub type ValueParseError<'i> = cssparser::ParseError<'i, ValueParseErrorKind<'i>>;
-size_of_test!(ValueParseError, 48);
 
 #[derive(Clone, Debug, PartialEq)]
 /// Errors that can be encountered while parsing CSS values.
@@ -149,7 +167,6 @@ pub enum StyleParseErrorKind<'i> {
     /// The property is not allowed within a page rule.
     NotAllowedInPageRule,
 }
-size_of_test!(StyleParseErrorKind, 56);
 
 impl<'i> From<ValueParseErrorKind<'i>> for StyleParseErrorKind<'i> {
     fn from(this: ValueParseErrorKind<'i>) -> Self {
@@ -171,7 +188,6 @@ pub enum ValueParseErrorKind<'i> {
     /// An invalid filter value was encountered.
     InvalidFilter(Token<'i>),
 }
-size_of_test!(ValueParseErrorKind, 40);
 
 impl<'i> StyleParseErrorKind<'i> {
     /// Create an InvalidValue parse error

--- a/components/style_traits/owned_slice.rs
+++ b/components/style_traits/owned_slice.rs
@@ -6,14 +6,13 @@
 
 //! A replacement for `Box<[T]>` that cbindgen can understand.
 
+use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 use std::{fmt, iter, mem, slice};
-
-use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
-use serde::de::{Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
 use to_shmem::{self, SharedMemoryBuilder, ToShmem};
 
 /// A struct that basically replaces a `Box<[T]>`, but which cbindgen can

--- a/components/style_traits/owned_str.rs
+++ b/components/style_traits/owned_str.rs
@@ -6,13 +6,9 @@
 
 //! A replacement for `Box<str>` that has a defined layout for FFI.
 
+use crate::owned_slice::OwnedSlice;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
-
-use malloc_size_of_derive::MallocSizeOf;
-use to_shmem_derive::ToShmem;
-
-use crate::owned_slice::OwnedSlice;
 
 /// A struct that basically replaces a Box<str>, but with a defined layout,
 /// suitable for FFI.

--- a/components/style_traits/rustfmt.toml
+++ b/components/style_traits/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/components/style_traits/specified_value_info.rs
+++ b/components/style_traits/specified_value_info.rs
@@ -4,13 +4,11 @@
 
 //! Value information for devtools.
 
-use std::ops::Range;
-use std::sync::Arc as StdArc;
-
-use servo_arc::Arc;
-
 use crate::arc_slice::ArcSlice;
 use crate::owned_slice::OwnedSlice;
+use servo_arc::Arc;
+use std::ops::Range;
+use std::sync::Arc as StdArc;
 
 /// Type of value that a property supports. This is used by Gecko's
 /// devtools to make sense about value it parses, and types listed

--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -4,13 +4,11 @@
 
 //! Helper types and traits for the handling of CSS values.
 
-use std::fmt::{self, Write};
-
 use app_units::Au;
-use cssparser::{
-    serialize_string, ParseError, Parser, ToCss as CssparserToCss, Token, UnicodeRange,
-};
+use cssparser::ToCss as CssparserToCss;
+use cssparser::{serialize_string, ParseError, Parser, Token, UnicodeRange};
 use servo_arc::Arc;
+use std::fmt::{self, Write};
 
 /// Serialises a value according to its CSS representation.
 ///
@@ -380,7 +378,7 @@ impl Separator for Space {
         let mut results = vec![parse_one(input)?];
         loop {
             input.skip_whitespace(); // Unnecessary for correctness, but may help try() rewind less.
-            if let Ok(item) = input.r#try(&mut parse_one) {
+            if let Ok(item) = input.try(&mut parse_one) {
                 results.push(item);
             } else {
                 return Ok(results);
@@ -406,9 +404,9 @@ impl Separator for CommaWithSpace {
         loop {
             input.skip_whitespace(); // Unnecessary for correctness, but may help try() rewind less.
             let comma_location = input.current_source_location();
-            let comma = input.r#try(|i| i.expect_comma()).is_ok();
+            let comma = input.try(|i| i.expect_comma()).is_ok();
             input.skip_whitespace(); // Unnecessary for correctness, but may help try() rewind less.
-            if let Ok(item) = input.r#try(&mut parse_one) {
+            if let Ok(item) = input.try(&mut parse_one) {
                 results.push(item);
             } else if comma {
                 return Err(comma_location.new_unexpected_token_error(Token::Comma));
@@ -506,9 +504,6 @@ impl_to_css_for_predefined_type!(::cssparser::UnicodeRange);
 
 /// Helper types for the handling of specified values.
 pub mod specified {
-    use malloc_size_of_derive::MallocSizeOf;
-    use serde::{Deserialize, Serialize};
-
     use crate::ParsingMode;
 
     /// Whether to allow negative lengths or not.


### PR DESCRIPTION
This reverts the Rust edition updates to these three traits as well as
incorporates https://phabricator.services.mozilla.com/D117887. The
purpose of this change is to reduce the diff with upstream stylo.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change any behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
