### PR TITLE
ci: Fix packaging step on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,6 +78,11 @@ jobs:
           python mach fetch
           python mach bootstrap-gstreamer
           cargo install --path support/crown
+      # For some reason WiX isn't currently on the GitHub runner path. This is a
+      # temporary workaround until that is fixed.
+      - name: Add WiX to Path
+        run: |
+          "$env:WIX\bin" >> $env:GITHUB_PATH
       - name: Build (${{ inputs.profile }})
         run: |
           python mach build --${{ inputs.profile }}


### PR DESCRIPTION
WiX doesn't seem to be on the path any longer, so it must be added
manually as a temporary workaround.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix the CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
