### PR TITLE
clippy: fix warnings in components/config*

### DIFF
--- a/components/config/basedir.rs
+++ b/components/config/basedir.rs
@@ -35,7 +35,7 @@ pub fn default_config_dir() -> Option<PathBuf> {
     Some(config_dir)
 }
 
-#[cfg(all(target_os = "windows"))]
+#[cfg(target_os = "windows")]
 pub fn default_config_dir() -> Option<PathBuf> {
     let mut config_dir = ::dirs_next::config_dir().unwrap();
     config_dir.push("Servo");

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -7,7 +7,7 @@
 
 use std::default::Default;
 use std::fs::{self, File};
-use std::io::{self, Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{RwLock, RwLockReadGuard};
@@ -385,7 +385,7 @@ pub enum OutputOptions {
 }
 
 fn args_fail(msg: &str) -> ! {
-    writeln!(io::stderr(), "{}", msg).unwrap();
+    eprintln!("{}", msg);
     process::exit(1)
 }
 
@@ -793,7 +793,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         set_pref!(layout.threads, layout_threads as i64);
     }
 
-    return ArgumentParsingResult::ChromeProcess(opt_match);
+    ArgumentParsingResult::ChromeProcess(opt_match)
 }
 
 pub enum ArgumentParsingResult {

--- a/components/config_plugins/parse.rs
+++ b/components/config_plugins/parse.rs
@@ -132,7 +132,7 @@ impl Parse for RootTypeDef {
 impl Parse for NewTypeDef {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let content;
-        #[allow(clippy::eval_order_dependence)]
+        #[allow(clippy::mixed_read_write_in_expression)]
         Ok(NewTypeDef {
             _braces: braced!(content in input),
             fields: Punctuated::parse_terminated_with(&content, Field::parse)?,


### PR DESCRIPTION
Split from #31514, fixes some clippy warnings in `components/config` and `components/config_plugins`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.