### PR TITLE
servoshell: add support for tabbed browsing

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3046,11 +3046,6 @@ where
         let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
         let browsing_context =
             self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
-        if self.webviews.focused_webview().map(|(id, _)| id) == Some(top_level_browsing_context_id)
-        {
-            self.embedder_proxy
-                .send((None, EmbedderMsg::WebViewBlurred));
-        }
         self.webviews.remove(top_level_browsing_context_id);
         self.compositor_proxy
             .send(CompositorMsg::RemoveWebView(top_level_browsing_context_id));

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3049,6 +3049,9 @@ where
         self.webviews.remove(top_level_browsing_context_id);
         self.compositor_proxy
             .send(CompositorMsg::RemoveWebView(top_level_browsing_context_id));
+
+        // Notify the embedder that the webview was closed, but don’t notify that it was blurred.
+        // Let the embedder deduce that, so it can focus another webview if it wants.
         self.embedder_proxy.send((
             Some(top_level_browsing_context_id),
             EmbedderMsg::WebViewClosed(top_level_browsing_context_id),

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -218,6 +218,7 @@ impl Minibrowser {
                         }
 
                         let mut clicked_tab_webview_id = None;
+                        let mut middle_clicked_tab_webview_id = None;
                         for (&webview_id, _) in webviews.creation_order() {
                             let text = format!("{:?}", webview_id.0);
                             let tab =
@@ -225,6 +226,10 @@ impl Minibrowser {
                             if tab.clicked() {
                                 info!("Clicked tab {webview_id}");
                                 clicked_tab_webview_id = Some(webview_id);
+                            }
+                            if tab.clicked_by(egui::PointerButton::Middle) {
+                                info!("Middle-clicked tab {webview_id}");
+                                middle_clicked_tab_webview_id = Some(webview_id);
                             }
                         }
                         if let Some(clicked_tab_webview_id) = clicked_tab_webview_id {
@@ -235,6 +240,9 @@ impl Minibrowser {
                             ));
                             embedder_events
                                 .push(EmbedderEvent::FocusWebView(clicked_tab_webview_id));
+                        }
+                        if let Some(webview_id) = middle_clicked_tab_webview_id {
+                            embedder_events.push(EmbedderEvent::CloseWebView(webview_id));
                         }
                     },
                 );

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -228,18 +228,13 @@ impl Minibrowser {
                             }
                         }
                         if let Some(clicked_tab_webview_id) = clicked_tab_webview_id {
-                            // Blur then raise then focus, to avoid clickjacking.
                             embedder_events.push(EmbedderEvent::BlurWebView);
-                            embedder_events
-                                .push(EmbedderEvent::RaiseWebViewToTop(clicked_tab_webview_id));
+                            embedder_events.push(EmbedderEvent::RaiseWebViewToTop(
+                                clicked_tab_webview_id,
+                                true,
+                            ));
                             embedder_events
                                 .push(EmbedderEvent::FocusWebView(clicked_tab_webview_id));
-                            // Hide all other webviews, since only one needs to be visible at a time.
-                            for (&webview_id, _) in webviews.creation_order() {
-                                if webview_id != clicked_tab_webview_id {
-                                    embedder_events.push(EmbedderEvent::HideWebView(webview_id));
-                                }
-                            }
                         }
                     },
                 );

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -759,10 +759,12 @@ where
                 EmbedderMsg::EventDelivered(event) => match (webview_id, event) {
                     (Some(webview_id), CompositorEventVariant::MouseButtonEvent) => {
                         trace!("{}: Got a mouse button event", webview_id);
-                        self.event_queue
-                            .push(EmbedderEvent::RaiseWebViewToTop(webview_id, true));
-                        self.event_queue
-                            .push(EmbedderEvent::FocusWebView(webview_id));
+                        if self.focused_webview_id != Some(webview_id) {
+                            self.event_queue
+                                .push(EmbedderEvent::RaiseWebViewToTop(webview_id, true));
+                            self.event_queue
+                                .push(EmbedderEvent::FocusWebView(webview_id));
+                        }
                     },
                     (_, _) => {},
                 },

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -122,6 +122,12 @@ where
         self.focused_webview_id.clone()
     }
 
+    pub fn creation_order(&self) -> impl Iterator<Item = (&WebViewId, &WebView)> {
+        self.creation_order
+            .iter()
+            .flat_map(move |webview_id| self.webviews.get(webview_id).map(|b| (webview_id, b)))
+    }
+
     pub fn current_url_string(&self) -> Option<&str> {
         self.current_url_string.as_deref()
     }

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -46,6 +46,10 @@ pub struct WebViewManager<Window: WindowPortsMethods + ?Sized> {
     /// The order in which the webviews were created.
     creation_order: Vec<WebViewId>,
 
+    /// The order in which the webviews were focused.
+    /// Modified by EmbedderMsg::WebViewFocused.
+    focus_order: Vec<WebViewId>,
+
     /// The webview that is currently focused.
     /// Modified by EmbedderMsg::WebViewFocused and EmbedderMsg::WebViewBlurred.
     focused_webview_id: Option<WebViewId>,
@@ -88,6 +92,7 @@ where
             current_url_string: None,
             webviews: HashMap::default(),
             creation_order: vec![],
+            focus_order: vec![],
             focused_webview_id: None,
             window,
             clipboard: match Clipboard::new() {
@@ -606,15 +611,21 @@ where
                 EmbedderMsg::WebViewClosed(webview_id) => {
                     self.webviews.retain(|&id, _| id != webview_id);
                     self.creation_order.retain(|&id| id != webview_id);
-                    self.focused_webview_id = None;
-                    if let Some(&newest_webview_id) = self.creation_order.last() {
-                        self.event_queue
-                            .push(EmbedderEvent::FocusWebView(newest_webview_id));
-                    } else {
+                    self.focus_order.retain(|&id| id != webview_id);
+                    if self.focused_webview_id == Some(webview_id) {
+                        self.focused_webview_id = None;
+                        if let Some(&last_focused_webview_id) = self.focus_order.last() {
+                            self.event_queue
+                                .push(EmbedderEvent::FocusWebView(last_focused_webview_id));
+                        }
+                    }
+                    if self.webviews.is_empty() {
                         self.event_queue.push(EmbedderEvent::Quit);
                     }
                 },
                 EmbedderMsg::WebViewFocused(webview_id) => {
+                    self.focus_order.retain(|&id| id != webview_id);
+                    self.focus_order.push(webview_id);
                     self.focused_webview_id = Some(webview_id);
                     // Show the most recently created webview and hide all others.
                     // TODO: Stop doing this once we have full multiple webviews support

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -453,6 +453,20 @@ where
                 trace_embedder_msg!(msg, "{msg:?}");
             }
             match msg {
+                EmbedderMsg::WebViewOpened(webview_id) |
+                EmbedderMsg::WebViewClosed(webview_id) |
+                EmbedderMsg::WebViewFocused(webview_id) => {
+                    info!("Got event: {msg:?} {webview_id:?}");
+                },
+                EmbedderMsg::WebViewBlurred => {
+                    info!("Got event: {msg:?}");
+                },
+                EmbedderMsg::WebViewPaintingOrder(ref webview_ids) => {
+                    info!("Got event: {msg:?} {webview_ids:?}");
+                },
+                _ => {},
+            }
+            match msg {
                 EmbedderMsg::Status(_status) => {
                     // FIXME: surface this status string in the UI somehow
                 },


### PR DESCRIPTION
This patch adds support for tabbed browsing in servoshell’s minibrowser, like #30785 but rebased onto #31417 and simplified to avoid current multiview and egui limitations.

![image](https://github.com/servo/servo/assets/465303/271cebed-3e5e-4954-affd-19c0751fb67b)

For now, only one webview will be focused and shown at a time. To close a tab, click the ❌︎ in the tab bar, or middle-click the tab itself. When closing a tab that is currently focused, we switch to the next most recently focused tab.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___