### PR TITLE
Add `--with-asan` option

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -331,7 +331,10 @@ class CommandBase(object):
         apk_name = "servoapp.apk"
         return path.join(base_path, build_type.directory_name(), apk_name)
 
-    def get_binary_path(self, build_type: BuildType, target=None, android=False):
+    def get_binary_path(self, build_type: BuildType, target=None, android=False, asan=False):
+        if target is None and asan:
+            target = servo.platform.host_triple()
+
         base_path = util.get_target_dir()
         if android:
             base_path = path.join(base_path, self.config["android"]["target"])
@@ -343,7 +346,11 @@ class CommandBase(object):
         binary_path = path.join(base_path, build_type.directory_name(), binary_name)
 
         if not path.exists(binary_path):
-            raise BuildNotFound('No Servo binary found. Perhaps you forgot to run `./mach build`?')
+            if target is None:
+                print("WARNING: Fallback to host-triplet prefixed target dirctory for binary path.")
+                return self.get_binary_path(build_type, target=servo.platform.host_triple(), android=android)
+            else:
+                raise BuildNotFound('No Servo binary found. Perhaps you forgot to run `./mach build`?')
         return binary_path
 
     def detach_volume(self, mounted_volume):
@@ -670,6 +677,7 @@ class CommandBase(object):
                                 help='Build in release mode without debug assertions'),
                 CommandArgument('--profile', group="Build Type",
                                 help='Build with custom Cargo profile'),
+                CommandArgument('--with-asan', action='store_true', help="Build with AddressSanitizer")
             ]
 
         if build_configuration:
@@ -831,6 +839,7 @@ class CommandBase(object):
         env=None, verbose=False,
         debug_mozjs=False, with_debug_assertions=False,
         with_frame_pointer=False, without_wgl=False,
+        target_override: Optional[str] = None,
         **_kwargs
     ):
         env = env or self.build_env()
@@ -856,7 +865,9 @@ class CommandBase(object):
                 "--manifest-path",
                 path.join(self.context.topdir, "ports", port, "Cargo.toml"),
             ]
-        if self.cross_compile_target:
+        if target_override:
+            args += ["--target", target_override]
+        elif self.cross_compile_target:
             args += ["--target", self.cross_compile_target]
 
         if "-p" not in cargo_args:  # We're building specific package, that may not have features

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -143,7 +143,7 @@ class PackageCommands(CommandBase):
                      action='store_true',
                      help='Create a local Maven repository')
     @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def package(self, build_type: BuildType, android=None, target=None, flavor=None, maven=False):
+    def package(self, build_type: BuildType, android=None, target=None, flavor=None, maven=False, with_asan=False):
         if android is None:
             android = self.config["build"]["android"]
         if target and android:
@@ -156,7 +156,7 @@ class PackageCommands(CommandBase):
 
         self.cross_compile_target = target
         env = self.build_env()
-        binary_path = self.get_binary_path(build_type, target=target, android=android)
+        binary_path = self.get_binary_path(build_type, target=target, android=android, asan=with_asan)
         dir_to_root = self.get_top_dir()
         target_dir = path.dirname(binary_path)
         if android:
@@ -382,7 +382,7 @@ class PackageCommands(CommandBase):
                      default=None,
                      help='Install the given target platform')
     @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def install(self, build_type: BuildType, android=False, emulator=False, usb=False, target=None):
+    def install(self, build_type: BuildType, android=False, emulator=False, usb=False, target=None, with_asan=False):
         if target and android:
             print("Please specify either --target or --android.")
             sys.exit(1)
@@ -392,7 +392,7 @@ class PackageCommands(CommandBase):
 
         env = self.build_env()
         try:
-            binary_path = self.get_binary_path(build_type, android=android)
+            binary_path = self.get_binary_path(build_type, android=android, asan=with_asan)
         except BuildNotFound:
             print("Servo build not found. Building servo...")
             result = Registrar.dispatch(
@@ -401,7 +401,7 @@ class PackageCommands(CommandBase):
             if result:
                 return result
             try:
-                binary_path = self.get_binary_path(build_type, android=android)
+                binary_path = self.get_binary_path(build_type, android=android, asan=with_asan)
             except BuildNotFound:
                 print("Rebuilding Servo did not solve the missing build problem.")
                 return 1

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -80,7 +80,7 @@ class PostBuildCommands(CommandBase):
         help="Command-line arguments to be passed through to Servo")
     @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
     def run(self, params, build_type: BuildType, android=None, debugger=False, debugger_cmd=None,
-            headless=False, software=False, bin=None, emulator=False, usb=False, nightly=None):
+            headless=False, software=False, bin=None, emulator=False, usb=False, nightly=None, with_asan=False):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
         if software:
@@ -133,7 +133,7 @@ class PostBuildCommands(CommandBase):
             shell.communicate(bytes("\n".join(script) + "\n", "utf8"))
             return shell.wait()
 
-        args = [bin or self.get_nightly_binary_path(nightly) or self.get_binary_path(build_type)]
+        args = [bin or self.get_nightly_binary_path(nightly) or self.get_binary_path(build_type, asan=with_asan)]
 
         if headless:
             args.append('-z')
@@ -205,12 +205,12 @@ class PostBuildCommands(CommandBase):
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
     @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def rr_record(self, build_type: BuildType, bin=None, nightly=None, params=[]):
+    def rr_record(self, build_type: BuildType, bin=None, nightly=None, with_asan=False, params=[]):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
         servo_cmd = [bin or self.get_nightly_binary_path(nightly)
-                     or self.get_binary_path(build_type)] + params
+                     or self.get_binary_path(build_type, asan=with_asan)] + params
         rr_cmd = ['rr', '--fatal-errors', 'record']
         try:
             check_call(rr_cmd + servo_cmd)


### PR DESCRIPTION
Based on https://github.com/servo/servo/pull/27474, but if finding binary fails in /target/{profile}
 it fallback to /target/{target}/{profile}/servo or you can provide `--with-asan` to commands for direct binary finding.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://github.com/servo/servo/issues/27190
<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
