### PR TITLE
Fix several clippy warnings in components/hyper_serde

### DIFF
--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -138,7 +138,7 @@ impl<T> De<T> {
     /// Returns a new `De` wrapper
     #[inline(always)]
     pub fn new(v: T) -> Self {
-        De { v: v }
+        De { v }
     }
 }
 
@@ -366,7 +366,7 @@ impl<'de> Deserialize<'de> for De<HeaderMap> {
                     for v in values.0.iter() {
                         headers.append(
                             HeaderName::from_str(&k).map_err(V::Error::custom)?,
-                            HeaderValue::from_bytes(&v).map_err(V::Error::custom)?,
+                            HeaderValue::from_bytes(v).map_err(V::Error::custom)?,
                         );
                     }
                 }
@@ -453,7 +453,7 @@ impl<'a> Serialize for Ser<'a, HeaderMap> {
                 &Value(
                     &values
                         .iter()
-                        .map(|v| v.as_bytes().iter().cloned().collect())
+                        .map(|v| v.as_bytes().to_vec())
                         .collect::<Vec<Vec<u8>>>(),
                     self.pretty,
                 ),
@@ -531,7 +531,7 @@ impl<'a> Serialize for Ser<'a, Mime> {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.v.to_string())
+        serializer.serialize_str(&self.v.as_ref())
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes several clippy warnings in the components/hyper_serde directory. It is part of https://github.com/servo/servo/issues/31500.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
