### PR TITLE
Treat video elements as replaced content and render the current frame.

### DIFF
--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -93,6 +93,7 @@ pub(crate) trait NodeExt<'dom>: 'dom + LayoutNode<'dom> {
     fn as_image(self) -> Option<(Option<Arc<NetImage>>, PhysicalSize<f64>)>;
     fn as_canvas(self) -> Option<(CanvasInfo, PhysicalSize<f64>)>;
     fn as_iframe(self) -> Option<(PipelineId, BrowsingContextId)>;
+    fn as_video(self) -> Option<(webrender_api::ImageKey, PhysicalSize<f64>)>;
     fn style(self, context: &LayoutContext) -> ServoArc<ComputedValues>;
 
     fn get_style_and_layout_data(self) -> Option<StyleAndLayoutData<'dom>>;
@@ -123,6 +124,13 @@ where
             height /= density;
         }
         Some((resource, PhysicalSize::new(width, height)))
+    }
+
+    fn as_video(self) -> Option<(webrender_api::ImageKey, PhysicalSize<f64>)> {
+        let node = self.to_threadsafe();
+        let frame_data = node.media_data()?.current_frame?;
+        let (width, height) = (frame_data.1 as f64, frame_data.2 as f64);
+        Some((frame_data.0, PhysicalSize::new(width, height)))
     }
 
     fn as_canvas(self) -> Option<(CanvasInfo, PhysicalSize<f64>)> {

--- a/tests/wpt/meta/css/css-images/object-view-box-fit-cover-video.html.ini
+++ b/tests/wpt/meta/css/css-images/object-view-box-fit-cover-video.html.ini
@@ -1,0 +1,2 @@
+[object-view-box-fit-cover-video.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-images/object-view-box-writing-mode-video.html.ini
+++ b/tests/wpt/meta/css/css-images/object-view-box-writing-mode-video.html.ini
@@ -1,0 +1,2 @@
+[object-view-box-writing-mode-video.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_dynamic_poster_absolute.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_dynamic_poster_absolute.htm.ini
@@ -1,2 +1,0 @@
-[video_dynamic_poster_absolute.htm]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_dynamic_poster_relative.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_dynamic_poster_relative.htm.ini
@@ -1,2 +1,0 @@
-[video_dynamic_poster_relative.htm]
-  expected: FAIL


### PR DESCRIPTION
These changes allow videos that autoplay to render as expected in Layout 2020. Both legacy layout and layout 2020 do not render any video frames when the videos are paused initially, which can be addressed separately.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31208
- [x] There are tests for these changes