### PR TITLE
tidy: Fix WHATWG replacement links

### DIFF
--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -70,8 +70,8 @@ class CheckTidiness(unittest.TestCase):
 
     def test_whatwg_link(self):
         errors = tidy.collect_errors_for_files(iterFile('whatwg_link.rs'), [], [tidy.check_by_line], print_text=False)
-        self.assertTrue('link to WHATWG may break in the future, use this format instead:' in next(errors)[2])
-        self.assertTrue('links to WHATWG single-page url, change to multi page:' in next(errors)[2])
+        self.assertEqual('link to WHATWG may break in the future, use this format instead: https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata', next(errors)[2])
+        self.assertEqual('links to WHATWG single-page url, change to multi page: https://html.spec.whatwg.org/multipage/#typographic-conventions', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_license(self):

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -271,14 +271,14 @@ def is_unsplittable(file_name, line):
 def check_whatwg_specific_url(idx, line):
     match = re.search(br"https://html\.spec\.whatwg\.org/multipage/[\w-]+\.html#([\w\'\:-]+)", line)
     if match is not None:
-        preferred_link = "https://html.spec.whatwg.org/multipage/#{}".format(match.group(1))
+        preferred_link = "https://html.spec.whatwg.org/multipage/#{}".format(match.group(1).decode("utf-8"))
         yield (idx + 1, "link to WHATWG may break in the future, use this format instead: {}".format(preferred_link))
 
 
 def check_whatwg_single_page_url(idx, line):
     match = re.search(br"https://html\.spec\.whatwg\.org/#([\w\'\:-]+)", line)
     if match is not None:
-        preferred_link = "https://html.spec.whatwg.org/multipage/#{}".format(match.group(1))
+        preferred_link = "https://html.spec.whatwg.org/multipage/#{}".format(match.group(1).decode("utf-8"))
         yield (idx + 1, "links to WHATWG single-page url, change to multi page: {}".format(preferred_link))
 
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes the test-tidy output so that it recommends the correct WHATWG URL
```
…use this format instead: https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsetx
```
Instead of a URL containing `b'`
```
…use this format instead: https://html.spec.whatwg.org/multipage/#b'dom-context-2d-shadowoffsetx'
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
