### PR TITLE
clippy: fix warnings on modules outside components

### DIFF
--- a/ports/jniapi/build.rs
+++ b/ports/jniapi/build.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Generate GL bindings. For now, we only support EGL.
     if target.contains("android") {
-        let mut file = File::create(&dest.join("egl_bindings.rs")).unwrap();
+        let mut file = File::create(dest.join("egl_bindings.rs")).unwrap();
         Registry::new(Api::Egl, (1, 5), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StaticStructGenerator, &mut file)
             .unwrap();
@@ -38,6 +38,6 @@ fn main() {
     let mut default_prefs = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     default_prefs.push("../../resources/prefs.json");
     let prefs: Value = serde_json::from_reader(File::open(&default_prefs).unwrap()).unwrap();
-    let file = File::create(&dest.join("prefs.json")).unwrap();
+    let file = File::create(dest.join("prefs.json")).unwrap();
     serde_json::to_writer(file, &prefs).unwrap();
 }

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -84,11 +84,9 @@ impl App {
 
         // Handle browser state.
         let webviews = WebViewManager::new(window.clone());
-        let initial_url = get_default_url(
-            url.as_ref().map(String::as_str),
-            env::current_dir().unwrap(),
-            |path| fs::metadata(path).is_ok(),
-        );
+        let initial_url = get_default_url(url.as_deref(), env::current_dir().unwrap(), |path| {
+            fs::metadata(path).is_ok()
+        });
 
         let mut app = App {
             event_queue: RefCell::new(vec![]),
@@ -270,7 +268,7 @@ impl App {
                         window.winit_window().unwrap().request_redraw();
                     },
                     winit::event::Event::WindowEvent { ref event, .. } => {
-                        let response = minibrowser.on_event(&event);
+                        let response = minibrowser.on_event(event);
                         if response.repaint {
                             // Request a winit redraw event, so we can recomposite, update and paint
                             // the minibrowser, and present the new frame.

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -28,17 +28,14 @@ pub fn get_default_url(
     // If the url is not provided, we fallback to the homepage in prefs,
     // or a blank page in case the homepage is not set either.
     let mut new_url = None;
-    let cmdline_url = url_opt
-        .clone()
-        .map(|s| s.to_string())
-        .and_then(|url_string| {
-            parse_url_or_filename(cwd.as_ref(), &url_string)
-                .map_err(|error| {
-                    warn!("URL parsing failed ({:?}).", error);
-                    error
-                })
-                .ok()
-        });
+    let cmdline_url = url_opt.map(|s| s.to_string()).and_then(|url_string| {
+        parse_url_or_filename(cwd.as_ref(), &url_string)
+            .map_err(|error| {
+                warn!("URL parsing failed ({:?}).", error);
+                error
+            })
+            .ok()
+    });
 
     if let Some(url) = cmdline_url.clone() {
         // Check if the URL path corresponds to a file
@@ -50,7 +47,7 @@ pub fn get_default_url(
         }
     }
 
-    if new_url.is_none() && !url_opt.is_none() {
+    if new_url.is_none() && url_opt.is_some() {
         new_url = location_bar_input_to_url(url_opt.unwrap());
     }
 

--- a/ports/servoshell/test.rs
+++ b/ports/servoshell/test.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use crate::parser::{get_default_url, location_bar_input_to_url, parse_url_or_filename};
 
 #[cfg(not(target_os = "windows"))]
-const FAKE_CWD: &'static str = "/fake/cwd";
+const FAKE_CWD: &str = "/fake/cwd";
 
 #[cfg(target_os = "windows")]
 const FAKE_CWD: &'static str = "C:/fake/cwd";

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -127,7 +127,7 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
         let recur_into_subtree = match t.kind() {
             ty::Adt(did, substs) => {
                 if let Some(pos) =
-                    get_must_not_have_traceable(sym, &cx.tcx.get_attrs_unchecked(did.did()))
+                    get_must_not_have_traceable(sym, cx.tcx.get_attrs_unchecked(did.did()))
                 {
                     let inner = substs.type_at(pos);
                     if inner.is_primitive_ty() {
@@ -169,7 +169,7 @@ impl<'tcx> LateLintPass<'tcx> for NotracePass {
             return;
         }*/
         if let hir::ItemKind::Struct(def, ..) = &item.kind {
-            for ref field in def.fields() {
+            for field in def.fields() {
                 let field_type = cx.tcx.type_of(field.def_id);
                 incorrect_no_trace(&self.symbols, cx, field_type.skip_binder(), field.span);
             }

--- a/tests/unit/style/parsing/selectors.rs
+++ b/tests/unit/style/parsing/selectors.rs
@@ -9,8 +9,8 @@ use style::stylesheets::{Namespaces, Origin};
 use style_traits::ParseError;
 use url::Url;
 
-fn parse_selector<'i, 't>(
-    input: &mut Parser<'i, 't>,
+fn parse_selector<'i>(
+    input: &mut Parser<'i, '_>,
 ) -> Result<SelectorList<SelectorImpl>, ParseError<'i>> {
     let mut ns = Namespaces::default();
     ns.prefixes

--- a/tests/unit/style/str.rs
+++ b/tests/unit/style/str.rs
@@ -17,7 +17,7 @@ pub fn split_html_space_chars_whitespace() {
 #[test]
 pub fn test_str_join_empty() {
     let slice: [&str; 0] = [];
-    let actual = str_join(&slice, "-");
+    let actual = str_join(slice, "-");
     let expected = "";
     assert_eq!(actual, expected);
 }
@@ -25,7 +25,7 @@ pub fn test_str_join_empty() {
 #[test]
 pub fn test_str_join_one() {
     let slice = ["alpha"];
-    let actual = str_join(&slice, "-");
+    let actual = str_join(slice, "-");
     let expected = "alpha";
     assert_eq!(actual, expected);
 }
@@ -33,7 +33,7 @@ pub fn test_str_join_one() {
 #[test]
 pub fn test_str_join_many() {
     let slice = ["", "alpha", "", "beta", "gamma", ""];
-    let actual = str_join(&slice, "-");
+    let actual = str_join(slice, "-");
     let expected = "-alpha--beta-gamma-";
     assert_eq!(actual, expected);
 }

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -35,7 +35,7 @@ fn get_mock_rules(css_selectors: &[&str]) -> (Vec<Vec<Rule>>, SharedRwLock) {
                         .unwrap();
 
                 let locked = Arc::new(shared_lock.wrap(StyleRule {
-                    selectors: selectors,
+                    selectors,
                     block: Arc::new(shared_lock.wrap(PropertyDeclarationBlock::with_one(
                         PropertyDeclaration::Display(longhands::display::SpecifiedValue::Block),
                         Importance::Normal,
@@ -75,7 +75,7 @@ fn parse_selectors(selectors: &[&str]) -> Vec<Selector<SelectorImpl>> {
                 .unwrap()
                 .0
                 .into_iter()
-                .nth(0)
+                .next()
                 .unwrap()
         })
         .collect()
@@ -130,7 +130,7 @@ fn test_revalidation_selectors() {
         "p:first-child span",
     ])
     .into_iter()
-    .filter(|s| needs_revalidation_for_testing(&s))
+    .filter(needs_revalidation_for_testing)
     .collect::<Vec<_>>();
 
     let reference = parse_selectors(&[


### PR DESCRIPTION
Split from #31514, fixes some clippy warnings in `ports/`, `support/` and `tests/`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.