### PR TITLE
Fix unused import left in #31564

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -218,7 +218,7 @@ impl ImageBytes {
                 ImageBytes::InProgress(ref mut bytes) => bytes,
                 ImageBytes::Complete(_) => panic!("attempted modification of complete image bytes"),
             };
-            std::mem::take(own_bytes)
+            mem::take(own_bytes)
         };
         let bytes = Arc::new(bytes);
         *self = ImageBytes::Complete(bytes.clone());


### PR DESCRIPTION
#31564 had an unused import issue while compiling. I changed `std::mem::take` to `mem::take` to use the import and be consistent with the rest of `std` uses. (Sorry for not noticing before the merge!)

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31607
- [x] These changes do not require tests because they are just a fix for an import warning