### PR TITLE
Fix clippy warnings in components/shared/net/request.rs

### DIFF
--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -210,14 +210,6 @@ impl RequestBody {
     pub fn len(&self) -> Option<usize> {
         self.total_bytes
     }
-
-    pub fn is_empty(&self) -> bool {
-        if let Some(v) = self.len() {
-            v == 0
-        } else {
-            false
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -208,7 +208,15 @@ impl RequestBody {
     }
 
     pub fn len(&self) -> Option<usize> {
-        self.total_bytes.clone()
+        self.total_bytes
+    }
+
+    pub fn is_empty(&self) -> bool {
+        if let Some(v) = self.len() {
+            v == 0
+        } else {
+            false
+        }
     }
 }
 
@@ -567,19 +575,19 @@ impl Request {
 
     /// <https://fetch.spec.whatwg.org/#subresource-request>
     pub fn is_subresource_request(&self) -> bool {
-        match self.destination {
+        matches!(
+            self.destination,
             Destination::Audio |
-            Destination::Font |
-            Destination::Image |
-            Destination::Manifest |
-            Destination::Script |
-            Destination::Style |
-            Destination::Track |
-            Destination::Video |
-            Destination::Xslt |
-            Destination::None => true,
-            _ => false,
-        }
+                Destination::Font |
+                Destination::Image |
+                Destination::Manifest |
+                Destination::Script |
+                Destination::Style |
+                Destination::Track |
+                Destination::Video |
+                Destination::Xslt |
+                Destination::None
+        )
     }
 
     pub fn timing_type(&self) -> ResourceTimingType {
@@ -605,7 +613,7 @@ impl Referrer {
 // TODO: values in the control-code range are being quietly stripped out by
 // HeaderMap and never reach this function to be loudly rejected!
 fn is_cors_unsafe_request_header_byte(value: &u8) -> bool {
-    match value {
+    matches!(value,
         0x00..=0x08 |
         0x10..=0x19 |
         0x22 |
@@ -621,9 +629,8 @@ fn is_cors_unsafe_request_header_byte(value: &u8) -> bool {
         0x5D |
         0x7B |
         0x7D |
-        0x7F => true,
-        _ => false,
-    }
+        0x7F
+    )
 }
 
 // https://fetch.spec.whatwg.org/#cors-safelisted-request-header
@@ -635,18 +642,19 @@ fn is_cors_safelisted_request_accept(value: &[u8]) -> bool {
 // https://fetch.spec.whatwg.org/#cors-safelisted-request-header
 // subclauses `accept-language`, `content-language`
 fn is_cors_safelisted_language(value: &[u8]) -> bool {
-    value.iter().all(|&x| match x {
-        0x30..=0x39 |
-        0x41..=0x5A |
-        0x61..=0x7A |
-        0x20 |
-        0x2A |
-        0x2C |
-        0x2D |
-        0x2E |
-        0x3B |
-        0x3D => true,
-        _ => false,
+    value.iter().all(|&x| {
+        matches!(x,
+            0x30..=0x39 |
+            0x41..=0x5A |
+            0x61..=0x7A |
+            0x20 |
+            0x2A |
+            0x2C |
+            0x2D |
+            0x2E |
+            0x3B |
+            0x3D
+        )
     })
 }
 
@@ -697,10 +705,7 @@ pub fn is_cors_safelisted_request_header<N: AsRef<str>, V: AsRef<[u8]>>(
 
 /// <https://fetch.spec.whatwg.org/#cors-safelisted-method>
 pub fn is_cors_safelisted_method(m: &Method) -> bool {
-    match *m {
-        Method::GET | Method::HEAD | Method::POST => true,
-        _ => false,
-    }
+    matches!(*m, Method::GET | Method::HEAD | Method::POST)
 }
 
 /// <https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name>
@@ -733,7 +738,7 @@ pub fn get_cors_unsafe_header_names(headers: &HeaderMap) -> Vec<HeaderName> {
     }
 
     // Step 6
-    return convert_header_names_to_sorted_lowercase_set(unsafe_names);
+    convert_header_names_to_sorted_lowercase_set(unsafe_names)
 }
 
 /// <https://fetch.spec.whatwg.org/#ref-for-convert-header-names-to-a-sorted-lowercase-set>
@@ -745,5 +750,5 @@ pub fn convert_header_names_to_sorted_lowercase_set(
     let mut ordered_set = header_names.to_vec();
     ordered_set.sort_by(|a, b| a.as_str().partial_cmp(b.as_str()).unwrap());
     ordered_set.dedup();
-    return ordered_set.into_iter().cloned().collect();
+    ordered_set.into_iter().cloned().collect()
 }


### PR DESCRIPTION
Fix clippy warnings in components/shared/net/request.rs.
Part of #31500.

Notable change is the addition of RequestBody::is_empty()

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they do not change functionality
