### PR TITLE
clippy: Fix warnings in `components/constellation`

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![allow(clippy::too_many_arguments)]
+
 use std::collections::{HashMap, HashSet};
 
 use euclid::Size2D;
@@ -198,7 +200,7 @@ impl<'a> Iterator for AllBrowsingContextsIterator<'a> {
             let child_browsing_context_ids = browsing_context
                 .pipelines
                 .iter()
-                .filter_map(|pipeline_id| pipelines.get(&pipeline_id))
+                .filter_map(|pipeline_id| pipelines.get(pipeline_id))
                 .flat_map(|pipeline| pipeline.children.iter());
             self.stack.extend(child_browsing_context_ids);
             return Some(browsing_context);

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1828,11 +1828,12 @@ where
                 // Events coming from inactive media sessions are discarded.
                 if self.active_media_session.is_some() {
                     if let MediaSessionEvent::PlaybackStateChange(ref state) = event {
-                        match state {
-                            MediaSessionPlaybackState::Playing |
-                            MediaSessionPlaybackState::Paused => (),
-                            _ => return,
-                        };
+                        if !matches!(
+                            state,
+                            MediaSessionPlaybackState::Playing | MediaSessionPlaybackState::Paused
+                        ) {
+                            return;
+                        }
                     };
                 }
                 self.active_media_session = Some(pipeline_id);

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -31,7 +31,7 @@ impl EventLoop {
     /// Create a new event loop from the channel to its script thread.
     pub fn new(script_chan: IpcSender<ConstellationControlMsg>) -> Rc<EventLoop> {
         Rc::new(EventLoop {
-            script_chan: script_chan,
+            script_chan,
             dont_send_or_sync: PhantomData,
         })
     }

--- a/components/constellation/network_listener.rs
+++ b/components/constellation/network_listener.rs
@@ -54,7 +54,7 @@ impl NetworkListener {
             request_builder: self.request_builder.clone(),
             resource_threads: self.resource_threads.clone(),
             sender: self.sender.clone(),
-            pipeline_id: self.pipeline_id.clone(),
+            pipeline_id: self.pipeline_id,
             should_send: false,
         };
 
@@ -119,7 +119,7 @@ impl NetworkListener {
                         self.request_builder.referrer = metadata
                             .referrer
                             .clone()
-                            .map(|referrer_url| Referrer::ReferrerUrl(referrer_url))
+                            .map(Referrer::ReferrerUrl)
                             .unwrap_or(Referrer::NoReferrer);
                         self.request_builder.referrer_policy = metadata.referrer_policy;
 

--- a/components/constellation/timer_scheduler.rs
+++ b/components/constellation/timer_scheduler.rs
@@ -30,7 +30,7 @@ impl PartialOrd for ScheduledEvent {
 impl Eq for ScheduledEvent {}
 impl PartialEq for ScheduledEvent {
     fn eq(&self, other: &ScheduledEvent) -> bool {
-        self as *const ScheduledEvent == other as *const ScheduledEvent
+        std::ptr::eq(self, other)
     }
 }
 


### PR DESCRIPTION
Continuation to #31500, fixes most clippy warnings in `components/constellation`, excluding:

```rust
warning: large size difference between variants
  --> components/constellation/sandboxing.rs:31:1
   |
31 | / pub enum UnprivilegedContent {
32 | |     Pipeline(UnprivilegedPipelineContent),
   | |     ------------------------------------- the second-largest variant contains at least 0 bytes
33 | |     ServiceWorker(ServiceWorkerUnprivilegedContent),
   | |     ----------------------------------------------- the largest variant contains at least 472 bytes
34 | | }
   | |_^ the entire enum is at least 0 bytes
```

Should I apply the solution it offers (change the second member to `ServiceWorker(Box<ServiceWorkerUnprivilegedContent>)`, or simple add an ignore to it? On one hand, adding a `Box` could be detrimental for performance, but on the other side the big difference between variants can waste memory.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.