### PR TITLE
fix invalid video poster image loading from panicking

### DIFF
--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -302,8 +302,8 @@ impl ImageCacheListener for HTMLVideoElement {
                 LoadBlocker::terminate(&mut *self.load_blocker.borrow_mut());
             },
             ImageResponse::MetadataLoaded(..) => {},
-            ImageResponse::PlaceholderLoaded(..) => unreachable!(),
-            ImageResponse::None => {
+            // The image cache may have loaded a placeholder for an invalid poster url
+            ImageResponse::PlaceholderLoaded(..) | ImageResponse::None => {
                 // A failed load should unblock the document load.
                 LoadBlocker::terminate(&mut *self.load_blocker.borrow_mut());
             },


### PR DESCRIPTION
This fixes #31438. When an image is loaded from cache, it will load a placeholder if the url is not a valid image url. This may be unexpected when using the image cache and specifying UsePlaceholder::No but that has no effect on loading an image not in the cache.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #31438 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

I didnt spot any WPT tests for this so maybe one needs to be made?
