### PR TITLE
clippy: fix warnings in components/canvas

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -74,23 +74,23 @@ impl PathState {
 pub trait Backend {
     fn get_composition_op(&self, opts: &DrawOptions) -> CompositionOp;
     fn need_to_draw_shadow(&self, color: &Color) -> bool;
-    fn set_shadow_color<'a>(&mut self, color: RGBA, state: &mut CanvasPaintState<'a>);
-    fn set_fill_style<'a>(
+    fn set_shadow_color(&mut self, color: RGBA, state: &mut CanvasPaintState<'_>);
+    fn set_fill_style(
         &mut self,
         style: FillOrStrokeStyle,
-        state: &mut CanvasPaintState<'a>,
+        state: &mut CanvasPaintState<'_>,
         drawtarget: &dyn GenericDrawTarget,
     );
-    fn set_stroke_style<'a>(
+    fn set_stroke_style(
         &mut self,
         style: FillOrStrokeStyle,
-        state: &mut CanvasPaintState<'a>,
+        state: &mut CanvasPaintState<'_>,
         drawtarget: &dyn GenericDrawTarget,
     );
-    fn set_global_composition<'a>(
+    fn set_global_composition(
         &mut self,
         op: CompositionOrBlending,
-        state: &mut CanvasPaintState<'a>,
+        state: &mut CanvasPaintState<'_>,
     );
     fn create_drawtarget(&self, size: Size2D<u64>) -> Box<dyn GenericDrawTarget>;
     fn recreate_paint_state<'a>(&self, state: &CanvasPaintState<'a>) -> CanvasPaintState<'a>;
@@ -222,10 +222,9 @@ impl<'a> PathBuilderRef<'a> {
             Some(i) => i,
             None => return None,
         };
-        match self.builder.get_current_point() {
-            Some(point) => Some(inverse.transform_point(Point2D::new(point.x, point.y))),
-            None => None,
-        }
+        self.builder
+            .get_current_point()
+            .map(|point| inverse.transform_point(Point2D::new(point.x, point.y)))
     }
 
     fn close(&mut self) {
@@ -428,7 +427,7 @@ impl<'a> CanvasData<'a> {
         let source_rect = source_rect.ceil();
         // It discards the extra pixels (if any) that won't be painted
         let image_data = if Rect::from_size(image_size).contains_rect(&source_rect) {
-            pixels::rgba8_get_rect(&image_data, image_size.to_u64(), source_rect.to_u64()).into()
+            pixels::rgba8_get_rect(image_data, image_size.to_u64(), source_rect.to_u64()).into()
         } else {
             image_data.into()
         };
@@ -493,7 +492,7 @@ impl<'a> CanvasData<'a> {
         let font = font_style.map_or_else(
             || load_system_font_from_style(None),
             |style| {
-                with_thread_local_font_context(&self, |font_context| {
+                with_thread_local_font_context(self, |font_context| {
                     let font_group = font_context.font_group(ServoArc::new(style.clone()));
                     let font = font_group
                         .borrow_mut()
@@ -651,7 +650,7 @@ impl<'a> CanvasData<'a> {
         }
 
         if self.need_to_draw_shadow() {
-            self.draw_with_shadow(&rect, |new_draw_target: &mut dyn GenericDrawTarget| {
+            self.draw_with_shadow(rect, |new_draw_target: &mut dyn GenericDrawTarget| {
                 new_draw_target.stroke_rect(
                     rect,
                     self.state.stroke_style.clone(),
@@ -918,7 +917,7 @@ impl<'a> CanvasData<'a> {
             Some(p) => p,
             None => {
                 self.path_builder().move_to(cp1);
-                cp1.clone()
+                *cp1
             },
         };
         let cp1 = *cp1;
@@ -1042,7 +1041,7 @@ impl<'a> CanvasData<'a> {
                 }
             },
         }
-        self.state.transform = transform.clone();
+        self.state.transform = *transform;
         self.drawtarget.set_transform(transform)
     }
 
@@ -1200,10 +1199,7 @@ impl<'a> CanvasData<'a> {
         draw_shadow_source(&mut *new_draw_target);
         self.drawtarget.draw_surface_with_shadow(
             new_draw_target.snapshot(),
-            &Point2D::new(
-                shadow_src_rect.origin.x as f32,
-                shadow_src_rect.origin.y as f32,
-            ),
+            &Point2D::new(shadow_src_rect.origin.x, shadow_src_rect.origin.y),
             &self.state.shadow_color,
             &Vector2D::new(
                 self.state.shadow_offset_x as f32,
@@ -1394,18 +1390,18 @@ fn load_system_font_from_style(font_style: Option<&FontStyleStruct>) -> Option<F
         })
         .weight(Weight(style.font_weight.value()))
         .stretch(Stretch(style.font_stretch.to_percentage().0));
-    let font_handle = match SystemSource::new().select_best_match(&family_names, &properties) {
+    let font_handle = match SystemSource::new().select_best_match(&family_names, properties) {
         Ok(handle) => handle,
         Err(e) => {
             error!("error getting font handle for style {:?}: {}", style, e);
-            return load_default_system_fallback_font(&properties);
+            return load_default_system_fallback_font(properties);
         },
     };
     match font_handle.load() {
         Ok(f) => Some(f),
         Err(e) => {
             error!("error loading font for style {:?}: {}", style, e);
-            load_default_system_fallback_font(&properties)
+            load_default_system_fallback_font(properties)
         },
     }
 }

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -130,7 +130,7 @@ impl<'a> CanvasPaintThread<'a> {
 
         let font_cache_thread = self.font_cache_thread.clone();
 
-        let canvas_id = self.next_canvas_id.clone();
+        let canvas_id = self.next_canvas_id;
         self.next_canvas_id.0 += 1;
 
         let canvas_data = CanvasData::new(
@@ -139,7 +139,7 @@ impl<'a> CanvasPaintThread<'a> {
             antialias,
             font_cache_thread,
         );
-        self.canvases.insert(canvas_id.clone(), canvas_data);
+        self.canvases.insert(canvas_id, canvas_data);
 
         canvas_id
     }
@@ -181,7 +181,7 @@ impl<'a> CanvasPaintThread<'a> {
                 source_rect,
                 smoothing_enabled,
             ) => self.canvas(canvas_id).draw_image(
-                &*image_data,
+                image_data,
                 image_size,
                 dest_rect,
                 source_rect,

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -65,7 +65,7 @@ impl WebGLComm {
         WebGLComm {
             webgl_threads: WebGLThreads(sender),
             image_handler: Box::new(external),
-            webxr_layer_grand_manager: webxr_layer_grand_manager,
+            webxr_layer_grand_manager,
         }
     }
 }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -289,7 +289,7 @@ impl WebGLThread {
             let exit = self.handle_msg(msg, &webgl_chan);
             if exit {
                 // Call remove_context functions in order to correctly delete WebRender image keys.
-                let context_ids: Vec<WebGLContextId> = self.contexts.keys().map(|id| *id).collect();
+                let context_ids: Vec<WebGLContextId> = self.contexts.keys().copied().collect();
                 for id in context_ids {
                     self.remove_webgl_context(id);
                 }
@@ -323,7 +323,7 @@ impl WebGLThread {
                             &mut self.bound_context_id,
                         )
                         .expect("WebGLContext not found");
-                        let glsl_version = Self::get_glsl_version(&*data.gl);
+                        let glsl_version = Self::get_glsl_version(&data.gl);
                         let api_type = match data.gl.get_type() {
                             gl::GlType::Gl => GlType::Gl,
                             gl::GlType::Gles => GlType::Gles,
@@ -458,7 +458,7 @@ impl WebGLThread {
             WebGLImpl::apply(
                 &self.device,
                 &data.ctx,
-                &*data.gl,
+                &data.gl,
                 &mut data.state,
                 &data.attributes,
                 command,
@@ -497,12 +497,12 @@ impl WebGLThread {
             ContextAttributeFlags::STENCIL;
         let context_attributes = &ContextAttributes {
             version: webgl_version.to_surfman_version(self.api_type),
-            flags: flags,
+            flags,
         };
 
         let context_descriptor = self
             .device
-            .create_context_descriptor(&context_attributes)
+            .create_context_descriptor(context_attributes)
             .map_err(|err| format!("Failed to create context descriptor: {:?}", err))?;
 
         let safe_size = Size2D::new(
@@ -562,7 +562,7 @@ impl WebGLThread {
             })),
         };
 
-        let limits = GLLimits::detect(&*gl, webgl_version);
+        let limits = GLLimits::detect(&gl, webgl_version);
 
         let size = clamp_viewport(&gl, requested_size);
         if safe_size != size {
@@ -583,7 +583,7 @@ impl WebGLThread {
             .device
             .context_surface_info(&ctx)
             .map_err(|err| format!("Failed to get context surface info: {:?}", err))?
-            .ok_or_else(|| format!("Failed to get context surface info"))?
+            .ok_or_else(|| "Failed to get context surface info".to_string())?
             .framebuffer_object;
 
         gl.bind_framebuffer(gl::FRAMEBUFFER, framebuffer);
@@ -616,7 +616,7 @@ impl WebGLThread {
         };
         debug!("Created state {:?}", state);
 
-        state.restore_invariant(&*gl);
+        state.restore_invariant(&gl);
         debug_assert_eq!(gl.get_error(), gl::NO_ERROR);
 
         self.contexts.insert(
@@ -663,7 +663,7 @@ impl WebGLThread {
         // Check to see if any of the current framebuffer bindings are the surface we're about to
         // throw out. If so, we'll have to reset them after destroying the surface.
         let framebuffer_rebinding_info =
-            FramebufferRebindingInfo::detect(&self.device, &data.ctx, &*data.gl);
+            FramebufferRebindingInfo::detect(&self.device, &data.ctx, &data.gl);
 
         // Resize the swap chains
         if let Some(swap_chain) = self.webrender_swap_chains.get(context_id) {
@@ -676,14 +676,14 @@ impl WebGLThread {
                 .resize(&mut self.device, &mut data.ctx, size.to_i32())
                 .map_err(|err| format!("Failed to resize swap chain: {:?}", err))?;
             swap_chain
-                .clear_surface(&mut self.device, &mut data.ctx, &*data.gl, clear_color)
+                .clear_surface(&mut self.device, &mut data.ctx, &data.gl, clear_color)
                 .map_err(|err| format!("Failed to clear resized swap chain: {:?}", err))?;
         } else {
             error!("Failed to find swap chain");
         }
 
         // Reset framebuffer bindings as appropriate.
-        framebuffer_rebinding_info.apply(&self.device, &data.ctx, &*data.gl);
+        framebuffer_rebinding_info.apply(&self.device, &data.ctx, &data.gl);
         debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
         let has_alpha = data
@@ -764,7 +764,7 @@ impl WebGLThread {
             // Check to see if any of the current framebuffer bindings are the surface we're about
             // to swap out. If so, we'll have to reset them after destroying the surface.
             let framebuffer_rebinding_info =
-                FramebufferRebindingInfo::detect(&self.device, &data.ctx, &*data.gl);
+                FramebufferRebindingInfo::detect(&self.device, &data.ctx, &data.gl);
             debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             debug!("Getting swap chain for {:?}", context_id);
@@ -779,7 +779,7 @@ impl WebGLThread {
                     &mut self.device,
                     &mut data.ctx,
                     if data.attributes.preserve_drawing_buffer {
-                        PreserveBuffer::Yes(&*data.gl)
+                        PreserveBuffer::Yes(&data.gl)
                     } else {
                         PreserveBuffer::No
                     },
@@ -795,14 +795,14 @@ impl WebGLThread {
                     .contains(ContextAttributeFlags::ALPHA);
                 let clear_color = [0.0, 0.0, 0.0, !alpha as i32 as f32];
                 swap_chain
-                    .clear_surface(&mut self.device, &mut data.ctx, &*data.gl, clear_color)
+                    .clear_surface(&mut self.device, &mut data.ctx, &data.gl, clear_color)
                     .unwrap();
                 debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
             }
 
             // Rebind framebuffers as appropriate.
             debug!("Rebinding {:?}", context_id);
-            framebuffer_rebinding_info.apply(&self.device, &data.ctx, &*data.gl);
+            framebuffer_rebinding_info.apply(&self.device, &data.ctx, &data.gl);
             debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             let SurfaceInfo {
@@ -941,7 +941,7 @@ impl WebGLThread {
         image_buffer_kind: ImageBufferKind,
     ) -> ImageData {
         let data = ExternalImageData {
-            id: ExternalImageId(context_id.0 as u64),
+            id: ExternalImageId(context_id.0),
             channel_index: 0,
             image_type: ExternalImageType::TextureHandle(image_buffer_kind),
         };
@@ -1288,7 +1288,7 @@ impl WebGLImpl {
                 sender.send(location).unwrap();
             },
             WebGLCommand::GetUniformLocation(program_id, ref name, ref chan) => {
-                Self::uniform_location(gl, program_id, &name, chan)
+                Self::uniform_location(gl, program_id, name, chan)
             },
             WebGLCommand::GetShaderInfoLog(shader_id, ref chan) => {
                 Self::shader_info_log(gl, shader_id, chan)
@@ -1297,7 +1297,7 @@ impl WebGLImpl {
                 Self::program_info_log(gl, program_id, chan)
             },
             WebGLCommand::CompileShader(shader_id, ref source) => {
-                Self::compile_shader(gl, shader_id, &source)
+                Self::compile_shader(gl, shader_id, source)
             },
             WebGLCommand::CreateBuffer(ref chan) => Self::create_buffer(gl, chan),
             WebGLCommand::CreateFramebuffer(ref chan) => Self::create_framebuffer(gl, chan),
@@ -1426,7 +1426,7 @@ impl WebGLImpl {
                     alpha_treatment,
                     y_axis_treatment,
                     pixel_format,
-                    Cow::Borrowed(&*data),
+                    Cow::Borrowed(data),
                 );
 
                 gl.pixel_store_i(gl::UNPACK_ALIGNMENT, unpacking_alignment as i32);
@@ -1489,7 +1489,7 @@ impl WebGLImpl {
                     alpha_treatment,
                     y_axis_treatment,
                     pixel_format,
-                    Cow::Borrowed(&*data),
+                    Cow::Borrowed(data),
                 );
 
                 gl.pixel_store_i(gl::UNPACK_ALIGNMENT, unpacking_alignment as i32);
@@ -1519,7 +1519,7 @@ impl WebGLImpl {
                     size.width as i32,
                     size.height as i32,
                     0,
-                    &*data,
+                    data,
                 );
             },
             WebGLCommand::CompressedTexSubImage2D {
@@ -1533,13 +1533,13 @@ impl WebGLImpl {
             } => {
                 gl.compressed_tex_sub_image_2d(
                     target,
-                    level as i32,
-                    xoffset as i32,
-                    yoffset as i32,
+                    level,
+                    xoffset,
+                    yoffset,
                     size.width as i32,
                     size.height as i32,
                     format,
-                    &*data,
+                    data,
                 );
             },
             WebGLCommand::TexStorage2D(target, levels, internal_format, width, height) => gl
@@ -1561,7 +1561,7 @@ impl WebGLImpl {
                 ),
             WebGLCommand::DrawingBufferWidth(ref sender) => {
                 let size = device
-                    .context_surface_info(&ctx)
+                    .context_surface_info(ctx)
                     .unwrap()
                     .expect("Where's the front buffer?")
                     .size;
@@ -1569,7 +1569,7 @@ impl WebGLImpl {
             },
             WebGLCommand::DrawingBufferHeight(ref sender) => {
                 let size = device
-                    .context_surface_info(&ctx)
+                    .context_surface_info(ctx)
                     .unwrap()
                     .expect("Where's the front buffer?")
                     .size;
@@ -1615,7 +1615,7 @@ impl WebGLImpl {
                 sender.send(value).unwrap();
             },
             WebGLCommand::ClientWaitSync(sync_id, flags, timeout, ref sender) => {
-                let value = gl.client_wait_sync(sync_id.get() as *const _, flags, timeout as u64);
+                let value = gl.client_wait_sync(sync_id.get() as *const _, flags, timeout);
                 sender.send(value).unwrap();
             },
             WebGLCommand::WaitSync(sync_id, flags, timeout) => {
@@ -1744,10 +1744,10 @@ impl WebGLImpl {
                 }
             },
             WebGLCommand::TexParameteri(target, param, value) => {
-                gl.tex_parameter_i(target, param as u32, value)
+                gl.tex_parameter_i(target, param, value)
             },
             WebGLCommand::TexParameterf(target, param, value) => {
-                gl.tex_parameter_f(target, param as u32, value)
+                gl.tex_parameter_f(target, param, value)
             },
             WebGLCommand::LinkProgram(program_id, ref sender) => {
                 return sender.send(Self::link_program(gl, program_id)).unwrap();
@@ -2503,7 +2503,7 @@ impl WebGLImpl {
 ///
 /// To avoid hard-coding this we would need to use the `sh::GetAttributes` and `sh::GetUniforms`
 /// API to look up the `x.name` and `x.mappedName` members.
-const ANGLE_NAME_PREFIX: &'static str = "_u";
+const ANGLE_NAME_PREFIX: &str = "_u";
 
 fn to_name_in_compiled_shader(s: &str) -> String {
     map_dot_separated(s, |s, mapped| {
@@ -3057,7 +3057,7 @@ impl WebXRBridge {
             .map_err(|_| WebXRError::CommunicationError)?;
         let manager = factory.build(device, contexts)?;
         let manager_id = unsafe { WebXRLayerManagerId::new(self.next_manager_id) };
-        self.next_manager_id = self.next_manager_id + 1;
+        self.next_manager_id += 1;
         self.managers.insert(manager_id, manager);
         Ok(manager_id)
     }
@@ -3315,8 +3315,8 @@ impl<'a> WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'a> {
         let data = WebGLThread::make_current_if_needed_mut(
             device,
             WebGLContextId::from(context_id),
-            &mut self.contexts,
-            &mut self.bound_context_id,
+            self.contexts,
+            self.bound_context_id,
         )?;
         Some(&mut data.ctx)
     }
@@ -3324,8 +3324,8 @@ impl<'a> WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'a> {
         let data = WebGLThread::make_current_if_needed(
             device,
             WebGLContextId::from(context_id),
-            &self.contexts,
-            &mut self.bound_context_id,
+            self.contexts,
+            self.bound_context_id,
         )?;
         Some(&data.gl)
     }

--- a/components/compositing/build.rs
+++ b/components/compositing/build.rs
@@ -38,11 +38,11 @@ fn main() {
                         .and_then(|pkg| pkg.get("source").and_then(|source| source.as_str()))
                         .unwrap_or("unknown");
 
-                    let parsed: Vec<&str> = source.split("#").collect();
+                    let parsed: Vec<&str> = source.split('#').collect();
                     let revision = if parsed.len() > 1 { parsed[1] } else { source };
 
-                    let mut revision_module_file = File::create(&revision_file_path).unwrap();
-                    write!(&mut revision_module_file, "{}", format!("\"{}\"", revision)).unwrap();
+                    let mut revision_module_file = File::create(revision_file_path).unwrap();
+                    write!(&mut revision_module_file, "\"{}\"", revision).unwrap();
                 },
                 _ => panic!("Cannot find package definitions in lockfile"),
             }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -525,6 +525,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     /// and the system creates a new native surface that needs to bound to the current
     /// context.
     #[allow(unsafe_code)]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)] // It has an unsafe block inside
     pub fn replace_native_surface(&mut self, native_widget: *mut c_void, coords: DeviceIntSize) {
         debug!("Replacing native surface in compositor: {native_widget:?}");
         let connection = self.rendering_context.connection();


### PR DESCRIPTION
Split from #31514, fixes some clippy warnings in `components/canvas` and `components/compositing`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.