### PR TITLE
layout: Add line height from preserved segment breaks in quirks mode

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 
-use html5ever::LocalName;
+use html5ever::{local_name, LocalName};
 use script_layout_interface::wrapper_traits::{ThreadSafeLayoutElement, ThreadSafeLayoutNode};
 use servo_arc::Arc as ServoArc;
 use style::properties::ComputedValues;
@@ -78,6 +78,9 @@ where
         let flags = match threadsafe_node.as_element() {
             Some(element) if element.is_body_element_of_html_element_root() => {
                 FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT
+            },
+            Some(element) if element.get_local_name() == &local_name!("br") => {
+                FragmentFlags::IS_BR_ELEMENT
             },
             _ => FragmentFlags::empty(),
         };

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -77,8 +77,10 @@ bitflags! {
     /// Flags used to track various information about a DOM node during layout.
     #[derive(Clone, Copy, Debug, Serialize)]
     pub(crate) struct FragmentFlags: u8 {
-        /// Whether or not this node is a body element on an HTML document.
+        /// Whether or not the node that created this fragment is a `<body>` element on an HTML document.
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 0b00000001;
+        /// Whether or not the node that created this Fragment is a `<br>` element.
+        const IS_BR_ELEMENT = 0b00000010;
     }
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -747,6 +747,10 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ThreadSafeLayoutElement<'dom>
         self.element
     }
 
+    fn get_local_name(&self) -> &LocalName {
+        self.element.local_name()
+    }
+
     fn get_attr_enum(&self, namespace: &Namespace, name: &LocalName) -> Option<&AttrValue> {
         self.element.get_attr_enum(namespace, name)
     }

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -345,6 +345,10 @@ pub trait ThreadSafeLayoutElement<'dom>:
     /// lazily_compute_pseudo_element_style, which operates on TElement.
     unsafe fn unsafe_get(self) -> Self::ConcreteElement;
 
+    /// Get the local name of this element. See
+    /// <https://dom.spec.whatwg.org/#concept-element-local-name>.
+    fn get_local_name(&self) -> &LocalName;
+
     fn get_attr(&self, namespace: &Namespace, name: &LocalName) -> Option<&str>;
 
     fn get_attr_enum(&self, namespace: &Namespace, name: &LocalName) -> Option<&AttrValue>;

--- a/tests/wpt/meta-legacy-layout/quirks/line-height-preserved-segment-break.html.ini
+++ b/tests/wpt/meta-legacy-layout/quirks/line-height-preserved-segment-break.html.ini
@@ -1,0 +1,2 @@
+[line-height-preserved-segment-break.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-legacy-layout/css/quirks-mode-br-line-height.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/css/quirks-mode-br-line-height.html.ini
@@ -1,0 +1,2 @@
+[quirks-mode-br-line-height.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5402,6 +5402,19 @@
       {}
      ]
     ],
+    "quirks-mode-br-line-height.html": [
+     "ecb49833f809e72cd57772e7a98085e787cb8baa",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/quirks-mode-br-line-height-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "quotes_none_a.html": [
      "c37ff23e9084d7d198b3c97e14d2e00ab417dd6c",
      [
@@ -9671,6 +9684,10 @@
     ],
     "pseudo_inherit_ref.html": [
      "0195f154cf3c4303e5aaf4fc9e7cfa358b8386d7",
+     []
+    ],
+    "quirks-mode-br-line-height-ref.html": [
+     "2108a4ae5e1f823cf2a3923070d54c42487fd8c6",
      []
     ],
     "quotes_none_ref.html": [

--- a/tests/wpt/mozilla/tests/css/quirks-mode-br-line-height-ref.html
+++ b/tests/wpt/mozilla/tests/css/quirks-mode-br-line-height-ref.html
@@ -1,0 +1,17 @@
+<link rel="author" href="mrobinson@igalia.com">
+<style>
+    span {
+        display: inline-block;
+        width: 50px;
+        height: 50px;
+        background: green;
+        color: transparent;
+    }
+</style>
+<body>
+    <div style="width: 100px; border: solid; line-height: 50px;">
+        <span></span><br>
+        <span style="background: transparent; color: transparent;">A</span>
+        <span></span>
+    </div>
+</body>

--- a/tests/wpt/mozilla/tests/css/quirks-mode-br-line-height.html
+++ b/tests/wpt/mozilla/tests/css/quirks-mode-br-line-height.html
@@ -1,0 +1,35 @@
+<!-- quirks mode -->
+<link rel="match" href="quirks-mode-br-line-height-ref.html">
+<link rel="author" href="mrobinson@igalia.com">
+<!--
+    Normally in quirks, only text and uncollapsible white space in inline boxes
+    adds the inline box line height to the line. A forced line break is a kind of
+    uncollapsible white space, so it should add line height to the line box.
+
+    We implement <br> in Servo with `white-space: pre-line`, but <br> doesn't act
+    like a preserved line break. It only adds its line height to the line if its
+    on an empty line.
+
+    This behavior doesn't seem to be specified, so is part of the "magic" behavior
+    of <br> elements.
+-->
+<style>
+    span {
+        display: inline-block;
+        width: 50px;
+        height: 50px;
+        background: green;
+        color: transparent;
+    }
+</style>
+<body>
+    <div style="width: 100px; border: solid; line-height: 50px;">
+        <span>A</span>
+        <!-- The first <br> ends the line and the second <br> adds 50px
+            of block size, because it inherits `line-height` from the
+            parent <div> -->
+        <br>
+        <br>
+        <span>A</span>
+    </div>
+</body>

--- a/tests/wpt/tests/quirks/line-height-preserved-segment-break.html
+++ b/tests/wpt/tests/quirks/line-height-preserved-segment-break.html
@@ -1,0 +1,24 @@
+<!-- quirks mode -->
+<link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk">
+<link rel="help" href="https://drafts.csswg.org/css-text/#valdef-white-space-pre-line">
+<link rel="match" href="../css/reference/ref-filled-green-100px-square.xht">
+
+<style>
+    .container {
+        width: 100px;
+        background: green;
+        white-space: pre-line;
+    }
+
+    .inline-box {
+        line-height: 100px;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 100px; height: 100px; background: red;">
+    <!-- The preserved segment break in the span should mean that "The line height calculation
+    quirk" does not apply. -->
+  <div class="container"><span class="inline-box">&#xA;</span></div>
+</div>


### PR DESCRIPTION
In quirks mode, preserved segment breaks should add line height to
lines. This matches the behavior of WebKit and Blink, but not Gecko.

This also handles the special-case of `<br>` elements, which are
implemented with preserved segment breaks via `white-space: pre-line`.
This is an implementation detail though because `<br>` has a special
behavior if the line isn't empty -- it doesn't add any line height in
this case.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
