### PR TITLE
Fix width of tables in block flow

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -410,6 +410,7 @@ impl FlexContainer {
         IndependentLayout {
             fragments,
             content_block_size: content_block_size.into(),
+            content_inline_size_for_table: None,
             baselines: Baselines::default(),
         }
     }

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -251,6 +251,18 @@ impl<'a> PlacementAmongFloats<'a> {
         }
     }
 
+    /// After placing a table and then laying it out, it may turn out wider than what
+    /// we initially expected. This method takes care of updating the data so that
+    /// the next place() can find the right area for the new size.
+    /// Note that if the new size is smaller, placement won't backtrack to consider
+    /// areas that weren't big enough for the old size.
+    pub(crate) fn set_inline_size(&mut self, inline_size: Au, pbm: &PaddingBorderMargin) {
+        self.object_size.inline = inline_size;
+        self.max_inline_end = (self.float_context.containing_block_info.inline_end -
+            pbm.margin.inline_end.auto_is(Length::zero).into())
+        .max(self.min_inline_start + inline_size);
+    }
+
     /// After placing an object with `height: auto` (and using the minimum inline and
     /// block size as the object size) and then laying it out, try to fit the object into
     /// the current set of bands, given block size after layout and the available inline

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -73,6 +73,11 @@ pub(crate) struct IndependentLayout {
     /// <https://drafts.csswg.org/css2/visudet.html#root-height>
     pub content_block_size: Au,
 
+    /// The contents of a table may force it to become wider than what we would expect
+    /// from 'width' and 'min-width'. This is the resulting inline content size,
+    /// or None for non-table layouts.
+    pub content_inline_size_for_table: Option<Au>,
+
     /// The offset of the last inflow baseline of this layout in the content area, if
     /// there was one. This is used to propagate baselines to the ancestors of `display:
     /// inline-block`.

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-014.xht.ini
@@ -1,2 +1,0 @@
-[floats-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-015.xht.ini
@@ -1,2 +1,0 @@
-[floats-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-001-left-table.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-001-left-table.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-001-left-table.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-001-right-table.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-001-right-table.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-001-right-table.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-003-left-table.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-003-left-table.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-003-left-table.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-003-right-table.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-003-right-table.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-003-right-table.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floats-wrap-bfc-004.xht.ini
@@ -1,2 +1,0 @@
-[floats-wrap-bfc-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-backgrounds-bs-table-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-backgrounds-bs-table-001.xht.ini
@@ -1,2 +1,0 @@
-[table-backgrounds-bs-table-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/anonymous-table-cell-margin-collapsing.html.ini
+++ b/tests/wpt/meta/css/css-tables/anonymous-table-cell-margin-collapsing.html.ini
@@ -1,2 +1,0 @@
-[anonymous-table-cell-margin-collapsing.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/bounding-box-computation-3.html.ini
+++ b/tests/wpt/meta/css/css-tables/bounding-box-computation-3.html.ini
@@ -1,7 +1,4 @@
 [bounding-box-computation-3.html]
-  [Control test: Table width is 120px]
-    expected: FAIL
-
   [First (empty) table-row-group should be located at 10px left]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/column-track-merging.html.ini
+++ b/tests/wpt/meta/css/css-tables/column-track-merging.html.ini
@@ -11,9 +11,6 @@
   [main table 5]
     expected: FAIL
 
-  [main table 6]
-    expected: FAIL
-
   [main table 10]
     expected: FAIL
 
@@ -21,9 +18,6 @@
     expected: FAIL
 
   [main table 12]
-    expected: FAIL
-
-  [main table 13]
     expected: FAIL
 
   [main table 9]

--- a/tests/wpt/meta/css/css-tables/dynamic-rowspan-change.html.ini
+++ b/tests/wpt/meta/css/css-tables/dynamic-rowspan-change.html.ini
@@ -1,6 +1,3 @@
 [dynamic-rowspan-change.html]
-  [main table 1]
-    expected: FAIL
-
   [main table 2]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/html-to-css-mapping-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/html-to-css-mapping-1.html.ini
@@ -1,9 +1,0 @@
-[html-to-css-mapping-1.html]
-  [HTML -> CSS Mapping is applied correctly on proper table markup (border-spacing, padding)]
-    expected: FAIL
-
-  [HTML -> CSS Mapping is applied correctly on improper table markup (no td => border-spacing, but no padding)]
-    expected: FAIL
-
-  [HTML -> CSS Mapping is applied correctly on empty table markup (no content => no border-spacing, no padding)]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-1.html.ini
@@ -1,15 +1,6 @@
 [html5-table-formatting-1.html]
-  [Empty tables can still get a lsyout]
-    expected: FAIL
-
-  [Empty tables do not take table-columns into account]
-    expected: FAIL
-
   [Table-columns are taken into account after missing cells are generated (empty line)]
     expected: FAIL
 
   [Table-columns are taken into account after missing cells are generated (partially empty line)]
-    expected: FAIL
-
-  [Table-columns are taken into account after missing cells are generated (non-empty line)]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-2.html.ini
@@ -8,19 +8,10 @@
   [Border-spacing is added between any two unmerged rows (1)]
     expected: FAIL
 
-  [Border-spacing is added between any two unmerged columns (2)]
-    expected: FAIL
-
   [Border-spacing is added between any two unmerged rows (2)]
     expected: FAIL
 
-  [Border-spacing is added between any two unmerged columns (3)]
-    expected: FAIL
-
   [Border-spacing is added between any two unmerged rows (3)]
-    expected: FAIL
-
-  [Border-spacing is added between any two unmerged columns (4)]
     expected: FAIL
 
   [Border-spacing is added between any two unmerged rows (4)]

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-3.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-3.html.ini
@@ -1,11 +1,5 @@
 [html5-table-formatting-3.html]
-  [Control test for table-cell padding and border-spacing, etc (width)]
-    expected: FAIL
-
   [Anonymous consecutive columns spanned by the same set of cells are merged]
-    expected: FAIL
-
-  [Explicitely-defined consecutive columns spanned by the same set of cells are not merged]
     expected: FAIL
 
   [Explicitely-defined consecutive columns spanned by the same set of cells are not merged, and cells span across border-spacing]

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-fixed-layout-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-fixed-layout-1.html.ini
@@ -1,3 +1,0 @@
-[html5-table-formatting-fixed-layout-1.html]
-  [Redundant columns of fixed-layout tables are not being merged]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/caption.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/caption.html.ini
@@ -8,9 +8,6 @@
   [table 3]
     expected: FAIL
 
-  [table 6]
-    expected: FAIL
-
   [table 7]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/colgroup-col.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/colgroup-col.html.ini
@@ -11,8 +11,5 @@
   [table 4]
     expected: FAIL
 
-  [table 5]
-    expected: FAIL
-
   [table 6]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/colspan-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/colspan-redistribution.html.ini
@@ -62,9 +62,6 @@
   [table 24]
     expected: FAIL
 
-  [table 25]
-    expected: FAIL
-
   [table 26]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/column-widths.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/column-widths.html.ini
@@ -2,46 +2,22 @@
   [table 1]
     expected: FAIL
 
-  [table 2]
-    expected: FAIL
-
   [table 3]
     expected: FAIL
 
   [table 5]
     expected: FAIL
 
-  [table 6]
-    expected: FAIL
-
-  [table 7]
-    expected: FAIL
-
   [table 8]
     expected: FAIL
 
-  [table 9]
-    expected: FAIL
-
-  [table 10]
-    expected: FAIL
-
   [table 11]
-    expected: FAIL
-
-  [table 12]
     expected: FAIL
 
   [table 13]
     expected: FAIL
 
   [table 14]
-    expected: FAIL
-
-  [table 15]
-    expected: FAIL
-
-  [table 16]
     expected: FAIL
 
   [table 17]
@@ -51,9 +27,6 @@
     expected: FAIL
 
   [table 19]
-    expected: FAIL
-
-  [table 20]
     expected: FAIL
 
   [table 21]
@@ -74,23 +47,14 @@
   [table 26]
     expected: FAIL
 
-  [table 27]
-    expected: FAIL
-
-  [table 28]
-    expected: FAIL
-
-  [table 29]
-    expected: FAIL
-
   [table 30]
-    expected: FAIL
-
-  [table 31]
     expected: FAIL
 
   [table 32]
     expected: FAIL
 
   [table 33]
+    expected: FAIL
+
+  [table 4]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-fixed-minmax.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-fixed-minmax.html.ini
@@ -13,3 +13,6 @@
 
   [table's width inside grid width:max-content is infinite]
     expected: FAIL
+
+  [table's width inside a table cell is infinite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-minmax.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-minmax.html.ini
@@ -5,32 +5,8 @@
   [table 5]
     expected: FAIL
 
-  [table 6]
-    expected: FAIL
-
-  [table 7]
-    expected: FAIL
-
-  [table 8]
-    expected: FAIL
-
-  [table 9]
-    expected: FAIL
-
-  [table 11]
-    expected: FAIL
-
-  [table 12]
-    expected: FAIL
-
-  [table 13]
-    expected: FAIL
-
-  [table 14]
-    expected: FAIL
-
-  [table 15]
-    expected: FAIL
-
   [table 16]
+    expected: FAIL
+
+  [table 1]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
@@ -5,8 +5,5 @@
   [table 2]
     expected: FAIL
 
-  [table 5]
-    expected: FAIL
-
   [table 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
@@ -1,7 +1,4 @@
 [table-width-redistribution-fixed.html]
-  [table 1]
-    expected: FAIL
-
   [table 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution.html.ini
@@ -44,8 +44,5 @@
   [table 20]
     expected: FAIL
 
-  [table 21]
-    expected: FAIL
-
   [table 22]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/tbody-height-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/tbody-height-redistribution.html.ini
@@ -2,9 +2,6 @@
   [table 1]
     expected: FAIL
 
-  [table 2]
-    expected: FAIL
-
   [table 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-001.html.ini
@@ -5,9 +5,6 @@
   [table 2]
     expected: FAIL
 
-  [table 5]
-    expected: FAIL
-
   [table 6]
     expected: FAIL
 
@@ -24,9 +21,6 @@
     expected: FAIL
 
   [table 11]
-    expected: FAIL
-
-  [table 13]
     expected: FAIL
 
   [table 14]

--- a/tests/wpt/meta/css/css-tables/visibility-hidden-col-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/visibility-hidden-col-001.html.ini
@@ -1,3 +1,0 @@
-[visibility-hidden-col-001.html]
-  [visibility:hidden doesn't change table width]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/visibility-hidden-nested-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/visibility-hidden-nested-001.html.ini
@@ -1,3 +1,0 @@
-[visibility-hidden-nested-001.html]
-  [table visibility:hidden doesn't change table width]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/computing-column-measure-0.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/computing-column-measure-0.html.ini
@@ -1,12 +1,3 @@
 [computing-column-measure-0.html]
-  [Checking intermediate min-content width for span 1 (1)]
-    expected: FAIL
-
-  [Checking intermediate min-content width for span 1 (2)]
-    expected: FAIL
-
-  [Checking intermediate min-content width for span 1 (3)]
-    expected: FAIL
-
   [Checking intermediate min-content width for span 1 (4)]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/computing-column-measure-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/computing-column-measure-2.html.ini
@@ -1,3 +1,0 @@
-[computing-column-measure-2.html]
-  [Table recalculations should match the reference]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/computing-table-width-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/computing-table-width-1.html.ini
@@ -1,3 +1,0 @@
-[computing-table-width-1.html]
-  [The box should be 300px since that is the size of the content]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/distribution-algo-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/distribution-algo-1.html.ini
@@ -1,3 +1,0 @@
-[distribution-algo-1.html]
-  [The box should be 300px since that is the size of the content]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/distribution-algo-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/distribution-algo-2.html.ini
@@ -1,3 +1,0 @@
-[distribution-algo-2.html]
-  [The box should be 300px since that is the size of the content]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/distribution-algo-min-content-guess.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/distribution-algo-min-content-guess.html.ini
@@ -1,3 +1,0 @@
-[distribution-algo-min-content-guess.html]
-  [The box should be 300px since that is the size of the content]
-    expected: FAIL


### PR DESCRIPTION
The contents of a table can make it bigger than what we would expect from its 'width' and 'min-width' properties. Also, 'width: auto' doesn't stretch it to fill the containing block.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
