### PR TITLE
layout: Place statically positioned absolutes in IFCs at their hypothetical box position

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -89,6 +89,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub(super) enum Contents {
     /// Refers to a DOM subtree, plus `::before` and `::after` pseudo-elements.
     OfElement,
@@ -107,6 +108,7 @@ pub(super) enum NonReplacedContents {
     OfPseudoElement(Vec<PseudoElementContentItem>),
 }
 
+#[derive(Debug)]
 pub(super) enum PseudoElementContentItem {
     Text(String),
     Replaced(ReplacedContent),

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -34,7 +34,7 @@ pub(crate) enum Display {
     GeneratingBox(DisplayGeneratingBox),
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DisplayGeneratingBox {
     OutsideInside {
         outside: DisplayOutside,
@@ -72,13 +72,13 @@ impl DisplayGeneratingBox {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DisplayOutside {
     Block,
     Inline,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum DisplayInside {
     // “list-items are limited to the Flow Layout display types”
     // <https://drafts.csswg.org/css-display/#list-items>

--- a/tests/wpt/meta/css/CSS2/abspos/between-float-and-text.html.ini
+++ b/tests/wpt/meta/css/CSS2/abspos/between-float-and-text.html.ini
@@ -1,2 +1,0 @@
-[between-float-and-text.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/abspos-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/abspos-007.xht.ini
@@ -1,2 +1,0 @@
-[abspos-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/abspos-block-level-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/abspos-block-level-001.html.ini
@@ -1,2 +1,0 @@
-[abspos-block-level-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/abspos-negative-margin-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/abspos-negative-margin-001.html.ini
@@ -1,2 +1,0 @@
-[abspos-negative-margin-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-inline.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-inline.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-dynamic-static-position-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/fractional-scale-gradient-bg-obscure-red-bg.html.ini
+++ b/tests/wpt/meta/css/css-transforms/fractional-scale-gradient-bg-obscure-red-bg.html.ini
@@ -1,2 +1,0 @@
-[fractional-scale-gradient-bg-obscure-red-bg.html]
-  expected: FAIL


### PR DESCRIPTION
Absolutes need to be placed at their hypothetical position as if the
`position` value was static. This position differs based on the value they
had before blockification. The code for placing absolutes was taking
into account the original display for the inline value, but not for the
block value. A static `display: block` box would placed at a new block
position past the end of the linebox.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19879.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
