### PR TITLE
Fix crash when closing window containing video element

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1998,8 +1998,6 @@ impl Drop for HTMLMediaElement {
                 warn!("GLPlayer disappeared!: {:?}", err);
             }
         }
-
-        self.remove_controls();
     }
 }
 
@@ -2453,6 +2451,8 @@ impl VirtualMethods for HTMLMediaElement {
     // https://html.spec.whatwg.org/multipage/#playing-the-media-resource:remove-an-element-from-a-document
     fn unbind_from_tree(&self, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(context);
+
+        self.remove_controls();
 
         if context.tree_connected {
             let task = MediaElementMicrotask::PauseIfNotInDocumentTask {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -812,6 +812,10 @@ thread_local!(
     static THREAD_ACTIVE: Cell<bool> = Cell::new(true);
 );
 
+pub(crate) fn runtime_is_alive() -> bool {
+    THREAD_ACTIVE.with(|t| t.get())
+}
+
 #[allow(unsafe_code)]
 unsafe extern "C" fn trace_rust_roots(tr: *mut JSTracer, _data: *mut os::raw::c_void) {
     if !THREAD_ACTIVE.with(|t| t.get()) {


### PR DESCRIPTION
It's unsafe to interact with the rest of the document from a DOM object's Drop implementation, since they can be triggered as part of shutting down the JS runtime. These changes attempt to catch more cases that might otherwise slip through if the associated memory has not been freed yet.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31308
- [x] There are tests for these changes