### PR TITLE
Fix column and row measures

### DIFF
--- a/tests/wpt/meta/css/css-tables/tentative/column-widths.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/column-widths.html.ini
@@ -23,9 +23,6 @@
   [table 17]
     expected: FAIL
 
-  [table 18]
-    expected: FAIL
-
   [table 19]
     expected: FAIL
 
@@ -36,9 +33,6 @@
     expected: FAIL
 
   [table 23]
-    expected: FAIL
-
-  [table 24]
     expected: FAIL
 
   [table 25]


### PR DESCRIPTION
The min-content size of a table track was >= the max-content size. So
- For the min-content size of a column, now we just use min-inline-size, ignoring inline-size and max-inline-size. This matches Gecko, Blink and WebKit.
- For the max-content size of a column, we keep matching Gecko. Note that Blink and WebKit are different, they ignore max-inline-size.
- For both the min-content and max-content sizes of a row, now we just use block-size. This matches Gecko, Blink and WebKit.

Also, if the computed value contains percentages, now we treat it as the initial value, instead of resolving percentages against zero. This matches Gecko and Blink, but not WebKit for rows.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
