### PR TITLE
mach: Do not use unstable rust for `rustfmt`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4951,7 +4951,9 @@ where
         // If there is no focus browsing context yet, the initial page has
         // not loaded, so there is nothing to save yet.
         let Some(top_level_browsing_context_id) = self.webviews.focused_webview().map(|(id, _)| id)
-            else { return ReadyToSave::NoTopLevelBrowsingContext };
+        else {
+            return ReadyToSave::NoTopLevelBrowsingContext;
+        };
 
         // If there are pending loads, wait for those to complete.
         if !self.pending_changes.is_empty() {

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -11,9 +11,8 @@ use app_units::Au;
 use euclid::default::Point2D;
 // Eventually we would like the shaper to be pluggable, as many operating systems have their own
 // shapers. For now, however, HarfBuzz is a hard dependency.
-use harfbuzz_sys::hb_blob_t;
 use harfbuzz_sys::{
-    hb_blob_create, hb_bool_t, hb_buffer_add_utf8, hb_buffer_create, hb_buffer_destroy,
+    hb_blob_create, hb_blob_t, hb_bool_t, hb_buffer_add_utf8, hb_buffer_create, hb_buffer_destroy,
     hb_buffer_get_glyph_infos, hb_buffer_get_glyph_positions, hb_buffer_get_length,
     hb_buffer_set_direction, hb_buffer_set_script, hb_buffer_t, hb_codepoint_t,
     hb_face_create_for_tables, hb_face_destroy, hb_face_t, hb_feature_t, hb_font_create,

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -269,8 +269,10 @@ where
                 buffer.get()
             },
         });
-        let Ok(array) = array as Result<CustomAutoRooterGuard<'_, TypedArray<T, *mut JSObject>>, &mut ()> else{
-             return Err(())
+        let Ok(array) =
+            array as Result<CustomAutoRooterGuard<'_, TypedArray<T, *mut JSObject>>, &mut ()>
+        else {
+            return Err(());
         };
         unsafe {
             let slice = (*array).as_slice();
@@ -305,9 +307,10 @@ where
                 buffer.get()
             },
         });
-        let Ok(mut array) =  array as Result<CustomAutoRooterGuard<'_, TypedArray<T, *mut JSObject>>, &mut ()> else
-        {
-            return Err(())
+        let Ok(mut array) =
+            array as Result<CustomAutoRooterGuard<'_, TypedArray<T, *mut JSObject>>, &mut ()>
+        else {
+            return Err(());
         };
         unsafe {
             let slice = (*array).as_mut_slice();

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -198,7 +198,9 @@ impl Minibrowser {
                     let rect = egui::Rect::from_min_size(min, size);
                     ui.allocate_space(size);
 
-                    let Some(servo_fbo) = servo_framebuffer_id else { return };
+                    let Some(servo_fbo) = servo_framebuffer_id else {
+                        return;
+                    };
                     ui.painter().add(PaintCallback {
                         rect,
                         callback: Arc::new(CallbackFn::new(move |info, painter| {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,2 @@
 match_block_trailing_comma = true
-binop_separator = "Back"
 reorder_imports = true
-group_imports = "StdExternalCrate"
-imports_granularity = "Module"
-ignore = ["third_party"]

--- a/third_party/blurmac/src/framework.rs
+++ b/third_party/blurmac/src/framework.rs
@@ -485,6 +485,8 @@ pub mod cb {
     // CBCentralManagerScanOption...Key
 
     // CBAdvertisementData...Key
-    pub use self::link::CBAdvertisementDataServiceUUIDsKey as ADVERTISEMENTDATASERVICEUUIDSKEY;
-    pub use self::link::CBCentralManagerScanOptionAllowDuplicatesKey as CENTRALMANAGERSCANOPTIONALLOWDUPLICATESKEY;
+    pub use self::link::{
+        CBAdvertisementDataServiceUUIDsKey as ADVERTISEMENTDATASERVICEUUIDSKEY,
+        CBCentralManagerScanOptionAllowDuplicatesKey as CENTRALMANAGERSCANOPTIONALLOWDUPLICATESKEY,
+    };
 }


### PR DESCRIPTION
We can use stable rust if we pass the unstable configuration as
command-line arguments to rustfmt itself. This prevents needing to
install an unstable rust toolchain.

The one downside here is that it doesn't seem that "ignore" is
supported so we have to start formatting the files in "third_party."
This shouldn't be a huge issue because we don't plan to check much more
rust code into those directories.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust the `rustfmt` call.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
