### PR TITLE
Fix rustdoc warnings in `components/layout 2020/positioned.rs`

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -182,7 +182,7 @@ impl PositioningContext {
         self.adjust_static_position_of_hoisted_fragments_with_offset(start_offset, index);
     }
 
-    /// See documentation for [adjust_static_position_of_hoisted_fragments].
+    /// See documentation for [PositioningContext::adjust_static_position_of_hoisted_fragments].
     pub(crate) fn adjust_static_position_of_hoisted_fragments_with_offset(
         &mut self,
         start_offset: &LogicalVec2<CSSPixelLength>,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -124,7 +124,7 @@ impl PositioningContext {
         }
     }
 
-    /// Create a [PositioninContext] to use for laying out a subtree. The idea is that
+    /// Create a [PositioningContext] to use for laying out a subtree. The idea is that
     /// when subtree layout is finished, the newly hoisted boxes can be processed
     /// (normally adjusting their static insets) and then appended to the parent
     /// [PositioningContext].

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -388,7 +388,7 @@ impl PositioningContext {
 
     /// Truncate this [PositioningContext] to the given [PositioningContextLength].  This
     /// is useful for "unhoisting" boxes in this context and returning it to the state at
-    /// the time that [`len()`] was called.
+    /// the time that [`PositioningContext::len()`] was called.
     pub(crate) fn truncate(&mut self, length: &PositioningContextLength) {
         if let Some(vec) = self.for_nearest_positioned_ancestor.as_mut() {
             vec.truncate(length.for_nearest_positioned_ancestor);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
* Fixed unresolved link to unresolved link to len() function of PositioningContext
* Fixed unresolved link to unresolved link to adjust_static_position_of_hoisted_fragments function
* Corrected typo in PositioningContext to fix unresolved link warning

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31575.
- [x] These changes do not require tests because they just fix documentation issues.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
