### PR TITLE
clippy: Fix several warnings in components/devtools

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -5,7 +5,7 @@
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::mem::replace;
+use std::mem;
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 
@@ -105,7 +105,7 @@ impl ActorRegistry {
 
     /// Get start stamp when registry was started
     pub fn start_stamp(&self) -> PreciseTime {
-        self.start_stamp.clone()
+        self.start_stamp
     }
 
     pub fn register_script_actor(&self, script_id: String, actor: String) {
@@ -194,12 +194,12 @@ impl ActorRegistry {
                 }
             },
         }
-        let new_actors = replace(&mut *self.new_actors.borrow_mut(), vec![]);
+        let new_actors = mem::take(&mut *self.new_actors.borrow_mut());
         for actor in new_actors.into_iter() {
             self.actors.insert(actor.name().to_owned(), actor);
         }
 
-        let old_actors = replace(&mut *self.old_actors.borrow_mut(), vec![]);
+        let old_actors = mem::take(&mut *self.old_actors.borrow_mut());
         for name in old_actors {
             self.drop_actor(name);
         }

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -284,11 +284,11 @@ impl BrowsingContextActor {
         let tabdesc = TabDescriptorActor::new(actors, name.clone());
 
         let target = BrowsingContextActor {
-            name: name,
+            name,
             script_chan: script_sender,
-            title: RefCell::new(String::from(title)),
+            title: RefCell::new(title),
             url: RefCell::new(url.into_string()),
-            console: console,
+            console,
             _emulation: emulation.name(),
             _inspector: inspector.name(),
             _timeline: timeline.name(),
@@ -355,7 +355,7 @@ impl BrowsingContextActor {
             from: self.name(),
             type_: "tabNavigated".to_owned(),
             url: url.as_str().to_owned(),
-            title: title,
+            title,
             nativeConsoleAPI: true,
             state: state.to_owned(),
             isFrameSwitching: false,

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -59,7 +59,7 @@ impl Actor for DeviceActor {
 
 impl DeviceActor {
     pub fn new(name: String) -> DeviceActor {
-        DeviceActor { name: name }
+        DeviceActor { name }
     }
 
     pub fn description() -> ActorDescription {

--- a/components/devtools/actors/emulation.rs
+++ b/components/devtools/actors/emulation.rs
@@ -21,19 +21,17 @@ impl Actor for EmulationActor {
     fn handle_message(
         &self,
         _registry: &ActorRegistry,
-        msg_type: &str,
+        _msg_type: &str,
         _msg: &Map<String, Value>,
         _stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
-        Ok(match msg_type {
-            _ => ActorMessageStatus::Ignored,
-        })
+        Ok(ActorMessageStatus::Ignored)
     }
 }
 
 impl EmulationActor {
     pub fn new(name: String) -> EmulationActor {
-        EmulationActor { name: name }
+        EmulationActor { name }
     }
 }

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -51,7 +51,7 @@ impl FramerateActor {
         let mut actor = FramerateActor {
             name: actor_name.clone(),
             pipeline: pipeline_id,
-            script_sender: script_sender,
+            script_sender,
             is_recording: false,
             ticks: Vec::new(),
         };
@@ -71,7 +71,7 @@ impl FramerateActor {
     }
 
     pub fn take_pending_ticks(&mut self) -> Vec<HighResolutionStamp> {
-        mem::replace(&mut self.ticks, Vec::new())
+        mem::take(&mut self.ticks)
     }
 
     fn start_recording(&mut self) {

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -207,8 +207,8 @@ impl NodeInfoToProtocol for NodeInfo {
             let name = actors.new_name("node");
             let node_actor = NodeActor {
                 name: name.clone(),
-                script_chan: script_chan,
-                pipeline: pipeline.clone(),
+                script_chan,
+                pipeline,
             };
             actors.register_script_actor(self.uniqueId, name.clone());
             actors.register_later(Box::new(node_actor));
@@ -315,7 +315,7 @@ impl Actor for WalkerActor {
 
                 let msg = DocumentElementReply {
                     from: self.name(),
-                    node: node,
+                    node,
                 };
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
@@ -538,16 +538,16 @@ impl Actor for PageStyleActor {
 
                 let auto_margins = msg
                     .get("autoMargins")
-                    .and_then(&Value::as_bool)
+                    .and_then(Value::as_bool)
                     .unwrap_or(false);
 
                 // http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/styles.js
                 let msg = GetLayoutReply {
                     from: self.name(),
-                    display: display,
-                    position: position,
-                    zIndex: zIndex,
-                    boxSizing: boxSizing,
+                    display,
+                    position,
+                    zIndex,
+                    boxSizing,
                     autoMargins: if auto_margins {
                         let mut m = Map::new();
                         let auto = serde_json::value::Value::String("auto".to_owned());
@@ -567,20 +567,20 @@ impl Actor for PageStyleActor {
                     } else {
                         serde_json::value::Value::Null
                     },
-                    marginTop: marginTop,
-                    marginRight: marginRight,
-                    marginBottom: marginBottom,
-                    marginLeft: marginLeft,
-                    borderTopWidth: borderTopWidth,
-                    borderRightWidth: borderRightWidth,
-                    borderBottomWidth: borderBottomWidth,
-                    borderLeftWidth: borderLeftWidth,
-                    paddingTop: paddingTop,
-                    paddingRight: paddingRight,
-                    paddingBottom: paddingBottom,
-                    paddingLeft: paddingLeft,
-                    width: width,
-                    height: height,
+                    marginTop,
+                    marginRight,
+                    marginBottom,
+                    marginLeft,
+                    borderTopWidth,
+                    borderRightWidth,
+                    borderBottomWidth,
+                    borderLeftWidth,
+                    paddingTop,
+                    paddingRight,
+                    paddingBottom,
+                    paddingLeft,
+                    width,
+                    height,
                 };
                 let msg = serde_json::to_string(&msg).unwrap();
                 let msg = serde_json::from_str::<Value>(&msg).unwrap();
@@ -614,7 +614,7 @@ impl Actor for InspectorActor {
                     let walker = WalkerActor {
                         name: registry.new_name("walker"),
                         script_chan: self.script_chan.clone(),
-                        pipeline: pipeline,
+                        pipeline,
                     };
                     let mut walker_name = self.walker.borrow_mut();
                     *walker_name = Some(walker.name());
@@ -643,7 +643,7 @@ impl Actor for InspectorActor {
                     let style = PageStyleActor {
                         name: registry.new_name("pageStyle"),
                         script_chan: self.script_chan.clone(),
-                        pipeline: pipeline,
+                        pipeline,
                     };
                     let mut pageStyle = self.pageStyle.borrow_mut();
                     *pageStyle = Some(style.name());

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -200,7 +200,7 @@ impl Actor for NetworkEventActor {
                 }
                 let msg = GetRequestHeadersReply {
                     from: self.name(),
-                    headers: headers,
+                    headers,
                     headerSize: headersSize,
                     rawHeaders: rawHeadersString,
                 };
@@ -218,7 +218,7 @@ impl Actor for NetworkEventActor {
 
                 let msg = GetRequestCookiesReply {
                     from: self.name(),
-                    cookies: cookies,
+                    cookies,
                 };
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
@@ -244,13 +244,13 @@ impl Actor for NetworkEventActor {
                         });
                         headersSize += name.as_str().len() + value.len();
                         rawHeadersString.push_str(name.as_str());
-                        rawHeadersString.push_str(":");
+                        rawHeadersString.push(':');
                         rawHeadersString.push_str(value.to_str().unwrap());
                         rawHeadersString.push_str("\r\n");
                     }
                     let msg = GetResponseHeadersReply {
                         from: self.name(),
-                        headers: headers,
+                        headers,
                         headerSize: headersSize,
                         rawHeaders: rawHeadersString,
                     };
@@ -269,7 +269,7 @@ impl Actor for NetworkEventActor {
 
                 let msg = GetResponseCookiesReply {
                     from: self.name(),
-                    cookies: cookies,
+                    cookies,
                 };
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
@@ -322,7 +322,7 @@ impl Actor for NetworkEventActor {
 impl NetworkEventActor {
     pub fn new(name: String) -> NetworkEventActor {
         NetworkEventActor {
-            name: name,
+            name,
             request: HttpRequest {
                 url: String::new(),
                 method: Method::GET,
@@ -378,8 +378,8 @@ impl NetworkEventActor {
                 .as_millis() as i64,
         ) {
             LocalResult::None => "".to_owned(),
-            LocalResult::Single(dateTime) => format!("{}", dateTime.to_rfc3339()),
-            LocalResult::Ambiguous(dateTime, _) => format!("{}", dateTime.to_rfc3339()),
+            LocalResult::Single(dateTime) => dateTime.to_rfc3339().to_string(),
+            LocalResult::Ambiguous(dateTime, _) => dateTime.to_rfc3339().to_string(),
         };
 
         EventActor {

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -31,7 +31,7 @@ impl Actor for ObjectActor {
 }
 
 impl ObjectActor {
-    pub fn new(registry: &ActorRegistry, uuid: String) -> String {
+    pub fn register(registry: &ActorRegistry, uuid: String) -> String {
         if !registry.script_actor_registered(uuid.clone()) {
             let name = registry.new_name("object");
             let actor = ObjectActor {

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -98,7 +98,7 @@ impl Actor for PerformanceActor {
 
 impl PerformanceActor {
     pub fn new(name: String) -> PerformanceActor {
-        PerformanceActor { name: name }
+        PerformanceActor { name }
     }
 
     pub fn description() -> ActorDescription {

--- a/components/devtools/actors/profiler.rs
+++ b/components/devtools/actors/profiler.rs
@@ -32,6 +32,6 @@ impl Actor for ProfilerActor {
 
 impl ProfilerActor {
     pub fn new(name: String) -> ProfilerActor {
-        ProfilerActor { name: name }
+        ProfilerActor { name }
     }
 }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -189,7 +189,7 @@ impl Actor for RootActor {
                         .map(|target| {
                             registry
                                 .find::<TabDescriptorActor>(target)
-                                .encodable(&registry)
+                                .encodable(registry)
                         })
                         .collect(),
                 };
@@ -223,7 +223,7 @@ impl Actor for RootActor {
                 let tab = registry.find::<TabDescriptorActor>(&self.tabs[0]);
                 let reply = GetTabReply {
                     from: self.name(),
-                    tab: tab.encodable(&registry),
+                    tab: tab.encodable(registry),
                 };
                 let _ = stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -50,6 +50,6 @@ impl Actor for StyleSheetsActor {
 
 impl StyleSheetsActor {
     pub fn new(name: String) -> StyleSheetsActor {
-        StyleSheetsActor { name: name }
+        StyleSheetsActor { name }
     }
 }

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -79,7 +79,7 @@ impl TabDescriptorActor {
         let root = actors.find_mut::<RootActor>("root");
         root.tabs.push(name.clone());
         TabDescriptorActor {
-            name: name,
+            name,
             browsing_context_actor,
         }
     }

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -73,7 +73,7 @@ pub struct ThreadActor {
 
 impl ThreadActor {
     pub fn new(name: String) -> ThreadActor {
-        ThreadActor { name: name }
+        ThreadActor { name }
     }
 }
 

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -107,7 +107,7 @@ pub struct HighResolutionStamp(f64);
 impl HighResolutionStamp {
     pub fn new(start_stamp: PreciseTime, time: PreciseTime) -> HighResolutionStamp {
         let duration = start_stamp.to(time).as_micros();
-        HighResolutionStamp(duration as f64 / 1000 as f64)
+        HighResolutionStamp(duration as f64 / 1000_f64)
     }
 
     pub fn wrap(time: f64) -> HighResolutionStamp {
@@ -132,10 +132,10 @@ impl TimelineActor {
         let marker_types = vec![TimelineMarkerType::Reflow, TimelineMarkerType::DOMEvent];
 
         TimelineActor {
-            name: name,
-            pipeline: pipeline,
-            marker_types: marker_types,
-            script_sender: script_sender,
+            name,
+            pipeline,
+            marker_types,
+            script_sender,
             is_recording: Arc::new(Mutex::new(false)),
             stream: RefCell::new(None),
 
@@ -217,7 +217,7 @@ impl Actor for TimelineActor {
                     if let Some(true) = with_ticks.as_bool() {
                         let framerate_actor = Some(FramerateActor::create(
                             registry,
-                            self.pipeline.clone(),
+                            self.pipeline,
                             self.script_sender.clone(),
                         ));
                         *self.framerate_actor.borrow_mut() = framerate_actor;
@@ -274,7 +274,7 @@ impl Actor for TimelineActor {
             "isRecording" => {
                 let msg = IsRecordingReply {
                     from: self.name(),
-                    value: self.is_recording.lock().unwrap().clone(),
+                    value: *self.is_recording.lock().unwrap(),
                 };
 
                 let _ = stream.write_json_packet(&msg);
@@ -297,9 +297,9 @@ impl Emitter {
     ) -> Emitter {
         Emitter {
             from: name,
-            stream: stream,
-            registry: registry,
-            start_stamp: start_stamp,
+            stream,
+            registry,
+            start_stamp,
 
             framerate_actor: framerate_actor_name,
             memory_actor: memory_actor_name,
@@ -320,7 +320,7 @@ impl Emitter {
         let end_time = PreciseTime::now();
         let reply = MarkersEmitterReply {
             type_: "markers".to_owned(),
-            markers: markers,
+            markers,
             from: self.from.clone(),
             endTime: HighResolutionStamp::new(self.start_stamp, end_time),
         };

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -10,6 +10,7 @@
 #![crate_name = "devtools"]
 #![crate_type = "rlib"]
 #![allow(non_snake_case)]
+#![allow(clippy::too_many_arguments)]
 #![deny(unsafe_code)]
 
 use std::borrow::ToOwned;
@@ -135,7 +136,7 @@ fn run_server(
     port: u16,
     embedder: EmbedderProxy,
 ) {
-    let bound = TcpListener::bind(&("0.0.0.0", port)).ok().and_then(|l| {
+    let bound = TcpListener::bind(("0.0.0.0", port)).ok().and_then(|l| {
         l.local_addr()
             .map(|addr| addr.port())
             .ok()
@@ -259,7 +260,7 @@ fn run_server(
             Some(bc) => bc,
             None => return,
         };
-        let name = match browsing_contexts.get(&bc) {
+        let name = match browsing_contexts.get(bc) {
             Some(name) => name,
             None => return,
         };
@@ -299,7 +300,7 @@ fn run_server(
                 name: worker_name.clone(),
                 console: console_name.clone(),
                 thread: thread_name,
-                id: id,
+                id,
                 url: page_info.url.clone(),
                 type_: WorkerType::Dedicated,
                 script_chan: script_sender,
@@ -324,7 +325,7 @@ fn run_server(
                         page_info,
                         pipeline,
                         script_sender,
-                        &mut *actors,
+                        &mut actors,
                     );
                     let name = browsing_context_actor.name();
                     browsing_contexts.insert(browsing_context, name.clone());
@@ -366,7 +367,7 @@ fn run_server(
         let actors = actors.lock().unwrap();
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(id), UniqueId::Worker);
-        console_actor.handle_page_error(page_error, id, &*actors);
+        console_actor.handle_page_error(page_error, id, &actors);
     }
 
     fn handle_console_message(
@@ -392,7 +393,7 @@ fn run_server(
         let actors = actors.lock().unwrap();
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(id), UniqueId::Worker);
-        console_actor.handle_console_api(console_message, id, &*actors);
+        console_actor.handle_console_api(console_message, id, &actors);
     }
 
     fn find_console_actor(

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -80,7 +80,7 @@ impl JsonPacketStream for TcpStream {
                         Ok(packet_len) => packet_len,
                         Err(_) => return Err("nonvalid UTF8 in packet length".to_owned()),
                     };
-                    let packet_len = match u64::from_str_radix(&packet_len_str, 10) {
+                    let packet_len = match packet_len_str.parse::<u64>() {
                         Ok(packet_len) => packet_len,
                         Err(_) => return Err("packet length missing / not parsable".to_owned()),
                     };


### PR DESCRIPTION
Fixes several clippy warnings in the `components/devtools` directory. It is part of #31500.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500.
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
