### PR TITLE
Fix clippy warnings in `components/rand`

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -144,7 +144,7 @@ fn run_server(
     });
 
     // A token shared with the embedder to bypass permission prompt.
-    let token = format!("{:X}", servo_rand::ServoRng::new().next_u32());
+    let token = format!("{:X}", servo_rand::ServoRng::default().next_u32());
 
     let port = bound.as_ref().map(|(_, port)| *port).ok_or(());
     embedder.send((None, EmbedderMsg::OnDevtoolsStarted(port, token.clone())));

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -96,17 +96,11 @@ impl ServoRng {
 }
 
 impl Default for ServoRng {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ServoRng {
     /// Create an auto-reseeding instance of `ServoRng`.
     ///
     /// This uses the shared `OsRng`, so avoids consuming
     /// a file descriptor.
-    pub fn new() -> ServoRng {
+    fn default() -> Self {
         trace!("Creating new ServoRng.");
         let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
         let isaac_rng = IsaacCore::from_rng(&mut *os_rng).unwrap();

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -95,6 +95,12 @@ impl ServoRng {
     }
 }
 
+impl Default for ServoRng {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ServoRng {
     /// Create an auto-reseeding instance of `ServoRng`.
     ///

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -106,7 +106,7 @@ impl ServoRng {
     ///
     /// This uses the shared `OsRng`, so avoids consuming
     /// a file descriptor.
-    pub fn default() -> ServoRng {
+    pub fn new() -> ServoRng {
         trace!("Creating new ServoRng.");
         let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
         let isaac_rng = IsaacCore::from_rng(&mut *os_rng).unwrap();

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -106,7 +106,7 @@ impl ServoRng {
     ///
     /// This uses the shared `OsRng`, so avoids consuming
     /// a file descriptor.
-    pub fn new() -> ServoRng {
+    pub fn default() -> ServoRng {
         trace!("Creating new ServoRng.");
         let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
         let isaac_rng = IsaacCore::from_rng(&mut *os_rng).unwrap();
@@ -162,7 +162,7 @@ pub fn thread_rng() -> ServoThreadRng {
 }
 
 thread_local! {
-    static SERVO_THREAD_RNG: ServoThreadRng = ServoThreadRng { rng: Rc::new(RefCell::new(ServoRng::new())) };
+    static SERVO_THREAD_RNG: ServoThreadRng = ServoThreadRng { rng: Rc::new(RefCell::new(ServoRng::default())) };
 }
 
 impl RngCore for ServoThreadRng {

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -29,7 +29,7 @@ impl Crypto {
     fn new_inherited() -> Crypto {
         Crypto {
             reflector_: Reflector::new(),
-            rng: DomRefCell::new(ServoRng::new()),
+            rng: DomRefCell::new(ServoRng::default()),
         }
     }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -862,5 +862,5 @@ impl WebrenderIpcSender {
 }
 
 lazy_static! {
-    pub static ref PRIVILEGED_SECRET: u32 = servo_rand::ServoRng::new().next_u32();
+    pub static ref PRIVILEGED_SECRET: u32 = servo_rand::ServoRng::default().next_u32();
 }


### PR DESCRIPTION

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31500
- [x] These changes do not require tests because they do not modify functionality, it only adds a `Default` implementation for `ServoRng`

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
