### PR TITLE
compositor: Improve the way we wait for frames

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -207,7 +207,6 @@ impl webrender_api::RenderNotifier for RenderNotifier {
         composite_needed: bool,
         _render_time_ns: Option<u64>,
     ) {
-        println!("FRAME READY");
         self.compositor_proxy
             .send(CompositorMsg::NewWebRenderFrameReady(composite_needed));
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -33,8 +33,8 @@ use canvas_traits::webgl::WebGLThreads;
 use compositing::windowing::{EmbedderEvent, EmbedderMethods, WindowMethods};
 use compositing::{CompositeTarget, IOCompositor, InitialCompositorState, ShutdownState};
 use compositing_traits::{
-    CanvasToCompositorMsg, CompositingReason, CompositorMsg, CompositorProxy, CompositorReceiver,
-    ConstellationMsg, FontToCompositorMsg, ForwardedToCompositorMsg,
+    CanvasToCompositorMsg, CompositorMsg, CompositorProxy, CompositorReceiver, ConstellationMsg,
+    FontToCompositorMsg, ForwardedToCompositorMsg,
 };
 #[cfg(all(
     not(target_os = "windows"),
@@ -198,26 +198,18 @@ impl webrender_api::RenderNotifier for RenderNotifier {
         Box::new(RenderNotifier::new(self.compositor_proxy.clone()))
     }
 
-    fn wake_up(&self, composite_needed: bool) {
-        if composite_needed {
-            self.compositor_proxy
-                .recomposite(CompositingReason::NewWebRenderFrame);
-        }
-    }
+    fn wake_up(&self, _composite_needed: bool) {}
 
     fn new_frame_ready(
         &self,
         _document_id: DocumentId,
-        scrolled: bool,
+        _scrolled: bool,
         composite_needed: bool,
         _render_time_ns: Option<u64>,
     ) {
-        if scrolled {
-            self.compositor_proxy
-                .send(CompositorMsg::NewScrollFrameReady(composite_needed));
-        } else {
-            self.wake_up(true);
-        }
+        println!("FRAME READY");
+        self.compositor_proxy
+            .send(CompositorMsg::NewWebRenderFrameReady(composite_needed));
     }
 }
 


### PR DESCRIPTION
In the newest version of WebRender it will be harder to make the
distinction between frame queued for scrolling and other kinds of
pending frames. This change makes it so that we queue frames for both
kinds of changes the same way and keeps a counting of pending frames.
This is conceptually a lot simpler.

In addition, do queue a composite even when recomposite isn't necessary
for a WebRender frame when there are active requestAnimationFrame
callbacks. Doing a composite is what triggers the callbacks to actually
run in the script thread! I believe this was a bug, but the WebRender
upgrade made it much more obvious.

These changes are in preparation for the WebRender upgrade.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because there is no reliable behavior change, but we notice less flakes when running tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
