### PR TITLE
Fix build failure on NixOS

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation (androidEnvironment // rec {
     (let
       vendorTarball = rustPlatform.fetchCargoTarball {
         src = ../support/filterlock;
-        hash = "sha256-/kJNDtmv2uI7Qlmpi3DMWSw88rzEJSbroO0/QrgQrSc=";
+        hash = "sha256-EBrL0/cEJfGIXUYqFiufRYFBAk5LSf0Cd/19+9m9JZI=";
       };
       vendorConfig = builtins.toFile "toml" ''
         [source.crates-io]

--- a/support/filterlock/Cargo.toml
+++ b/support/filterlock/Cargo.toml
@@ -1,3 +1,5 @@
+# NOTE: The hash for the `vendorTarball` in etc/shell.nix should be
+# regenerated when this file is changed.
 [workspace]
 
 [package]

--- a/support/filterlock/src/main.rs
+++ b/support/filterlock/src/main.rs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+// NOTE: The hash for the `vendorTarball` in etc/shell.nix should be
+// regenerated when this file is changed.
+
 //! Filter the given lockfile to only the given package and its dependencies.
 //!
 //! Usage: `filterlock <path/to/Cargo.lock> <package>`


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes a build error when building on NixOS. This build error was introduced by #31465, which changed filterlock without also updating the `vendorTarball` hash in `etc/shell.nix`. (filterlock is not a part of the main Servo workspace (it has its own lockfile and target directory), since it has to be executed before any other Rust code can be compiled on NixOS)

```
$ nix-shell etc/shell.nix 
...
Running phase: buildPhase
error: failed to select a version for the requirement `toml = "^0.8.9"`
candidate versions found which didn't match: 0.8.8
location searched: directory source `/build/filterlock/vendor` (which is replacing registry `crates-io`)
required by package `filterlock v0.1.0 (/build/filterlock)`
perhaps a crate was updated and forgotten to be re-vendored?
As a reminder, you're using offline mode (--offline) which can sometimes cause surprising resolution failures, if this error is too confusing you may wish to retry without the offline flag.
```
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because none of the Nix configuration is tested in CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
