### PR TITLE
layout: Add an implementation of `process_resolved_font_style_query` for Layout 2020

### DIFF
--- a/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.font.html.ini
+++ b/tests/wpt/meta/html/canvas/element/reset/2d.reset.state.font.html.ini
@@ -1,3 +1,0 @@
-[2d.reset.state.font.html]
-  [check that the state is reset]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.basic.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.basic.html]
-  [Canvas test: 2d.text.font.parse.basic]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.complex.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.complex.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.complex.html]
-  [Canvas test: 2d.text.font.parse.complex]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.complex2.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.complex2.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.complex2.html]
-  [Canvas test: 2d.text.font.parse.complex2]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.family.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.family.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.family.html]
-  [Canvas test: 2d.text.font.parse.family]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.size.percentage.default.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.size.percentage.default.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.size.percentage.default.html]
-  [Canvas test: 2d.text.font.parse.size.percentage.default]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.size.percentage.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.size.percentage.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.size.percentage.html]
-  [Canvas test: 2d.text.font.parse.size.percentage]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.tiny.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.font.parse.tiny.html.ini
@@ -1,3 +1,0 @@
-[2d.text.font.parse.tiny.html]
-  [Canvas test: 2d.text.font.parse.tiny]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/parent-style-relative-units.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/parent-style-relative-units.html.ini
@@ -1,6 +1,3 @@
 [parent-style-relative-units.html]
-  [Font-size based on canvas element font-size]
-    expected: FAIL
-
   [Font-size based on canvas element line-height]
     expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implements `process_resolved_font_style_query` in layout 2020 to the same extent it's supported by layout 2013, to add support for setting the font of a Canvas2D context.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
