### PR TITLE
End ongoing IFC when inserting anonymous block-level table

### DIFF
--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -317,6 +317,7 @@ where
             self.current_inline_level_boxes()
                 .push(ArcRefCell::new(InlineLevelBox::Atomic(ifc)));
         } else {
+            self.end_ongoing_inline_formatting_context();
             let anonymous_info = self.info.new_anonymous(ifc.style().clone());
             let table_block = ArcRefCell::new(BlockLevelBox::Independent(ifc));
             self.block_level_boxes.push(BlockLevelJob {

--- a/tests/wpt/tests/css/CSS2/tables/table-anonymous-objects-212-ref.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-anonymous-objects-212-ref.xht
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com"/>
+</head>
+<body>
+  above<br />
+  below
+</body>
+</html>

--- a/tests/wpt/tests/css/CSS2/tables/table-anonymous-objects-212.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-anonymous-objects-212.xht
@@ -1,0 +1,16 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>CSS Test: Anonymous table objects</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="help" href="https://github.com/servo/servo/issues/31603"/>
+  <link rel="match" href="table-anonymous-objects-212-ref.xht"/>
+  <meta assert="The table cell is wrapped inside an anonymous block-level table,
+                so the text 'below' should appear below 'above'."/>
+</head>
+<body>
+  above
+  <span style="display: table-cell">below</span>
+</body>
+</html>


### PR DESCRIPTION
So that the table appears after preceding inline-level contents. Fixes #31603.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31603
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
