### PR TITLE
clippy: fix warnings in various modules in components

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -13,9 +13,7 @@ pub use crate::platform::*;
 mod platform {
     use std::os::raw::c_void;
 
-    use jemallocator;
-
-    pub use self::jemallocator::Jemalloc as Allocator;
+    pub use jemallocator::Jemalloc as Allocator;
 
     /// Get the size of a heap block.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -104,7 +104,7 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
             target_os = "android",
             all(target_os = "linux", any(target_arch = "arm", target_arch = "aarch64"))
         ))]
-        let sampler = crate::sampler::DummySampler::new();
+        let sampler = crate::sampler::DummySampler::default();
 
         // When a component is registered, and there's an exit request that
         // reached BHM, we want an exit signal to be delivered to the

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -92,9 +92,9 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
             target_os = "windows",
             any(target_arch = "x86_64", target_arch = "x86")
         ))]
-        let sampler = crate::sampler_windows::WindowsSampler::new();
+        let sampler = crate::sampler_windows::WindowsSampler::new_boxed();
         #[cfg(target_os = "macos")]
-        let sampler = crate::sampler_mac::MacOsSampler::new();
+        let sampler = crate::sampler_mac::MacOsSampler::new_boxed();
         #[cfg(all(
             target_os = "linux",
             not(any(target_arch = "arm", target_arch = "aarch64"))
@@ -104,7 +104,7 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
             target_os = "android",
             all(target_os = "linux", any(target_arch = "arm", target_arch = "aarch64"))
         ))]
-        let sampler = crate::sampler::DummySampler::default();
+        let sampler = crate::sampler::DummySampler::new_boxed();
 
         // When a component is registered, and there's an exit request that
         // reached BHM, we want an exit signal to be delivered to the

--- a/components/background_hang_monitor/sampler_mac.rs
+++ b/components/background_hang_monitor/sampler_mac.rs
@@ -16,7 +16,7 @@ pub struct MacOsSampler {
 
 impl MacOsSampler {
     #[allow(unsafe_code)]
-    pub fn new() -> Box<dyn Sampler> {
+    pub fn new_boxed() -> Box<dyn Sampler> {
         let thread_id = unsafe { mach2::mach_init::mach_thread_self() };
         Box::new(MacOsSampler { thread_id })
     }

--- a/components/background_hang_monitor/sampler_windows.rs
+++ b/components/background_hang_monitor/sampler_windows.rs
@@ -13,7 +13,7 @@ pub struct WindowsSampler {
 
 impl WindowsSampler {
     #[allow(unsafe_code, dead_code)]
-    pub fn new() -> Box<dyn Sampler> {
+    pub fn new_boxed() -> Box<dyn Sampler> {
         let thread_id = 0; // TODO: use winapi::um::processthreadsapi::GetThreadId
         Box::new(WindowsSampler { thread_id })
     }

--- a/components/constellation/webview.rs
+++ b/components/constellation/webview.rs
@@ -138,9 +138,9 @@ mod test {
         let mut webviews = WebViewManager::default();
 
         // add() adds the webview to the map, but does not focus it.
-        webviews.add(TopLevelBrowsingContextId::default(), 'a');
-        webviews.add(TopLevelBrowsingContextId::default(), 'b');
-        webviews.add(TopLevelBrowsingContextId::default(), 'c');
+        webviews.add(TopLevelBrowsingContextId::new(), 'a');
+        webviews.add(TopLevelBrowsingContextId::new(), 'b');
+        webviews.add(TopLevelBrowsingContextId::new(), 'c');
         assert_eq!(
             webviews_sorted(&webviews),
             vec![

--- a/components/constellation/webview.rs
+++ b/components/constellation/webview.rs
@@ -138,9 +138,9 @@ mod test {
         let mut webviews = WebViewManager::default();
 
         // add() adds the webview to the map, but does not focus it.
-        webviews.add(TopLevelBrowsingContextId::new(), 'a');
-        webviews.add(TopLevelBrowsingContextId::new(), 'b');
-        webviews.add(TopLevelBrowsingContextId::new(), 'c');
+        webviews.add(TopLevelBrowsingContextId::default(), 'a');
+        webviews.add(TopLevelBrowsingContextId::default(), 'b');
+        webviews.add(TopLevelBrowsingContextId::default(), 'c');
         assert_eq!(
             webviews_sorted(&webviews),
             vec![

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -20,13 +20,13 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
     // Work around https://github.com/rust-lang/rust/issues/46489
     let attributes: TokenStream = attributes.to_string().parse().unwrap();
 
-    let output: TokenStream = attributes.into_iter().chain(input.into_iter()).collect();
+    let output: TokenStream = attributes.into_iter().chain(input).collect();
 
     let item: Item = syn::parse(output).unwrap();
 
     if let Item::Struct(s) = item {
         let s2 = s.clone();
-        if s.generics.params.len() > 0 {
+        if !s.generics.params.is_empty() {
             return quote!(#s2).into();
         }
         if let Fields::Named(ref f) = s.fields {

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -4,7 +4,6 @@
 
 #![recursion_limit = "128"]
 
-use proc_macro2;
 use quote::{quote, TokenStreamExt};
 use syn::parse_quote;
 

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -531,7 +531,7 @@ impl<'a> Serialize for Ser<'a, Mime> {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.v.as_ref())
+        serializer.serialize_str(self.v.as_ref())
     }
 }
 

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -80,7 +80,7 @@ static THREAD_TINT_COLORS: [ColorF; 8] = [
         a: 0.7,
     },
     ColorF {
-        r: 255.0 / 255.0,
+        r: 1.0,
         g: 212.0 / 255.0,
         b: 83.0 / 255.0,
         a: 0.7,
@@ -110,7 +110,7 @@ static THREAD_TINT_COLORS: [ColorF; 8] = [
         a: 0.7,
     },
     ColorF {
-        r: 255.0 / 255.0,
+        r: 1.0,
         g: 249.0 / 255.0,
         b: 201.0 / 255.0,
         a: 0.7,

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -29,16 +29,23 @@ const CHUNK_SIZE: usize = 16;
 pub type FlowList = SmallVec<[UnsafeFlow; CHUNK_SIZE]>;
 
 /// Vtable + pointer representation of a Flow trait object.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq)]
 pub struct UnsafeFlow(*const dyn Flow);
 
 unsafe impl Sync for UnsafeFlow {}
 unsafe impl Send for UnsafeFlow {}
+impl PartialEq for UnsafeFlow {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare the pointers explicitly to avoid clippy lint
+        self.0 as *const u8 == other.0 as *const u8
+    }
+}
 
 fn null_unsafe_flow() -> UnsafeFlow {
     UnsafeFlow(ptr::null::<BlockFlow>())
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)] // It has an unsafe block inside
 pub fn mut_owned_flow_to_unsafe_flow(flow: *mut FlowRef) -> UnsafeFlow {
     unsafe { UnsafeFlow(&**flow) }
 }

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::type_complexity)]
 
 mod media_channel;
 mod media_thread;

--- a/components/media/media_channel/mod.rs
+++ b/components/media/media_channel/mod.rs
@@ -74,6 +74,7 @@ where
         }
     }
 
+    #[allow(clippy::wrong_self_convention)] // It is an alias to the underlying module
     pub fn to_opaque(self) -> ipc_channel::ipc::OpaqueIpcReceiver {
         match self {
             GLPlayerReceiver::Ipc(receiver) => receiver.to_opaque(),

--- a/components/media/media_thread.rs
+++ b/components/media/media_thread.rs
@@ -79,14 +79,14 @@ impl GLPlayerThread {
                 }
             },
             GLPlayerMsg::Lock(id, handler_sender) => {
-                self.players.get(&id).map(|sender| {
+                if let Some(sender) = self.players.get(&id) {
                     sender.send(GLPlayerMsgForward::Lock(handler_sender)).ok();
-                });
+                }
             },
             GLPlayerMsg::Unlock(id) => {
-                self.players.get(&id).map(|sender| {
+                if let Some(sender) = self.players.get(&id) {
                     sender.send(GLPlayerMsgForward::Unlock()).ok();
-                });
+                }
             },
             GLPlayerMsg::Exit => return true,
         }

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -49,9 +49,7 @@ pub fn rgba8_get_rect(pixels: &[u8], size: Size2D<u64>, rect: Rect<u64>) -> Cow<
 pub fn rgba8_byte_swap_colors_inplace(pixels: &mut [u8]) {
     assert!(pixels.len() % 4 == 0);
     for rgba in pixels.chunks_mut(4) {
-        let b = rgba[0];
-        rgba[0] = rgba[2];
-        rgba[2] = b;
+        rgba.swap(0, 2);
     }
 }
 
@@ -79,7 +77,7 @@ pub fn rgba8_premultiply_inplace(pixels: &mut [u8]) -> bool {
 }
 
 pub fn multiply_u8_color(a: u8, b: u8) -> u8 {
-    return (a as u32 * b as u32 / 255) as u8;
+    (a as u32 * b as u32 / 255) as u8
 }
 
 pub fn clip(

--- a/components/profile/trace_dump.rs
+++ b/components/profile/trace_dump.rs
@@ -37,7 +37,7 @@ impl TraceDump {
     {
         let mut file = fs::File::create(trace_file_path)?;
         write_prologue(&mut file)?;
-        Ok(TraceDump { file: file })
+        Ok(TraceDump { file })
     }
 
     /// Write one trace to the trace dump file.

--- a/components/range/lib.rs
+++ b/components/range/lib.rs
@@ -204,10 +204,7 @@ impl<I: RangeIndex> Range<I> {
     /// ~~~
     #[inline]
     pub fn new(begin: I, length: I) -> Range<I> {
-        Range {
-            begin: begin,
-            length: length,
-        }
+        Range { begin, length }
     }
 
     #[inline]

--- a/components/remutex/lib.rs
+++ b/components/remutex/lib.rs
@@ -36,7 +36,7 @@ impl ThreadId {
         ThreadId(NonZeroUsize::new(number).unwrap())
     }
     pub fn current() -> ThreadId {
-        THREAD_ID.with(|tls| tls.clone())
+        THREAD_ID.with(|tls| *tls)
     }
 }
 
@@ -46,10 +46,13 @@ thread_local! { static THREAD_ID: ThreadId = ThreadId::new() }
 #[derive(Debug)]
 pub struct AtomicOptThreadId(AtomicUsize);
 
-impl AtomicOptThreadId {
-    pub fn new() -> AtomicOptThreadId {
+impl Default for AtomicOptThreadId {
+    fn default() -> Self {
         AtomicOptThreadId(AtomicUsize::new(0))
     }
+}
+
+impl AtomicOptThreadId {
     pub fn store(&self, value: Option<ThreadId>, ordering: Ordering) {
         let number = value.map(|id| id.0.get()).unwrap_or(0);
         self.0.store(number, ordering);
@@ -75,14 +78,17 @@ pub struct HandOverHandMutex {
     guard: UnsafeCell<Option<MutexGuard<'static, ()>>>,
 }
 
-impl HandOverHandMutex {
-    pub fn new() -> HandOverHandMutex {
-        HandOverHandMutex {
+impl Default for HandOverHandMutex {
+    fn default() -> Self {
+        Self {
             mutex: Mutex::new(()),
-            owner: AtomicOptThreadId::new(),
+            owner: AtomicOptThreadId::default(),
             guard: UnsafeCell::new(None),
         }
     }
+}
+
+impl HandOverHandMutex {
     #[allow(unsafe_code)]
     unsafe fn set_guard_and_owner<'a>(&'a self, guard: MutexGuard<'a, ()>) {
         // The following two lines allow us to unsafely store
@@ -107,7 +113,7 @@ impl HandOverHandMutex {
         assert_eq!(old_owner, Some(ThreadId::current()));
     }
     #[allow(unsafe_code)]
-    pub fn lock<'a>(&'a self) -> LockResult<()> {
+    pub fn lock(&self) -> LockResult<()> {
         let (guard, result) = match self.mutex.lock() {
             Ok(guard) => (guard, Ok(())),
             Err(err) => (err.into_inner(), Err(PoisonError::new(()))),
@@ -163,9 +169,9 @@ impl<T> ReentrantMutex<T> {
     pub fn new(data: T) -> ReentrantMutex<T> {
         trace!("{:?} Creating new lock.", ThreadId::current());
         ReentrantMutex {
-            mutex: HandOverHandMutex::new(),
+            mutex: HandOverHandMutex::default(),
             count: Cell::new(0),
-            data: data,
+            data,
         }
     }
 
@@ -173,7 +179,7 @@ impl<T> ReentrantMutex<T> {
         trace!("{:?} Locking.", ThreadId::current());
         if self.mutex.owner() != Some(ThreadId::current()) {
             trace!("{:?} Becoming owner.", ThreadId::current());
-            if let Err(_) = self.mutex.lock() {
+            if self.mutex.lock().is_err() {
                 trace!("{:?} Poison!", ThreadId::current());
                 return Err(PoisonError::new(self.mk_guard()));
             }

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -31,16 +31,16 @@ fn main() {
     println!("Binding generation completed in {:?}", start.elapsed());
 
     let json = out_dir.join("InterfaceObjectMapData.json");
-    let json: Value = serde_json::from_reader(File::open(&json).unwrap()).unwrap();
+    let json: Value = serde_json::from_reader(File::open(json).unwrap()).unwrap();
     let mut map = phf_codegen::Map::new();
     for (key, value) in json.as_object().unwrap() {
         map.entry(Bytes(key), value.as_str().unwrap());
     }
     let phf = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("InterfaceObjectMapPhf.rs");
-    let mut phf = File::create(&phf).unwrap();
-    write!(
+    let mut phf = File::create(phf).unwrap();
+    writeln!(
         &mut phf,
-        "pub static MAP: phf::Map<&'static [u8], fn(JSContext, HandleObject)> = {};\n",
+        "pub static MAP: phf::Map<&'static [u8], fn(JSContext, HandleObject)> = {};",
         map.build(),
     )
     .unwrap();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -387,7 +387,7 @@ where
             embedder.register_webxr(&mut webxr_main_thread, embedder_proxy.clone());
         }
 
-        let wgpu_image_handler = webgpu::WGPUExternalImages::new();
+        let wgpu_image_handler = webgpu::WGPUExternalImages::default();
         let wgpu_image_map = wgpu_image_handler.images.clone();
         external_image_handlers.set_handler(
             Box::new(wgpu_image_handler),

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -176,7 +176,7 @@ impl ServoUrl {
                 // Strip `scheme://`, which is hardly useful for identifying websites
                 let mut st = self.as_str();
                 st = st.strip_prefix(self.scheme()).unwrap_or(st);
-                st = st.strip_prefix(":").unwrap_or(st);
+                st = st.strip_prefix(':').unwrap_or(st);
                 st = st.trim_start_matches('/');
 
                 // Don't want to return an empty string

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -919,8 +919,8 @@ impl<'a> WGPU<'a> {
                         pipeline_id,
                     } => {
                         let desc = DeviceDescriptor {
-                            label: descriptor.label.as_ref().map(|l| crate::Cow::from(l)),
-                            features: descriptor.features.clone(),
+                            label: descriptor.label.as_ref().map(crate::Cow::from),
+                            features: descriptor.features,
                             limits: descriptor.limits.clone(),
                         };
                         let global = &self.global;
@@ -1336,18 +1336,10 @@ webgpu_resource!(WebGPUSurface, id::SurfaceId);
 webgpu_resource!(WebGPUTexture, id::TextureId);
 webgpu_resource!(WebGPUTextureView, id::TextureViewId);
 
+#[derive(Default)]
 pub struct WGPUExternalImages {
     pub images: Arc<Mutex<HashMap<u64, PresentationData>>>,
     pub locked_ids: HashMap<u64, Vec<u8>>,
-}
-
-impl WGPUExternalImages {
-    pub fn new() -> Self {
-        Self {
-            images: Arc::new(Mutex::new(HashMap::new())),
-            locked_ids: HashMap::new(),
-        }
-    }
 }
 
 impl WebrenderExternalImageApi for WGPUExternalImages {


### PR DESCRIPTION
Split from #31514, fixes multiple small clippy warnings in multiple modules from `components`:

- `allocator`
- `background_hang_monitor`
- `dom_struct`
- `domobject_derive`
- `hyper_serde`
- `layout`
- `media`
- `pixels`
- `profile`
- `range`
- `remutex`
- `url`

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.