### PR TITLE
Use libc::malloc_size on apple

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -39,7 +39,10 @@ mod platform {
         #[cfg(target_os = "linux")]
         return libc::malloc_usable_size(ptr as *mut _);
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(target_vendor = "apple")]
+        return libc::malloc_size(ptr);
+
+        #[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
         return libc::malloc_usable_size(ptr);
     }
 

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -36,14 +36,11 @@ mod platform {
 
     /// Get the size of a heap block.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {
-        #[cfg(target_os = "linux")]
-        return libc::malloc_usable_size(ptr as *mut _);
-
         #[cfg(target_vendor = "apple")]
         return libc::malloc_size(ptr);
 
-        #[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
-        return libc::malloc_usable_size(ptr);
+        #[cfg(not(target_vendor = "apple"))]
+        return libc::malloc_usable_size(ptr as *mut _);
     }
 
     pub mod libc_compat {


### PR DESCRIPTION
As discovered in https://github.com/servo/servo/issues/31397#issuecomment-1987155922 Apple does not offer `malloc_usable_size`. Same is also used in Firefox: https://searchfox.org/mozilla-central/source/memory/mozalloc/mozalloc.cpp#128

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
