### PR TITLE
Revert remaining Stylo changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,7 +3492,6 @@ dependencies = [
  "cssparser",
  "euclid",
  "http",
- "hyper_serde",
  "indexmap 2.2.3",
  "keyboard-types",
  "selectors",

--- a/components/derive_common/cg.rs
+++ b/components/derive_common/cg.rs
@@ -5,11 +5,11 @@
 use darling::{FromDeriveInput, FromField, FromVariant};
 use proc_macro2::{Span, TokenStream};
 use quote::TokenStreamExt;
-use syn::{
-    self, AngleBracketedGenericArguments, AssocType, DeriveInput, Field, GenericArgument,
-    GenericParam, Ident, Path, PathArguments, PathSegment, QSelf, Type, TypeArray, TypeGroup,
-    TypeParam, TypeParen, TypePath, TypeSlice, TypeTuple, Variant, WherePredicate,
-};
+use syn::{self, AngleBracketedGenericArguments, AssocType, DeriveInput, Field};
+use syn::{GenericArgument, GenericParam, Ident, Path};
+use syn::{PathArguments, PathSegment, QSelf, Type, TypeArray, TypeGroup};
+use syn::{TypeParam, TypeParen, TypePath, TypeSlice, TypeTuple};
+use syn::{Variant, WherePredicate};
 use synstructure::{self, BindStyle, BindingInfo, VariantAst, VariantInfo};
 
 /// Given an input type which has some where clauses already, like:

--- a/components/derive_common/rustfmt.toml
+++ b/components/derive_common/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -14,7 +14,6 @@ servo = [
     "content-security-policy",
     "crossbeam-channel",
     "http",
-    "hyper_serde",
     "keyboard-types",
     "serde",
     "serde_bytes",
@@ -34,10 +33,9 @@ crossbeam-channel = { workspace = true, optional = true }
 cssparser = { workspace = true }
 euclid = { workspace = true }
 http = { workspace = true, optional = true }
-hyper_serde = { workspace = true, optional = true }
 indexmap = { workspace = true }
 keyboard-types = { workspace = true, optional = true }
-selectors = { path = "../selectors", features = ["shmem"] }
+selectors = { path = "../selectors" }
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 servo_arc = { path = "../servo_arc" }
@@ -46,7 +44,7 @@ smallvec = { workspace = true }
 string_cache = { workspace = true, optional = true }
 thin-vec = { workspace = true }
 time = { workspace = true, optional = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 void = "1.0.2"

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -81,24 +81,18 @@ extern crate webrender_api;
 #[cfg(feature = "servo")]
 extern crate xml5ever;
 
-use std::hash::{BuildHasher, Hash};
-use std::mem::size_of;
-use std::ops::{Deref, DerefMut, Range};
-use std::os::raw::c_void;
-
 #[cfg(feature = "servo")]
 use content_security_policy as csp;
 #[cfg(feature = "servo")]
 use serde_bytes::ByteBuf;
+use std::hash::{BuildHasher, Hash};
+use std::mem::size_of;
+use std::ops::Range;
+use std::ops::{Deref, DerefMut};
+use std::os::raw::c_void;
 #[cfg(feature = "servo")]
 use uuid::Uuid;
 use void::Void;
-use webrender_api::{
-    BorderRadius, BorderStyle, BoxShadowClipMode, ColorF, ComplexClipRegion, ExtendMode,
-    ExternalScrollId, FilterOp, FontInstanceKey, GlyphInstance, GradientStop, ImageKey,
-    ImageRendering, LineStyle, MixBlendMode, NinePatchBorder, NormalBorder, RepeatMode,
-    StickyOffsetBounds, TransformStyle,
-};
 
 /// A C function that takes a pointer to a heap allocation and returns its size.
 type VoidPtrToSizeFn = unsafe extern "C" fn(ptr: *const c_void) -> usize;
@@ -863,45 +857,45 @@ impl MallocSizeOf for url::Host {
     }
 }
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(BorderRadius);
+malloc_size_of_is_0!(webrender_api::BorderRadius);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(BorderStyle);
+malloc_size_of_is_0!(webrender_api::BorderStyle);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(BoxShadowClipMode);
+malloc_size_of_is_0!(webrender_api::BoxShadowClipMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(ColorF);
+malloc_size_of_is_0!(webrender_api::ColorF);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(ComplexClipRegion);
+malloc_size_of_is_0!(webrender_api::ComplexClipRegion);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(ExtendMode);
+malloc_size_of_is_0!(webrender_api::ExtendMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(FilterOp);
+malloc_size_of_is_0!(webrender_api::FilterOp);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(ExternalScrollId);
+malloc_size_of_is_0!(webrender_api::ExternalScrollId);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(FontInstanceKey);
+malloc_size_of_is_0!(webrender_api::FontInstanceKey);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(GradientStop);
+malloc_size_of_is_0!(webrender_api::GradientStop);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(GlyphInstance);
+malloc_size_of_is_0!(webrender_api::GlyphInstance);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(NinePatchBorder);
+malloc_size_of_is_0!(webrender_api::NinePatchBorder);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(ImageKey);
+malloc_size_of_is_0!(webrender_api::ImageKey);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(ImageRendering);
+malloc_size_of_is_0!(webrender_api::ImageRendering);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(LineStyle);
+malloc_size_of_is_0!(webrender_api::LineStyle);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(MixBlendMode);
+malloc_size_of_is_0!(webrender_api::MixBlendMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(NormalBorder);
+malloc_size_of_is_0!(webrender_api::NormalBorder);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(RepeatMode);
+malloc_size_of_is_0!(webrender_api::RepeatMode);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(StickyOffsetBounds);
+malloc_size_of_is_0!(webrender_api::StickyOffsetBounds);
 #[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(TransformStyle);
+malloc_size_of_is_0!(webrender_api::TransformStyle);
 
 #[cfg(feature = "servo")]
 impl MallocSizeOf for keyboard_types::Key {
@@ -933,18 +927,6 @@ malloc_size_of_is_0!(std::time::Duration);
 malloc_size_of_is_0!(std::time::SystemTime);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(std::time::Instant);
-
-#[cfg(feature = "servo")]
-impl<T> MallocSizeOf for hyper_serde::Serde<T>
-where
-    for<'de> hyper_serde::De<T>: serde::Deserialize<'de>,
-    for<'a> hyper_serde::Ser<'a, T>: serde::Serialize,
-    T: MallocSizeOf,
-{
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        self.0.size_of(ops)
-    }
-}
 
 // Placeholder for unique case where internals of Sender cannot be measured.
 // malloc size of is 0 macro complains about type supplied!

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -87,7 +87,7 @@ ref_filter_map = "1.0.1"
 regex = { workspace = true }
 script_layout_interface = { workspace = true }
 script_traits = { workspace = true }
-selectors = { path = "../selectors", features = ["shmem"] }
+selectors = { path = "../selectors" }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 servo-media = { git = "https://github.com/servo/media" }

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -16,7 +16,6 @@ path = "lib.rs"
 
 [features]
 bench = []
-shmem = ["dep:to_shmem", "dep:to_shmem_derive"]
 
 [dependencies]
 bitflags = "1.0"
@@ -30,8 +29,8 @@ precomputed-hash = "0.1"
 servo_arc = { version = "0.2", path = "../servo_arc" }
 size_of_test = { path = "../size_of_test" }
 smallvec = "1.0"
-to_shmem = { version = "0.0.1", path = "../to_shmem", optional = true }
-to_shmem_derive = { version = "0.0.1", path = "../to_shmem_derive", optional = true }
+to_shmem = { version = "0.0.1", path = "../to_shmem" }
+to_shmem_derive = { version = "0.0.1", path = "../to_shmem_derive" }
 
 [build-dependencies]
 phf_codegen = "0.10"

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -28,7 +28,7 @@ net_traits = { workspace = true }
 profile_traits = { workspace = true }
 range = { path = "../../range" }
 script_traits = { workspace = true }
-selectors = { path = "../../selectors", features = ["shmem"] }
+selectors = { path = "../../selectors" }
 servo_arc = { path = "../../servo_arc" }
 servo_atoms = { path = "../../atoms" }
 servo_url = { path = "../../url" }

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -18,9 +18,20 @@ doctest = false
 
 [features]
 gecko = ["style_traits/gecko", "bindgen", "regex", "toml", "mozbuild"]
-servo = ["serde", "style_traits/servo", "servo_atoms", "servo_config", "html5ever",
-         "cssparser/serde", "encoding_rs", "malloc_size_of/servo",
-         "string_cache", "to_shmem/servo", "servo_arc/servo", "url"]
+servo = [
+    "serde",
+    "style_traits/servo",
+    "servo_atoms",
+    "servo_config",
+    "html5ever",
+    "cssparser/serde",
+    "encoding_rs",
+    "malloc_size_of/servo",
+    "string_cache",
+    "to_shmem/servo",
+    "servo_arc/servo",
+    "url",
+]
 gecko_debug = []
 gecko_refcount_logging = []
 
@@ -56,7 +67,7 @@ rayon = "1"
 selectors = { path = "../selectors" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 servo_arc = { path = "../servo_arc" }
-servo_atoms = {path = "../atoms", optional = true}
+servo_atoms = { path = "../atoms", optional = true }
 servo_config = { path = "../config", optional = true }
 smallbitvec = "2.3.0"
 smallvec = "1.0"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -18,20 +18,9 @@ doctest = false
 
 [features]
 gecko = ["style_traits/gecko", "bindgen", "regex", "toml", "mozbuild"]
-servo = [
-    "serde",
-    "style_traits/servo",
-    "servo_atoms",
-    "servo_config",
-    "html5ever",
-    "cssparser/serde",
-    "encoding_rs",
-    "malloc_size_of/servo",
-    "string_cache",
-    "to_shmem/servo",
-    "servo_arc/servo",
-    "url",
-]
+servo = ["serde", "style_traits/servo", "servo_atoms", "servo_config", "html5ever",
+         "cssparser/serde", "encoding_rs", "malloc_size_of/servo",
+         "string_cache", "to_shmem/servo", "servo_arc/servo", "url"]
 gecko_debug = []
 gecko_refcount_logging = []
 
@@ -64,10 +53,10 @@ owning_ref = "0.4"
 parking_lot = "0.12"
 precomputed-hash = "0.1.1"
 rayon = "1"
-selectors = { path = "../selectors", features = ["shmem"] }
+selectors = { path = "../selectors" }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 servo_arc = { path = "../servo_arc" }
-servo_atoms = { path = "../atoms", optional = true }
+servo_atoms = {path = "../atoms", optional = true}
 servo_config = { path = "../config", optional = true }
 smallbitvec = "2.3.0"
 smallvec = "1.0"
@@ -75,15 +64,15 @@ static_assertions = "1.1"
 static_prefs = { path = "../style_static_prefs" }
 string_cache = { version = "0.8", optional = true }
 style_derive = { path = "../style_derive" }
-style_traits = { workspace = true }
+style_traits = { path = "../style_traits" }
 time = "0.1"
 thin-vec = { workspace = true }
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }
-url = { workspace = true, optional = true, features = ["serde"] }
 uluru = "3.0"
 unicode-bidi = "0.3"
 unicode-segmentation = "1.0"
+url = { workspace = true, optional = true }
 void = "1.0.2"
 
 [build-dependencies]

--- a/components/style/invalidation/element/invalidation_map.rs
+++ b/components/style/invalidation/element/invalidation_map.rs
@@ -14,7 +14,7 @@ use crate::{Atom, LocalName, Namespace, ShrinkIfNeeded};
 use selectors::attr::NamespaceConstraint;
 use selectors::parser::{Combinator, Component};
 use selectors::parser::{Selector, SelectorIter};
-use selectors::visitor::{SelectorVisitor, SelectorListKind};
+use selectors::visitor::{SelectorListKind, SelectorVisitor};
 use smallvec::SmallVec;
 use style_traits::dom::{DocumentState, ElementState};
 

--- a/components/style/properties/longhands/list.mako.rs
+++ b/components/style/properties/longhands/list.mako.rs
@@ -27,10 +27,10 @@ ${helpers.single_keyword(
     ${helpers.single_keyword(
         "list-style-type",
         """disc none circle square disclosure-open disclosure-closed
-           decimal lower-alpha upper-alpha arabic-indic bengali cambodian cjk-decimal devanagari
-           gujarati gurmukhi kannada khmer lao malayalam mongolian myanmar oriya persian telugu
-           thai tibetan cjk-earthly-branch cjk-heavenly-stem lower-greek hiragana hiragana-iroha
-           katakana katakana-iroha
+            decimal lower-alpha upper-alpha arabic-indic bengali cambodian cjk-decimal devanagari
+            gujarati gurmukhi kannada khmer lao malayalam mongolian myanmar oriya persian telugu
+            thai tibetan cjk-earthly-branch cjk-heavenly-stem lower-greek hiragana hiragana-iroha
+            katakana katakana-iroha
         """,
         engines="servo",
         animation_value_type="discrete",

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -31,8 +31,7 @@ use crate::stylesheets::{
 };
 use crate::values::computed::font::FamilyName;
 use crate::values::{CssUrl, CustomIdent, DashedIdent, KeyframesName};
-use crate::Atom;
-use crate::{Namespace, Prefix};
+use crate::{Atom, Namespace, Prefix};
 use cssparser::{
     AtRuleParser, BasicParseError, BasicParseErrorKind, CowRcStr, DeclarationParser, Parser,
     ParserState, QualifiedRuleParser, RuleBodyItemParser, RuleBodyParser, SourceLocation,

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -1591,7 +1591,7 @@ macro_rules! impl_variant_numeric {
     } => {
         bitflags! {
             #[derive(MallocSizeOf, ToComputedValue, ToResolvedValue, ToShmem)]
-            /// Vairants of numeric values
+            /// Variants of numeric values
             pub struct FontVariantNumeric: u8 {
                 /// None of other variants are enabled.
                 const NORMAL = 0;

--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -370,15 +370,9 @@ impl Side for VerticalPositionKeyword {
 }
 
 bitflags! {
-    /// Controls how the auto-placement algorithm works
-    /// specifying exactly how auto-placed items get flowed into the grid
-    #[derive(
-        MallocSizeOf,
-        SpecifiedValueInfo,
-        ToComputedValue,
-        ToResolvedValue,
-        ToShmem
-    )]
+    /// Controls how the auto-placement algorithm works specifying exactly how auto-placed items
+    /// get flowed into the grid.
+    #[derive(MallocSizeOf, SpecifiedValueInfo, ToComputedValue, ToResolvedValue, ToShmem)]
     #[value_info(other_values = "row,column,dense")]
     #[repr(C)]
     pub struct GridAutoFlow: u8 {

--- a/components/style_traits/rustfmt.toml
+++ b/components/style_traits/rustfmt.toml
@@ -1,1 +1,0 @@
-disable_all_formatting = true

--- a/components/style_traits/rustfmt.toml
+++ b/components/style_traits/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -16,7 +16,7 @@ euclid = { workspace = true }
 html5ever = { workspace = true }
 rayon = { workspace = true }
 serde_json = { workspace = true }
-selectors = {path = "../../../components/selectors", features = ["shmem"] }
+selectors = {path = "../../../components/selectors" }
 servo_arc = {path = "../../../components/servo_arc"}
 servo_atoms = {path = "../../../components/atoms"}
 servo_config = {path = "../../../components/config"}


### PR DESCRIPTION
This patch reverts all remaining changes from the Stylo split-into-commits branch, except those that would fail mach test-tidy, in preparation for switching to the [external repo](https://github.com/servo/stylo). There are no functional changes.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because there are no functional changes