### PR TITLE
layout: Fix the pseudo for anonymous tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3304,7 +3304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5075,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "nodrop",
  "serde",
@@ -5373,7 +5373,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5579,7 +5579,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "static_assertions",
 ]
@@ -5705,7 +5705,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 
 [[package]]
 name = "str-buf"
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5806,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "lazy_static",
 ]
@@ -5814,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "darling",
  "derive_common",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "app_units",
  "bitflags 1.3.2",
@@ -6188,7 +6188,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6201,7 +6201,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#3f129fb95a345f0057a6b72901eb7eb795840a76"
+source = "git+https://github.com/servo/stylo.git?branch=2023-07-23#ca5648ca155a7cfc23dfd7fec61befe82f866879"
 dependencies = [
  "darling",
  "derive_common",

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -84,9 +84,7 @@ impl Table {
             .stylist
             .style_for_anonymous::<Node::ConcreteElement>(
                 &context.shared_context().guards,
-                // TODO: This should be updated for Layout 2020 once we've determined
-                // which styles should be inherited for tables.
-                &PseudoElement::ServoLegacyAnonymousTable,
+                &PseudoElement::ServoAnonymousTable,
                 &parent_info.style,
             );
         let anonymous_info = parent_info.new_replacing_style(anonymous_style.clone());

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -230,6 +230,10 @@ svg > * {
     overflow: visible;
 }
 
+*|*::-servo-anonymous-table {
+    display: table;
+}
+
 *|*::-servo-anonymous-table-row {
     display: table-row;
     position: static;

--- a/tests/wpt/meta/css/CSS2/box-display/box-generation-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/box-generation-001.xht.ini
@@ -1,2 +1,0 @@
-[box-generation-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/box-generation-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/box-generation-002.xht.ini
@@ -1,2 +1,0 @@
-[box-generation-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/blocks-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/blocks-017.xht.ini
@@ -1,2 +1,0 @@
-[blocks-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/table-in-inline-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/table-in-inline-001.xht.ini
@@ -1,2 +1,0 @@
-[table-in-inline-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/word-spacing-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/word-spacing-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[word-spacing-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/table-pseudo-in-part3-1.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/table-pseudo-in-part3-1.html.ini
@@ -1,2 +1,0 @@
-[table-pseudo-in-part3-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/dynamic-table-cell-height.html.ini
+++ b/tests/wpt/meta/css/css-tables/dynamic-table-cell-height.html.ini
@@ -1,2 +1,0 @@
-[dynamic-table-cell-height.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/fixup-dynamic-anonymous-inline-table-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/fixup-dynamic-anonymous-inline-table-001.html.ini
@@ -1,2 +1,0 @@
-[fixup-dynamic-anonymous-inline-table-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/fixup-dynamic-anonymous-inline-table-002.html.ini
+++ b/tests/wpt/meta/css/css-tables/fixup-dynamic-anonymous-inline-table-002.html.ini
@@ -1,2 +1,0 @@
-[fixup-dynamic-anonymous-inline-table-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/percentages-grandchildren-quirks-mode-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/percentages-grandchildren-quirks-mode-001.html.ini
@@ -1,2 +1,0 @@
-[percentages-grandchildren-quirks-mode-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform-table-011.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-table-011.html.ini
@@ -1,2 +1,0 @@
-[transform-table-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-ui/outline-005.html.ini
+++ b/tests/wpt/meta/css/css-ui/outline-005.html.ini
@@ -1,2 +1,0 @@
-[outline-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-ui/outline-011.html.ini
+++ b/tests/wpt/meta/css/css-ui/outline-011.html.ini
@@ -1,2 +1,0 @@
-[outline-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-ui/outline-019.html.ini
+++ b/tests/wpt/meta/css/css-ui/outline-019.html.ini
@@ -1,2 +1,0 @@
-[outline-019.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/button-layout/shrink-wrap.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/button-layout/shrink-wrap.html.ini
@@ -41,12 +41,6 @@
   [float: left - available width: 200px]
     expected: FAIL
 
-  [display: table-row - available width: 300px]
-    expected: FAIL
-
-  [display: table-cell - available width: 300px]
-    expected: FAIL
-
   [float: left - available width: 300px]
     expected: FAIL
 


### PR DESCRIPTION
Anonymous tables should not use legacy pseudos, as the legacy layout
engine had them inherit lots of random properites that lead to bad
layout in the new layout engine.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
