### PR TITLE
Treat indefinite percentages as auto offsets in relative positioning

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -875,17 +875,22 @@ pub(crate) fn relative_adjustement(
     style: &ComputedValues,
     containing_block: &ContainingBlock,
 ) -> LogicalVec2<Length> {
-    // "If the height of the containing block is not specified explicitly (i.e.,
-    // it depends on content height), and this element is not absolutely
-    // positioned, the value computes to 'auto'.""
-    // https://www.w3.org/TR/CSS2/visudet.html#the-height-property
+    // It's not completely clear what to do with indefinite percentages
+    // (https://github.com/w3c/csswg-drafts/issues/9353), so we match
+    // other browsers and treat them as 'auto' offsets.
     let cbis = containing_block.inline_size;
-    let cbbs = containing_block.block_size.auto_is(Au::zero);
+    let cbbs = containing_block.block_size;
     let box_offsets = style
         .box_offsets(containing_block)
         .map_inline_and_block_axes(
             |v| v.percentage_relative_to(cbis.into()),
-            |v| v.percentage_relative_to(cbbs.into()),
+            |v| match cbbs.non_auto() {
+                Some(cbbs) => v.percentage_relative_to(cbbs.into()),
+                None => match v.non_auto().and_then(|v| v.to_length()) {
+                    Some(v) => LengthOrAuto::LengthPercentage(v),
+                    None => LengthOrAuto::Auto,
+                },
+            },
         );
     fn adjust(start: LengthOrAuto, end: LengthOrAuto) -> Length {
         match (start, end) {

--- a/tests/wpt/meta/css/css-position/position-relative-007.html.ini
+++ b/tests/wpt/meta/css/css-position/position-relative-007.html.ini
@@ -1,2 +1,0 @@
-[position-relative-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/calc-offsets-relative-bottom-1.html.ini
+++ b/tests/wpt/meta/css/css-values/calc-offsets-relative-bottom-1.html.ini
@@ -1,2 +1,0 @@
-[calc-offsets-relative-bottom-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/calc-offsets-relative-top-1.html.ini
+++ b/tests/wpt/meta/css/css-values/calc-offsets-relative-top-1.html.ini
@@ -1,2 +1,0 @@
-[calc-offsets-relative-top-1.html]
-  expected: FAIL


### PR DESCRIPTION
Instead of just resolving the percentages against zero.
The spec is not clear (https://github.com/w3c/csswg-drafts/issues/9353), but this way we match Gecko, Blink and WebKit.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
