### PR TITLE
layout: Do not inherit node and fragment flags in anonymous boxes

### DIFF
--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -160,9 +160,7 @@ where
                         self.context,
                         self.text_decoration_line,
                     );
-                    let info = &self
-                        .info
-                        .new_replacing_style(anonymous_style.clone().unwrap());
+                    let info = &self.info.new_anonymous(anonymous_style.clone().unwrap());
                     IndependentFormattingContext::NonReplaced(NonReplacedFormattingContext {
                         base_fragment_info: info.into(),
                         style: info.style.clone(),

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -317,7 +317,7 @@ where
             self.current_inline_level_boxes()
                 .push(ArcRefCell::new(InlineLevelBox::Atomic(ifc)));
         } else {
-            let anonymous_info = self.info.new_replacing_style(ifc.style().clone());
+            let anonymous_info = self.info.new_anonymous(ifc.style().clone());
             let table_block = ArcRefCell::new(BlockLevelBox::Independent(ifc));
             self.block_level_boxes.push(BlockLevelJob {
                 info: anonymous_info,
@@ -690,7 +690,7 @@ where
         );
         std::mem::swap(&mut self.ongoing_inline_formatting_context, &mut ifc);
 
-        let info = self.info.new_replacing_style(anonymous_style.clone());
+        let info = self.info.new_anonymous(anonymous_style.clone());
         self.block_level_boxes.push(BlockLevelJob {
             info,
             // FIXME(nox): We should be storing this somewhere.

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -47,8 +47,8 @@ impl BaseFragment {
 /// Information necessary to construct a new BaseFragment.
 #[derive(Clone, Copy, Debug, Serialize)]
 pub(crate) struct BaseFragmentInfo {
-    /// The tag to use for the new BaseFragment.
-    pub tag: Tag,
+    /// The tag to use for the new BaseFragment, if it is not an anonymous Fragment.
+    pub tag: Option<Tag>,
 
     /// The flags to use for the new BaseFragment.
     pub flags: FragmentFlags,
@@ -57,7 +57,14 @@ pub(crate) struct BaseFragmentInfo {
 impl BaseFragmentInfo {
     pub(crate) fn new_for_node(node: OpaqueNode) -> Self {
         Self {
-            tag: Tag::new(node),
+            tag: Some(Tag::new(node)),
+            flags: FragmentFlags::empty(),
+        }
+    }
+
+    pub(crate) fn anonymous() -> Self {
+        Self {
+            tag: None,
             flags: FragmentFlags::empty(),
         }
     }
@@ -66,7 +73,7 @@ impl BaseFragmentInfo {
 impl From<BaseFragmentInfo> for BaseFragment {
     fn from(info: BaseFragmentInfo) -> Self {
         Self {
-            tag: Some(info.tag),
+            tag: info.tag,
             debug_id: DebugId::new(),
             flags: info.flags,
         }

--- a/components/layout_2020/lists.rs
+++ b/components/layout_2020/lists.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use log::warn;
 use style::properties::longhands::list_style_type::computed_value::T as ListStyleType;
 use style::properties::style_structs;
 use style::values::computed::Image;
@@ -20,12 +21,19 @@ where
     Node: NodeExt<'dom>,
 {
     let style = info.style.get_list();
+    let node = match info.node {
+        Some(node) => node,
+        None => {
+            warn!("Tried to make a marker for an anonymous node!");
+            return None;
+        },
+    };
 
     // https://drafts.csswg.org/css-lists/#marker-image
     let marker_image = || match &style.list_style_image {
         Image::Url(url) => Some(vec![
             PseudoElementContentItem::Replaced(ReplacedContent::from_image_url(
-                info.node, context, url,
+                node, context, url,
             )?),
             PseudoElementContentItem::Text(" ".into()),
         ]),

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -26,7 +26,7 @@ use crate::formatting_contexts::{
     IndependentFormattingContext, NonReplacedFormattingContext,
     NonReplacedFormattingContextContents,
 };
-use crate::fragment_tree::{BaseFragmentInfo, FragmentFlags, Tag};
+use crate::fragment_tree::BaseFragmentInfo;
 use crate::style_ext::{DisplayGeneratingBox, DisplayLayoutInternal};
 
 /// A reference to a slot and its coordinates in the table
@@ -87,7 +87,7 @@ impl Table {
                 &PseudoElement::ServoAnonymousTable,
                 &parent_info.style,
             );
-        let anonymous_info = parent_info.new_replacing_style(anonymous_style.clone());
+        let anonymous_info = parent_info.new_anonymous(anonymous_style.clone());
 
         let mut table_builder =
             TableBuilderTraversal::new(context, &anonymous_info, propagated_text_decoration_line);
@@ -642,7 +642,7 @@ where
                 &PseudoElement::ServoAnonymousTableCell,
                 &self.info.style,
             );
-        let anonymous_info = self.info.new_replacing_style(anonymous_style);
+        let anonymous_info = self.info.new_anonymous(anonymous_style);
         let mut row_builder =
             TableRowBuilder::new(self, &anonymous_info, self.current_text_decoration_line);
 
@@ -756,8 +756,12 @@ where
                     ::std::mem::forget(box_slot)
                 },
                 DisplayLayoutInternal::TableColumn => {
-                    let node = info.node.to_threadsafe();
-                    let span = (node.get_span().unwrap_or(1) as usize).min(1000);
+                    let span = info
+                        .node
+                        .and_then(|node| node.to_threadsafe().get_span())
+                        .unwrap_or(1)
+                        .min(1000);
+
                     for _ in 0..span + 1 {
                         self.builder.table.columns.push(TableTrack {
                             base_fragment_info: info.into(),
@@ -785,8 +789,11 @@ where
 
                     let first_column = self.builder.table.columns.len();
                     if column_group_builder.columns.is_empty() {
-                        let node = info.node.to_threadsafe();
-                        let span = (node.get_span().unwrap_or(1) as usize).min(1000);
+                        let span = info
+                            .node
+                            .and_then(|node| node.to_threadsafe().get_span())
+                            .unwrap_or(1)
+                            .min(1000) as usize;
 
                         self.builder.table.columns.extend(
                             repeat(TableTrack {
@@ -894,7 +901,7 @@ where
                 &PseudoElement::ServoAnonymousTableCell,
                 &self.info.style,
             );
-        let anonymous_info = self.info.new_replacing_style(anonymous_style);
+        let anonymous_info = self.info.new_anonymous(anonymous_style);
         let mut builder =
             BlockContainerBuilder::new(context, &anonymous_info, self.text_decoration_line);
 
@@ -914,22 +921,13 @@ where
             }
         }
 
-        let tag = Tag::new_pseudo(
-            self.info.node.opaque(),
-            Some(PseudoElement::ServoAnonymousTableCell),
-        );
-        let base_fragment_info = BaseFragmentInfo {
-            tag,
-            flags: FragmentFlags::empty(),
-        };
-
         let block_container = builder.finish();
         self.table_traversal.builder.add_cell(TableSlotCell {
             contents: BlockFormattingContext::from_block_container(block_container),
             colspan: 1,
             rowspan: 1,
             style: anonymous_info.style,
-            base_fragment_info,
+            base_fragment_info: BaseFragmentInfo::anonymous(),
         });
     }
 }
@@ -965,9 +963,12 @@ where
                     // 65534 and `colspan` to 1000, so we also enforce the same limits
                     // when dealing with arbitrary DOM elements (perhaps created via
                     // script).
-                    let node = info.node.to_threadsafe();
-                    let rowspan = (node.get_rowspan().unwrap_or(1) as usize).min(65534);
-                    let colspan = (node.get_colspan().unwrap_or(1) as usize).min(1000);
+                    let (rowspan, colspan) = info.node.map_or((1, 1), |node| {
+                        let node = node.to_threadsafe();
+                        let rowspan = node.get_rowspan().unwrap_or(1).min(65534) as usize;
+                        let colspan = node.get_colspan().unwrap_or(1).min(1000) as usize;
+                        (rowspan, colspan)
+                    });
 
                     let contents = match contents.try_into() {
                         Ok(non_replaced_contents) => {

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -198,7 +198,7 @@ impl TableSlotCell {
 
     /// Get the node id of this cell's [`BaseFragmentInfo`]. This is used for unit tests.
     pub fn node_id(&self) -> usize {
-        self.base_fragment_info.tag.node.0
+        self.base_fragment_info.tag.map_or(0, |tag| tag.node.0)
     }
 }
 


### PR DESCRIPTION
This doesn't really have observable behavior right now, as much as I
tried to trigger some kind of bug. On the other hand, it's just wrong
and is very obvious when you dump the Fragment tree. If you create a
`display: table-cell` that is a child of the `<body>` all parts of the
anonymous table are flagged as if they are the `<body>` element.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
