### PR TITLE
ci: Fix nightly release action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Create Draft GH Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - id: create-release
         run: |
@@ -43,7 +43,7 @@ jobs:
     # This job is only useful when run on upstream servo.
     if: always() && (github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch')
     name: Publish GH Release for nightly
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Publish as latest (success)
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Publish as latest (success)
-        if: success()
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: |
           gh api \
             --method PATCH \
@@ -55,7 +55,7 @@ jobs:
             /repos/${NIGHTLY_REPO}/releases/${RELEASE_ID} \
             -F draft=false
       - name: Publish as latest (failure)
-        if: failure()
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
           gh api \
             --method PATCH \


### PR DESCRIPTION
As observed in #31373, the changes introduced by #31348 don't
seem to work as expected. The workflow [always executes](https://github.com/servo/servo/actions/runs/7954978996/job/21714145504) the step
corresponding to `if: success()` despite the failure in one of the
prerequisite jobs specified under 'needs'.

This seems to be a quirk of how GH Actions work. Checking the
status of the prerequisite jobs using `contains(needs.*.result)` 
seems to work correctly as we would expect.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31373
- [x] These changes do not require tests because they fix a bug in CI configuration.
