### PR TITLE
Make image decoding thread pool the size of the system's CPUs

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -4,8 +4,9 @@
 
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
-use std::mem;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
+use std::{mem, thread};
 
 use embedder_traits::resources::{self, Resource};
 use imsz::imsz_from_reader;
@@ -427,6 +428,12 @@ impl ImageCache for ImageCacheImpl {
         debug!("New image cache");
 
         let rippy_data = resources::read_bytes(Resource::RippyPNG);
+        // Uses an estimate of the system cpus to decode images
+        // See https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
+        // If no information can be obtained about the system, uses 4 threads as a default
+        let thread_count = thread::available_parallelism()
+            .unwrap_or(NonZeroUsize::new(4).unwrap())
+            .get();
 
         ImageCacheImpl {
             store: Arc::new(Mutex::new(ImageCacheStore {
@@ -436,7 +443,7 @@ impl ImageCache for ImageCacheImpl {
                 placeholder_url: ServoUrl::parse("chrome://resources/rippy.png").unwrap(),
                 webrender_api: webrender_api,
             })),
-            thread_pool: CoreResourceThreadPool::new(16),
+            thread_pool: CoreResourceThreadPool::new(thread_count),
         }
     }
 


### PR DESCRIPTION
Followup to #31517. Initially it just created 16 threads for the image decoding, which could be too many for CPUs with less cores.

This change makes it so it tries to get the number of CPUs, or an estimate of the amount of parallelism the program should use, see [`std::thread::available_parallelism`](https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html). It usually matches, but even in the cases it doesn't it is still a good metric for how many threads to create (and it is platform independent).

I also added a fallback so if there is an error in the calculation it defaults to 4, which seems a reasonable compromise, but let me know if another default is preferred.

I tested it on my machine (`Intel i7-4770HQ - 8 cores`), and it correctly returns 8.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they don't change functionality, only the implementation