### PR TITLE
Move servoshell code into an internal lib crate

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 build = "build.rs"
 publish = false
 
+[lib]
+name = "servoshell"
+path = "lib.rs"
+bench = false
+
 [[bin]]
 name = "servo"
 path = "main.rs"

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -2,6 +2,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+// For Android, see /support/android/apk/ + /ports/libsimpleservo/.
+#![cfg(not(target_os = "android"))]
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[macro_use]
+extern crate sig;
+
+#[cfg(test)]
+mod test;
+
+mod app;
+mod backtrace;
+mod crash_handler;
+mod egui_glue;
+mod embedder;
+mod events_loop;
+mod geometry;
+mod headed_window;
+mod headless_window;
+mod keyutils;
+mod minibrowser;
+mod parser;
+mod prefs;
+mod resources;
+mod webview;
+mod window_trait;
+
+pub mod platform {
+    #[cfg(target_os = "macos")]
+    pub use crate::platform::macos::deinit;
+
+    #[cfg(target_os = "macos")]
+    pub mod macos;
+
+    #[cfg(not(target_os = "macos"))]
+    pub fn deinit(_clean_shutdown: bool) {}
+}
+
 use std::io::Write;
 use std::{env, panic, process, thread};
 

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// For Android, see /support/android/apk/ + /ports/libsimpleservo/.
+// For Android, see /support/android/apk/ + /ports/jniapi/.
 #![cfg(not(target_os = "android"))]
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/ports/servoshell/main.rs
+++ b/ports/servoshell/main.rs
@@ -20,52 +20,14 @@
 // mode is turned on.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-cfg_if::cfg_if! {
-    if #[cfg(not(target_os = "android"))] {
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
-        #[macro_use]
-        extern crate sig;
-
-        #[cfg(test)]
-        mod test;
-
-        mod app;
-        mod backtrace;
-        mod crash_handler;
-        mod egui_glue;
-        mod embedder;
-        mod events_loop;
-        mod geometry;
-        mod headed_window;
-        mod headless_window;
-        mod keyutils;
-        mod main2;
-        mod minibrowser;
-        mod parser;
-        mod prefs;
-        mod resources;
-        mod webview;
-        mod window_trait;
-
-        pub mod platform {
-            #[cfg(target_os = "macos")]
-            pub use crate::platform::macos::deinit;
-
-            #[cfg(target_os = "macos")]
-            pub mod macos;
-
-            #[cfg(not(target_os = "macos"))]
-            pub fn deinit(_clean_shutdown: bool) {}
-        }
-
-        pub fn main() {
-            main2::main()
-        }
-    } else {
-        pub fn main() {
+fn main() {
+    cfg_if::cfg_if! {
+        if #[cfg(not(target_os = "android"))] {
+            servoshell::main()
+        } else {
             println!(
-                "Cannot start /ports/servo/ on Android. \
-                 Use /support/android/apk/ + /ports/libsimpleservo/ instead"
+                "Cannot start /ports/servoshell/ on Android. \
+                Use /support/android/apk/ + /ports/libsimpleservo/ instead"
             );
         }
     }

--- a/ports/servoshell/main.rs
+++ b/ports/servoshell/main.rs
@@ -27,7 +27,7 @@ fn main() {
         } else {
             println!(
                 "Cannot start /ports/servoshell/ on Android. \
-                Use /support/android/apk/ + /ports/libsimpleservo/ instead"
+                Use /support/android/apk/ + /ports/jniapi/ instead"
             );
         }
     }


### PR DESCRIPTION
This patch moves as much of servoshell’s code as possible from the “servo” bin crate (not to be confused with the “servo” lib crate in libservo) to a “servoshell” lib crate in the same package. As a result:

- we can get rid of ports/servoshell/main2.rs
- you can now distinguish servoshell logging from libservo (RUST_LOG=servoshell vs RUST_LOG=servo)
- [cargo timings](https://doc.rust-lang.org/cargo/reference/timings.html) [now list](https://fasterthanli.me/articles/why-is-my-rust-build-so-slow#how-much-time-are-we-spending-on-these-steps) how much time we spend on servoshell’s codegen

![image](https://github.com/servo/servo/assets/465303/0843110b-d39b-4883-a5bc-79ff5943f05a)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes