### PR TITLE
Use thread pool to decode image

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -418,7 +418,7 @@ impl ImageCacheStore {
 pub struct ImageCacheImpl {
     store: Arc<Mutex<ImageCacheStore>>,
 
-    // Thread pool for image decoding
+    /// Thread pool for image decoding
     thread_pool: CoreResourceThreadPool,
 }
 


### PR DESCRIPTION
Following the discussion on #31504, changes image decoding in `components/net/image_cache.rs` from creating a new thread into a `CoreResourceThreadPool` (different from the one created in `components/net/resource_thread.rs`).

I would appreciate if someone could add the testing labels to check that automated tests keep working well, thanks!

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31504
- [x] These changes do not require tests because they don't change functionality, only the implementation
