### PR TITLE
Fix rustdoc warnings in `components/layout_2020`

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1372,7 +1372,7 @@ fn solve_block_margins_for_in_flow_block_level(pbm: &PaddingBorderMargin) -> (Le
 }
 
 /// This is supposed to handle 'justify-self', but no browser supports it on block boxes.
-/// Instead, <center> and <div align> are implemented via internal 'text-align' values.
+/// Instead, <center/> and <div align/> are implemented via internal 'text-align' values.
 /// The provided free space should already take margins into account. In particular,
 /// it should be zero if there is an auto margin.
 /// <https://drafts.csswg.org/css-align/#justify-block>

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1372,7 +1372,7 @@ fn solve_block_margins_for_in_flow_block_level(pbm: &PaddingBorderMargin) -> (Le
 }
 
 /// This is supposed to handle 'justify-self', but no browser supports it on block boxes.
-/// Instead, <center/> and <div align/> are implemented via internal 'text-align' values.
+/// Instead, `<center>` and `<div align>` are implemented via internal 'text-align' values.
 /// The provided free space should already take margins into account. In particular,
 /// it should be zero if there is an auto margin.
 /// <https://drafts.csswg.org/css-align/#justify-block>

--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -450,7 +450,7 @@ impl TextRun {
 /// Whether or not this character will rpevent a soft wrap opportunity when it
 /// comes before or after an atomic inline element.
 ///
-/// From <https://www.w3.org/TR/css-text-3/#line-break-details:>
+/// From <https://www.w3.org/TR/css-text-3/#line-break-details>:
 ///
 /// > For Web-compatibility there is a soft wrap opportunity before and after each
 /// > replaced element or other atomic inline, even when adjacent to a character that

--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -36,7 +36,7 @@ const XI_LINE_BREAKING_CLASS_ZW: u8 = 28;
 const XI_LINE_BREAKING_CLASS_WJ: u8 = 30;
 const XI_LINE_BREAKING_CLASS_ZWJ: u8 = 40;
 
-/// https://www.w3.org/TR/css-display-3/#css-text-run
+/// <https://www.w3.org/TR/css-display-3/#css-text-run>
 #[derive(Debug, Serialize)]
 pub(crate) struct TextRun {
     pub base_fragment_info: BaseFragmentInfo,
@@ -450,7 +450,7 @@ impl TextRun {
 /// Whether or not this character will rpevent a soft wrap opportunity when it
 /// comes before or after an atomic inline element.
 ///
-/// From https://www.w3.org/TR/css-text-3/#line-break-details:
+/// From <https://www.w3.org/TR/css-text-3/#line-break-details:>
 ///
 /// > For Web-compatibility there is a soft wrap opportunity before and after each
 /// > replaced element or other atomic inline, even when adjacent to a character that


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Converted URL in plain text format to clickable links in components/layout_2020/flow/text_run.rs
2. Fixed unclosed HTML tag warnings in components/layout_2020/flow/mod.rs

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach doc` does not report above stated warnings
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31575 
- [x] These changes do not require tests because they do not change any functionality

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
