### PR TITLE
clippy: Fix more warnings

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -13,9 +13,7 @@ pub use crate::platform::*;
 mod platform {
     use std::os::raw::c_void;
 
-    use jemallocator;
-
-    pub use self::jemallocator::Jemalloc as Allocator;
+    pub use jemallocator::Jemalloc as Allocator;
 
     /// Get the size of a heap block.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -208,7 +208,7 @@ impl BackgroundHangMonitorChan {
         BackgroundHangMonitorChan {
             sender,
             _tether: tether,
-            component_id: component_id,
+            component_id,
             disconnected: Default::default(),
             monitoring_enabled,
         }
@@ -360,7 +360,7 @@ impl BackgroundHangMonitorWorker {
             let profile = stack.to_hangprofile();
             let name = match self.component_names.get(&id) {
                 Some(ref s) => format!("\"{}\"", s),
-                None => format!("null"),
+                None => "null".to_string(),
             };
             let json = format!(
                 "{}{{ \"name\": {}, \"namespace\": {}, \"index\": {}, \"type\": \"{:?}\", \
@@ -389,12 +389,10 @@ impl BackgroundHangMonitorWorker {
                 .checked_sub(Instant::now() - self.last_sample)
                 .unwrap_or_else(|| Duration::from_millis(0));
             after(duration)
+        } else if self.monitoring_enabled {
+            after(Duration::from_millis(100))
         } else {
-            if self.monitoring_enabled {
-                after(Duration::from_millis(100))
-            } else {
-                never()
-            }
+            never()
         };
 
         let received = select! {

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -312,14 +312,14 @@ struct BackgroundHangMonitorWorker {
     monitoring_enabled: bool,
 }
 
-type PortSender = Arc<Sender<(MonitoredComponentId, MonitoredComponentMsg)>>;
-type Port = Receiver<(MonitoredComponentId, MonitoredComponentMsg)>;
+type MonitoredComponentSender = Sender<(MonitoredComponentId, MonitoredComponentMsg)>;
+type MonitoredComponentReceiver = Receiver<(MonitoredComponentId, MonitoredComponentMsg)>;
 
 impl BackgroundHangMonitorWorker {
     fn new(
         constellation_chan: IpcSender<HangMonitorAlert>,
         control_port: IpcReceiver<BackgroundHangMonitorControlMsg>,
-        (port_sender, port): (PortSender, Port),
+        (port_sender, port): (Arc<MonitoredComponentSender>, MonitoredComponentReceiver),
         tether_port: Receiver<Never>,
         monitoring_enabled: bool,
     ) -> Self {

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -403,10 +403,7 @@ impl BackgroundHangMonitorWorker {
             },
             recv(self.tether_port) -> event => {
                 // This arm can only reached by a tether disconnection
-                match event {
-                    Ok(x) => match x {}
-                    Err(_) => {}
-                }
+                if let Ok(x) = event { match x {} }
 
                 // All associated `HangMonitorRegister` and
                 // `BackgroundHangMonitorChan` have been dropped. Suppress

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -401,10 +401,8 @@ impl BackgroundHangMonitorWorker {
                 // gets disconnected.
                 Some(event.unwrap())
             },
-            recv(self.tether_port) -> event => {
+            recv(self.tether_port) -> _ => {
                 // This arm can only reached by a tether disconnection
-                if let Ok(x) = event { match x {} }
-
                 // All associated `HangMonitorRegister` and
                 // `BackgroundHangMonitorChan` have been dropped. Suppress
                 // `signal_to_exit` and exit the BHM.

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -99,7 +99,7 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
             target_os = "linux",
             not(any(target_arch = "arm", target_arch = "aarch64"))
         ))]
-        let sampler = crate::sampler_linux::LinuxSampler::new();
+        let sampler = crate::sampler_linux::LinuxSampler::new_boxed();
         #[cfg(any(
             target_os = "android",
             all(target_os = "linux", any(target_arch = "arm", target_arch = "aarch64"))
@@ -312,14 +312,14 @@ struct BackgroundHangMonitorWorker {
     monitoring_enabled: bool,
 }
 
+type PortSender = Arc<Sender<(MonitoredComponentId, MonitoredComponentMsg)>>;
+type Port = Receiver<(MonitoredComponentId, MonitoredComponentMsg)>;
+
 impl BackgroundHangMonitorWorker {
     fn new(
         constellation_chan: IpcSender<HangMonitorAlert>,
         control_port: IpcReceiver<BackgroundHangMonitorControlMsg>,
-        (port_sender, port): (
-            Arc<Sender<(MonitoredComponentId, MonitoredComponentMsg)>>,
-            Receiver<(MonitoredComponentId, MonitoredComponentMsg)>,
-        ),
+        (port_sender, port): (PortSender, Port),
         tether_port: Receiver<Never>,
         monitoring_enabled: bool,
     ) -> Self {

--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -4,7 +4,6 @@
 
 use std::ptr;
 
-
 use msg::constellation_msg::{HangProfile, HangProfileSymbol};
 
 const MAX_NATIVE_FRAMES: usize = 1024;

--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -4,7 +4,7 @@
 
 use std::ptr;
 
-use backtrace;
+
 use msg::constellation_msg::{HangProfile, HangProfileSymbol};
 
 const MAX_NATIVE_FRAMES: usize = 1024;
@@ -64,12 +64,12 @@ impl NativeStack {
         instruction_ptr: *mut std::ffi::c_void,
         stack_ptr: *mut std::ffi::c_void,
     ) -> Result<(), ()> {
-        if !(self.count < MAX_NATIVE_FRAMES) {
+        if self.count >= MAX_NATIVE_FRAMES {
             return Err(());
         }
         self.instruction_ptrs[self.count] = instruction_ptr;
         self.stack_ptrs[self.count] = stack_ptr;
-        self.count = self.count + 1;
+        self.count += 1;
         Ok(())
     }
 
@@ -85,7 +85,7 @@ impl NativeStack {
                 // TODO: use the demangled or C++ demangled symbols if available.
                 let name = symbol
                     .name()
-                    .map(|n| String::from_utf8_lossy(&n.as_bytes()).to_string());
+                    .map(|n| String::from_utf8_lossy(n.as_bytes()).to_string());
                 let filename = symbol.filename().map(|n| n.to_string_lossy().to_string());
                 let lineno = symbol.lineno();
                 profile.backtrace.push(HangProfileSymbol {

--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -17,7 +17,7 @@ pub struct DummySampler;
 
 impl DummySampler {
     #[allow(dead_code)]
-    pub fn new() -> Box<dyn Sampler> {
+    pub fn new_boxed() -> Box<dyn Sampler> {
         Box::new(DummySampler)
     }
 }

--- a/components/background_hang_monitor/sampler_linux.rs
+++ b/components/background_hang_monitor/sampler_linux.rs
@@ -6,8 +6,7 @@
 
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicPtr, Ordering};
-use std::{io, mem, process, ptr, thread};
-
+use std::{cmp, io, mem, process, ptr, thread};
 
 use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
 use unwind_sys::{
@@ -181,12 +180,10 @@ fn step(cursor: *mut unw_cursor_t) -> Result<bool, i32> {
         }
 
         let ret = unw_step(cursor);
-        if ret > 0 {
-            Ok(true)
-        } else if ret == 0 {
-            Ok(false)
-        } else {
-            Err(ret)
+        match ret.cmp(&0) {
+            cmp::Ordering::Less => Err(ret),
+            cmp::Ordering::Greater => Ok(true),
+            cmp::Ordering::Equal => Ok(false),
         }
     }
 }

--- a/components/background_hang_monitor/sampler_linux.rs
+++ b/components/background_hang_monitor/sampler_linux.rs
@@ -8,7 +8,7 @@ use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::{io, mem, process, ptr, thread};
 
-use libc;
+
 use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
 use unwind_sys::{
     unw_cursor_t, unw_get_reg, unw_init_local, unw_step, UNW_ESUCCESS, UNW_REG_IP, UNW_REG_SP,

--- a/components/background_hang_monitor/sampler_linux.rs
+++ b/components/background_hang_monitor/sampler_linux.rs
@@ -137,7 +137,7 @@ pub struct LinuxSampler {
 
 impl LinuxSampler {
     #[allow(unsafe_code, dead_code)]
-    pub fn new() -> Box<dyn Sampler> {
+    pub fn new_boxed() -> Box<dyn Sampler> {
         let thread_id = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
         let handler = SigHandler::SigAction(sigprof_handler);
         let action = SigAction::new(
@@ -219,6 +219,7 @@ impl Sampler for LinuxSampler {
             let ret = unsafe { unw_init_local(cursor.as_mut_ptr(), context) };
             result = if ret == UNW_ESUCCESS {
                 let mut native_stack = NativeStack::new();
+                #[allow(clippy::while_let_loop)] // False positive
                 loop {
                     let ip = match get_register(cursor.as_mut_ptr(), RegNum::Ip) {
                         Ok(ip) => ip,

--- a/components/bluetooth/adapter.rs
+++ b/components/bluetooth/adapter.rs
@@ -197,6 +197,7 @@ impl BluetoothAdapter {
     pub fn create_discovery_session(&self) -> Result<BluetoothDiscoverySession, Box<dyn Error>> {
         let discovery_session = match self {
             #[cfg(all(target_os = "linux", feature = "native-bluetooth"))]
+            #[allow(clippy::arc_with_non_send_sync)] // Problem with underlying library
             BluetoothAdapter::Bluez(inner) => BluetoothDiscoverySession::Bluez(Arc::new(
                 BluetoothDiscoverySessionBluez::create_session(inner.get_id())?,
             )),

--- a/components/bluetooth/adapter.rs
+++ b/components/bluetooth/adapter.rs
@@ -292,7 +292,10 @@ impl BluetoothAdapter {
     pub fn set_id(&self, id: String) -> Result<(), Box<dyn Error>> {
         match self {
             #[cfg(feature = "bluetooth-test")]
-            BluetoothAdapter::Mock(inner) => Ok(inner.set_id(id)),
+            BluetoothAdapter::Mock(inner) => {
+                inner.set_id(id);
+                Ok(())
+            },
             _ => Err(Box::from(
                 "Error! Test functions are not supported on real devices!",
             )),

--- a/components/bluetooth/bluetooth.rs
+++ b/components/bluetooth/bluetooth.rs
@@ -192,9 +192,8 @@ impl BluetoothDevice {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        match self {
-            BluetoothDevice::Mock(fake_adapter) => fake_adapter.set_id(id),
-            _ => (),
+        if let BluetoothDevice::Mock(fake_adapter) = self {
+            fake_adapter.set_id(id)
         }
     }
 

--- a/components/bluetooth/bluetooth.rs
+++ b/components/bluetooth/bluetooth.rs
@@ -83,8 +83,7 @@ use super::macros::get_inner_and_call;
 use super::macros::get_inner_and_call_test_func;
 
 #[cfg(feature = "bluetooth-test")]
-const NOT_SUPPORTED_ON_MOCK_ERROR: &'static str =
-    "Error! The first parameter must be a mock structure!";
+const NOT_SUPPORTED_ON_MOCK_ERROR: &str = "Error! The first parameter must be a mock structure!";
 
 #[derive(Debug)]
 pub enum BluetoothDiscoverySession {
@@ -194,7 +193,7 @@ impl BluetoothDevice {
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
         match self {
-            &BluetoothDevice::Mock(ref fake_adapter) => fake_adapter.set_id(id),
+            BluetoothDevice::Mock(fake_adapter) => fake_adapter.set_id(id),
             _ => (),
         }
     }
@@ -473,9 +472,8 @@ impl BluetoothGATTService {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        match self {
-            &BluetoothGATTService::Mock(ref fake_service) => fake_service.set_id(id),
-            _ => (),
+        if let BluetoothGATTService::Mock(fake_service) = self {
+            fake_service.set_id(id)
         }
     }
 
@@ -578,11 +576,8 @@ impl BluetoothGATTCharacteristic {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        match self {
-            &BluetoothGATTCharacteristic::Mock(ref fake_characteristic) => {
-                fake_characteristic.set_id(id)
-            },
-            _ => (),
+        if let BluetoothGATTCharacteristic::Mock(fake_characteristic) = self {
+            fake_characteristic.set_id(id)
         }
     }
 
@@ -710,9 +705,8 @@ impl BluetoothGATTDescriptor {
 
     #[cfg(feature = "bluetooth-test")]
     pub fn set_id(&self, id: String) {
-        match self {
-            &BluetoothGATTDescriptor::Mock(ref fake_descriptor) => fake_descriptor.set_id(id),
-            _ => (),
+        if let BluetoothGATTDescriptor::Mock(fake_descriptor) = self {
+            fake_descriptor.set_id(id)
         }
     }
 

--- a/components/bluetooth/test.rs
+++ b/components/bluetooth/test.rs
@@ -18,46 +18,45 @@ use crate::BluetoothManager;
 
 thread_local!(pub static CACHED_IDS: RefCell<HashSet<Uuid>> = RefCell::new(HashSet::new()));
 
-const ADAPTER_ERROR: &'static str = "No adapter found";
-const WRONG_DATA_SET_ERROR: &'static str = "Wrong data set name was provided";
-const READ_FLAG: &'static str = "read";
-const WRITE_FLAG: &'static str = "write";
-const NOTIFY_FLAG: &'static str = "notify";
+const ADAPTER_ERROR: &str = "No adapter found";
+const WRONG_DATA_SET_ERROR: &str = "Wrong data set name was provided";
+const READ_FLAG: &str = "read";
+const WRITE_FLAG: &str = "write";
+const NOTIFY_FLAG: &str = "notify";
 
 // Adapter names
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=65
-const NOT_PRESENT_ADAPTER: &'static str = "NotPresentAdapter";
+const NOT_PRESENT_ADAPTER: &str = "NotPresentAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=83
-const NOT_POWERED_ADAPTER: &'static str = "NotPoweredAdapter";
+const NOT_POWERED_ADAPTER: &str = "NotPoweredAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=118
-const EMPTY_ADAPTER: &'static str = "EmptyAdapter";
+const EMPTY_ADAPTER: &str = "EmptyAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=126
-const GLUCOSE_HEART_RATE_ADAPTER: &'static str = "GlucoseHeartRateAdapter";
+const GLUCOSE_HEART_RATE_ADAPTER: &str = "GlucoseHeartRateAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=135
-const UNICODE_DEVICE_ADAPTER: &'static str = "UnicodeDeviceAdapter";
+const UNICODE_DEVICE_ADAPTER: &str = "UnicodeDeviceAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=205
-const MISSING_SERVICE_HEART_RATE_ADAPTER: &'static str = "MissingServiceHeartRateAdapter";
+const MISSING_SERVICE_HEART_RATE_ADAPTER: &str = "MissingServiceHeartRateAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=219
-const MISSING_CHARACTERISTIC_HEART_RATE_ADAPTER: &'static str =
-    "MissingCharacteristicHeartRateAdapter";
-const MISSING_DESCRIPTOR_HEART_RATE_ADAPTER: &'static str = "MissingDescriptorHeartRateAdapter";
+const MISSING_CHARACTERISTIC_HEART_RATE_ADAPTER: &str = "MissingCharacteristicHeartRateAdapter";
+const MISSING_DESCRIPTOR_HEART_RATE_ADAPTER: &str = "MissingDescriptorHeartRateAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=234
-const HEART_RATE_ADAPTER: &'static str = "HeartRateAdapter";
+const HEART_RATE_ADAPTER: &str = "HeartRateAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=250
-const EMPTY_NAME_HEART_RATE_ADAPTER: &'static str = "EmptyNameHeartRateAdapter";
+const EMPTY_NAME_HEART_RATE_ADAPTER: &str = "EmptyNameHeartRateAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=267
-const NO_NAME_HEART_RATE_ADAPTER: &'static str = "NoNameHeartRateAdapter";
+const NO_NAME_HEART_RATE_ADAPTER: &str = "NoNameHeartRateAdapter";
 // https://cs.chromium.org/chromium/src/content/shell/browser/layout_test/layout_test_bluetooth_adapter_provider.h?l=284
-const TWO_HEART_RATE_SERVICES_ADAPTER: &'static str = "TwoHeartRateServicesAdapter";
-const BLOCKLIST_TEST_ADAPTER: &'static str = "BlocklistTestAdapter";
+const TWO_HEART_RATE_SERVICES_ADAPTER: &str = "TwoHeartRateServicesAdapter";
+const BLOCKLIST_TEST_ADAPTER: &str = "BlocklistTestAdapter";
 
 // Device names
-const CONNECTABLE_DEVICE_NAME: &'static str = "Connectable Device";
-const EMPTY_DEVICE_NAME: &'static str = "";
+const CONNECTABLE_DEVICE_NAME: &str = "Connectable Device";
+const EMPTY_DEVICE_NAME: &str = "";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#glucosedevice
-const GLUCOSE_DEVICE_NAME: &'static str = "Glucose Device";
+const GLUCOSE_DEVICE_NAME: &str = "Glucose Device";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#heartratedevice
-const HEART_RATE_DEVICE_NAME: &'static str = "Heart Rate Device";
+const HEART_RATE_DEVICE_NAME: &str = "Heart Rate Device";
 const UNICODE_DEVICE_NAME: &'static str = "❤❤❤❤❤❤❤❤❤";
 
 // Device addresses
@@ -65,63 +64,57 @@ const CONNECTABLE_DEVICE_ADDRESS: &'static str = "00:00:00:00:00:04";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#glucosedevice
 const GLUCOSE_DEVICE_ADDRESS: &'static str = "00:00:00:00:00:02";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#heartratedevice
-const HEART_RATE_DEVICE_ADDRESS: &'static str = "00:00:00:00:00:03";
-const UNICODE_DEVICE_ADDRESS: &'static str = "00:00:00:00:00:01";
+const HEART_RATE_DEVICE_ADDRESS: &str = "00:00:00:00:00:03";
+const UNICODE_DEVICE_ADDRESS: &str = "00:00:00:00:00:01";
 
 // Service UUIDs
-const BLOCKLIST_TEST_SERVICE_UUID: &'static str = "611c954a-263b-4f4a-aab6-01ddb953f985";
+const BLOCKLIST_TEST_SERVICE_UUID: &str = "611c954a-263b-4f4a-aab6-01ddb953f985";
 // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.device_information.xml
-const DEVICE_INFORMATION_UUID: &'static str = "0000180a-0000-1000-8000-00805f9b34fb";
+const DEVICE_INFORMATION_UUID: &str = "0000180a-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.generic_access.xml
-const GENERIC_ACCESS_SERVICE_UUID: &'static str = "00001800-0000-1000-8000-00805f9b34fb";
+const GENERIC_ACCESS_SERVICE_UUID: &str = "00001800-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.glucose.xml
-const GLUCOSE_SERVICE_UUID: &'static str = "00001808-0000-1000-8000-00805f9b34fb";
+const GLUCOSE_SERVICE_UUID: &str = "00001808-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.heart_rate.xml
-const HEART_RATE_SERVICE_UUID: &'static str = "0000180d-0000-1000-8000-00805f9b34fb";
+const HEART_RATE_SERVICE_UUID: &str = "0000180d-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.service.human_interface_device.xml
-const HUMAN_INTERFACE_DEVICE_SERVICE_UUID: &'static str = "00001812-0000-1000-8000-00805f9b34fb";
+const HUMAN_INTERFACE_DEVICE_SERVICE_UUID: &str = "00001812-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.tx_power.xml
-const TX_POWER_SERVICE_UUID: &'static str = "00001804-0000-1000-8000-00805f9b34fb";
+const TX_POWER_SERVICE_UUID: &str = "00001804-0000-1000-8000-00805f9b34fb";
 
 // Characteristic UUIDs
-const BLOCKLIST_EXCLUDE_READS_CHARACTERISTIC_UUID: &'static str =
-    "bad1c9a2-9a5b-4015-8b60-1579bbbf2135";
+const BLOCKLIST_EXCLUDE_READS_CHARACTERISTIC_UUID: &str = "bad1c9a2-9a5b-4015-8b60-1579bbbf2135";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.characteristic.body_sensor_location.xml
-const BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID: &'static str =
-    "00002a38-0000-1000-8000-00805f9b34fb";
+const BODY_SENSOR_LOCATION_CHARACTERISTIC_UUID: &str = "00002a38-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.characteristic.gap.device_name.xml
-const DEVICE_NAME_CHARACTERISTIC_UUID: &'static str = "00002a00-0000-1000-8000-00805f9b34fb";
+const DEVICE_NAME_CHARACTERISTIC_UUID: &str = "00002a00-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.characteristic.heart_rate_measurement.xml
-const HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID: &'static str =
-    "00002a37-0000-1000-8000-00805f9b34fb";
+const HEART_RATE_MEASUREMENT_CHARACTERISTIC_UUID: &str = "00002a37-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.characteristic.gap.peripheral_privacy_flag.xml
-const PERIPHERAL_PRIVACY_FLAG_CHARACTERISTIC_UUID: &'static str =
-    "00002a02-0000-1000-8000-00805f9b34fb";
+const PERIPHERAL_PRIVACY_FLAG_CHARACTERISTIC_UUID: &str = "00002a02-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.characteristic.serial_number_string.xml
-const SERIAL_NUMBER_STRING_UUID: &'static str = "00002a25-0000-1000-8000-00805f9b34fb";
+const SERIAL_NUMBER_STRING_UUID: &str = "00002a25-0000-1000-8000-00805f9b34fb";
 
 // Descriptor UUIDs
-const BLOCKLIST_EXCLUDE_READS_DESCRIPTOR_UUID: &'static str =
-    "aaaaaaaa-aaaa-1181-0510-810819516110";
-const BLOCKLIST_DESCRIPTOR_UUID: &'static str = "07711111-6104-0970-7011-1107105110aa";
+const BLOCKLIST_EXCLUDE_READS_DESCRIPTOR_UUID: &str = "aaaaaaaa-aaaa-1181-0510-810819516110";
+const BLOCKLIST_DESCRIPTOR_UUID: &str = "07711111-6104-0970-7011-1107105110aa";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.descriptor.gatt.characteristic_user_description.xml
-const CHARACTERISTIC_USER_DESCRIPTION_UUID: &'static str = "00002901-0000-1000-8000-00805f9b34fb";
+const CHARACTERISTIC_USER_DESCRIPTION_UUID: &str = "00002901-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml
-const CLIENT_CHARACTERISTIC_CONFIGURATION_UUID: &'static str =
-    "00002902-0000-1000-8000-00805f9b34fb";
+const CLIENT_CHARACTERISTIC_CONFIGURATION_UUID: &str = "00002902-0000-1000-8000-00805f9b34fb";
 // https://www.bluetooth.com/specifications/gatt/
 // viewer?attributeXmlFile=org.bluetooth.descriptor.number_of_digitals.xml
-const NUMBER_OF_DIGITALS_UUID: &'static str = "00002909-0000-1000-8000-00805f9b34fb";
+const NUMBER_OF_DIGITALS_UUID: &str = "00002909-0000-1000-8000-00805f9b34fb";
 
-const HEART_RATE_DEVICE_NAME_DESCRIPTION: &'static str = "The name of this device.";
+const HEART_RATE_DEVICE_NAME_DESCRIPTION: &str = "The name of this device.";
 
 fn generate_id() -> Uuid {
     let mut id = Uuid::nil();
@@ -130,7 +123,7 @@ fn generate_id() -> Uuid {
         id = Uuid::new_v4();
         CACHED_IDS.with(|cache| {
             if !cache.borrow().contains(&id) {
-                cache.borrow_mut().insert(id.clone());
+                cache.borrow_mut().insert(id);
                 generated = true;
             }
         });
@@ -539,7 +532,7 @@ pub fn test(manager: &mut BluetoothManager, data_set_name: String) -> Result<(),
         },
         GLUCOSE_HEART_RATE_ADAPTER => {
             set_adapter(adapter, GLUCOSE_HEART_RATE_ADAPTER.to_owned())?;
-            let _ = create_glucose_heart_rate_devices(adapter)?;
+            create_glucose_heart_rate_devices(adapter)?;
         },
         UNICODE_DEVICE_ADAPTER => {
             set_adapter(adapter, UNICODE_DEVICE_ADAPTER.to_owned())?;
@@ -561,12 +554,12 @@ pub fn test(manager: &mut BluetoothManager, data_set_name: String) -> Result<(),
                 MISSING_CHARACTERISTIC_HEART_RATE_ADAPTER.to_owned(),
             )?;
 
-            let _ = create_missing_characterisitc_heart_rate_device(adapter)?;
+            create_missing_characterisitc_heart_rate_device(adapter)?;
         },
         MISSING_DESCRIPTOR_HEART_RATE_ADAPTER => {
             set_adapter(adapter, MISSING_DESCRIPTOR_HEART_RATE_ADAPTER.to_owned())?;
 
-            let _ = create_missing_descriptor_heart_rate_device(adapter)?;
+            create_missing_descriptor_heart_rate_device(adapter)?;
         },
         HEART_RATE_ADAPTER => {
             set_adapter(adapter, HEART_RATE_ADAPTER.to_owned())?;
@@ -588,14 +581,14 @@ pub fn test(manager: &mut BluetoothManager, data_set_name: String) -> Result<(),
         TWO_HEART_RATE_SERVICES_ADAPTER => {
             set_adapter(adapter, TWO_HEART_RATE_SERVICES_ADAPTER.to_owned())?;
 
-            let _ = create_two_heart_rate_services_device(adapter)?;
+            create_two_heart_rate_services_device(adapter)?;
         },
         BLOCKLIST_TEST_ADAPTER => {
             set_adapter(adapter, BLOCKLIST_TEST_ADAPTER.to_owned())?;
 
-            let _ = create_blocklisted_device(adapter)?;
+            create_blocklisted_device(adapter)?;
         },
         _ => return Err(Box::from(WRONG_DATA_SET_ERROR.to_string())),
     }
-    return Ok(());
+    Ok(())
 }

--- a/components/bluetooth/test.rs
+++ b/components/bluetooth/test.rs
@@ -57,12 +57,12 @@ const EMPTY_DEVICE_NAME: &str = "";
 const GLUCOSE_DEVICE_NAME: &str = "Glucose Device";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#heartratedevice
 const HEART_RATE_DEVICE_NAME: &str = "Heart Rate Device";
-const UNICODE_DEVICE_NAME: &'static str = "❤❤❤❤❤❤❤❤❤";
+const UNICODE_DEVICE_NAME: &str = "❤❤❤❤❤❤❤❤❤";
 
 // Device addresses
-const CONNECTABLE_DEVICE_ADDRESS: &'static str = "00:00:00:00:00:04";
+const CONNECTABLE_DEVICE_ADDRESS: &str = "00:00:00:00:00:04";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#glucosedevice
-const GLUCOSE_DEVICE_ADDRESS: &'static str = "00:00:00:00:00:02";
+const GLUCOSE_DEVICE_ADDRESS: &str = "00:00:00:00:00:02";
 // https://webbluetoothcg.github.io/web-bluetooth/tests.html#heartratedevice
 const HEART_RATE_DEVICE_ADDRESS: &str = "00:00:00:00:00:03";
 const UNICODE_DEVICE_ADDRESS: &str = "00:00:00:00:00:01";

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -74,23 +74,23 @@ impl PathState {
 pub trait Backend {
     fn get_composition_op(&self, opts: &DrawOptions) -> CompositionOp;
     fn need_to_draw_shadow(&self, color: &Color) -> bool;
-    fn set_shadow_color<'a>(&mut self, color: RGBA, state: &mut CanvasPaintState<'a>);
-    fn set_fill_style<'a>(
+    fn set_shadow_color(&mut self, color: RGBA, state: &mut CanvasPaintState<'_>);
+    fn set_fill_style(
         &mut self,
         style: FillOrStrokeStyle,
-        state: &mut CanvasPaintState<'a>,
+        state: &mut CanvasPaintState<'_>,
         drawtarget: &dyn GenericDrawTarget,
     );
-    fn set_stroke_style<'a>(
+    fn set_stroke_style(
         &mut self,
         style: FillOrStrokeStyle,
-        state: &mut CanvasPaintState<'a>,
+        state: &mut CanvasPaintState<'_>,
         drawtarget: &dyn GenericDrawTarget,
     );
-    fn set_global_composition<'a>(
+    fn set_global_composition(
         &mut self,
         op: CompositionOrBlending,
-        state: &mut CanvasPaintState<'a>,
+        state: &mut CanvasPaintState<'_>,
     );
     fn create_drawtarget(&self, size: Size2D<u64>) -> Box<dyn GenericDrawTarget>;
     fn recreate_paint_state<'a>(&self, state: &CanvasPaintState<'a>) -> CanvasPaintState<'a>;
@@ -222,10 +222,9 @@ impl<'a> PathBuilderRef<'a> {
             Some(i) => i,
             None => return None,
         };
-        match self.builder.get_current_point() {
-            Some(point) => Some(inverse.transform_point(Point2D::new(point.x, point.y))),
-            None => None,
-        }
+        self.builder
+            .get_current_point()
+            .map(|point| inverse.transform_point(Point2D::new(point.x, point.y)))
     }
 
     fn close(&mut self) {
@@ -428,7 +427,7 @@ impl<'a> CanvasData<'a> {
         let source_rect = source_rect.ceil();
         // It discards the extra pixels (if any) that won't be painted
         let image_data = if Rect::from_size(image_size).contains_rect(&source_rect) {
-            pixels::rgba8_get_rect(&image_data, image_size.to_u64(), source_rect.to_u64()).into()
+            pixels::rgba8_get_rect(image_data, image_size.to_u64(), source_rect.to_u64()).into()
         } else {
             image_data.into()
         };
@@ -493,7 +492,7 @@ impl<'a> CanvasData<'a> {
         let font = font_style.map_or_else(
             || load_system_font_from_style(None),
             |style| {
-                with_thread_local_font_context(&self, |font_context| {
+                with_thread_local_font_context(self, |font_context| {
                     let font_group = font_context.font_group(ServoArc::new(style.clone()));
                     let font = font_group
                         .borrow_mut()
@@ -651,7 +650,7 @@ impl<'a> CanvasData<'a> {
         }
 
         if self.need_to_draw_shadow() {
-            self.draw_with_shadow(&rect, |new_draw_target: &mut dyn GenericDrawTarget| {
+            self.draw_with_shadow(rect, |new_draw_target: &mut dyn GenericDrawTarget| {
                 new_draw_target.stroke_rect(
                     rect,
                     self.state.stroke_style.clone(),
@@ -918,7 +917,7 @@ impl<'a> CanvasData<'a> {
             Some(p) => p,
             None => {
                 self.path_builder().move_to(cp1);
-                cp1.clone()
+                *cp1
             },
         };
         let cp1 = *cp1;
@@ -1042,7 +1041,7 @@ impl<'a> CanvasData<'a> {
                 }
             },
         }
-        self.state.transform = transform.clone();
+        self.state.transform = *transform;
         self.drawtarget.set_transform(transform)
     }
 
@@ -1200,10 +1199,7 @@ impl<'a> CanvasData<'a> {
         draw_shadow_source(&mut *new_draw_target);
         self.drawtarget.draw_surface_with_shadow(
             new_draw_target.snapshot(),
-            &Point2D::new(
-                shadow_src_rect.origin.x as f32,
-                shadow_src_rect.origin.y as f32,
-            ),
+            &Point2D::new(shadow_src_rect.origin.x, shadow_src_rect.origin.y),
             &self.state.shadow_color,
             &Vector2D::new(
                 self.state.shadow_offset_x as f32,
@@ -1394,18 +1390,18 @@ fn load_system_font_from_style(font_style: Option<&FontStyleStruct>) -> Option<F
         })
         .weight(Weight(style.font_weight.value()))
         .stretch(Stretch(style.font_stretch.to_percentage().0));
-    let font_handle = match SystemSource::new().select_best_match(&family_names, &properties) {
+    let font_handle = match SystemSource::new().select_best_match(&family_names, properties) {
         Ok(handle) => handle,
         Err(e) => {
             error!("error getting font handle for style {:?}: {}", style, e);
-            return load_default_system_fallback_font(&properties);
+            return load_default_system_fallback_font(properties);
         },
     };
     match font_handle.load() {
         Ok(f) => Some(f),
         Err(e) => {
             error!("error loading font for style {:?}: {}", style, e);
-            load_default_system_fallback_font(&properties)
+            load_default_system_fallback_font(properties)
         },
     }
 }

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -130,7 +130,7 @@ impl<'a> CanvasPaintThread<'a> {
 
         let font_cache_thread = self.font_cache_thread.clone();
 
-        let canvas_id = self.next_canvas_id.clone();
+        let canvas_id = self.next_canvas_id;
         self.next_canvas_id.0 += 1;
 
         let canvas_data = CanvasData::new(
@@ -139,7 +139,7 @@ impl<'a> CanvasPaintThread<'a> {
             antialias,
             font_cache_thread,
         );
-        self.canvases.insert(canvas_id.clone(), canvas_data);
+        self.canvases.insert(canvas_id, canvas_data);
 
         canvas_id
     }
@@ -181,7 +181,7 @@ impl<'a> CanvasPaintThread<'a> {
                 source_rect,
                 smoothing_enabled,
             ) => self.canvas(canvas_id).draw_image(
-                &*image_data,
+                image_data,
                 image_size,
                 dest_rect,
                 source_rect,

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -65,7 +65,7 @@ impl WebGLComm {
         WebGLComm {
             webgl_threads: WebGLThreads(sender),
             image_handler: Box::new(external),
-            webxr_layer_grand_manager: webxr_layer_grand_manager,
+            webxr_layer_grand_manager,
         }
     }
 }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -289,7 +289,7 @@ impl WebGLThread {
             let exit = self.handle_msg(msg, &webgl_chan);
             if exit {
                 // Call remove_context functions in order to correctly delete WebRender image keys.
-                let context_ids: Vec<WebGLContextId> = self.contexts.keys().map(|id| *id).collect();
+                let context_ids: Vec<WebGLContextId> = self.contexts.keys().copied().collect();
                 for id in context_ids {
                     self.remove_webgl_context(id);
                 }
@@ -323,7 +323,7 @@ impl WebGLThread {
                             &mut self.bound_context_id,
                         )
                         .expect("WebGLContext not found");
-                        let glsl_version = Self::get_glsl_version(&*data.gl);
+                        let glsl_version = Self::get_glsl_version(&data.gl);
                         let api_type = match data.gl.get_type() {
                             gl::GlType::Gl => GlType::Gl,
                             gl::GlType::Gles => GlType::Gles,
@@ -458,7 +458,7 @@ impl WebGLThread {
             WebGLImpl::apply(
                 &self.device,
                 &data.ctx,
-                &*data.gl,
+                &data.gl,
                 &mut data.state,
                 &data.attributes,
                 command,
@@ -497,12 +497,12 @@ impl WebGLThread {
             ContextAttributeFlags::STENCIL;
         let context_attributes = &ContextAttributes {
             version: webgl_version.to_surfman_version(self.api_type),
-            flags: flags,
+            flags,
         };
 
         let context_descriptor = self
             .device
-            .create_context_descriptor(&context_attributes)
+            .create_context_descriptor(context_attributes)
             .map_err(|err| format!("Failed to create context descriptor: {:?}", err))?;
 
         let safe_size = Size2D::new(
@@ -562,7 +562,7 @@ impl WebGLThread {
             })),
         };
 
-        let limits = GLLimits::detect(&*gl, webgl_version);
+        let limits = GLLimits::detect(&gl, webgl_version);
 
         let size = clamp_viewport(&gl, requested_size);
         if safe_size != size {
@@ -583,7 +583,7 @@ impl WebGLThread {
             .device
             .context_surface_info(&ctx)
             .map_err(|err| format!("Failed to get context surface info: {:?}", err))?
-            .ok_or_else(|| format!("Failed to get context surface info"))?
+            .ok_or_else(|| "Failed to get context surface info".to_string())?
             .framebuffer_object;
 
         gl.bind_framebuffer(gl::FRAMEBUFFER, framebuffer);
@@ -616,7 +616,7 @@ impl WebGLThread {
         };
         debug!("Created state {:?}", state);
 
-        state.restore_invariant(&*gl);
+        state.restore_invariant(&gl);
         debug_assert_eq!(gl.get_error(), gl::NO_ERROR);
 
         self.contexts.insert(
@@ -663,7 +663,7 @@ impl WebGLThread {
         // Check to see if any of the current framebuffer bindings are the surface we're about to
         // throw out. If so, we'll have to reset them after destroying the surface.
         let framebuffer_rebinding_info =
-            FramebufferRebindingInfo::detect(&self.device, &data.ctx, &*data.gl);
+            FramebufferRebindingInfo::detect(&self.device, &data.ctx, &data.gl);
 
         // Resize the swap chains
         if let Some(swap_chain) = self.webrender_swap_chains.get(context_id) {
@@ -676,14 +676,14 @@ impl WebGLThread {
                 .resize(&mut self.device, &mut data.ctx, size.to_i32())
                 .map_err(|err| format!("Failed to resize swap chain: {:?}", err))?;
             swap_chain
-                .clear_surface(&mut self.device, &mut data.ctx, &*data.gl, clear_color)
+                .clear_surface(&mut self.device, &mut data.ctx, &data.gl, clear_color)
                 .map_err(|err| format!("Failed to clear resized swap chain: {:?}", err))?;
         } else {
             error!("Failed to find swap chain");
         }
 
         // Reset framebuffer bindings as appropriate.
-        framebuffer_rebinding_info.apply(&self.device, &data.ctx, &*data.gl);
+        framebuffer_rebinding_info.apply(&self.device, &data.ctx, &data.gl);
         debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
         let has_alpha = data
@@ -764,7 +764,7 @@ impl WebGLThread {
             // Check to see if any of the current framebuffer bindings are the surface we're about
             // to swap out. If so, we'll have to reset them after destroying the surface.
             let framebuffer_rebinding_info =
-                FramebufferRebindingInfo::detect(&self.device, &data.ctx, &*data.gl);
+                FramebufferRebindingInfo::detect(&self.device, &data.ctx, &data.gl);
             debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             debug!("Getting swap chain for {:?}", context_id);
@@ -779,7 +779,7 @@ impl WebGLThread {
                     &mut self.device,
                     &mut data.ctx,
                     if data.attributes.preserve_drawing_buffer {
-                        PreserveBuffer::Yes(&*data.gl)
+                        PreserveBuffer::Yes(&data.gl)
                     } else {
                         PreserveBuffer::No
                     },
@@ -795,14 +795,14 @@ impl WebGLThread {
                     .contains(ContextAttributeFlags::ALPHA);
                 let clear_color = [0.0, 0.0, 0.0, !alpha as i32 as f32];
                 swap_chain
-                    .clear_surface(&mut self.device, &mut data.ctx, &*data.gl, clear_color)
+                    .clear_surface(&mut self.device, &mut data.ctx, &data.gl, clear_color)
                     .unwrap();
                 debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
             }
 
             // Rebind framebuffers as appropriate.
             debug!("Rebinding {:?}", context_id);
-            framebuffer_rebinding_info.apply(&self.device, &data.ctx, &*data.gl);
+            framebuffer_rebinding_info.apply(&self.device, &data.ctx, &data.gl);
             debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             let SurfaceInfo {
@@ -941,7 +941,7 @@ impl WebGLThread {
         image_buffer_kind: ImageBufferKind,
     ) -> ImageData {
         let data = ExternalImageData {
-            id: ExternalImageId(context_id.0 as u64),
+            id: ExternalImageId(context_id.0),
             channel_index: 0,
             image_type: ExternalImageType::TextureHandle(image_buffer_kind),
         };
@@ -1288,7 +1288,7 @@ impl WebGLImpl {
                 sender.send(location).unwrap();
             },
             WebGLCommand::GetUniformLocation(program_id, ref name, ref chan) => {
-                Self::uniform_location(gl, program_id, &name, chan)
+                Self::uniform_location(gl, program_id, name, chan)
             },
             WebGLCommand::GetShaderInfoLog(shader_id, ref chan) => {
                 Self::shader_info_log(gl, shader_id, chan)
@@ -1297,7 +1297,7 @@ impl WebGLImpl {
                 Self::program_info_log(gl, program_id, chan)
             },
             WebGLCommand::CompileShader(shader_id, ref source) => {
-                Self::compile_shader(gl, shader_id, &source)
+                Self::compile_shader(gl, shader_id, source)
             },
             WebGLCommand::CreateBuffer(ref chan) => Self::create_buffer(gl, chan),
             WebGLCommand::CreateFramebuffer(ref chan) => Self::create_framebuffer(gl, chan),
@@ -1426,7 +1426,7 @@ impl WebGLImpl {
                     alpha_treatment,
                     y_axis_treatment,
                     pixel_format,
-                    Cow::Borrowed(&*data),
+                    Cow::Borrowed(data),
                 );
 
                 gl.pixel_store_i(gl::UNPACK_ALIGNMENT, unpacking_alignment as i32);
@@ -1489,7 +1489,7 @@ impl WebGLImpl {
                     alpha_treatment,
                     y_axis_treatment,
                     pixel_format,
-                    Cow::Borrowed(&*data),
+                    Cow::Borrowed(data),
                 );
 
                 gl.pixel_store_i(gl::UNPACK_ALIGNMENT, unpacking_alignment as i32);
@@ -1519,7 +1519,7 @@ impl WebGLImpl {
                     size.width as i32,
                     size.height as i32,
                     0,
-                    &*data,
+                    data,
                 );
             },
             WebGLCommand::CompressedTexSubImage2D {
@@ -1533,13 +1533,13 @@ impl WebGLImpl {
             } => {
                 gl.compressed_tex_sub_image_2d(
                     target,
-                    level as i32,
-                    xoffset as i32,
-                    yoffset as i32,
+                    level,
+                    xoffset,
+                    yoffset,
                     size.width as i32,
                     size.height as i32,
                     format,
-                    &*data,
+                    data,
                 );
             },
             WebGLCommand::TexStorage2D(target, levels, internal_format, width, height) => gl
@@ -1561,7 +1561,7 @@ impl WebGLImpl {
                 ),
             WebGLCommand::DrawingBufferWidth(ref sender) => {
                 let size = device
-                    .context_surface_info(&ctx)
+                    .context_surface_info(ctx)
                     .unwrap()
                     .expect("Where's the front buffer?")
                     .size;
@@ -1569,7 +1569,7 @@ impl WebGLImpl {
             },
             WebGLCommand::DrawingBufferHeight(ref sender) => {
                 let size = device
-                    .context_surface_info(&ctx)
+                    .context_surface_info(ctx)
                     .unwrap()
                     .expect("Where's the front buffer?")
                     .size;
@@ -1615,7 +1615,7 @@ impl WebGLImpl {
                 sender.send(value).unwrap();
             },
             WebGLCommand::ClientWaitSync(sync_id, flags, timeout, ref sender) => {
-                let value = gl.client_wait_sync(sync_id.get() as *const _, flags, timeout as u64);
+                let value = gl.client_wait_sync(sync_id.get() as *const _, flags, timeout);
                 sender.send(value).unwrap();
             },
             WebGLCommand::WaitSync(sync_id, flags, timeout) => {
@@ -1744,10 +1744,10 @@ impl WebGLImpl {
                 }
             },
             WebGLCommand::TexParameteri(target, param, value) => {
-                gl.tex_parameter_i(target, param as u32, value)
+                gl.tex_parameter_i(target, param, value)
             },
             WebGLCommand::TexParameterf(target, param, value) => {
-                gl.tex_parameter_f(target, param as u32, value)
+                gl.tex_parameter_f(target, param, value)
             },
             WebGLCommand::LinkProgram(program_id, ref sender) => {
                 return sender.send(Self::link_program(gl, program_id)).unwrap();
@@ -2503,7 +2503,7 @@ impl WebGLImpl {
 ///
 /// To avoid hard-coding this we would need to use the `sh::GetAttributes` and `sh::GetUniforms`
 /// API to look up the `x.name` and `x.mappedName` members.
-const ANGLE_NAME_PREFIX: &'static str = "_u";
+const ANGLE_NAME_PREFIX: &str = "_u";
 
 fn to_name_in_compiled_shader(s: &str) -> String {
     map_dot_separated(s, |s, mapped| {
@@ -3057,7 +3057,7 @@ impl WebXRBridge {
             .map_err(|_| WebXRError::CommunicationError)?;
         let manager = factory.build(device, contexts)?;
         let manager_id = unsafe { WebXRLayerManagerId::new(self.next_manager_id) };
-        self.next_manager_id = self.next_manager_id + 1;
+        self.next_manager_id += 1;
         self.managers.insert(manager_id, manager);
         Ok(manager_id)
     }
@@ -3315,8 +3315,8 @@ impl<'a> WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'a> {
         let data = WebGLThread::make_current_if_needed_mut(
             device,
             WebGLContextId::from(context_id),
-            &mut self.contexts,
-            &mut self.bound_context_id,
+            self.contexts,
+            self.bound_context_id,
         )?;
         Some(&mut data.ctx)
     }
@@ -3324,8 +3324,8 @@ impl<'a> WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'a> {
         let data = WebGLThread::make_current_if_needed(
             device,
             WebGLContextId::from(context_id),
-            &self.contexts,
-            &mut self.bound_context_id,
+            self.contexts,
+            self.bound_context_id,
         )?;
         Some(&data.gl)
     }

--- a/components/compositing/build.rs
+++ b/components/compositing/build.rs
@@ -42,7 +42,7 @@ fn main() {
                     let revision = if parsed.len() > 1 { parsed[1] } else { source };
 
                     let mut revision_module_file = File::create(revision_file_path).unwrap();
-                    write!(&mut revision_module_file, "{}", format!("\"{}\"", revision)).unwrap();
+                    write!(&mut revision_module_file, "\"{}\"", revision).unwrap();
                 },
                 _ => panic!("Cannot find package definitions in lockfile"),
             }

--- a/components/compositing/build.rs
+++ b/components/compositing/build.rs
@@ -38,10 +38,10 @@ fn main() {
                         .and_then(|pkg| pkg.get("source").and_then(|source| source.as_str()))
                         .unwrap_or("unknown");
 
-                    let parsed: Vec<&str> = source.split("#").collect();
+                    let parsed: Vec<&str> = source.split('#').collect();
                     let revision = if parsed.len() > 1 { parsed[1] } else { source };
 
-                    let mut revision_module_file = File::create(&revision_file_path).unwrap();
+                    let mut revision_module_file = File::create(revision_file_path).unwrap();
                     write!(&mut revision_module_file, "{}", format!("\"{}\"", revision)).unwrap();
                 },
                 _ => panic!("Cannot find package definitions in lockfile"),

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -525,7 +525,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     /// and the system creates a new native surface that needs to bound to the current
     /// context.
     #[allow(unsafe_code)]
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)] // It has an unsafe block inside
     pub fn replace_native_surface(&mut self, native_widget: *mut c_void, coords: DeviceIntSize) {
         debug!("Replacing native surface in compositor: {native_widget:?}");
         let connection = self.rendering_context.connection();

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -525,6 +525,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     /// and the system creates a new native surface that needs to bound to the current
     /// context.
     #[allow(unsafe_code)]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn replace_native_surface(&mut self, native_widget: *mut c_void, coords: DeviceIntSize) {
         debug!("Replacing native surface in compositor: {native_widget:?}");
         let connection = self.rendering_context.connection();

--- a/components/config/basedir.rs
+++ b/components/config/basedir.rs
@@ -35,7 +35,7 @@ pub fn default_config_dir() -> Option<PathBuf> {
     Some(config_dir)
 }
 
-#[cfg(all(target_os = "windows"))]
+#[cfg(target_os = "windows")]
 pub fn default_config_dir() -> Option<PathBuf> {
     let mut config_dir = ::dirs_next::config_dir().unwrap();
     config_dir.push("Servo");

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -7,7 +7,7 @@
 
 use std::default::Default;
 use std::fs::{self, File};
-use std::io::{self, Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{RwLock, RwLockReadGuard};
@@ -385,7 +385,7 @@ pub enum OutputOptions {
 }
 
 fn args_fail(msg: &str) -> ! {
-    writeln!(io::stderr(), "{}", msg).unwrap();
+    eprintln!("{}", msg);
     process::exit(1)
 }
 
@@ -793,7 +793,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         set_pref!(layout.threads, layout_threads as i64);
     }
 
-    return ArgumentParsingResult::ChromeProcess(opt_match);
+    ArgumentParsingResult::ChromeProcess(opt_match)
 }
 
 pub enum ArgumentParsingResult {

--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -55,10 +55,7 @@ impl PrefValue {
     }
 
     pub fn is_missing(&self) -> bool {
-        match self {
-            PrefValue::Missing => true,
-            _ => false,
-        }
+        matches!(self, PrefValue::Missing)
     }
 
     pub fn from_json_value(value: &Value) -> Option<Self> {
@@ -164,7 +161,7 @@ impl From<PrefValue> for [f64; 4] {
                 let mut f = values.into_iter().map(|v| v.try_into());
                 if f.all(|v| v.is_ok()) {
                     let f = f.flatten().collect::<Vec<f64>>();
-                    return [f[0], f[1], f[2], f[3]];
+                    [f[0], f[1], f[2], f[3]]
                 } else {
                     panic!(
                         "Cannot convert PrefValue to {:?}",
@@ -191,7 +188,7 @@ pub enum PrefError {
 impl fmt::Display for PrefError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            PrefError::NoSuchPref(s) | PrefError::InvalidValue(s) => f.write_str(&s),
+            PrefError::NoSuchPref(s) | PrefError::InvalidValue(s) => f.write_str(s),
             PrefError::JsonParseErr(e) => e.fmt(f),
         }
     }
@@ -261,7 +258,7 @@ impl<'m, P: Clone> Preferences<'m, P> {
     }
 
     /// Creates an iterator over all keys and values
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (String, PrefValue)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (String, PrefValue)> + '_ {
         let prefs = self.user_prefs.read().unwrap();
         self.accessors
             .iter()
@@ -269,16 +266,17 @@ impl<'m, P: Clone> Preferences<'m, P> {
     }
 
     /// Creates an iterator over all keys
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = &'a str> + 'a {
+    pub fn keys(&self) -> impl Iterator<Item = &'_ str> {
         self.accessors.keys().map(String::as_str)
     }
 
-    fn set_inner<V>(&self, key: &str, mut prefs: &mut P, val: V) -> Result<(), PrefError>
+    fn set_inner<V>(&self, key: &str, prefs: &mut P, val: V) -> Result<(), PrefError>
     where
         V: Into<PrefValue>,
     {
         if let Some(accessor) = self.accessors.get(key) {
-            Ok((accessor.setter)(&mut prefs, val.into()))
+            (accessor.setter)(prefs, val.into());
+            Ok(())
         } else {
             Err(PrefError::NoSuchPref(String::from(key)))
         }

--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -198,6 +198,7 @@ impl std::error::Error for PrefError {}
 
 pub struct Accessor<P, V> {
     pub getter: Box<dyn Fn(&P) -> V + Sync>,
+    #[allow(clippy::type_complexity)]
     pub setter: Box<dyn Fn(&mut P, V) + Sync>,
 }
 

--- a/components/config_plugins/parse.rs
+++ b/components/config_plugins/parse.rs
@@ -132,7 +132,7 @@ impl Parse for RootTypeDef {
 impl Parse for NewTypeDef {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let content;
-        #[allow(clippy::eval_order_dependence)]
+        #[allow(clippy::mixed_read_write_in_expression)]
         Ok(NewTypeDef {
             _braces: braced!(content in input),
             fields: Punctuated::parse_terminated_with(&content, Field::parse)?,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2832,7 +2832,7 @@ where
 
         warn!("creating replacement pipeline for crash page");
 
-        let new_pipeline_id = PipelineId::new();
+        let new_pipeline_id = PipelineId::default();
         let new_load_data = LoadData {
             crash: Some(
                 backtrace
@@ -2953,7 +2953,7 @@ where
         top_level_browsing_context_id: TopLevelBrowsingContextId,
     ) {
         let window_size = self.window_size.initial_viewport;
-        let pipeline_id = PipelineId::new();
+        let pipeline_id = PipelineId::default();
         let msg = (
             Some(top_level_browsing_context_id),
             EmbedderMsg::WebViewOpened(top_level_browsing_context_id),
@@ -3558,7 +3558,7 @@ where
                     HistoryEntryReplacement::Disabled => None,
                 };
 
-                let new_pipeline_id = PipelineId::new();
+                let new_pipeline_id = PipelineId::default();
                 let sandbox = IFrameSandboxState::IFrameUnsandboxed;
                 self.new_pipeline(
                     new_pipeline_id,
@@ -3860,7 +3860,7 @@ where
                     Some(pipeline) => pipeline.opener,
                     None => None,
                 };
-                let new_pipeline_id = PipelineId::new();
+                let new_pipeline_id = PipelineId::default();
                 self.new_pipeline(
                     new_pipeline_id,
                     browsing_context_id,

--- a/components/constellation/webview.rs
+++ b/components/constellation/webview.rs
@@ -138,9 +138,9 @@ mod test {
         let mut webviews = WebViewManager::default();
 
         // add() adds the webview to the map, but does not focus it.
-        webviews.add(TopLevelBrowsingContextId::new(), 'a');
-        webviews.add(TopLevelBrowsingContextId::new(), 'b');
-        webviews.add(TopLevelBrowsingContextId::new(), 'c');
+        webviews.add(TopLevelBrowsingContextId::default(), 'a');
+        webviews.add(TopLevelBrowsingContextId::default(), 'b');
+        webviews.add(TopLevelBrowsingContextId::default(), 'c');
         assert_eq!(
             webviews_sorted(&webviews),
             vec![

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -20,13 +20,13 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
     // Work around https://github.com/rust-lang/rust/issues/46489
     let attributes: TokenStream = attributes.to_string().parse().unwrap();
 
-    let output: TokenStream = attributes.into_iter().chain(input.into_iter()).collect();
+    let output: TokenStream = attributes.into_iter().chain(input).collect();
 
     let item: Item = syn::parse(output).unwrap();
 
     if let Item::Struct(s) = item {
         let s2 = s.clone();
-        if s.generics.params.len() > 0 {
+        if !s.generics.params.is_empty() {
             return quote!(#s2).into();
         }
         if let Fields::Named(ref f) = s.fields {

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -4,7 +4,7 @@
 
 #![recursion_limit = "128"]
 
-use proc_macro2;
+
 use quote::{quote, TokenStreamExt};
 use syn::parse_quote;
 

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -4,7 +4,6 @@
 
 #![recursion_limit = "128"]
 
-
 use quote::{quote, TokenStreamExt};
 use syn::parse_quote;
 

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -96,7 +96,7 @@ impl FontTableTagConversions for FontTableTag {
             (self >> 24) as u8,
             (self >> 16) as u8,
             (self >> 8) as u8,
-            (self >> 0) as u8,
+            *self as u8,
         ];
         str::from_utf8(&bytes).unwrap().to_owned()
     }
@@ -190,7 +190,7 @@ impl Font {
         let metrics = handle.metrics();
 
         Font {
-            handle: handle,
+            handle,
             shaper: None,
             descriptor,
             metrics,
@@ -403,7 +403,7 @@ impl FontGroup {
             .font_family
             .families
             .iter()
-            .map(|family| FontGroupFamily::new(descriptor.clone(), &family))
+            .map(|family| FontGroupFamily::new(descriptor.clone(), family))
             .collect();
 
         FontGroup {
@@ -419,7 +419,7 @@ impl FontGroup {
     /// found, returns None.
     pub fn find_by_codepoint<S: FontSource>(
         &mut self,
-        mut font_context: &mut FontContext<S>,
+        font_context: &mut FontContext<S>,
         codepoint: char,
     ) -> Option<FontRef> {
         let should_look_for_small_caps = self.descriptor.variant == font_variant_caps::T::SmallCaps &&
@@ -436,43 +436,40 @@ impl FontGroup {
 
         let has_glyph = |font: &FontRef| font.borrow().has_glyph_for(codepoint);
 
-        if let Some(font) = self.find(&mut font_context, |font| has_glyph(font)) {
+        if let Some(font) = self.find(font_context, has_glyph) {
             return font_or_synthesized_small_caps(font);
         }
 
         if let Some(ref last_matching_fallback) = self.last_matching_fallback {
-            if has_glyph(&last_matching_fallback) {
+            if has_glyph(last_matching_fallback) {
                 return font_or_synthesized_small_caps(last_matching_fallback.clone());
             }
         }
 
-        if let Some(font) = self.find_fallback(&mut font_context, Some(codepoint), has_glyph) {
+        if let Some(font) = self.find_fallback(font_context, Some(codepoint), has_glyph) {
             self.last_matching_fallback = Some(font.clone());
             return font_or_synthesized_small_caps(font);
         }
 
-        self.first(&mut font_context)
+        self.first(font_context)
     }
 
     /// Find the first available font in the group, or the first available fallback font.
-    pub fn first<S: FontSource>(
-        &mut self,
-        mut font_context: &mut FontContext<S>,
-    ) -> Option<FontRef> {
-        self.find(&mut font_context, |_| true)
-            .or_else(|| self.find_fallback(&mut font_context, None, |_| true))
+    pub fn first<S: FontSource>(&mut self, font_context: &mut FontContext<S>) -> Option<FontRef> {
+        self.find(font_context, |_| true)
+            .or_else(|| self.find_fallback(font_context, None, |_| true))
     }
 
     /// Find a font which returns true for `predicate`. This method mutates because we may need to
     /// load new font data in the process of finding a suitable font.
-    fn find<S, P>(&mut self, mut font_context: &mut FontContext<S>, predicate: P) -> Option<FontRef>
+    fn find<S, P>(&mut self, font_context: &mut FontContext<S>, predicate: P) -> Option<FontRef>
     where
         S: FontSource,
         P: FnMut(&FontRef) -> bool,
     {
         self.families
             .iter_mut()
-            .filter_map(|family| family.font(&mut font_context))
+            .filter_map(|family| family.font(font_context))
             .find(predicate)
     }
 
@@ -567,8 +564,7 @@ impl RunMetrics {
 }
 
 pub fn get_and_reset_text_shaping_performance_counter() -> usize {
-    let value = TEXT_SHAPING_PERFORMANCE_COUNTER.swap(0, Ordering::SeqCst);
-    value
+    TEXT_SHAPING_PERFORMANCE_COUNTER.swap(0, Ordering::SeqCst)
 }
 
 /// The scope within which we will look for a font.

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -371,9 +371,7 @@ impl FontCache {
         self.local_families.clear();
         for_each_available_family(|family_name| {
             let family_name = LowercaseString::new(&family_name);
-            self.local_families
-                .entry(family_name)
-                .or_insert_with(|| FontTemplates::new());
+            self.local_families.entry(family_name).or_default();
         });
     }
 

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -31,6 +31,7 @@ use crate::platform::font_list::{
 use crate::platform::font_template::FontTemplateData;
 
 /// A list of font templates that make up a given font family.
+#[derive(Default)]
 pub struct FontTemplates {
     templates: Vec<FontTemplate>,
 }
@@ -61,10 +62,6 @@ impl SerializedFontTemplate {
 }
 
 impl FontTemplates {
-    pub fn new() -> FontTemplates {
-        FontTemplates { templates: vec![] }
-    }
-
     /// Find a font in this family that matches a given descriptor.
     pub fn find_font_for_style(
         &mut self,
@@ -121,12 +118,6 @@ impl FontTemplates {
         if let Ok(template) = FontTemplate::new(identifier, maybe_data) {
             self.templates.push(template);
         }
-    }
-}
-
-impl Default for FontTemplates {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -268,7 +259,7 @@ impl FontCache {
         };
 
         if !self.web_families.contains_key(&family_name) {
-            let templates = FontTemplates::new();
+            let templates = FontTemplates::default();
             self.web_families.insert(family_name.clone(), templates);
         }
 
@@ -497,7 +488,7 @@ impl FontCacheThread {
                     generic_fonts,
                     local_families: HashMap::new(),
                     web_families: HashMap::new(),
-                    font_context: FontContextHandle::new(),
+                    font_context: FontContextHandle::default(),
                     core_resource_thread,
                     webrender_api,
                     webrender_fonts: HashMap::new(),

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -65,7 +65,7 @@ pub struct FontContext<S: FontSource> {
 
 impl<S: FontSource> FontContext<S> {
     pub fn new(font_source: S) -> FontContext<S> {
-        let handle = FontContextHandle::new();
+        let handle = FontContextHandle::default();
         FontContext {
             platform_handle: handle,
             font_source,

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -99,8 +99,8 @@ impl<S: FontSource> FontContext<S> {
             style,
         };
 
-        if let Some(ref font_group) = self.font_group_cache.get(&cache_key) {
-            return (*font_group).clone();
+        if let Some(font_group) = self.font_group_cache.get(&cache_key) {
+            return font_group.clone();
         }
 
         let font_group = Rc::new(RefCell::new(FontGroup::new(&cache_key.style)));
@@ -150,30 +150,27 @@ impl<S: FontSource> FontContext<S> {
             family_descriptor: family_descriptor.clone(),
         };
 
-        self.font_cache
-            .get(&cache_key)
-            .map(|v| v.clone())
-            .unwrap_or_else(|| {
-                debug!(
-                    "FontContext::font cache miss for font_descriptor={:?} family_descriptor={:?}",
-                    font_descriptor, family_descriptor
-                );
+        self.font_cache.get(&cache_key).cloned().unwrap_or_else(|| {
+            debug!(
+                "FontContext::font cache miss for font_descriptor={:?} family_descriptor={:?}",
+                font_descriptor, family_descriptor
+            );
 
-                let font = self
-                    .font_template(&font_descriptor.template_descriptor, family_descriptor)
-                    .and_then(|template_info| {
-                        self.create_font(
-                            template_info,
-                            font_descriptor.to_owned(),
-                            synthesized_small_caps_font,
-                        )
-                        .ok()
-                    })
-                    .map(|font| Rc::new(RefCell::new(font)));
+            let font = self
+                .font_template(&font_descriptor.template_descriptor, family_descriptor)
+                .and_then(|template_info| {
+                    self.create_font(
+                        template_info,
+                        font_descriptor.to_owned(),
+                        synthesized_small_caps_font,
+                    )
+                    .ok()
+                })
+                .map(|font| Rc::new(RefCell::new(font)));
 
-                self.font_cache.insert(cache_key, font.clone());
-                font
-            })
+            self.font_cache.insert(cache_key, font.clone());
+            font
+        })
     }
 
     fn font_template(
@@ -182,11 +179,11 @@ impl<S: FontSource> FontContext<S> {
         family_descriptor: &FontFamilyDescriptor,
     ) -> Option<FontTemplateInfo> {
         let cache_key = FontTemplateCacheKey {
-            template_descriptor: template_descriptor.clone(),
+            template_descriptor: *template_descriptor,
             family_descriptor: family_descriptor.clone(),
         };
 
-        self.font_template_cache.get(&cache_key).map(|v| v.clone()).unwrap_or_else(|| {
+        self.font_template_cache.get(&cache_key).cloned().unwrap_or_else(|| {
             debug!(
                 "FontContext::font_template cache miss for template_descriptor={:?} family_descriptor={:?}",
                 template_descriptor,
@@ -194,7 +191,7 @@ impl<S: FontSource> FontContext<S> {
             );
 
             let template_info = self.font_source.font_template(
-                template_descriptor.clone(),
+                *template_descriptor,
                 family_descriptor.clone(),
             );
 

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -111,9 +111,7 @@ impl FontTemplate {
 
         let maybe_strong_ref = maybe_data.map(Arc::new);
 
-        let maybe_weak_ref = maybe_strong_ref
-            .as_ref()
-            .map(|strong_ref| Arc::downgrade(strong_ref));
+        let maybe_weak_ref = maybe_strong_ref.as_ref().map(Arc::downgrade);
 
         Ok(FontTemplate {
             identifier,

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -109,18 +109,14 @@ impl FontTemplate {
             None => None,
         };
 
-        let maybe_strong_ref = match maybe_data {
-            Some(data) => Some(Arc::new(data)),
-            None => None,
-        };
+        let maybe_strong_ref = maybe_data.map(Arc::new);
 
-        let maybe_weak_ref = match maybe_strong_ref {
-            Some(ref strong_ref) => Some(Arc::downgrade(strong_ref)),
-            None => None,
-        };
+        let maybe_weak_ref = maybe_strong_ref
+            .as_ref()
+            .map(|strong_ref| Arc::downgrade(strong_ref));
 
         Ok(FontTemplate {
-            identifier: identifier,
+            identifier,
             descriptor: None,
             weak_ref: maybe_weak_ref,
             strong_ref: maybe_strong_ref,
@@ -161,7 +157,7 @@ impl FontTemplate {
         fctx: &FontContextHandle,
         requested_desc: &FontTemplateDescriptor,
     ) -> Option<Arc<FontTemplateData>> {
-        self.descriptor(&fctx).and_then(|descriptor| {
+        self.descriptor(fctx).and_then(|descriptor| {
             if *requested_desc == descriptor {
                 self.data().ok()
             } else {
@@ -177,7 +173,7 @@ impl FontTemplate {
         font_context: &FontContextHandle,
         requested_descriptor: &FontTemplateDescriptor,
     ) -> Option<(Arc<FontTemplateData>, f32)> {
-        self.descriptor(&font_context).and_then(|descriptor| {
+        self.descriptor(font_context).and_then(|descriptor| {
             self.data()
                 .ok()
                 .map(|data| (data, descriptor.distance_from(requested_descriptor)))

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -147,7 +147,7 @@ impl FontHandleMethods for FontHandle {
         let face = create_face(ft_ctx, &template, pt_size)?;
 
         let mut handle = FontHandle {
-            face: face,
+            face,
             font_data: template,
             context_handle: fctx.clone(),
             can_do_fast_shaping: false,
@@ -264,7 +264,7 @@ impl FontHandleMethods for FontHandle {
             let res = FT_Load_Glyph(self.face, glyph as FT_UInt, GLYPH_LOAD_FLAGS);
             if succeeded(res) {
                 let void_glyph = (*self.face).glyph;
-                let slot: FT_GlyphSlot = mem::transmute(void_glyph);
+                let slot: FT_GlyphSlot = void_glyph;
                 assert!(!slot.is_null());
                 let advance = (*slot).metrics.horiAdvance;
                 debug!("h_advance for {} is {}", glyph, advance);
@@ -313,17 +313,17 @@ impl FontHandleMethods for FontHandle {
             .map_or(max_advance, |advance| self.font_units_to_au(advance));
 
         let metrics = FontMetrics {
-            underline_size: underline_size,
-            underline_offset: underline_offset,
-            strikeout_size: strikeout_size,
-            strikeout_offset: strikeout_offset,
-            leading: leading,
-            x_height: x_height,
-            em_size: em_size,
-            ascent: ascent,
+            underline_size,
+            underline_offset,
+            strikeout_size,
+            strikeout_offset,
+            leading,
+            x_height,
+            em_size,
+            ascent,
             descent: -descent, // linux font's seem to use the opposite sign from mac
-            max_advance: max_advance,
-            average_advance: average_advance,
+            max_advance,
+            average_advance,
             line_gap: height,
         };
 
@@ -402,10 +402,10 @@ impl<'a> FontHandle {
         // face.size is a *c_void in the bindings, presumably to avoid
         // recursive structural types
         let size: &FT_SizeRec = unsafe { mem::transmute(&(*face.size)) };
-        let metrics: &FT_Size_Metrics = &(*size).metrics;
+        let metrics: &FT_Size_Metrics = &(size).metrics;
 
         let em_size = face.units_per_EM as f64;
-        let x_scale = (metrics.x_ppem as f64) / em_size as f64;
+        let x_scale = (metrics.x_ppem as f64) / em_size;
 
         // If this isn't true then we're scaling one of the axes wrong
         assert_eq!(metrics.x_ppem, metrics.y_ppem);

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -392,7 +392,7 @@ impl<'a> FontHandle {
         }
     }
 
-    #[allow(clippy::mut_from_ref)]
+    #[allow(clippy::mut_from_ref)] // Intended for this function
     fn face_rec_mut(&'a self) -> &'a mut FT_FaceRec {
         unsafe { &mut (*self.face) }
     }

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -392,6 +392,7 @@ impl<'a> FontHandle {
         }
     }
 
+    #[allow(clippy::mut_from_ref)]
     fn face_rec_mut(&'a self) -> &'a mut FT_FaceRec {
         unsafe { &mut (*self.face) }
     }

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -134,3 +134,9 @@ impl FontContextHandle {
         }
     }
 }
+
+impl Default for FontContextHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -109,8 +109,8 @@ impl MallocSizeOf for FontContextHandle {
     }
 }
 
-impl FontContextHandle {
-    pub fn new() -> FontContextHandle {
+impl Default for FontContextHandle {
+    fn default() -> Self {
         let user = Box::into_raw(Box::new(User { size: 0 }));
         let mem = Box::into_raw(Box::new(FT_MemoryRec_ {
             user: user as *mut c_void,
@@ -132,11 +132,5 @@ impl FontContextHandle {
                 ctx: Rc::new(FreeTypeLibraryHandle { ctx, mem, user }),
             }
         }
-    }
-}
-
-impl Default for FontContextHandle {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -17,10 +17,10 @@ use log::debug;
 use super::c_str_to_string;
 use crate::text::util::is_cjk;
 
-static FC_FAMILY: &'static [u8] = b"family\0";
-static FC_FILE: &'static [u8] = b"file\0";
-static FC_INDEX: &'static [u8] = b"index\0";
-static FC_FONTFORMAT: &'static [u8] = b"fontformat\0";
+static FC_FAMILY: &[u8] = b"family\0";
+static FC_FILE: &[u8] = b"file\0";
+static FC_INDEX: &[u8] = b"index\0";
+static FC_FONTFORMAT: &[u8] = b"fontformat\0";
 
 pub fn for_each_available_family<F>(mut callback: F)
 where
@@ -150,7 +150,7 @@ pub fn system_default_family(generic_name: &str) -> Option<String> {
     }
 }
 
-pub static SANS_SERIF_FONT_FAMILY: &'static str = "DejaVu Sans";
+pub static SANS_SERIF_FONT_FAMILY: &str = "DejaVu Sans";
 
 // Based on gfxPlatformGtk::GetCommonFallbackFonts() in Gecko
 pub fn fallback_font_families(codepoint: Option<char>) -> Vec<&'static str> {

--- a/components/gfx/platform/freetype/font_template.rs
+++ b/components/gfx/platform/freetype/font_template.rs
@@ -36,10 +36,7 @@ impl fmt::Debug for FontTemplateData {
 
 impl FontTemplateData {
     pub fn new(identifier: Atom, bytes: Option<Vec<u8>>) -> Result<FontTemplateData, Error> {
-        Ok(FontTemplateData {
-            bytes: bytes,
-            identifier: identifier,
-        })
+        Ok(FontTemplateData { bytes, identifier })
     }
 
     /// Returns a clone of the data in this font. This may be a hugely expensive

--- a/components/gfx/rendering_context.rs
+++ b/components/gfx/rendering_context.rs
@@ -30,8 +30,8 @@ struct RenderingContextData {
 
 impl Drop for RenderingContextData {
     fn drop(&mut self) {
-        let ref mut device = self.device.borrow_mut();
-        let ref mut context = self.context.borrow_mut();
+        let device = &mut self.device.borrow_mut();
+        let context = &mut self.context.borrow_mut();
         if let Some(ref swap_chain) = self.swap_chain {
             let _ = swap_chain.destroy(device, context);
         }
@@ -45,7 +45,7 @@ impl RenderingContext {
         adapter: &Adapter,
         surface_type: SurfaceType<NativeWidget>,
     ) -> Result<Self, Error> {
-        let mut device = connection.create_device(&adapter)?;
+        let mut device = connection.create_device(adapter)?;
         let flags = ContextAttributeFlags::ALPHA |
             ContextAttributeFlags::DEPTH |
             ContextAttributeFlags::STENCIL;
@@ -94,8 +94,8 @@ impl RenderingContext {
         &self,
         surface: Surface,
     ) -> Result<SurfaceTexture, (Error, Surface)> {
-        let ref device = self.0.device.borrow();
-        let ref mut context = self.0.context.borrow_mut();
+        let device = &self.0.device.borrow();
+        let context = &mut self.0.context.borrow_mut();
         device.create_surface_texture(context, surface)
     }
 
@@ -103,14 +103,14 @@ impl RenderingContext {
         &self,
         surface_texture: SurfaceTexture,
     ) -> Result<Surface, (Error, SurfaceTexture)> {
-        let ref device = self.0.device.borrow();
-        let ref mut context = self.0.context.borrow_mut();
+        let device = &self.0.device.borrow();
+        let context = &mut self.0.context.borrow_mut();
         device.destroy_surface_texture(context, surface_texture)
     }
 
     pub fn make_gl_context_current(&self) -> Result<(), Error> {
-        let ref device = self.0.device.borrow();
-        let ref context = self.0.context.borrow();
+        let device = &self.0.device.borrow();
+        let context = &self.0.context.borrow();
         device.make_context_current(context)
     }
 
@@ -119,8 +119,8 @@ impl RenderingContext {
     }
 
     pub fn resize(&self, size: Size2D<i32>) -> Result<(), Error> {
-        let ref mut device = self.0.device.borrow_mut();
-        let ref mut context = self.0.context.borrow_mut();
+        let device = &mut self.0.device.borrow_mut();
+        let context = &mut self.0.context.borrow_mut();
         if let Some(swap_chain) = self.0.swap_chain.as_ref() {
             return swap_chain.resize(device, context, size);
         }
@@ -135,8 +135,8 @@ impl RenderingContext {
     }
 
     pub fn present(&self) -> Result<(), Error> {
-        let ref mut device = self.0.device.borrow_mut();
-        let ref mut context = self.0.context.borrow_mut();
+        let device = &mut self.0.device.borrow_mut();
+        let context = &mut self.0.context.borrow_mut();
         if let Some(ref swap_chain) = self.0.swap_chain {
             return swap_chain.swap_buffers(device, context, PreserveBuffer::No);
         }
@@ -153,8 +153,8 @@ impl RenderingContext {
     /// Invoke a closure with the surface associated with the current front buffer.
     /// This can be used to create a surfman::SurfaceTexture to blit elsewhere.
     pub fn with_front_buffer<F: FnMut(&Device, Surface) -> Surface>(&self, mut f: F) {
-        let ref mut device = self.0.device.borrow_mut();
-        let ref mut context = self.0.context.borrow_mut();
+        let device = &mut self.0.device.borrow_mut();
+        let context = &mut self.0.context.borrow_mut();
         let surface = device
             .unbind_surface_from_context(context)
             .unwrap()
@@ -168,52 +168,52 @@ impl RenderingContext {
     }
 
     pub fn connection(&self) -> Connection {
-        let ref device = self.0.device.borrow();
+        let device = &self.0.device.borrow();
         device.connection()
     }
 
     pub fn adapter(&self) -> Adapter {
-        let ref device = self.0.device.borrow();
+        let device = &self.0.device.borrow();
         device.adapter()
     }
 
     pub fn native_context(&self) -> NativeContext {
-        let ref device = self.0.device.borrow();
-        let ref context = self.0.context.borrow();
+        let device = &self.0.device.borrow();
+        let context = &self.0.context.borrow();
         device.native_context(context)
     }
 
     pub fn native_device(&self) -> NativeDevice {
-        let ref device = self.0.device.borrow();
+        let device = &self.0.device.borrow();
         device.native_device()
     }
 
     pub fn context_attributes(&self) -> ContextAttributes {
-        let ref device = self.0.device.borrow();
-        let ref context = self.0.context.borrow();
-        let ref descriptor = device.context_descriptor(context);
+        let device = &self.0.device.borrow();
+        let context = &self.0.context.borrow();
+        let descriptor = &device.context_descriptor(context);
         device.context_descriptor_attributes(descriptor)
     }
 
     pub fn context_surface_info(&self) -> Result<Option<SurfaceInfo>, Error> {
-        let ref device = self.0.device.borrow();
-        let ref context = self.0.context.borrow();
+        let device = &self.0.device.borrow();
+        let context = &self.0.context.borrow();
         device.context_surface_info(context)
     }
 
     pub fn surface_info(&self, surface: &Surface) -> SurfaceInfo {
-        let ref device = self.0.device.borrow();
+        let device = &self.0.device.borrow();
         device.surface_info(surface)
     }
 
     pub fn surface_texture_object(&self, surface: &SurfaceTexture) -> u32 {
-        let ref device = self.0.device.borrow();
+        let device = &self.0.device.borrow();
         device.surface_texture_object(surface)
     }
 
     pub fn get_proc_address(&self, name: &str) -> *const c_void {
-        let ref device = self.0.device.borrow();
-        let ref context = self.0.context.borrow();
+        let device = &self.0.device.borrow();
+        let context = &self.0.context.borrow();
         device.get_proc_address(context, name)
     }
 
@@ -221,7 +221,7 @@ impl RenderingContext {
         let device = self.0.device.borrow_mut();
         let mut context = self.0.context.borrow_mut();
         let mut surface = device.unbind_surface_from_context(&mut context)?.unwrap();
-        let _ = device.destroy_surface(&mut context, &mut surface)?;
+        device.destroy_surface(&mut context, &mut surface)?;
         Ok(())
     }
 

--- a/components/gfx/tests/font_context.rs
+++ b/components/gfx/tests/font_context.rs
@@ -34,13 +34,13 @@ struct TestFontSource {
 
 impl TestFontSource {
     fn new() -> TestFontSource {
-        let mut csstest_ascii = FontTemplates::new();
+        let mut csstest_ascii = FontTemplates::default();
         Self::add_face(&mut csstest_ascii, "csstest-ascii", None);
 
-        let mut csstest_basic = FontTemplates::new();
+        let mut csstest_basic = FontTemplates::default();
         Self::add_face(&mut csstest_basic, "csstest-basic-regular", None);
 
-        let mut fallback = FontTemplates::new();
+        let mut fallback = FontTemplates::default();
         Self::add_face(&mut fallback, "csstest-basic-regular", Some("fallback"));
 
         let mut families = HashMap::new();
@@ -49,7 +49,7 @@ impl TestFontSource {
         families.insert(fallback_font_families(None)[0].to_owned(), fallback);
 
         TestFontSource {
-            handle: FontContextHandle::new(),
+            handle: FontContextHandle::default(),
             families,
             find_font_count: Rc::new(Cell::new(0)),
         }

--- a/components/gfx/tests/font_template.rs
+++ b/components/gfx/tests/font_template.rs
@@ -35,7 +35,7 @@ fn test_font_template_descriptor() {
         )
         .unwrap();
 
-        let context = FontContextHandle::new();
+        let context = FontContextHandle::default();
 
         template.descriptor(&context).unwrap()
     }

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -28,7 +28,7 @@ pub struct GlyphEntry {
 
 impl GlyphEntry {
     fn new(value: u32) -> GlyphEntry {
-        GlyphEntry { value: value }
+        GlyphEntry { value }
     }
 
     fn initial() -> GlyphEntry {
@@ -157,9 +157,9 @@ struct DetailedGlyph {
 impl DetailedGlyph {
     fn new(id: GlyphId, advance: Au, offset: Point2D<Au>) -> DetailedGlyph {
         DetailedGlyph {
-            id: id,
-            advance: advance,
-            offset: offset,
+            id,
+            advance,
+            offset,
         }
     }
 }
@@ -210,7 +210,7 @@ impl<'a> DetailedGlyphStore {
 
     fn add_detailed_glyphs_for_entry(&mut self, entry_offset: ByteIndex, glyphs: &[DetailedGlyph]) {
         let entry = DetailedGlyphRecord {
-            entry_offset: entry_offset,
+            entry_offset,
             detail_offset: self.detail_buffer.len(),
         };
 
@@ -245,7 +245,7 @@ impl<'a> DetailedGlyphStore {
         assert!(self.lookup_is_sorted);
 
         let key = DetailedGlyphRecord {
-            entry_offset: entry_offset,
+            entry_offset,
             detail_offset: 0, // unused
         };
 
@@ -268,7 +268,7 @@ impl<'a> DetailedGlyphStore {
         assert!(self.lookup_is_sorted);
 
         let key = DetailedGlyphRecord {
-            entry_offset: entry_offset,
+            entry_offset,
             detail_offset: 0, // unused
         };
 
@@ -329,11 +329,11 @@ impl GlyphData {
         ligature_start: bool,
     ) -> GlyphData {
         GlyphData {
-            id: id,
-            advance: advance,
+            id,
+            advance,
             offset: offset.unwrap_or(Point2D::zero()),
-            cluster_start: cluster_start,
-            ligature_start: ligature_start,
+            cluster_start,
+            ligature_start,
         }
     }
 }
@@ -455,8 +455,8 @@ impl<'a> GlyphStore {
             total_advance: Au(0),
             total_word_separators: 0,
             has_detailed_glyphs: false,
-            is_whitespace: is_whitespace,
-            is_rtl: is_rtl,
+            is_whitespace,
+            is_rtl,
         }
     }
 

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -138,7 +138,7 @@ impl Drop for Shaper {
 }
 
 impl Shaper {
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)] // Has an unsafe block inside
     pub fn new(font: *const Font) -> Shaper {
         unsafe {
             let hb_face: *mut hb_face_t = hb_face_create_for_tables(

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -488,7 +488,7 @@ impl Shaper {
                 }
 
                 // if no glyphs were found yet, extend the char byte range more.
-                if glyph_span.len() == 0 {
+                if glyph_span.is_empty() {
                     continue;
                 }
 
@@ -511,8 +511,8 @@ impl Shaper {
                 // span or reach the end of the text.
             }
 
-            assert!(byte_range.len() > 0);
-            assert!(glyph_span.len() > 0);
+            assert!(!byte_range.is_empty());
+            assert!(!glyph_span.is_empty());
 
             // Now byte_range is the ligature clump formed by the glyphs in glyph_span.
             // We will save these glyphs to the glyph store at the index of the first byte.
@@ -583,7 +583,7 @@ impl Shaper {
         options: &ShapingOptions,
     ) -> Au {
         if let Some(letter_spacing) = options.letter_spacing {
-            advance = advance + letter_spacing;
+            advance += letter_spacing;
         };
 
         // CSS 2.1 § 16.4 states that "word spacing affects each space (U+0020) and non-breaking
@@ -657,13 +657,10 @@ extern "C" fn glyph_h_advance_func(
 
 fn glyph_space_advance(font: *const Font) -> (hb_codepoint_t, f64) {
     let space_unicode = ' ';
-    let space_glyph: hb_codepoint_t;
-    match unsafe { (*font).glyph_index(space_unicode) } {
-        Some(g) => {
-            space_glyph = g as hb_codepoint_t;
-        },
+    let space_glyph: hb_codepoint_t = match unsafe { (*font).glyph_index(space_unicode) } {
+        Some(g) => g as hb_codepoint_t,
         None => panic!("No space info"),
-    }
+    };
     let space_advance = unsafe { (*font).glyph_h_advance(space_glyph as GlyphId) };
     (space_glyph, space_advance)
 }

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -59,8 +59,8 @@ impl ShapedGlyphData {
 
             ShapedGlyphData {
                 count: glyph_count as usize,
-                glyph_infos: glyph_infos,
-                pos_infos: pos_infos,
+                glyph_infos,
+                pos_infos,
             }
         }
     }
@@ -110,7 +110,7 @@ impl ShapedGlyphData {
             ShapedGlyphEntry {
                 codepoint: (*glyph_info_i).codepoint as GlyphId,
                 advance: x_advance,
-                offset: offset,
+                offset,
             }
         }
     }
@@ -165,9 +165,9 @@ impl Shaper {
             );
 
             Shaper {
-                hb_face: hb_face,
-                hb_font: hb_font,
-                font: font,
+                hb_face,
+                hb_font,
+                font,
             }
         }
     }

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -129,7 +129,7 @@ impl<'a> Iterator for NaturalWordSliceIterator<'a> {
 
         if !byte_range.is_empty() {
             Some(TextRunSlice {
-                glyphs: &*slice_glyphs.glyph_store,
+                glyphs: &slice_glyphs.glyph_store,
                 offset: slice_range_begin,
                 range: byte_range,
             })
@@ -172,7 +172,7 @@ impl<'a> Iterator for CharacterSliceIterator<'a> {
 
         let index_within_glyph_run = byte_start - glyph_run.range.begin();
         Some(TextRunSlice {
-            glyphs: &*glyph_run.glyph_store,
+            glyphs: &glyph_run.glyph_store,
             offset: glyph_run.range.begin(),
             range: Range::new(index_within_glyph_run, byte_len),
         })
@@ -217,7 +217,7 @@ impl<'a> TextRun {
         let mut break_at_zero = false;
 
         if breaker.is_none() {
-            if text.len() == 0 {
+            if text.is_empty() {
                 return (glyphs, true);
             }
             *breaker = Some(LineBreakLeafIter::new(text, 0));
@@ -253,7 +253,7 @@ impl<'a> TextRun {
                 // keep-all, try increasing the slice.
                 continue;
             }
-            if slice.len() > 0 {
+            if !slice.is_empty() {
                 glyphs.push(GlyphRun {
                     glyph_store: font.shape_text(&text[slice.clone()], options),
                     range: Range::new(
@@ -262,8 +262,8 @@ impl<'a> TextRun {
                     ),
                 });
             }
-            if whitespace.len() > 0 {
-                let mut options = options.clone();
+            if !whitespace.is_empty() {
+                let mut options = *options;
                 options
                     .flags
                     .insert(ShapingFlags::IS_WHITESPACE_SHAPING_FLAG);
@@ -348,7 +348,9 @@ impl<'a> TextRun {
                 }
             }
 
-            if let Ok(result) = (&**self.glyphs).binary_search_by(|current| current.compare(&index))
+            if let Ok(result) = self
+                .glyphs
+                .binary_search_by(|current| current.compare(&index))
             {
                 index_of_first_glyph_run_cache.set(Some((self_ptr, index, result)));
                 Some(result)

--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -197,7 +197,7 @@ impl<'a> TextRun {
                 font_key: font.font_key,
                 pt_size: font.descriptor.pt_size,
                 glyphs: Arc::new(glyphs),
-                bidi_level: bidi_level,
+                bidi_level,
                 extra_word_spacing: Au(0),
             },
             break_at_zero,
@@ -396,7 +396,7 @@ impl<'a> TextRun {
         };
         NaturalWordSliceIterator {
             glyphs: &self.glyphs[..],
-            index: index,
+            index,
             range: *range,
             reverse: false,
         }
@@ -424,9 +424,9 @@ impl<'a> TextRun {
         };
         NaturalWordSliceIterator {
             glyphs: &self.glyphs[..],
-            index: index,
+            index,
             range: *range,
-            reverse: reverse,
+            reverse,
         }
     }
 
@@ -445,7 +445,7 @@ impl<'a> TextRun {
         CharacterSliceIterator {
             text: &self.text,
             glyph_run: first_glyph_run,
-            glyph_run_iter: glyph_run_iter,
+            glyph_run_iter,
             range: *range,
         }
     }

--- a/components/gfx/text/util.rs
+++ b/components/gfx/text/util.rs
@@ -113,12 +113,7 @@ pub fn fixed_to_float(before: usize, f: i32) -> f64 {
 }
 
 pub fn is_bidi_control(c: char) -> bool {
-    match c {
-        '\u{202A}'..='\u{202E}' => true,
-        '\u{2066}'..='\u{2069}' => true,
-        '\u{200E}' | '\u{200F}' | '\u{061C}' => true,
-        _ => false,
-    }
+    matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}' | '\u{200E}' | '\u{200F}' | '\u{061C}')
 }
 
 pub fn unicode_plane(codepoint: char) -> u32 {

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -531,7 +531,7 @@ impl<'a> Serialize for Ser<'a, Mime> {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.v.as_ref())
+        serializer.serialize_str(self.v.as_ref())
     }
 }
 

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -80,7 +80,7 @@ static THREAD_TINT_COLORS: [ColorF; 8] = [
         a: 0.7,
     },
     ColorF {
-        r: 255.0 / 255.0,
+        r: 1.0,
         g: 212.0 / 255.0,
         b: 83.0 / 255.0,
         a: 0.7,
@@ -110,7 +110,7 @@ static THREAD_TINT_COLORS: [ColorF; 8] = [
         a: 0.7,
     },
     ColorF {
-        r: 255.0 / 255.0,
+        r: 1.0,
         g: 249.0 / 255.0,
         b: 201.0 / 255.0,
         a: 0.7,

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -29,16 +29,23 @@ const CHUNK_SIZE: usize = 16;
 pub type FlowList = SmallVec<[UnsafeFlow; CHUNK_SIZE]>;
 
 /// Vtable + pointer representation of a Flow trait object.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq)]
 pub struct UnsafeFlow(*const dyn Flow);
 
 unsafe impl Sync for UnsafeFlow {}
 unsafe impl Send for UnsafeFlow {}
+impl PartialEq for UnsafeFlow {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare the pointers explicitly to avoid clippy lint
+        self.0 as *const u8 == other.0 as *const u8
+    }
+}
 
 fn null_unsafe_flow() -> UnsafeFlow {
     UnsafeFlow(ptr::null::<BlockFlow>())
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)] // It has an unsafe block inside
 pub fn mut_owned_flow_to_unsafe_flow(flow: *mut FlowRef) -> UnsafeFlow {
     unsafe { UnsafeFlow(&**flow) }
 }

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::type_complexity)]
 
 mod media_channel;
 mod media_thread;

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::type_complexity)]
 
 mod media_channel;
 mod media_thread;
@@ -20,14 +21,12 @@ pub use crate::media_channel::glplayer_channel;
 use crate::media_channel::{GLPlayerChan, GLPlayerPipeline, GLPlayerReceiver, GLPlayerSender};
 use crate::media_thread::GLPlayerThread;
 
-type GLPlayerSenderType = GLPlayerSender<(u32, Size2D<i32>, usize)>;
-
 /// These are the messages that the GLPlayer thread will forward to
 /// the video player which lives in htmlmediaelement
 #[derive(Debug, Deserialize, Serialize)]
 pub enum GLPlayerMsgForward {
     PlayerId(u64),
-    Lock(GLPlayerSenderType),
+    Lock(GLPlayerSender<(u32, Size2D<i32>, usize)>),
     Unlock(),
 }
 
@@ -54,7 +53,7 @@ pub enum GLPlayerMsg {
     ///
     /// Currently OpenGL Sync Objects are used to implement the
     /// synchronization mechanism.
-    Lock(u64, GLPlayerSenderType),
+    Lock(u64, GLPlayerSender<(u32, Size2D<i32>, usize)>),
     /// Unlocks a specific texture from a player. Unlock messages are
     /// used for a correct synchronization with WebRender external
     /// image API.

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
-#![allow(clippy::type_complexity)]
 
 mod media_channel;
 mod media_thread;
@@ -21,12 +20,14 @@ pub use crate::media_channel::glplayer_channel;
 use crate::media_channel::{GLPlayerChan, GLPlayerPipeline, GLPlayerReceiver, GLPlayerSender};
 use crate::media_thread::GLPlayerThread;
 
+type GLPlayerSenderType = GLPlayerSender<(u32, Size2D<i32>, usize)>;
+
 /// These are the messages that the GLPlayer thread will forward to
 /// the video player which lives in htmlmediaelement
 #[derive(Debug, Deserialize, Serialize)]
 pub enum GLPlayerMsgForward {
     PlayerId(u64),
-    Lock(GLPlayerSender<(u32, Size2D<i32>, usize)>),
+    Lock(GLPlayerSenderType),
     Unlock(),
 }
 
@@ -53,7 +54,7 @@ pub enum GLPlayerMsg {
     ///
     /// Currently OpenGL Sync Objects are used to implement the
     /// synchronization mechanism.
-    Lock(u64, GLPlayerSender<(u32, Size2D<i32>, usize)>),
+    Lock(u64, GLPlayerSenderType),
     /// Unlocks a specific texture from a player. Unlock messages are
     /// used for a correct synchronization with WebRender external
     /// image API.

--- a/components/media/media_channel/mod.rs
+++ b/components/media/media_channel/mod.rs
@@ -74,6 +74,7 @@ where
         }
     }
 
+    #[allow(clippy::wrong_self_convention)] // It is an alias to the underlying module
     pub fn to_opaque(self) -> ipc_channel::ipc::OpaqueIpcReceiver {
         match self {
             GLPlayerReceiver::Ipc(receiver) => receiver.to_opaque(),

--- a/components/media/media_thread.rs
+++ b/components/media/media_thread.rs
@@ -79,14 +79,14 @@ impl GLPlayerThread {
                 }
             },
             GLPlayerMsg::Lock(id, handler_sender) => {
-                self.players.get(&id).map(|sender| {
+                if let Some(sender) = self.players.get(&id) {
                     sender.send(GLPlayerMsgForward::Lock(handler_sender)).ok();
-                });
+                }
             },
             GLPlayerMsg::Unlock(id) => {
-                self.players.get(&id).map(|sender| {
+                if let Some(sender) = self.players.get(&id) {
                     sender.send(GLPlayerMsgForward::Unlock()).ok();
-                });
+                }
             },
             GLPlayerMsg::Exit => return true,
         }

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -54,7 +54,7 @@ impl Service<Destination> for ServoHttpConnector {
             let authority = if let Some(port) = auth.port() {
                 format!("{}:{}", host, port.as_str())
             } else {
-                format!("{}", &*host)
+                (*host).to_string()
             };
 
             if let Ok(authority) = Authority::from_maybe_shared(authority) {

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -106,8 +106,8 @@ impl Cookie {
                 ""
             })
             .to_owned();
-        if path.chars().next() != Some('/') {
-            path = Cookie::default_path(&request.path().to_owned()).to_string();
+        if !path.starts_with('/') {
+            path = Cookie::default_path(request.path()).to_string();
         }
         cookie.set_path(path);
 
@@ -152,12 +152,12 @@ impl Cookie {
     // http://tools.ietf.org/html/rfc6265#section-5.1.4
     pub fn default_path(request_path: &str) -> &str {
         // Step 2
-        if request_path.chars().next() != Some('/') {
+        if !request_path.starts_with('/') {
             return "/";
         }
 
         // Step 3
-        let rightmost_slash_idx = request_path.rfind("/").unwrap();
+        let rightmost_slash_idx = request_path.rfind('/').unwrap();
         if rightmost_slash_idx == 0 {
             // There's only one slash; it's the first character
             return "/";
@@ -178,11 +178,11 @@ impl Cookie {
                 (
                     // The cookie-path is a prefix of the request-path, and the last
                     // character of the cookie-path is %x2F ("/").
-                    cookie_path.ends_with("/") ||
+                    cookie_path.ends_with('/') ||
             // The cookie-path is a prefix of the request-path, and the first
             // character of the request-path that is not included in the cookie-
             // path is a %x2F ("/") character.
-            request_path[cookie_path.len()..].starts_with("/")
+            request_path[cookie_path.len()..].starts_with('/')
                 ))
     }
 
@@ -205,13 +205,13 @@ impl Cookie {
             if self.cookie.domain() != domain {
                 return false;
             }
-        } else if let (Some(domain), &Some(ref cookie_domain)) = (domain, &self.cookie.domain()) {
+        } else if let (Some(domain), Some(cookie_domain)) = (domain, &self.cookie.domain()) {
             if !Cookie::domain_match(domain, cookie_domain) {
                 return false;
             }
         }
 
-        if let Some(ref cookie_path) = self.cookie.path() {
+        if let Some(cookie_path) = self.cookie.path() {
             if !Cookie::path_match(url.path(), cookie_path) {
                 return false;
             }

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -205,11 +205,9 @@ impl Cookie {
             if self.cookie.domain() != domain {
                 return false;
             }
-        } else {
-            if let (Some(domain), &Some(ref cookie_domain)) = (domain, &self.cookie.domain()) {
-                if !Cookie::domain_match(domain, cookie_domain) {
-                    return false;
-                }
+        } else if let (Some(domain), &Some(ref cookie_domain)) = (domain, &self.cookie.domain()) {
+            if !Cookie::domain_match(domain, cookie_domain) {
+                return false;
             }
         }
 

--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -42,7 +42,7 @@ impl CookieStorage {
         source: CookieSource,
     ) -> Result<Option<Cookie>, ()> {
         let domain = reg_host(cookie.cookie.domain().as_ref().unwrap_or(&""));
-        let cookies = self.cookies_map.entry(domain).or_insert(vec![]);
+        let cookies = self.cookies_map.entry(domain).or_default();
 
         // https://www.ietf.org/id/draft-ietf-httpbis-cookie-alone-01.txt Step 2
         if !cookie.cookie.secure().unwrap_or(false) && !url.is_secure_scheme() {
@@ -90,7 +90,7 @@ impl CookieStorage {
     }
     pub fn clear_storage(&mut self, url: &ServoUrl) {
         let domain = reg_host(url.host_str().unwrap_or(""));
-        let cookies = self.cookies_map.entry(domain).or_insert(vec![]);
+        let cookies = self.cookies_map.entry(domain).or_default();
         for cookie in cookies.iter_mut() {
             cookie.set_expiry_time_negative();
         }
@@ -116,12 +116,12 @@ impl CookieStorage {
         }
 
         // Step 12
-        let domain = reg_host(&cookie.cookie.domain().as_ref().unwrap_or(&""));
-        let cookies = self.cookies_map.entry(domain).or_insert(vec![]);
+        let domain = reg_host(cookie.cookie.domain().as_ref().unwrap_or(&""));
+        let cookies = self.cookies_map.entry(domain).or_default();
 
         if cookies.len() == self.max_per_host {
             let old_len = cookies.len();
-            cookies.retain(|c| !is_cookie_expired(&c));
+            cookies.retain(|c| !is_cookie_expired(c));
             let new_len = cookies.len();
 
             // https://www.ietf.org/id/draft-ietf-httpbis-cookie-alone-01.txt
@@ -153,8 +153,8 @@ impl CookieStorage {
         let domain = reg_host(url.host_str().unwrap_or(""));
         if let Entry::Occupied(mut entry) = self.cookies_map.entry(domain) {
             let cookies = entry.get_mut();
-            cookies.retain(|c| !is_cookie_expired(&c));
-            if cookies.len() == 0 {
+            cookies.retain(|c| !is_cookie_expired(c));
+            if cookies.is_empty() {
                 entry.remove_entry();
             }
         }
@@ -179,10 +179,10 @@ impl CookieStorage {
         };
         // Step 2
         let domain = reg_host(url.host_str().unwrap_or(""));
-        let cookies = self.cookies_map.entry(domain).or_insert(vec![]);
+        let cookies = self.cookies_map.entry(domain).or_default();
 
         let mut url_cookies: Vec<&mut Cookie> = cookies.iter_mut().filter(filterer).collect();
-        url_cookies.sort_by(|a, b| CookieStorage::cookie_comparator(*a, *b));
+        url_cookies.sort_by(|a, b| CookieStorage::cookie_comparator(a, b));
 
         let reducer = |acc: String, c: &mut &mut Cookie| -> String {
             // Step 3
@@ -211,7 +211,7 @@ impl CookieStorage {
         source: CookieSource,
     ) -> impl Iterator<Item = cookie_rs::Cookie<'static>> + 'a {
         let domain = reg_host(url.host_str().unwrap_or(""));
-        let cookies = self.cookies_map.entry(domain).or_insert(vec![]);
+        let cookies = self.cookies_map.entry(domain).or_default();
 
         cookies
             .iter_mut()
@@ -223,7 +223,7 @@ impl CookieStorage {
     }
 }
 
-fn reg_host<'a>(url: &'a str) -> String {
+fn reg_host(url: &str) -> String {
     reg_suffix(url).to_lowercase()
 }
 
@@ -250,7 +250,7 @@ fn evict_one_cookie(is_secure_cookie: bool, cookies: &mut Vec<Cookie>) -> bool {
             cookies.remove(index);
         }
     }
-    return true;
+    true
 }
 
 fn get_oldest_accessed(is_secure_cookie: bool, cookies: &mut Vec<Cookie>) -> Option<(usize, Tm)> {

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -130,7 +130,7 @@ impl Decoder {
         Decoder {
             inner: Inner::Pending(Pending {
                 body: ReadableChunks::new(body),
-                type_: type_,
+                type_,
             }),
         }
     }
@@ -222,7 +222,7 @@ impl Gzip {
         Gzip {
             buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
             inner: Box::new(gzip::Decoder::new(Peeked::new(stream))),
-            reader: reader,
+            reader,
         }
     }
 }
@@ -286,7 +286,7 @@ impl Brotli {
         Self {
             buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
             inner: Box::new(Decompressor::new(Peeked::new(stream), BUF_SIZE)),
-            reader: reader,
+            reader,
         }
     }
 }
@@ -318,7 +318,7 @@ impl Deflate {
         Self {
             buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
             inner: Box::new(DeflateDecoder::new(Peeked::new(stream))),
-            reader: reader,
+            reader,
         }
     }
 }
@@ -382,7 +382,7 @@ impl<R> Peeked<R> {
         Peeked {
             state: PeekedState::NotReady,
             peeked_buf: [0; 10],
-            inner: inner,
+            inner,
             pos: 0,
         }
     }
@@ -444,7 +444,7 @@ impl<S> ReadableChunks<S> {
     fn new(stream: S) -> Self {
         ReadableChunks {
             state: ReadState::NotReady,
-            stream: stream,
+            stream,
             waker: None,
         }
     }

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -418,10 +418,10 @@ impl<R: Read> Read for Peeked<R> {
                     return Ok(len);
                 },
                 PeekedState::NotReady => {
-                    let mut buf = &mut self.peeked_buf[self.pos..];
+                    let buf = &mut self.peeked_buf[self.pos..];
                     let stream = self.inner.clone();
                     let mut reader = stream.lock().unwrap();
-                    let read = reader.read(&mut buf);
+                    let read = reader.read(buf);
 
                     match read {
                         Ok(0) => self.ready(),

--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -80,6 +80,12 @@ fn match_headers(cors_cache: &CorsCacheEntry, cors_req: &Request) -> bool {
 #[derive(Clone)]
 pub struct CorsCache(Vec<CorsCacheEntry>);
 
+impl Default for CorsCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CorsCache {
     pub fn new() -> CorsCache {
         CorsCache(vec![])
@@ -122,7 +128,7 @@ impl CorsCache {
     /// Returns true if an entry with a
     /// [matching header](https://fetch.spec.whatwg.org/#concept-cache-match-header) is found
     pub fn match_header(&mut self, request: &Request, header_name: &HeaderName) -> bool {
-        self.find_entry_by_header(&request, header_name).is_some()
+        self.find_entry_by_header(request, header_name).is_some()
     }
 
     /// Updates max age if an entry for a
@@ -136,7 +142,7 @@ impl CorsCache {
         new_max_age: u32,
     ) -> bool {
         match self
-            .find_entry_by_header(&request, header_name)
+            .find_entry_by_header(request, header_name)
             .map(|e| e.max_age = new_max_age)
         {
             Some(_) => true,
@@ -156,7 +162,7 @@ impl CorsCache {
     /// Returns true if an entry with a
     /// [matching method](https://fetch.spec.whatwg.org/#concept-cache-match-method) is found
     pub fn match_method(&mut self, request: &Request, method: Method) -> bool {
-        self.find_entry_by_method(&request, method).is_some()
+        self.find_entry_by_method(request, method).is_some()
     }
 
     /// Updates max age if an entry for
@@ -170,7 +176,7 @@ impl CorsCache {
         new_max_age: u32,
     ) -> bool {
         match self
-            .find_entry_by_method(&request, method.clone())
+            .find_entry_by_method(request, method.clone())
             .map(|e| e.max_age = new_max_age)
         {
             Some(_) => true,

--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -77,20 +77,10 @@ fn match_headers(cors_cache: &CorsCacheEntry, cors_req: &Request) -> bool {
 }
 
 /// A simple, vector-based CORS Cache
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CorsCache(Vec<CorsCacheEntry>);
 
-impl Default for CorsCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl CorsCache {
-    pub fn new() -> CorsCache {
-        CorsCache(vec![])
-    }
-
     fn find_entry_by_header<'a>(
         &'a mut self,
         request: &Request,

--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -60,11 +60,11 @@ impl CorsCacheEntry {
         header_or_method: HeaderOrMethod,
     ) -> CorsCacheEntry {
         CorsCacheEntry {
-            origin: origin,
-            url: url,
-            max_age: max_age,
-            credentials: credentials,
-            header_or_method: header_or_method,
+            origin,
+            url,
+            max_age,
+            credentials,
+            header_or_method,
             created: time::now().to_timespec(),
         }
     }

--- a/components/net/fetch/headers.rs
+++ b/components/net/fetch/headers.rs
@@ -17,14 +17,14 @@ pub fn determine_nosniff(headers: &HeaderMap) -> bool {
 
     match values {
         None => false,
-        Some(values) => !values.is_empty() && (&values[0]).eq_ignore_ascii_case("nosniff"),
+        Some(values) => !values.is_empty() && values[0].eq_ignore_ascii_case("nosniff"),
     }
 }
 
 /// <https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split>
 fn get_header_value_as_list(name: &str, headers: &HeaderMap) -> Option<Vec<String>> {
     fn char_is_not_quote_or_comma(c: char) -> bool {
-        return c != '\u{0022}' && c != '\u{002C}';
+        c != '\u{0022}' && c != '\u{002C}'
     }
 
     // Step 1
@@ -33,7 +33,7 @@ fn get_header_value_as_list(name: &str, headers: &HeaderMap) -> Option<Vec<Strin
     if let Some(input) = initial_value {
         // https://fetch.spec.whatwg.org/#header-value-get-decode-and-split
         // Step 1
-        let input = input.into_iter().map(|u| char::from(u)).collect::<String>();
+        let input = input.into_iter().map(char::from).collect::<String>();
 
         // Step 2
         let mut position = input.chars().peekable();
@@ -81,7 +81,7 @@ fn get_header_value_as_list(name: &str, headers: &HeaderMap) -> Option<Vec<Strin
     }
 
     // Step 2
-    return None;
+    None
 }
 
 /// <https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points>
@@ -102,13 +102,13 @@ where
     }
 
     // Step 3
-    return result;
+    result
 }
 
 /// <https://fetch.spec.whatwg.org/#collect-an-http-quoted-string>
 fn collect_http_quoted_string(position: &mut Peekable<Chars>, extract_value: bool) -> String {
     fn char_is_not_quote_or_backslash(c: char) -> bool {
-        return c != '\u{0022}' && c != '\u{005C}';
+        c != '\u{0022}' && c != '\u{005C}'
     }
 
     // Step 2
@@ -159,5 +159,5 @@ fn collect_http_quoted_string(position: &mut Peekable<Chars>, extract_value: boo
     }
 
     // Step 6, 7
-    return value;
+    value
 }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -121,7 +121,7 @@ pub async fn fetch(request: &mut Request, target: Target<'_>, context: &FetchCon
         .unwrap()
         .set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
 
-    fetch_with_cors_cache(request, &mut CorsCache::new(), target, context).await;
+    fetch_with_cors_cache(request, &mut CorsCache::default(), target, context).await;
 }
 
 pub async fn fetch_with_cors_cache(

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -161,7 +161,7 @@ pub async fn fetch_with_cors_cache(
     }
 
     // Step 8.
-    main_fetch(request, cache, false, false, target, &mut None, &context).await;
+    main_fetch(request, cache, false, false, target, &mut None, context).await;
 }
 
 /// <https://www.w3.org/TR/CSP/#should-block-request>
@@ -267,7 +267,7 @@ pub async fn main_fetch(
             )
         },
     };
-    request.referrer = referrer_url.map_or(Referrer::NoReferrer, |url| Referrer::ReferrerUrl(url));
+    request.referrer = referrer_url.map_or(Referrer::NoReferrer, Referrer::ReferrerUrl);
 
     // Step 9.
     // TODO: handle FTP URLs.
@@ -451,7 +451,7 @@ pub async fn main_fetch(
             *body = ResponseBody::Empty;
         }
 
-        internal_response.get_network_error().map(|e| e.clone())
+        internal_response.get_network_error().cloned()
     };
 
     // Execute deferred rebinding of response.
@@ -469,7 +469,7 @@ pub async fn main_fetch(
         response_loaded = true;
 
         // Step 19.2.
-        let ref integrity_metadata = &request.integrity_metadata;
+        let integrity_metadata = &request.integrity_metadata;
         if response.termination_reason.is_none() &&
             !is_response_integrity_valid(integrity_metadata, &response)
         {
@@ -502,8 +502,8 @@ pub async fn main_fetch(
         // in http_network_fetch. However, we can't yet follow the request
         // upload progress, so I'm keeping it here for now and pretending
         // the body got sent in one chunk
-        target.process_request_body(&request);
-        target.process_request_eof(&request);
+        target.process_request_body(request);
+        target.process_request_eof(request);
     }
 
     // Step 22.
@@ -518,7 +518,7 @@ pub async fn main_fetch(
     target.process_response_eof(&response);
 
     if let Ok(http_cache) = context.state.http_cache.write() {
-        http_cache.update_awaiting_consumers(&request, &response);
+        http_cache.update_awaiting_consumers(request, &response);
     }
 
     // Steps 25-27.

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -84,7 +84,7 @@ pub struct CancellationListener {
 impl CancellationListener {
     pub fn new(cancel_chan: Option<IpcReceiver<()>>) -> Self {
         Self {
-            cancel_chan: cancel_chan,
+            cancel_chan,
             cancelled: false,
         }
     }
@@ -209,15 +209,15 @@ pub async fn main_fetch(
     }
 
     // Step 2.
-    if request.local_urls_only {
-        if !matches!(
+    if request.local_urls_only &&
+        !matches!(
             request.current_url().scheme(),
             "about" | "blob" | "data" | "filesystem"
-        ) {
-            response = Some(Response::network_error(NetworkError::Internal(
-                "Non-local scheme".into(),
-            )));
-        }
+        )
+    {
+        response = Some(Response::network_error(NetworkError::Internal(
+            "Non-local scheme".into(),
+        )));
     }
 
     // Step 2.2.

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -373,7 +373,7 @@ impl FileManager {
             FileImpl::Sliced(parent_id, inner_rel_pos) => {
                 // Next time we don't need to check validity since
                 // we have already done that for requesting URL if necessary.
-                return self.fetch_blob_buf(
+                self.fetch_blob_buf(
                     done_sender,
                     cancellation_listener,
                     &parent_id,
@@ -383,7 +383,7 @@ impl FileManager {
                         RelativePos::full_range().slice_inner(&inner_rel_pos),
                     ),
                     response,
-                );
+                )
             },
         }
     }
@@ -585,7 +585,6 @@ impl FileManagerStore {
             },
             None => {
                 let _ = sender.send(Err(FileManagerThreadError::UserCancelled));
-                return;
             },
         }
     }
@@ -631,7 +630,6 @@ impl FileManagerStore {
             },
             None => {
                 let _ = sender.send(Err(FileManagerThreadError::UserCancelled));
-                return;
             },
         }
     }
@@ -672,7 +670,7 @@ impl FileManagerStore {
             id,
             FileStoreEntry {
                 origin: origin.to_string(),
-                file_impl: file_impl,
+                file_impl,
                 refs: AtomicUsize::new(1),
                 // Invalid here since create_entry is called by file selection
                 is_valid_url: AtomicBool::new(false),
@@ -687,11 +685,11 @@ impl FileManagerStore {
         };
 
         Ok(SelectedFile {
-            id: id,
+            id,
             filename: filename_path.to_path_buf(),
             modified: modified_epoch,
             size: file_size,
-            type_string: type_string,
+            type_string,
         })
     }
 
@@ -913,7 +911,7 @@ fn read_file_in_chunks(
             buf.truncate(n);
             let blob_buf = BlobBuf {
                 filename: opt_filename,
-                type_string: type_string,
+                type_string,
                 size: size as u64,
                 bytes: buf,
             };

--- a/components/net/hosts.rs
+++ b/components/net/hosts.rs
@@ -19,7 +19,7 @@ lazy_static! {
 fn create_host_table() -> Option<HashMap<String, IpAddr>> {
     let path = env::var_os("HOST_FILE")?;
 
-    let file = File::open(&path).ok()?;
+    let file = File::open(path).ok()?;
     let mut reader = BufReader::new(file);
 
     let mut lines = String::new();

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -33,9 +33,9 @@ impl HstsEntry {
             None
         } else {
             Some(HstsEntry {
-                host: host,
+                host,
                 include_subdomains: (subdomains == IncludeSubdomains::Included),
-                max_age: max_age,
+                max_age,
                 timestamp: Some(time::get_time().sec as u64),
             })
         }
@@ -88,7 +88,7 @@ impl HstsList {
                 hsts_list.push(hsts_entry);
             }
 
-            return Some(hsts_list);
+            Some(hsts_list)
         })
     }
 

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -60,24 +60,12 @@ impl HstsEntry {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct HstsList {
     pub entries_map: HashMap<String, Vec<HstsEntry>>,
 }
 
-impl Default for HstsList {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl HstsList {
-    pub fn new() -> HstsList {
-        HstsList {
-            entries_map: HashMap::new(),
-        }
-    }
-
     /// Create an `HstsList` from the bytes of a JSON preload file.
     pub fn from_preload(preload_content: &str) -> Option<HstsList> {
         #[derive(Deserialize)]
@@ -88,7 +76,7 @@ impl HstsList {
         let hsts_entries: Option<HstsEntries> = serde_json::from_str(preload_content).ok();
 
         hsts_entries.map(|hsts_entries| {
-            let mut hsts_list: HstsList = HstsList::new();
+            let mut hsts_list: HstsList = HstsList::default();
 
             for hsts_entry in hsts_entries.entries {
                 hsts_list.push(hsts_entry);

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -65,6 +65,12 @@ pub struct HstsList {
     pub entries_map: HashMap<String, Vec<HstsEntry>>,
 }
 
+impl Default for HstsList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HstsList {
     pub fn new() -> HstsList {
         HstsList {
@@ -81,14 +87,14 @@ impl HstsList {
 
         let hsts_entries: Option<HstsEntries> = serde_json::from_str(preload_content).ok();
 
-        hsts_entries.map_or(None, |hsts_entries| {
+        hsts_entries.map(|hsts_entries| {
             let mut hsts_list: HstsList = HstsList::new();
 
             for hsts_entry in hsts_entries.entries {
                 hsts_list.push(hsts_entry);
             }
 
-            Some(hsts_list)
+            hsts_list
         })
     }
 
@@ -112,7 +118,7 @@ impl HstsList {
 
     fn has_domain(&self, host: &str, base_domain: &str) -> bool {
         self.entries_map.get(base_domain).map_or(false, |entries| {
-            entries.iter().any(|e| e.matches_domain(&host))
+            entries.iter().any(|e| e.matches_domain(host))
         })
     }
 
@@ -128,10 +134,7 @@ impl HstsList {
         let have_domain = self.has_domain(&entry.host, base_domain);
         let have_subdomain = self.has_subdomain(&entry.host, base_domain);
 
-        let entries = self
-            .entries_map
-            .entry(base_domain.to_owned())
-            .or_insert(vec![]);
+        let entries = self.entries_map.entry(base_domain.to_owned()).or_default();
         if !have_domain && !have_subdomain {
             entries.push(entry);
         } else if !have_subdomain {

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -759,7 +759,7 @@ impl HttpCache {
         assert_eq!(response.status.map(|s| s.0), Some(StatusCode::NOT_MODIFIED));
         let entry_key = CacheKey::new(&request);
         if let Some(cached_resources) = self.entries.get_mut(&entry_key) {
-            for cached_resource in cached_resources.iter_mut() {
+            if let Some(cached_resource) = cached_resources.iter_mut().next() {
                 // done_chan will have been set to Some(..) by http_network_fetch.
                 // If the body is not receiving data, set the done_chan back to None.
                 // Otherwise, create a new dedicated channel to update the consumer.

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -257,6 +257,7 @@ fn get_response_expiry(response: &Response) -> Duration {
             // Status codes that are cacheable by default can use heuristics to determine freshness.
             return heuristic_freshness;
         }
+        // Other status codes can only use heuristic freshness if the public cache directive is present.
         if let Some(ref directives) = response.headers.typed_get::<CacheControl>() {
             if directives.public() {
                 return heuristic_freshness;

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -109,9 +109,9 @@ impl HttpState {
     pub fn new() -> HttpState {
         let override_manager = CertificateErrorOverrideManager::new();
         HttpState {
-            hsts_list: RwLock::new(HstsList::new()),
+            hsts_list: RwLock::new(HstsList::default()),
             cookie_jar: RwLock::new(CookieStorage::new(150)),
-            auth_cache: RwLock::new(AuthCache::new()),
+            auth_cache: RwLock::new(AuthCache::default()),
             history_states: RwLock::new(HashMap::new()),
             http_cache: RwLock::new(HttpCache::new()),
             http_cache_state: Mutex::new(HashMap::new()),

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -5,8 +5,6 @@
 use core::convert::Infallible;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
-use std::mem;
-use std::ops::Deref;
 use std::sync::{Arc as StdArc, Condvar, Mutex, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -99,6 +97,12 @@ pub struct HttpState {
     pub history_states: RwLock<HashMap<HistoryStateId, Vec<u8>>>,
     pub client: Client<Connector, Body>,
     pub override_manager: CertificateErrorOverrideManager,
+}
+
+impl Default for HttpState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HttpState {
@@ -237,8 +241,8 @@ fn is_schemelessy_same_site(site_a: &ImmutableOrigin, site_b: &ImmutableOrigin) 
         let host_b_reg = reg_suffix(&host_b);
 
         // Step 2.2-2.3
-        (site_a.host() == site_b.host() && host_a_reg == "") ||
-            (host_a_reg == host_b_reg && host_a_reg != "")
+        (site_a.host() == site_b.host() && host_a_reg.is_empty()) ||
+            (host_a_reg == host_b_reg && !host_a_reg.is_empty())
     } else {
         // Step 3
         false
@@ -345,7 +349,7 @@ fn set_cookies_from_headers(
 ) {
     for cookie in headers.get_all(header::SET_COOKIE) {
         if let Ok(cookie_str) = std::str::from_utf8(cookie.as_bytes()) {
-            set_cookie_for_url(&cookie_jar, &url, &cookie_str);
+            set_cookie_for_url(cookie_jar, url, cookie_str);
         }
     }
 }
@@ -411,7 +415,7 @@ fn auth_from_cache(
     auth_cache: &RwLock<AuthCache>,
     origin: &ImmutableOrigin,
 ) -> Option<Authorization<Basic>> {
-    if let Some(ref auth_entry) = auth_cache
+    if let Some(auth_entry) = auth_cache
         .read()
         .unwrap()
         .entries
@@ -503,9 +507,9 @@ async fn obtain_response(
             .clone()
             .into_url()
             .as_ref()
-            .replace("|", "%7C")
-            .replace("{", "%7B")
-            .replace("}", "%7D");
+            .replace('|', "%7C")
+            .replace('{', "%7B")
+            .replace('}', "%7D");
 
         let request = if let Some(chunk_requester) = body {
             let (sink, stream) = if source_is_null {
@@ -649,7 +653,7 @@ async fn obtain_response(
             .set_attribute(ResourceAttribute::ConnectEnd(connect_end));
 
         let request_id = request_id.map(|v| v.to_owned());
-        let pipeline_id = pipeline_id.clone();
+        let pipeline_id = *pipeline_id;
         let closure_url = url.clone();
         let method = method.clone();
         let send_start = precise_time_ms();
@@ -760,13 +764,13 @@ pub async fn http_fetch(
             let method_mismatch = !method_cache_match &&
                 (!is_cors_safelisted_method(&request.method) || request.use_cors_preflight);
             let header_mismatch = request.headers.iter().any(|(name, value)| {
-                !cache.match_header(&*request, &name) &&
+                !cache.match_header(&*request, name) &&
                     !is_cors_safelisted_request_header(&name, &value)
             });
 
             // Sub-substep 1
             if method_mismatch || header_mismatch {
-                let preflight_result = cors_preflight_fetch(&request, cache, context).await;
+                let preflight_result = cors_preflight_fetch(request, cache, context).await;
                 // Sub-substep 2
                 if let Some(e) = preflight_result.get_network_error() {
                     return Response::network_error(e.clone());
@@ -798,7 +802,7 @@ pub async fn http_fetch(
         .await;
 
         // Substep 4
-        if cors_flag && cors_check(&request, &fetch_result).is_err() {
+        if cors_flag && cors_check(request, &fetch_result).is_err() {
             return Response::network_error(NetworkError::Internal("CORS check failed".into()));
         }
 
@@ -834,7 +838,7 @@ pub async fn http_fetch(
             .and_then(|v| {
                 HeaderValue::to_str(v)
                     .map(|l| {
-                        ServoUrl::parse_with_base(response.actual_response().url(), &l)
+                        ServoUrl::parse_with_base(response.actual_response().url(), l)
                             .map_err(|err| err.to_string())
                     })
                     .ok()
@@ -1093,7 +1097,7 @@ fn try_immutable_origin_to_hyper_origin(url_origin: &ImmutableOrigin) -> Option<
                 ("http", 80) | ("https", 443) => None,
                 _ => Some(*port),
             };
-            HyperOrigin::try_from_parts(&scheme, &host.to_string(), port).ok()
+            HyperOrigin::try_from_parts(scheme, &host.to_string(), port).ok()
         },
     }
 }
@@ -1286,7 +1290,7 @@ async fn http_network_or_cache_fetch(
     // That one happens when a fetch gets a cache hit, and the resource is pending completion from the network.
     {
         let (lock, cvar) = {
-            let entry_key = CacheKey::new(&http_request);
+            let entry_key = CacheKey::new(http_request);
             let mut state_map = context.state.http_cache_state.lock().unwrap();
             &*state_map
                 .entry(entry_key)
@@ -1315,7 +1319,7 @@ async fn http_network_or_cache_fetch(
         // Step 5.19
         if let Ok(http_cache) = context.state.http_cache.read() {
             if let Some(response_from_cache) =
-                http_cache.construct_response(&http_request, done_chan)
+                http_cache.construct_response(http_request, done_chan)
             {
                 let response_headers = response_from_cache.response.headers.clone();
                 // Substep 1, 2, 3, 4
@@ -1379,7 +1383,7 @@ async fn http_network_or_cache_fetch(
     // if no stores are pending.
     fn update_http_cache_state(context: &FetchContext, http_request: &Request) {
         let (lock, cvar) = {
-            let entry_key = CacheKey::new(&http_request);
+            let entry_key = CacheKey::new(http_request);
             let mut state_map = context.state.http_cache_state.lock().unwrap();
             &*state_map
                 .get_mut(&entry_key)
@@ -1438,7 +1442,7 @@ async fn http_network_or_cache_fetch(
         if http_request.cache_mode == CacheMode::OnlyIfCached {
             // The cache will not be updated,
             // set its state to ready to construct.
-            update_http_cache_state(context, &http_request);
+            update_http_cache_state(context, http_request);
             return Response::network_error(NetworkError::Internal(
                 "Couldn't find response in cache".into(),
             ));
@@ -1453,7 +1457,7 @@ async fn http_network_or_cache_fetch(
         if let Some((200..=399, _)) = forward_response.raw_status {
             if !http_request.method.is_safe() {
                 if let Ok(mut http_cache) = context.state.http_cache.write() {
-                    http_cache.invalidate(&http_request, &forward_response);
+                    http_cache.invalidate(http_request, &forward_response);
                 }
             }
         }
@@ -1468,7 +1472,7 @@ async fn http_network_or_cache_fetch(
                 // Ensure done_chan is None,
                 // since the network response will be replaced by the revalidated stored one.
                 *done_chan = None;
-                response = http_cache.refresh(&http_request, forward_response.clone(), done_chan);
+                response = http_cache.refresh(http_request, forward_response.clone(), done_chan);
             }
             wait_for_cached_response(done_chan, &mut response).await;
         }
@@ -1478,7 +1482,7 @@ async fn http_network_or_cache_fetch(
             if http_request.cache_mode != CacheMode::NoStore {
                 // Subsubstep 2, doing it first to avoid a clone of forward_response.
                 if let Ok(mut http_cache) = context.state.http_cache.write() {
-                    http_cache.store(&http_request, &forward_response);
+                    http_cache.store(http_request, &forward_response);
                 }
             }
             // Subsubstep 1
@@ -1489,7 +1493,7 @@ async fn http_network_or_cache_fetch(
     let mut response = response.unwrap();
 
     // The cache has been updated, set its state to ready to construct.
-    update_http_cache_state(context, &http_request);
+    update_http_cache_state(context, http_request);
 
     // Step 8
     // TODO: if necessary set response's range-requested flag
@@ -1538,7 +1542,7 @@ async fn http_network_or_cache_fetch(
         // Step 5
         if let Origin::Origin(ref request_origin) = request.origin {
             let schemeless_same_origin =
-                is_schemelessy_same_site(&request_origin, &current_url_origin);
+                is_schemelessy_same_site(request_origin, &current_url_origin);
             if schemeless_same_origin &&
                 (request_origin.scheme() == Some("https") ||
                     response.https_state == HttpsState::None)
@@ -1556,7 +1560,7 @@ async fn http_network_or_cache_fetch(
     }
 
     if http_request.response_tainting != ResponseTainting::CorsTainting &&
-        cross_origin_resource_policy_check(&http_request, &response) ==
+        cross_origin_resource_policy_check(http_request, &response) ==
             CrossOriginResourcePolicy::Blocked
     {
         return Response::network_error(NetworkError::Internal(
@@ -1723,7 +1727,7 @@ async fn http_network_fetch(
             .map(|body| body.source_is_null())
             .unwrap_or(false),
         &request.pipeline_id,
-        request_id.as_ref().map(Deref::deref),
+        request_id.as_deref(),
         is_xhr,
         context,
         fetch_terminated_sender,
@@ -1797,7 +1801,7 @@ async fn http_network_fetch(
     ));
     response.headers = res.headers().clone();
     response.referrer = request.referrer.to_url().cloned();
-    response.referrer_policy = request.referrer_policy.clone();
+    response.referrer_policy = request.referrer_policy;
 
     let res_body = response.body.clone();
 
@@ -1835,7 +1839,7 @@ async fn http_network_fetch(
             send_response_to_devtools(
                 &sender,
                 request_id.unwrap(),
-                meta_headers.map(|hdrs| Serde::into_inner(hdrs)),
+                meta_headers.map(Serde::into_inner),
                 meta_status,
                 pipeline_id,
             );
@@ -1862,7 +1866,7 @@ async fn http_network_fetch(
                 }
                 if let ResponseBody::Receiving(ref mut body) = *res_body.lock().unwrap() {
                     let bytes = chunk;
-                    body.extend_from_slice(&*bytes);
+                    body.extend_from_slice(&bytes);
                     let _ = done_sender.send(Data::Payload(bytes.to_vec()));
                 }
                 future::ready(Ok(res_body))
@@ -1871,7 +1875,7 @@ async fn http_network_fetch(
                 debug!("successfully finished response for {:?}", url1);
                 let mut body = res_body.lock().unwrap();
                 let completed_body = match *body {
-                    ResponseBody::Receiving(ref mut body) => mem::replace(body, vec![]),
+                    ResponseBody::Receiving(ref mut body) => std::mem::take(body),
                     _ => vec![],
                 };
                 *body = ResponseBody::Done(completed_body);
@@ -1886,7 +1890,7 @@ async fn http_network_fetch(
                 debug!("finished response for {:?}", url2);
                 let mut body = res_body2.lock().unwrap();
                 let completed_body = match *body {
-                    ResponseBody::Receiving(ref mut body) => mem::replace(body, vec![]),
+                    ResponseBody::Receiving(ref mut body) => std::mem::take(body),
                     _ => vec![],
                 };
                 *body = ResponseBody::Done(completed_body);
@@ -1974,8 +1978,8 @@ async fn cors_preflight_fetch(
             Origin::Origin(origin) => origin.clone(),
         })
         .pipeline_id(request.pipeline_id)
-        .initiator(request.initiator.clone())
-        .destination(request.destination.clone())
+        .initiator(request.initiator)
+        .destination(request.destination)
         .referrer_policy(request.referrer_policy)
         .mode(RequestMode::CorsMode)
         .response_tainting(ResponseTainting::CorsTainting)
@@ -2007,7 +2011,7 @@ async fn cors_preflight_fetch(
     let response =
         http_network_or_cache_fetch(&mut preflight, false, false, &mut None, context).await;
     // Step 7
-    if cors_check(&request, &response).is_ok() &&
+    if cors_check(request, &response).is_ok() &&
         response
             .status
             .as_ref()
@@ -2079,7 +2083,7 @@ async fn cors_preflight_fetch(
 
         // Substep 6
         if request.headers.iter().any(|(name, _)| {
-            is_cors_non_wildcard_request_header_name(&name) &&
+            is_cors_non_wildcard_request_header_name(name) &&
                 header_names.iter().all(|hn| hn != name)
         }) {
             return Response::network_error(NetworkError::Internal(
@@ -2116,12 +2120,12 @@ async fn cors_preflight_fetch(
 
         // Substep 12, 13
         for method in &methods {
-            cache.match_method_and_update(&*request, method.clone(), max_age);
+            cache.match_method_and_update(request, method.clone(), max_age);
         }
 
         // Substep 14, 15
         for header_name in &header_names {
-            cache.match_header_and_update(&*request, &*header_name, max_age);
+            cache.match_header_and_update(request, header_name, max_age);
         }
 
         // Substep 16

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -193,7 +193,7 @@ fn no_referrer_when_downgrade(referrer_url: ServoUrl, current_url: ServoUrl) -> 
         return None;
     }
     // Step 2
-    return strip_url_for_use_as_referrer(referrer_url, false);
+    strip_url_for_use_as_referrer(referrer_url, false)
 }
 
 /// <https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-strict-origin>
@@ -363,16 +363,16 @@ fn prepare_devtools_request(
     is_xhr: bool,
 ) -> ChromeToDevtoolsControlMsg {
     let request = DevtoolsHttpRequest {
-        url: url,
-        method: method,
-        headers: headers,
-        body: body,
-        pipeline_id: pipeline_id,
+        url,
+        method,
+        headers,
+        body,
+        pipeline_id,
         startedDateTime: now,
         timeStamp: now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as i64,
-        connect_time: connect_time,
-        send_time: send_time,
-        is_xhr: is_xhr,
+        connect_time,
+        send_time,
+        is_xhr,
     };
     let net_event = NetworkEvent::HttpRequest(request);
 
@@ -396,10 +396,10 @@ fn send_response_to_devtools(
     pipeline_id: PipelineId,
 ) {
     let response = DevtoolsHttpResponse {
-        headers: headers,
-        status: status,
+        headers,
+        status,
         body: None,
-        pipeline_id: pipeline_id,
+        pipeline_id,
     };
     let net_event_response = NetworkEvent::HttpResponse(response);
 
@@ -1257,13 +1257,14 @@ async fn http_network_or_cache_fetch(
             }
 
             // Substep 5
-            if authentication_fetch_flag && authorization_value.is_none() {
-                if has_credentials(&current_url) {
-                    authorization_value = Some(Authorization::basic(
-                        current_url.username(),
-                        current_url.password().unwrap_or(""),
-                    ));
-                }
+            if authentication_fetch_flag &&
+                authorization_value.is_none() &&
+                has_credentials(&current_url)
+            {
+                authorization_value = Some(Authorization::basic(
+                    current_url.username(),
+                    current_url.password().unwrap_or(""),
+                ));
             }
 
             // Substep 6
@@ -1852,7 +1853,6 @@ async fn http_network_fetch(
         res.into_body()
             .map_err(|e| {
                 warn!("Error streaming response body: {:?}", e);
-                ()
             })
             .try_fold(res_body, move |res_body, chunk| {
                 if cancellation_listener.lock().unwrap().cancelled() {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -21,8 +21,8 @@ use headers::authorization::Basic;
 use headers::{
     AccessControlAllowCredentials, AccessControlAllowHeaders, AccessControlAllowMethods,
     AccessControlAllowOrigin, AccessControlMaxAge, AccessControlRequestHeaders,
-    AccessControlRequestMethod, Authorization, CacheControl, ContentEncoding, ContentLength,
-    HeaderMapExt, IfModifiedSince, LastModified, Origin as HyperOrigin, Pragma, Referer, UserAgent,
+    AccessControlRequestMethod, Authorization, CacheControl, ContentLength, HeaderMapExt,
+    IfModifiedSince, LastModified, Origin as HyperOrigin, Pragma, Referer, UserAgent,
 };
 use http::header::{
     self, HeaderValue, ACCEPT, CONTENT_ENCODING, CONTENT_LANGUAGE, CONTENT_LOCATION, CONTENT_TYPE,
@@ -1917,11 +1917,11 @@ async fn http_network_fetch(
     // TODO when https://bugzilla.mozilla.org/show_bug.cgi?id=1030660
     // is resolved, this step will become uneccesary
     // TODO this step
-    if let Some(encoding) = response.headers.typed_get::<ContentEncoding>() {
-        if encoding.contains("gzip") {
-        } else if encoding.contains("compress") {
-        }
-    };
+    // if let Some(encoding) = response.headers.typed_get::<ContentEncoding>() {
+    //     if encoding.contains("gzip") {
+    //     } else if encoding.contains("compress") {
+    //     }
+    // };
 
     // Step 13
     // TODO this step isn't possible yet (CSP)

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -4,9 +4,7 @@
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
-use std::mem;
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 use embedder_traits::resources::{self, Resource};
 use imsz::imsz_from_reader;
@@ -635,13 +633,8 @@ impl ImageCache for ImageCacheImpl {
                         };
 
                         let local_store = self.store.clone();
-<<<<<<< HEAD
                         self.thread_pool.spawn(move || {
-                            let msg = decode_bytes_sync(key, &*bytes, cors_status);
-=======
-                        thread::spawn(move || {
                             let msg = decode_bytes_sync(key, &bytes, cors_status);
->>>>>>> 86264db0c7 (clippy: get rid of many of net warnings)
                             debug!("Image decoded");
                             local_store.lock().unwrap().handle_decoder(msg);
                         });

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -43,10 +43,7 @@ use crate::resource_thread::CoreResourceThreadPool;
 
 fn decode_bytes_sync(key: LoadKey, bytes: &[u8], cors: CorsStatus) -> DecoderMsg {
     let image = load_from_memory(bytes, cors);
-    DecoderMsg {
-        key: key,
-        image: image,
-    }
+    DecoderMsg { key, image }
 }
 
 fn get_placeholder_image(webrender_api: &WebrenderIpcSender, data: &[u8]) -> Arc<Image> {
@@ -191,10 +188,7 @@ struct CompletedLoad {
 
 impl CompletedLoad {
     fn new(image_response: ImageResponse, id: PendingImageId) -> CompletedLoad {
-        CompletedLoad {
-            image_response: image_response,
-            id: id,
-        }
+        CompletedLoad { image_response, id }
     }
 }
 
@@ -306,7 +300,7 @@ impl PendingLoad {
             metadata: None,
             result: None,
             listeners: vec![],
-            url: url,
+            url,
             load_origin,
             final_url: None,
             cors_setting,
@@ -434,7 +428,7 @@ impl ImageCache for ImageCacheImpl {
                 completed_loads: HashMap::new(),
                 placeholder_image: get_placeholder_image(&webrender_api, &rippy_data),
                 placeholder_url: ServoUrl::parse("chrome://resources/rippy.png").unwrap(),
-                webrender_api: webrender_api,
+                webrender_api,
             })),
             thread_pool: CoreResourceThreadPool::new(16),
         }

--- a/components/net/mime_classifier.rs
+++ b/components/net/mime_classifier.rs
@@ -51,7 +51,16 @@ pub enum NoSniffFlag {
 
 impl Default for MimeClassifier {
     fn default() -> Self {
-        Self::new()
+        Self {
+            image_classifier: GroupedClassifier::image_classifer(),
+            audio_video_classifier: GroupedClassifier::audio_video_classifier(),
+            scriptable_classifier: GroupedClassifier::scriptable_classifier(),
+            plaintext_classifier: GroupedClassifier::plaintext_classifier(),
+            archive_classifier: GroupedClassifier::archive_classifier(),
+            binary_or_plaintext: BinaryOrPlaintextClassifier,
+            feeds_classifier: FeedsClassifier,
+            font_classifier: GroupedClassifier::font_classifier(),
+        }
     }
 }
 
@@ -167,19 +176,6 @@ impl MimeClassifier {
                 // of this implementation.
                 "text/cache-manifest".parse().unwrap()
             },
-        }
-    }
-
-    pub fn new() -> MimeClassifier {
-        MimeClassifier {
-            image_classifier: GroupedClassifier::image_classifer(),
-            audio_video_classifier: GroupedClassifier::audio_video_classifier(),
-            scriptable_classifier: GroupedClassifier::scriptable_classifier(),
-            plaintext_classifier: GroupedClassifier::plaintext_classifier(),
-            archive_classifier: GroupedClassifier::archive_classifier(),
-            binary_or_plaintext: BinaryOrPlaintextClassifier,
-            feeds_classifier: FeedsClassifier,
-            font_classifier: GroupedClassifier::font_classifier(),
         }
     }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -159,7 +159,7 @@ fn create_http_states(
     ignore_certificate_errors: bool,
 ) -> (Arc<HttpState>, Arc<HttpState>) {
     let mut hsts_list = HstsList::from_servo_preload();
-    let mut auth_cache = AuthCache::new();
+    let mut auth_cache = AuthCache::default();
     let http_cache = HttpCache::new();
     let mut cookie_jar = CookieStorage::new(150);
     if let Some(config_dir) = config_dir {
@@ -188,7 +188,7 @@ fn create_http_states(
     let private_http_state = HttpState {
         hsts_list: RwLock::new(HstsList::from_servo_preload()),
         cookie_jar: RwLock::new(CookieStorage::new(150)),
-        auth_cache: RwLock::new(AuthCache::new()),
+        auth_cache: RwLock::new(AuthCache::default()),
         history_states: RwLock::new(HashMap::new()),
         http_cache: RwLock::new(HttpCache::new()),
         http_cache_state: Mutex::new(HashMap::new()),
@@ -451,13 +451,7 @@ pub struct AuthCacheEntry {
 
 impl Default for AuthCache {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AuthCache {
-    pub fn new() -> AuthCache {
-        AuthCache {
+        Self {
             version: 1,
             entries: HashMap::new(),
         }
@@ -712,7 +706,7 @@ impl CoreResourceManager {
                     let response = Response::from_init(res_init, timing_type);
                     http_redirect_fetch(
                         &mut request,
-                        &mut CorsCache::new(),
+                        &mut CorsCache::default(),
                         response,
                         true,
                         &mut sender,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -531,7 +531,7 @@ impl CoreResourceThreadPool {
             .build()
             .unwrap();
         let state = Arc::new(Mutex::new(ThreadPoolState::new()));
-        CoreResourceThreadPool { pool: pool, state }
+        CoreResourceThreadPool { pool, state }
     }
 
     /// Spawn work on the thread-pool, if still active.
@@ -613,7 +613,7 @@ impl CoreResourceManager {
         let pool = CoreResourceThreadPool::new(16);
         let pool_handle = Arc::new(pool);
         CoreResourceManager {
-            user_agent: user_agent,
+            user_agent,
             devtools_sender,
             sw_managers: Default::default(),
             filemanager: FileManager::new(embedder_proxy, Arc::downgrade(&pool_handle)),

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, BufReader};
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
@@ -213,7 +212,7 @@ impl ResourceChannelManager {
         memory_reporter: IpcReceiver<ReportsChan>,
     ) {
         let (public_http_state, private_http_state) = create_http_states(
-            self.config_dir.as_ref().map(Deref::deref),
+            self.config_dir.as_deref(),
             self.ca_certificates.clone(),
             self.ignore_certificate_errors,
         );
@@ -426,11 +425,10 @@ pub fn write_json_to_file<T>(data: &T, config_dir: &Path, filename: &str)
 where
     T: Serialize,
 {
-    let json_encoded: String;
-    match serde_json::to_string_pretty(&data) {
-        Ok(d) => json_encoded = d,
+    let json_encoded: String = match serde_json::to_string_pretty(&data) {
+        Ok(d) => d,
         Err(_) => return,
-    }
+    };
     let path = config_dir.join(filename);
     let display = path.display();
 
@@ -449,6 +447,12 @@ where
 pub struct AuthCacheEntry {
     pub user_name: String,
     pub password: String,
+}
+
+impl Default for AuthCache {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl AuthCache {

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -122,7 +122,7 @@ impl StorageManager {
         let origin = self.origin_as_string(url);
         let data = self.select_data(storage_type);
         sender
-            .send(data.get(&origin).map_or(0, |&(_, ref entry)| entry.len()))
+            .send(data.get(&origin).map_or(0, |(_, entry)| entry.len()))
             .unwrap();
     }
 
@@ -137,7 +137,7 @@ impl StorageManager {
         let data = self.select_data(storage_type);
         let key = data
             .get(&origin)
-            .and_then(|&(_, ref entry)| entry.keys().nth(index as usize))
+            .and_then(|(_, entry)| entry.keys().nth(index as usize))
             .cloned();
         sender.send(key).unwrap();
     }
@@ -147,7 +147,7 @@ impl StorageManager {
         let data = self.select_data(storage_type);
         let keys = data
             .get(&origin)
-            .map_or(vec![], |&(_, ref entry)| entry.keys().cloned().collect());
+            .map_or(vec![], |(_, entry)| entry.keys().cloned().collect());
 
         sender.send(keys).unwrap();
     }
@@ -225,7 +225,7 @@ impl StorageManager {
         sender
             .send(
                 data.get(&origin)
-                    .and_then(|&(_, ref entry)| entry.get(&name))
+                    .and_then(|(_, entry)| entry.get(&name))
                     .map(String::clone),
             )
             .unwrap();
@@ -244,9 +244,9 @@ impl StorageManager {
         let old_value = data
             .get_mut(&origin)
             .and_then(|&mut (ref mut total, ref mut entry)| {
-                entry.remove(&name).and_then(|old| {
+                entry.remove(&name).map(|old| {
                     *total -= name.as_bytes().len() + old.as_bytes().len();
-                    Some(old)
+                    old
                 })
             });
         sender.send(old_value).unwrap();

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -47,10 +47,10 @@ impl StorageManager {
             resource_thread::read_json_from_file(&mut local_data, config_dir, "local_data.json");
         }
         StorageManager {
-            port: port,
+            port,
             session_data: HashMap::new(),
-            local_data: local_data,
-            config_dir: config_dir,
+            local_data,
+            config_dir,
         }
     }
 }

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -11,7 +11,7 @@ use generic_array::ArrayLength;
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
-const SUPPORTED_ALGORITHM: &[&'static str] = &["sha256", "sha384", "sha512"];
+const SUPPORTED_ALGORITHM: &[&str] = &["sha256", "sha384", "sha512"];
 pub type StaticCharVec = &'static [char];
 /// A "space character" according to:
 ///
@@ -46,7 +46,7 @@ pub fn parsed_metadata(integrity_metadata: &str) -> Vec<SriEntry> {
     // Step 3
     let tokens = split_html_space_chars(integrity_metadata);
     for token in tokens {
-        let parsed_data: Vec<&str> = token.split("-").collect();
+        let parsed_data: Vec<&str> = token.split('-').collect();
 
         if parsed_data.len() > 1 {
             let alg = parsed_data[0];
@@ -55,7 +55,7 @@ pub fn parsed_metadata(integrity_metadata: &str) -> Vec<SriEntry> {
                 continue;
             }
 
-            let data: Vec<&str> = parsed_data[1].split("?").collect();
+            let data: Vec<&str> = parsed_data[1].split('?').collect();
             let digest = data[0];
 
             let opt = if data.len() > 1 {
@@ -78,11 +78,11 @@ pub fn get_prioritized_hash_function(
 ) -> Option<String> {
     let left_priority = SUPPORTED_ALGORITHM
         .iter()
-        .position(|s| s.to_owned() == hash_func_left)
+        .position(|s| *s == hash_func_left)
         .unwrap();
     let right_priority = SUPPORTED_ALGORITHM
         .iter()
-        .position(|s| s.to_owned() == hash_func_right)
+        .position(|s| *s == hash_func_right)
         .unwrap();
 
     if left_priority == right_priority {
@@ -102,7 +102,7 @@ pub fn get_strongest_metadata(integrity_metadata_list: Vec<SriEntry>) -> Vec<Sri
 
     for integrity_metadata in &integrity_metadata_list[1..] {
         let prioritized_hash =
-            get_prioritized_hash_function(&integrity_metadata.alg, &*current_algorithm);
+            get_prioritized_hash_function(&integrity_metadata.alg, &current_algorithm);
         if prioritized_hash.is_none() {
             result.push(integrity_metadata.clone());
         } else if let Some(algorithm) = prioritized_hash {
@@ -174,9 +174,7 @@ pub fn is_response_integrity_valid(integrity_metadata: &str, response: &Response
     false
 }
 
-pub fn split_html_space_chars<'a>(
-    s: &'a str,
-) -> Filter<Split<'a, StaticCharVec>, fn(&&str) -> bool> {
+pub fn split_html_space_chars(s: &str) -> Filter<Split<'_, StaticCharVec>, fn(&&str) -> bool> {
     fn not_empty(&split: &&str) -> bool {
         !split.is_empty()
     }

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -11,8 +11,8 @@ use generic_array::ArrayLength;
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
-const SUPPORTED_ALGORITHM: &'static [&'static str] = &["sha256", "sha384", "sha512"];
-pub type StaticCharVec = &'static [char];
+const SUPPORTED_ALGORITHM: &[&'static str] = &["sha256", "sha384", "sha512"];
+pub type StaticCharVec = &[char];
 /// A "space character" according to:
 ///
 /// <https://html.spec.whatwg.org/multipage/#space-character>
@@ -33,7 +33,7 @@ impl SriEntry {
         SriEntry {
             alg: alg.to_owned(),
             val: val.to_owned(),
-            opt: opt,
+            opt,
         }
     }
 }

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -12,7 +12,7 @@ use net_traits::response::{Response, ResponseBody, ResponseType};
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
 const SUPPORTED_ALGORITHM: &[&'static str] = &["sha256", "sha384", "sha512"];
-pub type StaticCharVec = &[char];
+pub type StaticCharVec = &'static [char];
 /// A "space character" according to:
 ///
 /// <https://html.spec.whatwg.org/multipage/#space-character>
@@ -68,7 +68,7 @@ pub fn parsed_metadata(integrity_metadata: &str) -> Vec<SriEntry> {
         }
     }
 
-    return result;
+    result
 }
 
 /// <https://w3c.github.io/webappsec-subresource-integrity/#getprioritizedhashfunction>

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -385,7 +385,7 @@ fn test_cors_preflight_cache_fetch() {
     static ACK: &'static [u8] = b"ACK";
     let state = Arc::new(AtomicUsize::new(0));
     let counter = state.clone();
-    let mut cache = CorsCache::new();
+    let mut cache = CorsCache::default();
     let handler = move |request: HyperRequest<Body>, response: &mut HyperResponse<Body>| {
         if request.method() == Method::OPTIONS && state.clone().fetch_add(1, Ordering::SeqCst) == 0
         {

--- a/components/net/tests/mime_classifier.rs
+++ b/components/net/tests/mime_classifier.rs
@@ -53,7 +53,7 @@ fn test_sniff_mp4_matcher_long() {
 
 #[test]
 fn test_validate_classifier() {
-    let classifier = MimeClassifier::new();
+    let classifier = MimeClassifier::default();
     classifier.validate().expect("Validation error")
 }
 
@@ -74,7 +74,7 @@ fn test_sniff_with_flags(
     let mut filename = PathBuf::from("tests/parsable_mime/");
     filename.push(filename_orig);
 
-    let classifier = MimeClassifier::new();
+    let classifier = MimeClassifier::default();
 
     let read_result = read_file(&filename);
 

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -94,7 +94,7 @@ fn create_request(
     }
 
     if resource_url.password().is_some() || resource_url.username() != "" {
-        let basic = base64::engine::general_purpose::STANDARD.encode(&format!(
+        let basic = base64::engine::general_purpose::STANDARD.encode(format!(
             "{}:{}",
             resource_url.username(),
             resource_url.password().unwrap_or("")
@@ -147,7 +147,7 @@ fn process_ws_response(
         .hsts_list
         .write()
         .unwrap()
-        .update_hsts_list_from_response(resource_url, &response.headers());
+        .update_hsts_list_from_response(resource_url, response.headers());
 
     Ok(protocol_in_use)
 }
@@ -389,7 +389,7 @@ fn connect(
         &req_url,
         &req_builder.origin.ascii_serialization(),
         &protocols,
-        &*http_state,
+        &http_state,
     ) {
         Ok(c) => c,
         Err(e) => return Err(e.to_string()),

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -49,9 +49,7 @@ pub fn rgba8_get_rect(pixels: &[u8], size: Size2D<u64>, rect: Rect<u64>) -> Cow<
 pub fn rgba8_byte_swap_colors_inplace(pixels: &mut [u8]) {
     assert!(pixels.len() % 4 == 0);
     for rgba in pixels.chunks_mut(4) {
-        let b = rgba[0];
-        rgba[0] = rgba[2];
-        rgba[2] = b;
+        rgba.swap(0, 2);
     }
 }
 
@@ -79,7 +77,7 @@ pub fn rgba8_premultiply_inplace(pixels: &mut [u8]) -> bool {
 }
 
 pub fn multiply_u8_color(a: u8, b: u8) -> u8 {
-    return (a as u32 * b as u32 / 255) as u8;
+    (a as u32 * b as u32 / 255) as u8
 }
 
 pub fn clip(

--- a/components/profile/trace_dump.rs
+++ b/components/profile/trace_dump.rs
@@ -37,7 +37,7 @@ impl TraceDump {
     {
         let mut file = fs::File::create(trace_file_path)?;
         write_prologue(&mut file)?;
-        Ok(TraceDump { file: file })
+        Ok(TraceDump { file })
     }
 
     /// Write one trace to the trace dump file.

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -95,12 +95,6 @@ impl ServoRng {
     }
 }
 
-impl Default for ServoRng {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ServoRng {
     /// Create an auto-reseeding instance of `ServoRng`.
     ///

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -95,6 +95,12 @@ impl ServoRng {
     }
 }
 
+impl Default for ServoRng {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ServoRng {
     /// Create an auto-reseeding instance of `ServoRng`.
     ///

--- a/components/range/lib.rs
+++ b/components/range/lib.rs
@@ -205,8 +205,8 @@ impl<I: RangeIndex> Range<I> {
     #[inline]
     pub fn new(begin: I, length: I) -> Range<I> {
         Range {
-            begin: begin,
-            length: length,
+            begin,
+            length,
         }
     }
 

--- a/components/range/lib.rs
+++ b/components/range/lib.rs
@@ -204,10 +204,7 @@ impl<I: RangeIndex> Range<I> {
     /// ~~~
     #[inline]
     pub fn new(begin: I, length: I) -> Range<I> {
-        Range {
-            begin,
-            length,
-        }
+        Range { begin, length }
     }
 
     #[inline]

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -31,16 +31,16 @@ fn main() {
     println!("Binding generation completed in {:?}", start.elapsed());
 
     let json = out_dir.join("InterfaceObjectMapData.json");
-    let json: Value = serde_json::from_reader(File::open(&json).unwrap()).unwrap();
+    let json: Value = serde_json::from_reader(File::open(json).unwrap()).unwrap();
     let mut map = phf_codegen::Map::new();
     for (key, value) in json.as_object().unwrap() {
         map.entry(Bytes(key), value.as_str().unwrap());
     }
     let phf = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("InterfaceObjectMapPhf.rs");
-    let mut phf = File::create(&phf).unwrap();
-    write!(
+    let mut phf = File::create(phf).unwrap();
+    writeln!(
         &mut phf,
-        "pub static MAP: phf::Map<&'static [u8], fn(JSContext, HandleObject)> = {};\n",
+        "pub static MAP: phf::Map<&'static [u8], fn(JSContext, HandleObject)> = {};",
         map.build(),
     )
     .unwrap();

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -50,7 +50,7 @@ impl DissimilarOriginWindow {
         let cx = GlobalScope::get_cx();
         let win = Box::new(Self {
             globalscope: GlobalScope::new_inherited(
-                PipelineId::new(),
+                PipelineId::default(),
                 global_to_clone_from.devtools_chan().cloned(),
                 global_to_clone_from.mem_profiler_chan().clone(),
                 global_to_clone_from.time_profiler_chan().clone(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1435,7 +1435,7 @@ impl GlobalScope {
                     }
                 }),
             );
-            let router_id = BroadcastChannelRouterId::new();
+            let router_id = BroadcastChannelRouterId::default();
             *current_state = BroadcastChannelState::Managed(router_id.clone(), HashMap::new());
             let _ = self
                 .script_to_constellation_chan()
@@ -1491,7 +1491,7 @@ impl GlobalScope {
                     }
                 }),
             );
-            let router_id = MessagePortRouterId::new();
+            let router_id = MessagePortRouterId::default();
             *current_state =
                 MessagePortState::Managed(router_id.clone(), HashMapTracedValues::new());
             let _ = self

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -228,7 +228,7 @@ impl History {
         // Step 8
         let state_id = match push_or_replace {
             PushOrReplace::Push => {
-                let state_id = HistoryStateId::new();
+                let state_id = HistoryStateId::default();
                 self.state_id.set(Some(state_id));
                 let msg = ScriptMsg::PushHistoryState(state_id, new_url.clone());
                 let _ = self
@@ -242,7 +242,7 @@ impl History {
                 let state_id = match self.state_id.get() {
                     Some(state_id) => state_id,
                     None => {
-                        let state_id = HistoryStateId::new();
+                        let state_id = HistoryStateId::default();
                         self.state_id.set(Some(state_id));
                         state_id
                     },

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -176,7 +176,7 @@ impl HTMLIFrameElement {
 
         let window = window_from_node(self);
         let old_pipeline_id = self.pipeline_id();
-        let new_pipeline_id = PipelineId::new();
+        let new_pipeline_id = PipelineId::default();
         self.pending_pipeline_id.set(Some(new_pipeline_id));
 
         let global_scope = window.upcast::<GlobalScope>();
@@ -380,7 +380,7 @@ impl HTMLIFrameElement {
             document.get_referrer_policy(),
             Some(window.upcast::<GlobalScope>().is_secure_context()),
         );
-        let browsing_context_id = BrowsingContextId::new();
+        let browsing_context_id = BrowsingContextId::default();
         let top_level_browsing_context_id = window.window_proxy().top_level_browsing_context_id();
         self.pipeline_id.set(None);
         self.pending_pipeline_id.set(None);

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -53,7 +53,7 @@ impl MessagePort {
 
     /// <https://html.spec.whatwg.org/multipage/#create-a-new-messageport-object>
     pub fn new(owner: &GlobalScope) -> DomRoot<MessagePort> {
-        let port_id = MessagePortId::new();
+        let port_id = MessagePortId::default();
         reflect_dom_object(Box::new(MessagePort::new_inherited(port_id)), owner)
     }
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -296,10 +296,10 @@ impl WindowProxy {
         let msg = EmbedderMsg::AllowOpeningWebView(chan);
         window.send_to_embedder(msg);
         if port.recv().unwrap() {
-            let new_top_level_browsing_context_id = TopLevelBrowsingContextId::new();
+            let new_top_level_browsing_context_id = TopLevelBrowsingContextId::default();
             let new_browsing_context_id =
                 BrowsingContextId::from(new_top_level_browsing_context_id);
-            let new_pipeline_id = PipelineId::new();
+            let new_pipeline_id = PipelineId::default();
             let document = self
                 .currently_active
                 .get()

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -142,7 +142,7 @@ struct ServiceWorkerRegistration {
 impl ServiceWorkerRegistration {
     pub fn new() -> ServiceWorkerRegistration {
         ServiceWorkerRegistration {
-            id: ServiceWorkerRegistrationId::new(),
+            id: ServiceWorkerRegistrationId::default(),
             active_worker: None,
             waiting_worker: None,
             installing_worker: None,
@@ -453,7 +453,7 @@ fn update_serviceworker(
 ) {
     let (sender, receiver) = unbounded();
     let (_devtools_sender, devtools_receiver) = ipc::channel().unwrap();
-    let worker_id = ServiceWorkerId::new();
+    let worker_id = ServiceWorkerId::default();
 
     let (control_sender, control_receiver) = unbounded();
     let (context_sender, context_receiver) = unbounded();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -283,7 +283,7 @@ where
 
         // Reserving a namespace to create TopLevelBrowsingContextId.
         PipelineNamespace::install(PipelineNamespaceId(0));
-        let top_level_browsing_context_id = TopLevelBrowsingContextId::new();
+        let top_level_browsing_context_id = TopLevelBrowsingContextId::default();
 
         // Get both endpoints of a special channel for communication between
         // the client window and the compositor. This channel is unique because
@@ -387,7 +387,7 @@ where
             embedder.register_webxr(&mut webxr_main_thread, embedder_proxy.clone());
         }
 
-        let wgpu_image_handler = webgpu::WGPUExternalImages::new();
+        let wgpu_image_handler = webgpu::WGPUExternalImages::default();
         let wgpu_image_map = wgpu_image_handler.images.clone();
         external_image_handlers.set_handler(
             Box::new(wgpu_image_handler),

--- a/components/shared/bluetooth/scanfilter.rs
+++ b/components/shared/bluetooth/scanfilter.rs
@@ -49,7 +49,7 @@ impl BluetoothScanfilter {
             name,
             name_prefix,
             services: ServiceUUIDSequence::new(services),
-            manufacturer_data: manufacturer_data,
+            manufacturer_data,
             service_data,
         }
     }
@@ -124,7 +124,7 @@ impl RequestDeviceoptions {
         services: ServiceUUIDSequence,
     ) -> RequestDeviceoptions {
         RequestDeviceoptions {
-            filters: filters,
+            filters,
             optional_services: services,
         }
     }

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -115,11 +115,11 @@ impl LinearGradientStyle {
         stops: Vec<CanvasGradientStop>,
     ) -> LinearGradientStyle {
         LinearGradientStyle {
-            x0: x0,
-            y0: y0,
-            x1: x1,
-            y1: y1,
-            stops: stops,
+            x0,
+            y0,
+            x1,
+            y1,
+            stops,
         }
     }
 }
@@ -146,13 +146,13 @@ impl RadialGradientStyle {
         stops: Vec<CanvasGradientStop>,
     ) -> RadialGradientStyle {
         RadialGradientStyle {
-            x0: x0,
-            y0: y0,
-            r0: r0,
-            x1: x1,
-            y1: y1,
-            r1: r1,
-            stops: stops,
+            x0,
+            y0,
+            r0,
+            x1,
+            y1,
+            r1,
+            stops,
         }
     }
 }
@@ -402,8 +402,9 @@ impl FromStr for CompositionOrBlending {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum TextAlign {
+    #[default]
     Start,
     End,
     Left,
@@ -426,17 +427,12 @@ impl FromStr for TextAlign {
     }
 }
 
-impl Default for TextAlign {
-    fn default() -> TextAlign {
-        TextAlign::Start
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum TextBaseline {
     Top,
     Hanging,
     Middle,
+    #[default]
     Alphabetic,
     Ideographic,
     Bottom,
@@ -458,16 +454,11 @@ impl FromStr for TextBaseline {
     }
 }
 
-impl Default for TextBaseline {
-    fn default() -> TextBaseline {
-        TextBaseline::Alphabetic
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum Direction {
     Ltr,
     Rtl,
+    #[default]
     Inherit,
 }
 
@@ -481,11 +472,5 @@ impl FromStr for Direction {
             "inherit" => Ok(Direction::Inherit),
             _ => Err(()),
         }
-    }
-}
-
-impl Default for Direction {
-    fn default() -> Direction {
-        Direction::Inherit
     }
 }

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -140,10 +140,7 @@ pub struct WebGLMsgSender {
 
 impl WebGLMsgSender {
     pub fn new(id: WebGLContextId, sender: WebGLChan) -> Self {
-        WebGLMsgSender {
-            ctx_id: id,
-            sender: sender,
-        }
+        WebGLMsgSender { ctx_id: id, sender }
     }
 
     /// Returns the WebGLContextId associated to this sender
@@ -922,7 +919,7 @@ mod gl_ext_constants {
     pub const COMPRESSED_RGBA_S3TC_DXT5_EXT: GLenum = 0x83F3;
     pub const COMPRESSED_RGB_ETC1_WEBGL: GLenum = 0x8D64;
 
-    pub static COMPRESSIONS: &'static [GLenum] = &[
+    pub static COMPRESSIONS: &[GLenum] = &[
         COMPRESSED_RGB_S3TC_DXT1_EXT,
         COMPRESSED_RGBA_S3TC_DXT1_EXT,
         COMPRESSED_RGBA_S3TC_DXT3_EXT,
@@ -1061,18 +1058,18 @@ impl TexFormat {
 
     /// Returns whether this format is a known sized or unsized format.
     pub fn is_sized(&self) -> bool {
-        match self {
+        !matches!(
+            self,
             TexFormat::DepthComponent |
-            TexFormat::DepthStencil |
-            TexFormat::Alpha |
-            TexFormat::Red |
-            TexFormat::RG |
-            TexFormat::RGB |
-            TexFormat::RGBA |
-            TexFormat::Luminance |
-            TexFormat::LuminanceAlpha => false,
-            _ => true,
-        }
+                TexFormat::DepthStencil |
+                TexFormat::Alpha |
+                TexFormat::Red |
+                TexFormat::RG |
+                TexFormat::RGB |
+                TexFormat::RGBA |
+                TexFormat::Luminance |
+                TexFormat::LuminanceAlpha
+        )
     }
 
     pub fn to_unsized(self) -> TexFormat {

--- a/components/shared/gfx/lib.rs
+++ b/components/shared/gfx/lib.rs
@@ -25,9 +25,9 @@ impl Epoch {
     }
 }
 
-impl Into<WebRenderEpoch> for Epoch {
-    fn into(self) -> WebRenderEpoch {
-        WebRenderEpoch(self.0)
+impl From<Epoch> for WebRenderEpoch {
+    fn from(val: Epoch) -> Self {
+        WebRenderEpoch(val.0)
     }
 }
 
@@ -114,7 +114,7 @@ pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) -> 
 
 pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
     if (id & !SPECIAL_SCROLL_ROOT_ID_MASK) != 0 {
-        return Some((id & !3) as usize);
+        return Some(id & !3);
     }
     None
 }

--- a/components/shared/gfx/print_tree.rs
+++ b/components/shared/gfx/print_tree.rs
@@ -28,17 +28,17 @@ impl PrintTree {
 
         self.print_level_prefix();
 
-        let items: Vec<&str> = queued_title.split("\n").collect();
+        let items: Vec<&str> = queued_title.split('\n').collect();
         println!("\u{251C}\u{2500} {}", items[0]);
         for i in 1..items.len() {
             self.print_level_child_indentation();
             print!("{}", items[i]);
             if i < items.len() {
-                print!("\n");
+                println!();
             }
         }
 
-        self.level = self.level + 1;
+        self.level += 1;
     }
 
     /// Ascend one level in the tree.
@@ -69,13 +69,13 @@ impl PrintTree {
     fn flush_queued_item(&mut self, prefix: &str) {
         if let Some(queued_item) = self.queued_item.take() {
             self.print_level_prefix();
-            let items: Vec<&str> = queued_item.split("\n").collect();
+            let items: Vec<&str> = queued_item.split('\n').collect();
             println!("{} {}", prefix, items[0]);
             for i in 1..items.len() {
                 self.print_level_child_indentation();
                 print!("{}", items[i]);
                 if i < items.len() {
-                    print!("\n");
+                    println!();
                 }
             }
         }

--- a/components/shared/msg/constellation_msg.rs
+++ b/components/shared/msg/constellation_msg.rs
@@ -80,14 +80,20 @@ pub struct PipelineNamespaceInstaller {
     namespace_receiver: IpcReceiver<PipelineNamespaceId>,
 }
 
+impl Default for PipelineNamespaceInstaller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PipelineNamespaceInstaller {
     pub fn new() -> Self {
         let (namespace_sender, namespace_receiver) =
             ipc::channel().expect("PipelineNamespaceInstaller ipc channel failure");
         PipelineNamespaceInstaller {
             request_sender: None,
-            namespace_sender: namespace_sender,
-            namespace_receiver: namespace_receiver,
+            namespace_sender,
+            namespace_receiver,
         }
     }
 
@@ -209,6 +215,12 @@ namespace_id! {PipelineId, PipelineIndex, "Pipeline"}
 size_of_test!(PipelineId, 8);
 size_of_test!(Option<PipelineId>, 8);
 
+impl Default for PipelineId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PipelineId {
     pub fn new() -> PipelineId {
         PIPELINE_NAMESPACE.with(|tls| {
@@ -245,6 +257,12 @@ namespace_id! {BrowsingContextId, BrowsingContextIndex, "BrowsingContext"}
 
 size_of_test!(BrowsingContextId, 8);
 size_of_test!(Option<BrowsingContextId>, 8);
+
+impl Default for BrowsingContextId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl BrowsingContextId {
     pub fn new() -> BrowsingContextId {
@@ -288,6 +306,12 @@ impl fmt::Display for TopLevelBrowsingContextId {
     }
 }
 
+impl Default for TopLevelBrowsingContextId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TopLevelBrowsingContextId {
     pub fn new() -> TopLevelBrowsingContextId {
         TopLevelBrowsingContextId(BrowsingContextId::new())
@@ -323,6 +347,12 @@ impl PartialEq<BrowsingContextId> for TopLevelBrowsingContextId {
 
 namespace_id! {MessagePortId, MessagePortIndex, "MessagePort"}
 
+impl Default for MessagePortId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MessagePortId {
     pub fn new() -> MessagePortId {
         PIPELINE_NAMESPACE.with(|tls| {
@@ -335,6 +365,12 @@ impl MessagePortId {
 }
 
 namespace_id! {MessagePortRouterId, MessagePortRouterIndex, "MessagePortRouter"}
+
+impl Default for MessagePortRouterId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl MessagePortRouterId {
     pub fn new() -> MessagePortRouterId {
@@ -349,6 +385,12 @@ impl MessagePortRouterId {
 
 namespace_id! {BroadcastChannelRouterId, BroadcastChannelRouterIndex, "BroadcastChannelRouter"}
 
+impl Default for BroadcastChannelRouterId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BroadcastChannelRouterId {
     pub fn new() -> BroadcastChannelRouterId {
         PIPELINE_NAMESPACE.with(|tls| {
@@ -362,6 +404,12 @@ impl BroadcastChannelRouterId {
 
 namespace_id! {ServiceWorkerId, ServiceWorkerIndex, "ServiceWorker"}
 
+impl Default for ServiceWorkerId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ServiceWorkerId {
     pub fn new() -> ServiceWorkerId {
         PIPELINE_NAMESPACE.with(|tls| {
@@ -374,6 +422,12 @@ impl ServiceWorkerId {
 }
 
 namespace_id! {ServiceWorkerRegistrationId, ServiceWorkerRegistrationIndex, "ServiceWorkerRegistration"}
+
+impl Default for ServiceWorkerRegistrationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl ServiceWorkerRegistrationId {
     pub fn new() -> ServiceWorkerRegistrationId {
@@ -389,6 +443,12 @@ impl ServiceWorkerRegistrationId {
 
 namespace_id! {BlobId, BlobIndex, "Blob"}
 
+impl Default for BlobId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BlobId {
     pub fn new() -> BlobId {
         PIPELINE_NAMESPACE.with(|tls| {
@@ -401,6 +461,12 @@ impl BlobId {
 }
 
 namespace_id! {HistoryStateId, HistoryStateIndex, "HistoryState"}
+
+impl Default for HistoryStateId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl HistoryStateId {
     pub fn new() -> HistoryStateId {
@@ -544,7 +610,7 @@ impl fmt::Debug for HangAlert {
                     "\n The following component is experiencing a transient hang: \n {:?}",
                     component_id
                 )?;
-                (annotation.clone(), None)
+                (*annotation, None)
             },
             HangAlert::Permanent(component_id, annotation, profile) => {
                 write!(
@@ -552,7 +618,7 @@ impl fmt::Debug for HangAlert {
                     "\n The following component is experiencing a permanent hang: \n {:?}",
                     component_id
                 )?;
-                (annotation.clone(), profile.clone())
+                (*annotation, profile.clone())
             },
         };
 

--- a/components/shared/msg/constellation_msg.rs
+++ b/components/shared/msg/constellation_msg.rs
@@ -82,21 +82,17 @@ pub struct PipelineNamespaceInstaller {
 
 impl Default for PipelineNamespaceInstaller {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PipelineNamespaceInstaller {
-    pub fn new() -> Self {
         let (namespace_sender, namespace_receiver) =
             ipc::channel().expect("PipelineNamespaceInstaller ipc channel failure");
-        PipelineNamespaceInstaller {
+        Self {
             request_sender: None,
             namespace_sender,
             namespace_receiver,
         }
     }
+}
 
+impl PipelineNamespaceInstaller {
     /// Provide a request sender to send requests to the constellation.
     pub fn set_sender(&mut self, sender: IpcSender<PipelineNamespaceRequest>) {
         self.request_sender = Some(sender);
@@ -127,7 +123,7 @@ lazy_static! {
     ///
     /// Use PipelineNamespace::fetch_install to install a unique pipeline-namespace from the calling thread.
     static ref PIPELINE_NAMESPACE_INSTALLER: Arc<Mutex<PipelineNamespaceInstaller>> =
-        Arc::new(Mutex::new(PipelineNamespaceInstaller::new()));
+        Arc::new(Mutex::new(PipelineNamespaceInstaller::default()));
 }
 
 /// Each pipeline ID needs to be unique. However, it also needs to be possible to
@@ -217,12 +213,6 @@ size_of_test!(Option<PipelineId>, 8);
 
 impl Default for PipelineId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl PipelineId {
-    pub fn new() -> PipelineId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let new_pipeline_id = namespace.next_pipeline_id();
@@ -230,7 +220,9 @@ impl PipelineId {
             new_pipeline_id
         })
     }
+}
 
+impl PipelineId {
     pub fn to_webrender(&self) -> WebRenderPipelineId {
         let PipelineNamespaceId(namespace_id) = self.namespace_id;
         let PipelineIndex(index) = self.index;
@@ -260,12 +252,6 @@ size_of_test!(Option<BrowsingContextId>, 8);
 
 impl Default for BrowsingContextId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl BrowsingContextId {
-    pub fn new() -> BrowsingContextId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let new_browsing_context_id = namespace.next_browsing_context_id();
@@ -286,7 +272,7 @@ impl fmt::Display for BrowsingContextGroupId {
 thread_local!(pub static TOP_LEVEL_BROWSING_CONTEXT_ID: Cell<Option<TopLevelBrowsingContextId>> = Cell::new(None));
 
 #[derive(
-    Clone, Copy, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
+    Clone, Copy, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize, Default,
 )]
 pub struct TopLevelBrowsingContextId(pub BrowsingContextId);
 pub type WebViewId = TopLevelBrowsingContextId;
@@ -306,16 +292,7 @@ impl fmt::Display for TopLevelBrowsingContextId {
     }
 }
 
-impl Default for TopLevelBrowsingContextId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl TopLevelBrowsingContextId {
-    pub fn new() -> TopLevelBrowsingContextId {
-        TopLevelBrowsingContextId(BrowsingContextId::new())
-    }
     /// Each script and layout thread should have the top-level browsing context id installed,
     /// since it is used by crash reporting.
     pub fn install(id: TopLevelBrowsingContextId) {
@@ -349,12 +326,6 @@ namespace_id! {MessagePortId, MessagePortIndex, "MessagePort"}
 
 impl Default for MessagePortId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MessagePortId {
-    pub fn new() -> MessagePortId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_message_port_id = namespace.next_message_port_id();
@@ -368,12 +339,6 @@ namespace_id! {MessagePortRouterId, MessagePortRouterIndex, "MessagePortRouter"}
 
 impl Default for MessagePortRouterId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MessagePortRouterId {
-    pub fn new() -> MessagePortRouterId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_message_port_router_id = namespace.next_message_port_router_id();
@@ -387,12 +352,6 @@ namespace_id! {BroadcastChannelRouterId, BroadcastChannelRouterIndex, "Broadcast
 
 impl Default for BroadcastChannelRouterId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl BroadcastChannelRouterId {
-    pub fn new() -> BroadcastChannelRouterId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_broadcast_channel_router_id = namespace.next_broadcast_channel_router_id();
@@ -406,12 +365,6 @@ namespace_id! {ServiceWorkerId, ServiceWorkerIndex, "ServiceWorker"}
 
 impl Default for ServiceWorkerId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ServiceWorkerId {
-    pub fn new() -> ServiceWorkerId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_service_worker_id = namespace.next_service_worker_id();
@@ -425,12 +378,6 @@ namespace_id! {ServiceWorkerRegistrationId, ServiceWorkerRegistrationIndex, "Ser
 
 impl Default for ServiceWorkerRegistrationId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ServiceWorkerRegistrationId {
-    pub fn new() -> ServiceWorkerRegistrationId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_service_worker_registration_id =
@@ -445,12 +392,6 @@ namespace_id! {BlobId, BlobIndex, "Blob"}
 
 impl Default for BlobId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl BlobId {
-    pub fn new() -> BlobId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_blob_id = namespace.next_blob_id();
@@ -464,12 +405,6 @@ namespace_id! {HistoryStateId, HistoryStateIndex, "HistoryState"}
 
 impl Default for HistoryStateId {
     fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl HistoryStateId {
-    pub fn new() -> HistoryStateId {
         PIPELINE_NAMESPACE.with(|tls| {
             let mut namespace = tls.get().expect("No namespace set for this thread!");
             let next_history_state_id = namespace.next_history_state_id();

--- a/components/shared/net/fetch/headers.rs
+++ b/components/shared/net/fetch/headers.rs
@@ -14,5 +14,5 @@ pub fn get_value_from_header_list(name: &str, headers: &HeaderMap) -> Option<Vec
     }
 
     // Step 2
-    return Some(values.collect::<Vec<&[u8]>>().join(&[0x2C, 0x20][..]));
+    Some(values.collect::<Vec<&[u8]>>().join(&[0x2C, 0x20][..]))
 }

--- a/components/shared/net/image/base.rs
+++ b/components/shared/net/image/base.rs
@@ -59,12 +59,12 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Image>
         Ok(_) => match image::load_from_memory(buffer) {
             Ok(image) => {
                 let mut rgba = image.into_rgba8();
-                pixels::rgba8_byte_swap_colors_inplace(&mut *rgba);
+                pixels::rgba8_byte_swap_colors_inplace(&mut rgba);
                 Some(Image {
                     width: rgba.width(),
                     height: rgba.height(),
                     format: PixelFormat::BGRA8,
-                    bytes: IpcSharedMemory::from_bytes(&*rgba),
+                    bytes: IpcSharedMemory::from_bytes(&rgba),
                     id: None,
                     cors_status,
                 })

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -42,10 +42,7 @@ pub struct ImageResponder {
 
 impl ImageResponder {
     pub fn new(sender: IpcSender<PendingImageResponse>, id: PendingImageId) -> ImageResponder {
-        ImageResponder {
-            sender,
-            id,
-        }
+        ImageResponder { sender, id }
     }
 
     pub fn respond(&self, response: ImageResponse) {

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -43,8 +43,8 @@ pub struct ImageResponder {
 impl ImageResponder {
     pub fn new(sender: IpcSender<PendingImageResponse>, id: PendingImageId) -> ImageResponder {
         ImageResponder {
-            sender: sender,
-            id: id,
+            sender,
+            id,
         }
     }
 
@@ -54,7 +54,7 @@ impl ImageResponder {
         // That's not a case that's worth warning about.
         // TODO(#15501): are there cases in which we should perform cleanup?
         let _ = self.sender.send(PendingImageResponse {
-            response: response,
+            response,
             id: self.id,
         });
     }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -94,9 +94,9 @@ impl CustomResponse {
         body: Vec<u8>,
     ) -> CustomResponse {
         CustomResponse {
-            headers: headers,
-            raw_status: raw_status,
-            body: body,
+            headers,
+            raw_status,
+            body,
         }
     }
 }
@@ -567,7 +567,7 @@ pub enum ResourceTimingType {
 impl ResourceFetchTiming {
     pub fn new(timing_type: ResourceTimingType) -> ResourceFetchTiming {
         ResourceFetchTiming {
-            timing_type: timing_type,
+            timing_type,
             timing_check_passed: true,
             domain_lookup_start: 0,
             redirect_count: 0,
@@ -782,7 +782,7 @@ impl NetworkError {
 /// Normalize `slice`, as defined by
 /// [the Fetch Spec](https://fetch.spec.whatwg.org/#concept-header-value-normalize).
 pub fn trim_http_whitespace(mut slice: &[u8]) -> &[u8] {
-    const HTTP_WS_BYTES: &'static [u8] = b"\x09\x0A\x0D\x20";
+    const HTTP_WS_BYTES: &[u8] = b"\x09\x0A\x0D\x20";
 
     loop {
         match slice.split_first() {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -587,12 +587,12 @@ impl ResourceFetchTiming {
     // TODO currently this is being set with precise time ns when it should be time since
     // time origin (as described in Performance::now)
     pub fn set_attribute(&mut self, attribute: ResourceAttribute) {
-        let should_attribute_always_be_updated = match attribute {
+        let should_attribute_always_be_updated = matches!(
+            attribute,
             ResourceAttribute::FetchStart |
-            ResourceAttribute::ResponseEnd |
-            ResourceAttribute::StartTime(_) => true,
-            _ => false,
-        };
+                ResourceAttribute::ResponseEnd |
+                ResourceAttribute::StartTime(_)
+        );
         if !self.timing_check_passed && !should_attribute_always_be_updated {
             return;
         }

--- a/components/shared/net/pub_domains.rs
+++ b/components/shared/net/pub_domains.rs
@@ -39,7 +39,7 @@ impl<'a> FromIterator<&'a str> for PubDomainRules {
     {
         let mut result = PubDomainRules::new();
         for item in iter {
-            if item.starts_with("!") {
+            if item.starts_with('!') {
                 result.exceptions.insert(String::from(&item[1..]));
             } else if item.starts_with("*.") {
                 result.wildcards.insert(String::from(&item[2..]));
@@ -48,6 +48,12 @@ impl<'a> FromIterator<&'a str> for PubDomainRules {
             }
         }
         result
+    }
+}
+
+impl Default for PubDomainRules {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -68,10 +74,10 @@ impl PubDomainRules {
             .collect()
     }
     fn suffix_pair<'a>(&self, domain: &'a str) -> (&'a str, &'a str) {
-        let domain = domain.trim_start_matches(".");
+        let domain = domain.trim_start_matches('.');
         let mut suffix = domain;
         let mut prev_suffix = domain;
-        for (index, _) in domain.match_indices(".") {
+        for (index, _) in domain.match_indices('.') {
             let next_suffix = &domain[index + 1..];
             if self.exceptions.contains(suffix) {
                 return (next_suffix, suffix);
@@ -84,7 +90,7 @@ impl PubDomainRules {
                 suffix = next_suffix;
             }
         }
-        return (suffix, prev_suffix);
+        (suffix, prev_suffix)
     }
     pub fn public_suffix<'a>(&self, domain: &'a str) -> &'a str {
         let (public, _) = self.suffix_pair(domain);
@@ -98,8 +104,8 @@ impl PubDomainRules {
         // Speeded-up version of
         // domain != "" &&
         // self.public_suffix(domain) == domain.
-        let domain = domain.trim_start_matches(".");
-        match domain.find(".") {
+        let domain = domain.trim_start_matches('.');
+        match domain.find('.') {
             None => !domain.is_empty(),
             Some(index) => {
                 !self.exceptions.contains(domain) && self.wildcards.contains(&domain[index + 1..]) ||
@@ -111,8 +117,8 @@ impl PubDomainRules {
         // Speeded-up version of
         // self.public_suffix(domain) != domain &&
         // self.registrable_suffix(domain) == domain.
-        let domain = domain.trim_start_matches(".");
-        match domain.find(".") {
+        let domain = domain.trim_start_matches('.');
+        match domain.find('.') {
             None => false,
             Some(index) => {
                 self.exceptions.contains(domain) ||
@@ -151,7 +157,7 @@ pub fn is_reg_domain(domain: &str) -> bool {
 pub fn reg_host(url: &ServoUrl) -> Option<Host> {
     match url.origin() {
         ImmutableOrigin::Tuple(_, Host::Domain(domain), _) => {
-            Some(Host::Domain(String::from(reg_suffix(&*domain))))
+            Some(Host::Domain(String::from(reg_suffix(&domain))))
         },
         ImmutableOrigin::Tuple(_, ip, _) => Some(ip),
         ImmutableOrigin::Opaque(_) => None,

--- a/components/shared/net/pub_domains.rs
+++ b/components/shared/net/pub_domains.rs
@@ -39,10 +39,10 @@ impl<'a> FromIterator<&'a str> for PubDomainRules {
     {
         let mut result = PubDomainRules::new();
         for item in iter {
-            if item.starts_with('!') {
-                result.exceptions.insert(String::from(&item[1..]));
-            } else if item.starts_with("*.") {
-                result.wildcards.insert(String::from(&item[2..]));
+            if let Some(stripped) = item.strip_prefix('!') {
+                result.exceptions.insert(String::from(stripped));
+            } else if let Some(stripped) = item.strip_prefix("*.") {
+                result.wildcards.insert(String::from(stripped));
             } else {
                 result.rules.insert(String::from(item));
             }
@@ -81,14 +81,12 @@ impl PubDomainRules {
             let next_suffix = &domain[index + 1..];
             if self.exceptions.contains(suffix) {
                 return (next_suffix, suffix);
-            } else if self.wildcards.contains(next_suffix) {
-                return (suffix, prev_suffix);
-            } else if self.rules.contains(suffix) {
-                return (suffix, prev_suffix);
-            } else {
-                prev_suffix = suffix;
-                suffix = next_suffix;
             }
+            if self.wildcards.contains(next_suffix) || self.rules.contains(suffix) {
+                return (suffix, prev_suffix);
+            }
+            prev_suffix = suffix;
+            suffix = next_suffix;
         }
         (suffix, prev_suffix)
     }

--- a/components/shared/net/pub_domains.rs
+++ b/components/shared/net/pub_domains.rs
@@ -21,7 +21,7 @@ use embedder_traits::resources::{self, Resource};
 use lazy_static::lazy_static;
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PubDomainRules {
     rules: HashSet<String>,
     wildcards: HashSet<String>,
@@ -37,7 +37,7 @@ impl<'a> FromIterator<&'a str> for PubDomainRules {
     where
         T: IntoIterator<Item = &'a str>,
     {
-        let mut result = PubDomainRules::new();
+        let mut result = PubDomainRules::default();
         for item in iter {
             if let Some(stripped) = item.strip_prefix('!') {
                 result.exceptions.insert(String::from(stripped));
@@ -51,20 +51,7 @@ impl<'a> FromIterator<&'a str> for PubDomainRules {
     }
 }
 
-impl Default for PubDomainRules {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl PubDomainRules {
-    pub fn new() -> PubDomainRules {
-        PubDomainRules {
-            rules: HashSet::new(),
-            wildcards: HashSet::new(),
-            exceptions: HashSet::new(),
-        }
-    }
     pub fn parse(content: &str) -> PubDomainRules {
         content
             .lines()

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -210,6 +210,10 @@ impl RequestBody {
     pub fn len(&self) -> Option<usize> {
         self.total_bytes
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_bytes == Some(0)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -567,19 +571,19 @@ impl Request {
 
     /// <https://fetch.spec.whatwg.org/#subresource-request>
     pub fn is_subresource_request(&self) -> bool {
-        match self.destination {
+        matches!(
+            self.destination,
             Destination::Audio |
-            Destination::Font |
-            Destination::Image |
-            Destination::Manifest |
-            Destination::Script |
-            Destination::Style |
-            Destination::Track |
-            Destination::Video |
-            Destination::Xslt |
-            Destination::None => true,
-            _ => false,
-        }
+                Destination::Font |
+                Destination::Image |
+                Destination::Manifest |
+                Destination::Script |
+                Destination::Style |
+                Destination::Track |
+                Destination::Video |
+                Destination::Xslt |
+                Destination::None
+        )
     }
 
     pub fn timing_type(&self) -> ResourceTimingType {
@@ -605,25 +609,25 @@ impl Referrer {
 // TODO: values in the control-code range are being quietly stripped out by
 // HeaderMap and never reach this function to be loudly rejected!
 fn is_cors_unsafe_request_header_byte(value: &u8) -> bool {
-    match value {
-        0x00..=0x08 |
-        0x10..=0x19 |
-        0x22 |
-        0x28 |
-        0x29 |
-        0x3A |
-        0x3C |
-        0x3E |
-        0x3F |
-        0x40 |
-        0x5B |
-        0x5C |
-        0x5D |
-        0x7B |
-        0x7D |
-        0x7F => true,
-        _ => false,
-    }
+    matches!(
+        value,
+        0x00..=0x08
+        | 0x10..=0x19
+        | 0x22
+        | 0x28
+        | 0x29
+        | 0x3A
+        | 0x3C
+        | 0x3E
+        | 0x3F
+        | 0x40
+        | 0x5B
+        | 0x5C
+        | 0x5D
+        | 0x7B
+        | 0x7D
+        | 0x7F
+    )
 }
 
 // https://fetch.spec.whatwg.org/#cors-safelisted-request-header
@@ -635,18 +639,20 @@ fn is_cors_safelisted_request_accept(value: &[u8]) -> bool {
 // https://fetch.spec.whatwg.org/#cors-safelisted-request-header
 // subclauses `accept-language`, `content-language`
 fn is_cors_safelisted_language(value: &[u8]) -> bool {
-    value.iter().all(|&x| match x {
-        0x30..=0x39 |
-        0x41..=0x5A |
-        0x61..=0x7A |
-        0x20 |
-        0x2A |
-        0x2C |
-        0x2D |
-        0x2E |
-        0x3B |
-        0x3D => true,
-        _ => false,
+    value.iter().all(|&x| {
+        matches!(
+            x,
+            0x30..=0x39
+            | 0x41..=0x5A
+            | 0x61..=0x7A
+            | 0x20
+            | 0x2A
+            | 0x2C
+            | 0x2D
+            | 0x2E
+            | 0x3B
+            | 0x3D
+        )
     })
 }
 
@@ -697,10 +703,7 @@ pub fn is_cors_safelisted_request_header<N: AsRef<str>, V: AsRef<[u8]>>(
 
 /// <https://fetch.spec.whatwg.org/#cors-safelisted-method>
 pub fn is_cors_safelisted_method(m: &Method) -> bool {
-    match *m {
-        Method::GET | Method::HEAD | Method::POST => true,
-        _ => false,
-    }
+    matches!(*m, Method::GET | Method::HEAD | Method::POST)
 }
 
 /// <https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name>

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -208,7 +208,7 @@ impl RequestBody {
     }
 
     pub fn len(&self) -> Option<usize> {
-        self.total_bytes.clone()
+        self.total_bytes
     }
 }
 
@@ -264,7 +264,7 @@ impl RequestBuilder {
     pub fn new(url: ServoUrl, referrer: Referrer) -> RequestBuilder {
         RequestBuilder {
             method: Method::GET,
-            url: url,
+            url,
             headers: HeaderMap::new(),
             unsafe_request: false,
             body: None,
@@ -277,7 +277,7 @@ impl RequestBuilder {
             credentials_mode: CredentialsMode::CredentialsSameOrigin,
             use_url_credentials: false,
             origin: ImmutableOrigin::new_opaque(),
-            referrer: referrer,
+            referrer,
             referrer_policy: None,
             pipeline_id: None,
             redirect_mode: RedirectMode::Follow,
@@ -524,9 +524,9 @@ impl Request {
             initiator: Initiator::None,
             destination: Destination::None,
             origin: origin.unwrap_or(Origin::Client),
-            referrer: referrer,
+            referrer,
             referrer_policy: None,
-            pipeline_id: pipeline_id,
+            pipeline_id,
             synchronous: false,
             mode: RequestMode::NoCors,
             use_cors_preflight: false,
@@ -540,7 +540,7 @@ impl Request {
             redirect_count: 0,
             response_tainting: ResponseTainting::Basic,
             csp_list: None,
-            https_state: https_state,
+            https_state,
             crash: None,
         }
     }
@@ -733,7 +733,7 @@ pub fn get_cors_unsafe_header_names(headers: &HeaderMap) -> Vec<HeaderName> {
     }
 
     // Step 6
-    return convert_header_names_to_sorted_lowercase_set(unsafe_names);
+    convert_header_names_to_sorted_lowercase_set(unsafe_names)
 }
 
 /// <https://fetch.spec.whatwg.org/#ref-for-convert-header-names-to-a-sorted-lowercase-set>
@@ -745,5 +745,5 @@ pub fn convert_header_names_to_sorted_lowercase_set(
     let mut ordered_set = header_names.to_vec();
     ordered_set.sort_by(|a, b| a.as_str().partial_cmp(b.as_str()).unwrap());
     ordered_set.dedup();
-    return ordered_set.into_iter().cloned().collect();
+    ordered_set.into_iter().cloned().collect()
 }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -212,7 +212,7 @@ impl RequestBody {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.total_bytes == Some(0)
+        self.total_bytes.is_none() || self.total_bytes == Some(0)
     }
 }
 

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -189,10 +189,7 @@ impl Response {
     }
 
     pub fn is_network_error(&self) -> bool {
-        match self.response_type {
-            ResponseType::Error(..) => true,
-            _ => false,
-        }
+        matches!(self.response_type, ResponseType::Error(..))
     }
 
     pub fn get_network_error(&self) -> Option<&NetworkError> {
@@ -258,10 +255,7 @@ impl Response {
 
             ResponseType::Basic => {
                 let headers = old_headers.iter().filter(|(name, _)| {
-                    match &*name.as_str().to_ascii_lowercase() {
-                        "set-cookie" | "set-cookie2" => false,
-                        _ => true
-                    }
+                    !matches!(&*name.as_str().to_ascii_lowercase(), "set-cookie" | "set-cookie2")
                 }).map(|(n, v)| (n.clone(), v.clone())).collect();
                 response.headers = headers;
             },

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -204,7 +204,7 @@ impl Response {
 
     pub fn actual_response(&self) -> &Response {
         if self.return_internal && self.internal_response.is_some() {
-            &**self.internal_response.as_ref().unwrap()
+            self.internal_response.as_ref().unwrap()
         } else {
             self
         }
@@ -212,7 +212,7 @@ impl Response {
 
     pub fn actual_response_mut(&mut self) -> &mut Response {
         if self.return_internal && self.internal_response.is_some() {
-            &mut **self.internal_response.as_mut().unwrap()
+            self.internal_response.as_mut().unwrap()
         } else {
             self
         }
@@ -315,7 +315,7 @@ impl Response {
             metadata.status = response.raw_status.clone();
             metadata.https_state = response.https_state;
             metadata.referrer = response.referrer.clone();
-            metadata.referrer_policy = response.referrer_policy.clone();
+            metadata.referrer_policy = response.referrer_policy;
             metadata.redirected = response.actual_response().url_list.len() > 1;
             metadata
         }

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -90,7 +90,7 @@ pub enum BlobData {
 impl BlobImpl {
     /// Construct memory-backed BlobImpl
     pub fn new_from_bytes(bytes: Vec<u8>, type_string: String) -> BlobImpl {
-        let blob_id = BlobId::new();
+        let blob_id = BlobId::default();
         let blob_data = BlobData::Memory(bytes);
         BlobImpl {
             blob_id,
@@ -102,7 +102,7 @@ impl BlobImpl {
 
     /// Construct file-backed BlobImpl from File ID
     pub fn new_from_file(file_id: Uuid, name: PathBuf, size: u64, type_string: String) -> BlobImpl {
-        let blob_id = BlobId::new();
+        let blob_id = BlobId::default();
         let blob_data = BlobData::File(FileBlob {
             id: file_id,
             name: Some(name),
@@ -119,7 +119,7 @@ impl BlobImpl {
 
     /// Construct a BlobImpl from a slice of a parent.
     pub fn new_sliced(rel_pos: RelativePos, parent: BlobId, type_string: String) -> BlobImpl {
-        let blob_id = BlobId::new();
+        let blob_id = BlobId::default();
         let blob_data = BlobData::Sliced(parent, rel_pos);
         BlobImpl {
             blob_id,

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -46,6 +46,12 @@ pub struct WebrenderExternalImageRegistry {
     next_image_id: u64,
 }
 
+impl Default for WebrenderExternalImageRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl WebrenderExternalImageRegistry {
     pub fn new() -> Self {
         Self {

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -39,6 +39,7 @@ pub enum WebrenderImageHandlerType {
 /// List of Webrender external images to be shared among all external image
 /// consumers (WebGL, Media, WebGPU).
 /// It ensures that external image identifiers are unique.
+#[derive(Default)]
 pub struct WebrenderExternalImageRegistry {
     /// Map of all generated external images.
     external_images: HashMap<ExternalImageId, WebrenderImageHandlerType>,
@@ -46,20 +47,7 @@ pub struct WebrenderExternalImageRegistry {
     next_image_id: u64,
 }
 
-impl Default for WebrenderExternalImageRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl WebrenderExternalImageRegistry {
-    pub fn new() -> Self {
-        Self {
-            external_images: HashMap::new(),
-            next_image_id: 0,
-        }
-    }
-
     pub fn next_id(&mut self, handler_type: WebrenderImageHandlerType) -> ExternalImageId {
         self.next_image_id += 1;
         let key = ExternalImageId(self.next_image_id);
@@ -90,7 +78,7 @@ pub struct WebrenderExternalImageHandlers {
 
 impl WebrenderExternalImageHandlers {
     pub fn new() -> (Self, Arc<Mutex<WebrenderExternalImageRegistry>>) {
-        let external_images = Arc::new(Mutex::new(WebrenderExternalImageRegistry::new()));
+        let external_images = Arc::new(Mutex::new(WebrenderExternalImageRegistry::default()));
         (
             Self {
                 webgl_handler: None,

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -176,7 +176,7 @@ impl ServoUrl {
                 // Strip `scheme://`, which is hardly useful for identifying websites
                 let mut st = self.as_str();
                 st = st.strip_prefix(self.scheme()).unwrap_or(st);
-                st = st.strip_prefix(":").unwrap_or(st);
+                st = st.strip_prefix(':').unwrap_or(st);
                 st = st.trim_start_matches('/');
 
                 // Don't want to return an empty string

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -1336,24 +1336,10 @@ webgpu_resource!(WebGPUSurface, id::SurfaceId);
 webgpu_resource!(WebGPUTexture, id::TextureId);
 webgpu_resource!(WebGPUTextureView, id::TextureViewId);
 
+#[derive(Default)]
 pub struct WGPUExternalImages {
     pub images: Arc<Mutex<HashMap<u64, PresentationData>>>,
     pub locked_ids: HashMap<u64, Vec<u8>>,
-}
-
-impl Default for WGPUExternalImages {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl WGPUExternalImages {
-    pub fn new() -> Self {
-        Self {
-            images: Arc::new(Mutex::new(HashMap::new())),
-            locked_ids: HashMap::new(),
-        }
-    }
 }
 
 impl WebrenderExternalImageApi for WGPUExternalImages {

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -919,8 +919,8 @@ impl<'a> WGPU<'a> {
                         pipeline_id,
                     } => {
                         let desc = DeviceDescriptor {
-                            label: descriptor.label.as_ref().map(|l| crate::Cow::from(l)),
-                            features: descriptor.features.clone(),
+                            label: descriptor.label.as_ref().map(crate::Cow::from),
+                            features: descriptor.features,
                             limits: descriptor.limits.clone(),
                         };
                         let global = &self.global;
@@ -1339,6 +1339,12 @@ webgpu_resource!(WebGPUTextureView, id::TextureViewId);
 pub struct WGPUExternalImages {
     pub images: Arc<Mutex<HashMap<u64, PresentationData>>>,
     pub locked_ids: HashMap<u64, Vec<u8>>,
+}
+
+impl Default for WGPUExternalImages {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl WGPUExternalImages {

--- a/ports/jniapi/build.rs
+++ b/ports/jniapi/build.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Generate GL bindings. For now, we only support EGL.
     if target.contains("android") {
-        let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("egl_bindings.rs")).unwrap();
         Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticStructGenerator, &mut file)
             .unwrap();
@@ -38,6 +38,6 @@ fn main() {
     let mut default_prefs = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     default_prefs.push("../../resources/prefs.json");
     let prefs: Value = serde_json::from_reader(File::open(&default_prefs).unwrap()).unwrap();
-    let file = File::create(&dest.join("prefs.json")).unwrap();
+    let file = File::create(dest.join("prefs.json")).unwrap();
     serde_json::to_writer(file, &prefs).unwrap();
 }

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -85,7 +85,7 @@ impl App {
         // Handle browser state.
         let webviews = WebViewManager::new(window.clone());
         let initial_url = get_default_url(
-            url.as_ref().map(String::as_str),
+            url.as_deref(),
             env::current_dir().unwrap(),
             |path| fs::metadata(path).is_ok(),
         );
@@ -142,19 +142,7 @@ impl App {
         let ev_waker = events_loop.create_event_loop_waker();
         events_loop.run_forever(move |event, w, control_flow| {
             let now = Instant::now();
-            match event {
-                // Uncomment to filter out logging of common events, which can be very noisy.
-                // winit::event::Event::DeviceEvent { .. } => {},
-                // winit::event::Event::WindowEvent {
-                //     event: WindowEvent::CursorMoved { .. },
-                //     ..
-                // } => {},
-                // winit::event::Event::MainEventsCleared => {},
-                // winit::event::Event::RedrawEventsCleared => {},
-                // winit::event::Event::UserEvent(..) => {},
-                // winit::event::Event::NewEvents(..) => {},
-                _ => trace!("@{:?} (+{:?}) {:?}", now - t_start, now - t, event),
-            }
+            trace!("@{:?} (+{:?}) {:?}", now - t_start, now - t, event);
             t = now;
             match event {
                 winit::event::Event::NewEvents(winit::event::StartCause::Init) => {
@@ -270,7 +258,7 @@ impl App {
                         window.winit_window().unwrap().request_redraw();
                     },
                     winit::event::Event::WindowEvent { ref event, .. } => {
-                        let response = minibrowser.on_event(&event);
+                        let response = minibrowser.on_event(event);
                         if response.repaint {
                             // Request a winit redraw event, so we can recomposite, update and paint
                             // the minibrowser, and present the new frame.

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -140,7 +140,19 @@ impl App {
         let ev_waker = events_loop.create_event_loop_waker();
         events_loop.run_forever(move |event, w, control_flow| {
             let now = Instant::now();
-            trace!("@{:?} (+{:?}) {:?}", now - t_start, now - t, event);
+            match event {
+                // Uncomment to filter out logging of common events, which can be very noisy.
+                // winit::event::Event::DeviceEvent { .. } => {},
+                // winit::event::Event::WindowEvent {
+                //     event: WindowEvent::CursorMoved { .. },
+                //     ..
+                // } => {},
+                // winit::event::Event::MainEventsCleared => {},
+                // winit::event::Event::RedrawEventsCleared => {},
+                // winit::event::Event::UserEvent(..) => {},
+                // winit::event::Event::NewEvents(..) => {},
+                _ => trace!("@{:?} (+{:?}) {:?}", now - t_start, now - t, event),
+            }
             t = now;
             match event {
                 winit::event::Event::NewEvents(winit::event::StartCause::Init) => {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -84,11 +84,9 @@ impl App {
 
         // Handle browser state.
         let webviews = WebViewManager::new(window.clone());
-        let initial_url = get_default_url(
-            url.as_deref(),
-            env::current_dir().unwrap(),
-            |path| fs::metadata(path).is_ok(),
-        );
+        let initial_url = get_default_url(url.as_deref(), env::current_dir().unwrap(), |path| {
+            fs::metadata(path).is_ok()
+        });
 
         let mut app = App {
             event_queue: RefCell::new(vec![]),

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -29,7 +29,6 @@ pub fn get_default_url(
     // or a blank page in case the homepage is not set either.
     let mut new_url = None;
     let cmdline_url = url_opt
-        .clone()
         .map(|s| s.to_string())
         .and_then(|url_string| {
             parse_url_or_filename(cwd.as_ref(), &url_string)
@@ -50,7 +49,7 @@ pub fn get_default_url(
         }
     }
 
-    if new_url.is_none() && !url_opt.is_none() {
+    if new_url.is_none() && url_opt.is_some() {
         new_url = location_bar_input_to_url(url_opt.unwrap());
     }
 

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -28,16 +28,14 @@ pub fn get_default_url(
     // If the url is not provided, we fallback to the homepage in prefs,
     // or a blank page in case the homepage is not set either.
     let mut new_url = None;
-    let cmdline_url = url_opt
-        .map(|s| s.to_string())
-        .and_then(|url_string| {
-            parse_url_or_filename(cwd.as_ref(), &url_string)
-                .map_err(|error| {
-                    warn!("URL parsing failed ({:?}).", error);
-                    error
-                })
-                .ok()
-        });
+    let cmdline_url = url_opt.map(|s| s.to_string()).and_then(|url_string| {
+        parse_url_or_filename(cwd.as_ref(), &url_string)
+            .map_err(|error| {
+                warn!("URL parsing failed ({:?}).", error);
+                error
+            })
+            .ok()
+    });
 
     if let Some(url) = cmdline_url.clone() {
         // Check if the URL path corresponds to a file

--- a/ports/servoshell/test.rs
+++ b/ports/servoshell/test.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use crate::parser::{get_default_url, location_bar_input_to_url, parse_url_or_filename};
 
 #[cfg(not(target_os = "windows"))]
-const FAKE_CWD: &'static str = "/fake/cwd";
+const FAKE_CWD: &str = "/fake/cwd";
 
 #[cfg(target_os = "windows")]
 const FAKE_CWD: &'static str = "C:/fake/cwd";

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -127,7 +127,7 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
         let recur_into_subtree = match t.kind() {
             ty::Adt(did, substs) => {
                 if let Some(pos) =
-                    get_must_not_have_traceable(sym, &cx.tcx.get_attrs_unchecked(did.did()))
+                    get_must_not_have_traceable(sym, cx.tcx.get_attrs_unchecked(did.did()))
                 {
                     let inner = substs.type_at(pos);
                     if inner.is_primitive_ty() {
@@ -169,7 +169,7 @@ impl<'tcx> LateLintPass<'tcx> for NotracePass {
             return;
         }*/
         if let hir::ItemKind::Struct(def, ..) = &item.kind {
-            for ref field in def.fields() {
+            for field in def.fields() {
                 let field_type = cx.tcx.type_of(field.def_id);
                 incorrect_no_trace(&self.symbols, cx, field_type.skip_binder(), field.span);
             }

--- a/tests/unit/style/parsing/selectors.rs
+++ b/tests/unit/style/parsing/selectors.rs
@@ -9,8 +9,8 @@ use style::stylesheets::{Namespaces, Origin};
 use style_traits::ParseError;
 use url::Url;
 
-fn parse_selector<'i, 't>(
-    input: &mut Parser<'i, 't>,
+fn parse_selector<'i>(
+    input: &mut Parser<'i, '_>,
 ) -> Result<SelectorList<SelectorImpl>, ParseError<'i>> {
     let mut ns = Namespaces::default();
     ns.prefixes

--- a/tests/unit/style/str.rs
+++ b/tests/unit/style/str.rs
@@ -17,7 +17,7 @@ pub fn split_html_space_chars_whitespace() {
 #[test]
 pub fn test_str_join_empty() {
     let slice: [&str; 0] = [];
-    let actual = str_join(&slice, "-");
+    let actual = str_join(slice, "-");
     let expected = "";
     assert_eq!(actual, expected);
 }
@@ -25,7 +25,7 @@ pub fn test_str_join_empty() {
 #[test]
 pub fn test_str_join_one() {
     let slice = ["alpha"];
-    let actual = str_join(&slice, "-");
+    let actual = str_join(slice, "-");
     let expected = "alpha";
     assert_eq!(actual, expected);
 }
@@ -33,7 +33,7 @@ pub fn test_str_join_one() {
 #[test]
 pub fn test_str_join_many() {
     let slice = ["", "alpha", "", "beta", "gamma", ""];
-    let actual = str_join(&slice, "-");
+    let actual = str_join(slice, "-");
     let expected = "-alpha--beta-gamma-";
     assert_eq!(actual, expected);
 }

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -35,7 +35,7 @@ fn get_mock_rules(css_selectors: &[&str]) -> (Vec<Vec<Rule>>, SharedRwLock) {
                         .unwrap();
 
                 let locked = Arc::new(shared_lock.wrap(StyleRule {
-                    selectors: selectors,
+                    selectors,
                     block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::with_one(
                         PropertyDeclaration::Display(longhands::display::SpecifiedValue::Block),
                         Importance::Normal,
@@ -74,8 +74,7 @@ fn parse_selectors(selectors: &[&str]) -> Vec<Selector<SelectorImpl>> {
             SelectorParser::parse_author_origin_no_namespace(x, &dummy_url_data)
                 .unwrap()
                 .0
-                .into_iter()
-                .nth(0)
+                .into_iter().next()
                 .unwrap()
         })
         .collect()
@@ -130,7 +129,7 @@ fn test_revalidation_selectors() {
         "p:first-child span",
     ])
     .into_iter()
-    .filter(|s| needs_revalidation_for_testing(&s))
+    .filter(needs_revalidation_for_testing)
     .collect::<Vec<_>>();
 
     let reference = parse_selectors(&[

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -74,7 +74,8 @@ fn parse_selectors(selectors: &[&str]) -> Vec<Selector<SelectorImpl>> {
             SelectorParser::parse_author_origin_no_namespace(x, &dummy_url_data)
                 .unwrap()
                 .0
-                .into_iter().next()
+                .into_iter()
+                .next()
                 .unwrap()
         })
         .collect()


### PR DESCRIPTION
Followup to #31501, fixes more clippy warnings. It specifically avoids the ones fixed in #31508, #31512 and #31549 to avoid conflicts.

Until now, it fixes most warnings until `net` is compiled, **excluding**:
- `result_unit_err`: use a custom `Error` type instead of `Result<_, ()>`
- `missing_safety_doc`: unsafe function's docs miss `# Safety` section

It also hopefully removes all clippy **errors** until `script` is compiled, so more warnings can be caught.

The next steps to tackle would be:
- Fix the remaining `net` warnings
- Create proper `Error` types for the first warnings
- Write safety documentation (probably someone that is familiar with the unsafe code in the project)
- Work with `canvas`, `webdriver_server` and a few small others before tackling the big ones, which are `script`, `layout` and `layout2020`. `script` alone has 27358 warnings and 433 errors, so it will be the biggest undertaking

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.
