### PR TITLE
Fix rustdoc errors in `components/shared`

### DIFF
--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -176,7 +176,7 @@ pub enum EmbedderMsg {
     SetCursor(Cursor),
     /// A favicon was detected
     NewFavicon(ServoUrl),
-    /// <head> tag finished parsing
+    /// `<head>` tag finished parsing
     HeadParsed,
     /// The history state has changed.
     HistoryChanged(Vec<ServoUrl>, usize),

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -186,7 +186,7 @@ impl RequestBody {
         }
     }
 
-    /// Step 12 of https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
+    /// Step 12 of <https://fetch.spec.whatwg.org/#concept-http-redirect-fetch>
     pub fn extract_source(&mut self) {
         match self.source {
             BodySource::Null => panic!("Null sources should never be re-directed."),

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -1350,6 +1350,6 @@ pub enum GamepadUpdateType {
     /// <https://www.w3.org/TR/gamepad/#dfn-represents-a-standard-gamepad-axis>
     Axis(usize, f64),
     /// Button index and input value
-    /// <https://www.w3.org/TR/gamepad/#dfn-represents-a-standard-gamepad-button
+    /// <https://www.w3.org/TR/gamepad/#dfn-represents-a-standard-gamepad-button>
     Button(usize, f64),
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

1. To fix error in components>shared>embedder>lib.rs: Changed the "unclosed" HTML tag to an inline code using back ticks.
2. To fix error in components>shared>net>request.rs: Added <URL> to convert into clickable link.
3. To fix error in components>shared>script>lib.rs: Added closing bracket (>) to fix error.
 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31575 
- [X] There are tests for these changes --> Run the command `./mach doc`. There shouldn't be any errors/warnings in the above mentioned.


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
