### PR TITLE
layout: Obey `box-sizing` for table cells

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -9,6 +9,7 @@ use log::warn;
 use servo_arc::Arc;
 use style::computed_values::border_collapse::T as BorderCollapse;
 use style::logical_geometry::WritingMode;
+use style::properties::longhands::box_sizing::computed_value::T as BoxSizing;
 use style::properties::ComputedValues;
 use style::values::computed::{
     CSSPixelLength, Length, LengthPercentage as ComputedLengthPercentage, Percentage,
@@ -143,11 +144,24 @@ impl<'a> TableLayout<'a> {
                     _ => continue,
                 };
 
-                let (size, min_size, max_size) = get_sizes_from_style(&cell.style, writing_mode);
+                let padding = cell
+                    .style
+                    .padding(writing_mode)
+                    .percentages_relative_to(Length::zero());
+                let border = cell.style.border_width(writing_mode);
+                let padding_border_sums = LogicalVec2 {
+                    inline: (padding.inline_sum() + border.inline_sum()).into(),
+                    block: (padding.block_sum() + border.block_sum()).into(),
+                };
+
+                let (size, min_size, max_size) =
+                    get_outer_sizes_from_style(&cell.style, writing_mode, &padding_border_sums);
                 let mut inline_content_sizes = cell
                     .contents
                     .contents
                     .inline_content_sizes(layout_context, writing_mode);
+                inline_content_sizes.min_content += padding_border_sums.inline;
+                inline_content_sizes.max_content += padding_border_sums.inline;
 
                 // TODO: the max-content size should never be smaller than the min-content size!
                 inline_content_sizes.max_content = inline_content_sizes
@@ -158,11 +172,11 @@ impl<'a> TableLayout<'a> {
                     get_size_percentage_contribution_from_style(&cell.style, writing_mode);
 
                 // These formulas differ from the spec, but seem to match Gecko and Blink.
-                let mut outer_min_content_width = inline_content_sizes
+                let outer_min_content_width = inline_content_sizes
                     .min_content
                     .min(max_size.inline)
                     .max(min_size.inline);
-                let mut outer_max_content_width = if self.columns[column_index].constrained {
+                let outer_max_content_width = if self.columns[column_index].constrained {
                     inline_content_sizes
                         .min_content
                         .max(size.inline)
@@ -176,17 +190,6 @@ impl<'a> TableLayout<'a> {
                         .max(min_size.inline)
                 };
                 assert!(outer_min_content_width <= outer_max_content_width);
-
-                let padding = cell
-                    .style
-                    .padding(writing_mode)
-                    .percentages_relative_to(Length::zero());
-                let border = cell.style.border_width(writing_mode);
-
-                let inline_padding_border_sum =
-                    Au::from(padding.inline_sum() + border.inline_sum());
-                outer_min_content_width += inline_padding_border_sum;
-                outer_max_content_width += inline_padding_border_sum;
 
                 let inline_measure = CellOrTrackMeasure {
                     content_sizes: ContentSizes {
@@ -203,8 +206,8 @@ impl<'a> TableLayout<'a> {
                 // TODO: Is it correct to use the block size as the minimum of the `outer min
                 // content height` here? The specification doesn't mention this, but it does cause
                 // a test to pass.
-                let mut outer_min_content_height = min_size.block.max(size.block);
-                let mut outer_max_content_height = if !self.rows[row_index].constrained {
+                let outer_min_content_height = min_size.block.max(size.block);
+                let outer_max_content_height = if !self.rows[row_index].constrained {
                     min_size.block.max(size.block)
                 } else {
                     min_size
@@ -212,10 +215,6 @@ impl<'a> TableLayout<'a> {
                         .max(size.block)
                         .max(max_size.block.min(size.block))
                 };
-
-                let block_padding_border_sum = Au::from(padding.block_sum() + border.block_sum());
-                outer_min_content_height += block_padding_border_sum;
-                outer_max_content_height += block_padding_border_sum;
 
                 let block_measure = CellOrTrackMeasure {
                     content_sizes: ContentSizes {
@@ -1743,7 +1742,8 @@ impl Table {
             None => return CellOrTrackMeasure::zero(),
         };
 
-        let (size, min_size, max_size) = get_sizes_from_style(&column.style, writing_mode);
+        let (size, min_size, max_size) =
+            get_outer_sizes_from_style(&column.style, writing_mode, &LogicalVec2::zero());
         let percentage_contribution =
             get_size_percentage_contribution_from_style(&column.style, writing_mode);
 
@@ -1921,40 +1921,34 @@ fn get_size_percentage_contribution_from_style(
     }
 }
 
-fn get_sizes_from_style(
+fn get_outer_sizes_from_style(
     style: &Arc<ComputedValues>,
     writing_mode: WritingMode,
+    padding_border_sums: &LogicalVec2<Au>,
 ) -> (LogicalVec2<Au>, LogicalVec2<Au>, LogicalVec2<Au>) {
-    let get_max_size_for_axis = |size: Option<&ComputedLengthPercentage>| {
-        size.and_then(|length_percentage| length_percentage.to_length())
-            .map_or(MAX_AU, Au::from)
+    let box_sizing = style.get_position().box_sizing;
+    let outer_size = |size: LogicalVec2<Au>| match box_sizing {
+        BoxSizing::ContentBox => &size + padding_border_sums,
+        BoxSizing::BorderBox => LogicalVec2 {
+            inline: size.inline.max(padding_border_sums.inline),
+            block: size.block.max(padding_border_sums.block),
+        },
     };
-
-    let max_size = style.max_box_size(writing_mode);
-    let max_size = LogicalVec2 {
-        inline: get_max_size_for_axis(max_size.inline),
-        block: get_max_size_for_axis(max_size.block),
-    };
-
-    let get_size_for_axis = |size: LengthPercentageOrAuto<'_>| {
+    let get_size_for_axis = |size: &LengthPercentageOrAuto<'_>| {
         size.non_auto()
             .and_then(|size| size.to_length())
             .map_or_else(Au::zero, Au::from)
     };
-
-    let min_size = style.min_box_size(writing_mode);
-    let min_size = LogicalVec2 {
-        inline: get_size_for_axis(min_size.inline),
-        block: get_size_for_axis(min_size.block),
+    let get_max_size_for_axis = |size: &Option<&ComputedLengthPercentage>| {
+        size.and_then(|length_percentage| length_percentage.to_length())
+            .map_or(MAX_AU, Au::from)
     };
 
-    let size = style.box_size(writing_mode);
-    let size = LogicalVec2 {
-        inline: get_size_for_axis(size.inline),
-        block: get_size_for_axis(size.block),
-    };
-
-    (size, min_size, max_size)
+    (
+        outer_size(style.box_size(writing_mode).map(get_size_for_axis)),
+        outer_size(style.min_box_size(writing_mode).map(get_size_for_axis)),
+        outer_size(style.max_box_size(writing_mode).map(get_max_size_for_axis)),
+    )
 }
 
 struct RowspanToDistribute<'a> {

--- a/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
@@ -2,8 +2,5 @@
   [table 1]
     expected: FAIL
 
-  [table 2]
-    expected: FAIL
-
   [table 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-001.html.ini
@@ -5,12 +5,6 @@
   [table 2]
     expected: FAIL
 
-  [table 6]
-    expected: FAIL
-
-  [table 8]
-    expected: FAIL
-
   [table 9]
     expected: FAIL
 
@@ -18,7 +12,4 @@
     expected: FAIL
 
   [table 11]
-    expected: FAIL
-
-  [table 14]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-003.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/td-box-sizing-003.html.ini
@@ -5,14 +5,5 @@
   [table 9]
     expected: FAIL
 
-  [table 5]
-    expected: FAIL
-
-  [table 6]
-    expected: FAIL
-
-  [table 7]
-    expected: FAIL
-
   [table 10]
     expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Instead of assuming `box-sizing: content-box`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
