### PR TITLE
script: Stop using chrono::NaiveDateTime::from_timestamp_opt

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -9,7 +9,7 @@ use std::ptr::NonNull;
 use std::{f64, ptr};
 
 use chrono::naive::{NaiveDate, NaiveDateTime};
-use chrono::{Datelike, Weekday};
+use chrono::{DateTime, Datelike, Weekday};
 use dom_struct::dom_struct;
 use embedder_traits::FilterPattern;
 use encoding_rs::Encoding;
@@ -2916,7 +2916,10 @@ fn milliseconds_to_datetime(value: f64) -> Result<NaiveDateTime, ()> {
     let seconds = (value / 1000.0).floor();
     let milliseconds = value - (seconds * 1000.0);
     let nanoseconds = milliseconds * 1e6;
-    NaiveDateTime::from_timestamp_opt(seconds as i64, nanoseconds as u32).ok_or(())
+    match DateTime::from_timestamp(seconds as i64, nanoseconds as u32) {
+        Some(datetime) => Ok(datetime.naive_utc()),
+        None => Err(()),
+    }
 }
 
 // This is used to compile JS-compatible regex provided in pattern attribute


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR resolves following warnings across project, following up #31584 :

```
warning: use of deprecated method 'chrono::NaiveDateTime::from_timestamp_opt' : use 'DateTime::from_timestamp' instead
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
<!-- Either: -->
- [x] These changes do not require tests, because they do not modify functionality

<img width="933" alt="Screenshot 2024-03-08 at 14 23 45" src="https://github.com/servo/servo/assets/31756707/599eef3e-8aff-44a7-9638-8655b8e04778">
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
****