### PR TITLE
Fix rustdoc warnings in `component/layout_2020`

### DIFF
--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -76,7 +76,7 @@ enum SegmentStartSoftWrapPolicy {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct TextRunSegment {
-    /// The index of this font in the parent [`InlineFormattingContext`]'s collection of font
+    /// The index of this font in the parent [`super::InlineFormattingContext`]'s collection of font
     /// information.
     pub font_index: usize,
 
@@ -524,7 +524,7 @@ pub struct WhitespaceCollapse<InputIterator> {
     white_space: WhiteSpace,
 
     /// Whether or not we should collapse white space completely at the start of the string.
-    /// This is true when the last character handled in our owning [`InlineFormattingContext`]
+    /// This is true when the last character handled in our owning [`super::InlineFormattingContext`]
     /// was collapsible white space.
     remove_collapsible_white_space_at_start: bool,
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Resolved remaining warning in components/layout_2020/flow/textrun.rs part of #31575 by 
   * Converting urls to hyperlinks
   * Fixing unresolved links by appropriately linking to parent

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
