### PR TITLE
Support <div align="..."> and <center> in block layout

### DIFF
--- a/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/div-align.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/div-align.html.ini
@@ -1,2 +1,0 @@
-[div-align.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/servo_center_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/servo_center_a.html.ini
@@ -1,2 +1,0 @@
-[servo_center_a.html]
-  expected: FAIL


### PR DESCRIPTION
As per HTML \[1\], `<div align="...">` and `<center>` should align descendants to the left/center/right. This is similar to having 'auto' margins \[2\], but without changing their used values \[3\].

\[1\]: https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3
\[2\]: https://html.spec.whatwg.org/multipage/rendering.html#align-descendants
\[3\]: https://github.com/whatwg/html/issues/10149

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
