### PR TITLE
mach: Speed up `taplo` runs on MacOS

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -48,6 +48,18 @@ UNSTABLE_RUSTFMT_ARGUMENTS = [
     "--config", "group_imports=StdExternalCrate",
 ]
 
+# Listing these globs manually is a work-around for very slow `taplo` invocation
+# on MacOS machines. If `taplo` runs fast without the globs on MacOS, this
+# can be removed.
+TOML_GLOBS = [
+    "*.toml",
+    ".cargo/*.toml",
+    "components/*/*.toml",
+    "components/shared/*.toml",
+    "ports/*/*.toml",
+    "support/*/*.toml",
+]
+
 
 def format_toml_files_with_taplo(check_only: bool = True) -> int:
     taplo = shutil.which("taplo")
@@ -56,9 +68,9 @@ def format_toml_files_with_taplo(check_only: bool = True) -> int:
         return 1
 
     if check_only:
-        return call([taplo, "fmt", "--check"], env={'RUST_LOG': 'error'})
+        return call([taplo, "fmt", "--check", *TOML_GLOBS], env={'RUST_LOG': 'error'})
     else:
-        return call([taplo, "fmt"], env={'RUST_LOG': 'error'})
+        return call([taplo, "fmt", *TOML_GLOBS], env={'RUST_LOG': 'error'})
 
 
 @CommandProvider


### PR DESCRIPTION
`taplo` is the TOML formatter that we use. It seems to be using a very
slow directory walking mechanism on MacOS. This change works around that
issue by explicitly listing globs of TOML files to format and check.

Before:
```text
real	0m17.632s
user	0m2.164s
sys	0m6.916s
```

After:
```text
real	0m1.519s
user	0m1.391s
sys	0m0.112s
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #31440.
- [x] These changes do not require tests because they merely make `./mach fmt` etc faster.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
