### PR TITLE
Fix percentages in CSS tables

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -411,7 +411,7 @@ impl<'a> TableLayout<'a> {
             let final_intrinsic_percentage_width = column_measure
                 .percentage
                 .0
-                .min(100. - total_intrinsic_percentage_width);
+                .min(1. - total_intrinsic_percentage_width);
             total_intrinsic_percentage_width += final_intrinsic_percentage_width;
             column_measure.percentage = Percentage(final_intrinsic_percentage_width);
         }
@@ -1148,7 +1148,7 @@ impl<'a> TableLayout<'a> {
                 });
             }
 
-            self.rows[row_index].percent = Percentage(percentage.min(100. - total_percentage));
+            self.rows[row_index].percent = Percentage(percentage.min(1. - total_percentage));
             total_percentage += self.rows[row_index].percent.0;
         }
 
@@ -1218,7 +1218,7 @@ impl<'a> TableLayout<'a> {
         if let Some(percentage_resolution_size) = percentage_resolution_size {
             let get_percent_block_size_deficit = |row_index: usize, track_size: Au| {
                 let size_needed_for_percent =
-                    percentage_resolution_size.scale_by(self.rows[row_index].percent.0 / 100.);
+                    percentage_resolution_size.scale_by(self.rows[row_index].percent.0);
                 (size_needed_for_percent - track_size).max(Au::zero())
             };
             let percent_block_size_deficit: Au = track_range

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution.html.ini
@@ -38,9 +38,6 @@
   [table 15]
     expected: FAIL
 
-  [table 19]
-    expected: FAIL
-
   [table 20]
     expected: FAIL
 


### PR DESCRIPTION
100% is stored as Percent(1.), not as percent(100.)

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
