### PR TITLE
ci: Update remaining GitHub actions to versions using Node.js 20

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: Install taplo
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: taplo-cli
           locked: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Bootstrap dependencies
         run: sudo apt update && python3 ./mach bootstrap
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,7 +41,7 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
           fetch-depth: 2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
       - name: Install taplo
         uses: baptiste0928/cargo-install@v2
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,7 +83,7 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2 # This is necessary for `test-tidy`.
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         if: ${{ !inputs.upload  }} # not needed on ubuntu 20.04 used for nightly
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,7 +113,7 @@ jobs:
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 20
           max_attempts: 2 # https://github.com/servo/servo/issues/30683

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,11 +91,10 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install taplo
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: taplo-cli
           locked: true
-          cache-key: ${{ inputs.upload && '20.04' || '22.04' }}
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: Install taplo
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: taplo-cli
           locked: true

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -93,7 +93,7 @@ jobs:
           python3 ./mach build --${{ inputs.profile }}
           cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5
           max_attempts: 2
@@ -102,7 +102,7 @@ jobs:
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 20 # https://github.com/servo/servo/issues/30275
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
@@ -110,7 +110,7 @@ jobs:
       - name: Build mach package
         run: python3 ./mach package --${{ inputs.profile }}
       - name: Run DMG smoketest
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5
           max_attempts: 2

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/head
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.4
       - name: Install taplo
         uses: baptiste0928/cargo-install@v2
         with:

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -48,7 +48,7 @@ jobs:
            } >> $GITHUB_OUTPUT
       - name: Configuration
         id: configuration
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // When triggered via a push try the `try` branch, search the last commit for a configuration object.

--- a/.github/workflows/try_labels.yml
+++ b/.github/workflows/try_labels.yml
@@ -15,7 +15,7 @@ jobs:
       try_string: ${{ steps.try_string.outputs.result }}
     steps:
       - name: Collect Labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: try_string
         with:
           result-encoding: string
@@ -99,7 +99,7 @@ jobs:
            } >> $GITHUB_OUTPUT
       - name: Comment Run Start
         if: ${{ steps.try_string.outputs.result }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
@@ -149,7 +149,7 @@ jobs:
     steps:
       - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
               const url = context.serverUrl +
@@ -165,7 +165,7 @@ jobs:
               });
       - name: Failure
         if: ${{ contains(needs.*.result, 'failure') }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
               const url = context.serverUrl +

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
         run: python mach smoketest --angle --${{ inputs.profile }}
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
       - name: Install taplo
-        uses: baptiste0928/cargo-install@v2
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: taplo-cli
           locked: true


### PR DESCRIPTION
This should remove all node16 warnings.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
