### PR TITLE
Enable `css-text` explicitly in include.ini

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -94,6 +94,7 @@ skip: true
   [css-speech]
     skip: true
   [css-text]
+    skip: false
     [i18n]
       skip: true
   [css-typed-om]

--- a/tests/wpt/meta-legacy-layout/css/css-text/letter-spacing/letter-spacing-percent-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/letter-spacing/letter-spacing-percent-001.html.ini
@@ -1,0 +1,2 @@
+[letter-spacing-percent-001.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text/parsing/letter-spacing-valid.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/parsing/letter-spacing-valid.html.ini
@@ -1,0 +1,12 @@
+[letter-spacing-valid.html]
+  [e.style['letter-spacing'\] = "120%" should set the property value]
+    expected: FAIL
+
+  [e.style['letter-spacing'\] = "-10%" should set the property value]
+    expected: FAIL
+
+  [e.style['letter-spacing'\] = "calc(2ch - 30%)" should set the property value]
+    expected: FAIL
+
+  [e.style['letter-spacing'\] = "calc(40% + 50px)" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text/word-spacing/word-spacing-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/word-spacing/word-spacing-002.html.ini
@@ -1,0 +1,2 @@
+[word-spacing-002.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text/word-spacing/word-spacing-percent-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/word-spacing/word-spacing-percent-001.html.ini
@@ -1,0 +1,2 @@
+[word-spacing-percent-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-percent-001.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-percent-001.html.ini
@@ -1,0 +1,2 @@
+[letter-spacing-percent-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/parsing/letter-spacing-computed.html.ini
+++ b/tests/wpt/meta/css/css-text/parsing/letter-spacing-computed.html.ini
@@ -1,7 +1,4 @@
 [letter-spacing-computed.html]
-  [Property letter-spacing value 'normal' computes to '0px']
-    expected: FAIL
-
   [Property letter-spacing value '110%']
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-text/parsing/letter-spacing-valid.html.ini
+++ b/tests/wpt/meta/css/css-text/parsing/letter-spacing-valid.html.ini
@@ -1,0 +1,12 @@
+[letter-spacing-valid.html]
+  [e.style['letter-spacing'\] = "120%" should set the property value]
+    expected: FAIL
+
+  [e.style['letter-spacing'\] = "-10%" should set the property value]
+    expected: FAIL
+
+  [e.style['letter-spacing'\] = "calc(2ch - 30%)" should set the property value]
+    expected: FAIL
+
+  [e.style['letter-spacing'\] = "calc(40% + 50px)" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-spacing/word-spacing-002.html.ini
+++ b/tests/wpt/meta/css/css-text/word-spacing/word-spacing-002.html.ini
@@ -1,0 +1,2 @@
+[word-spacing-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-spacing/word-spacing-percent-001.html.ini
+++ b/tests/wpt/meta/css/css-text/word-spacing/word-spacing-percent-001.html.ini
@@ -1,0 +1,2 @@
+[word-spacing-percent-001.html]
+  expected: FAIL


### PR DESCRIPTION
The WPT test runner has some strange logic for determining the key's value for a node like `[css]` or `[css-text]`. In this logic, if the node doesn't have an explicit value for a key (here `skip`), then the implicit root node's setting i.e key/value pair at the top of the file that is not nested under a heading, is used as the default fallback value [1]. Only when the implicit root node doesn't have an explicit value set does the logic starts looking at the current node's parent [2].

In our case, in `include.ini` the default value for `skip` is `true` as that is the first line in the file.
Since `[css-text]` doesn't have `skip` set explicitly, the default value of `true` is used even though the parent's value is `false`.

[1]: https://github.com/servo/servo/blob/2bafcf9f182bf907c4a4391f931a7364bd7b804f/tests/wpt/tests/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py#L265
[2]: https://github.com/servo/servo/blob/2bafcf9f182bf907c4a4391f931a7364bd7b804f/tests/wpt/tests/tools/wptrunner/wptrunner/manifestinclude.py#L59


- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only enable previously disabled tests.

