### PR TITLE
clippy: Fix warnings in `components/layout_2020`

### DIFF
--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![allow(clippy::too_many_arguments)]
+
 use style::color::mix::ColorInterpolationMethod;
 use style::properties::ComputedValues;
 use style::values::computed::image::{EndingShape, Gradient, LineDirection};

--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(clippy::too_many_arguments)]
-
 use style::color::mix::ColorInterpolationMethod;
 use style::properties::ComputedValues;
 use style::values::computed::image::{EndingShape, Gradient, LineDirection};
@@ -164,6 +162,7 @@ pub(super) fn build_linear(
 }
 
 /// <https://drafts.csswg.org/css-images-3/#radial-gradients>
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_radial(
     style: &ComputedValues,
     items: &[GradientItem<Color, LengthPercentage>],

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -430,11 +430,11 @@ impl StackingContext {
         debug_assert!(self
             .real_stacking_contexts_and_positioned_stacking_containers
             .iter()
-            .all(|c| match c.context_type {
+            .all(|c| matches!(
+                c.context_type,
                 StackingContextType::RealStackingContext |
-                StackingContextType::PositionedStackingContainer => true,
-                _ => false,
-            }));
+                    StackingContextType::PositionedStackingContainer
+            )));
         debug_assert!(self
             .float_stacking_containers
             .iter()

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1109,7 +1109,7 @@ impl<'a> FlexItem<'a> {
                             flex_context.layout_context,
                             &mut positioning_context,
                             &item_as_containing_block,
-                            &flex_context.containing_block,
+                            flex_context.containing_block,
                         );
 
                         let hypothetical_cross_size = self

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -54,7 +54,7 @@ impl BlockFormattingContext {
         }
     }
 
-    pub fn construct_for_text_runs<'dom>(
+    pub fn construct_for_text_runs(
         runs: impl Iterator<Item = TextRun>,
         layout_context: &LayoutContext,
         text_decoration_line: TextDecorationLine,
@@ -409,15 +409,11 @@ where
         // collecting all Cow strings into a vector and passing them along to text breaking
         // and shaping during final InlineFormattingContext construction.
         let inlines = self.current_inline_level_boxes();
-        match inlines.last_mut().map(|last| last.borrow_mut()) {
-            Some(mut last_box) => match *last_box {
-                InlineLevelBox::TextRun(ref mut text_run) => {
-                    text_run.text.push_str(&input);
-                    return;
-                },
-                _ => {},
-            },
-            _ => {},
+        if let Some(mut last_box) = inlines.last_mut().map(|last| last.borrow_mut()) {
+            if let InlineLevelBox::TextRun(ref mut text_run) = *last_box {
+                text_run.text.push_str(&input);
+                return;
+            }
         }
 
         inlines.push(ArcRefCell::new(InlineLevelBox::TextRun(TextRun::new(

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -951,7 +951,7 @@ impl FloatBox {
                             layout_context,
                             positioning_context,
                             &containing_block_for_children,
-                            &containing_block,
+                            containing_block,
                         );
                         content_size = LogicalVec2 {
                             inline: inline_size,

--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -587,11 +587,11 @@ impl FloatLineItem {
 }
 
 fn is_baseline_relative(vertical_align: GenericVerticalAlign<LengthPercentage>) -> bool {
-    match vertical_align {
+    !matches!(
+        vertical_align,
         GenericVerticalAlign::Keyword(VerticalAlignKeyword::Top) |
-        GenericVerticalAlign::Keyword(VerticalAlignKeyword::Bottom) => false,
-        _ => true,
-    }
+            GenericVerticalAlign::Keyword(VerticalAlignKeyword::Bottom)
+    )
 }
 
 fn line_height(parent_style: &ComputedValues, font_metrics: &FontMetrics) -> Length {

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #![allow(rustdoc::private_intra_doc_links)]
-#![allow(clippy::too_many_arguments)]
 
 //! Flow layout, also known as block-and-inline layout.
 
@@ -614,6 +613,7 @@ impl BlockLevelBox {
 ///
 /// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
 /// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
+#[allow(clippy::too_many_arguments)]
 fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #![allow(rustdoc::private_intra_doc_links)]
+#![allow(clippy::too_many_arguments)]
 
 //! Flow layout, also known as block-and-inline layout.
 
@@ -856,7 +857,7 @@ impl NonReplacedFormattingContext {
             layout_context,
             positioning_context,
             &containing_block_for_children,
-            &containing_block,
+            containing_block,
         );
 
         let (block_size, inline_size) = match layout.content_inline_size_for_table {
@@ -1162,7 +1163,7 @@ impl NonReplacedFormattingContext {
 /// <https://drafts.csswg.org/css2/visudet.html#block-replaced-width>
 /// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-width>
 /// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-height>
-fn layout_in_flow_replaced_block_level<'a>(
+fn layout_in_flow_replaced_block_level(
     containing_block: &ContainingBlock,
     base_fragment_info: BaseFragmentInfo,
     style: &Arc<ComputedValues>,
@@ -1348,8 +1349,8 @@ fn solve_margins(
     inline_size: Length,
 ) -> ResolvedMargins {
     let (inline_margins, effective_margin_inline_start) =
-        solve_inline_margins_for_in_flow_block_level(containing_block, &pbm, inline_size);
-    let block_margins = solve_block_margins_for_in_flow_block_level(&pbm);
+        solve_inline_margins_for_in_flow_block_level(containing_block, pbm, inline_size);
+    let block_margins = solve_block_margins_for_in_flow_block_level(pbm);
     ResolvedMargins {
         margin: LogicalSides {
             inline_start: inline_margins.0,

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -83,6 +83,7 @@ impl BoxTree {
     where
         Node: 'dom + Copy + LayoutNode<'dom> + Send + Sync,
     {
+        #[allow(clippy::enum_variant_names)]
         enum UpdatePoint {
             AbsolutelyPositionedBlockLevelBox(ArcRefCell<BlockLevelBox>),
             AbsolutelyPositionedInlineLevelBox(ArcRefCell<InlineLevelBox>),

--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -709,7 +709,7 @@ pub struct TextTransformation<InputIterator> {
     pending_case_conversion_result: Option<PendingCaseConversionResult>,
 }
 
-impl<'a, InputIterator> TextTransformation<InputIterator> {
+impl<InputIterator> TextTransformation<InputIterator> {
     pub fn new(char_iterator: InputIterator, text_transform: TextTransform) -> Self {
         Self {
             char_iterator,

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -117,7 +117,7 @@ impl Tag {
         self.pseudo.is_some()
     }
 
-    pub(crate) fn to_display_list_fragment_id(&self) -> u64 {
+    pub(crate) fn to_display_list_fragment_id(self) -> u64 {
         let fragment_type = match self.pseudo {
             Some(PseudoElement::Before) => FragmentType::BeforePseudoContent,
             Some(PseudoElement::After) => FragmentType::AfterPseudoContent,

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![allow(clippy::too_many_arguments)]
+
 use app_units::Au;
 use gfx_traits::print_tree::PrintTree;
 use serde::Serialize;

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(clippy::too_many_arguments)]
-
 use app_units::Au;
 use gfx_traits::print_tree::PrintTree;
 use serde::Serialize;
@@ -76,6 +74,7 @@ pub(crate) struct BoxFragment {
 }
 
 impl BoxFragment {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         base_fragment_info: BaseFragmentInfo,
         style: ServoArc<ComputedValues>,
@@ -110,6 +109,7 @@ impl BoxFragment {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_overconstrained(
         base_fragment_info: BaseFragmentInfo,
         style: ServoArc<ComputedValues>,

--- a/components/layout_2020/fragment_tree/hoisted_shared_fragment.rs
+++ b/components/layout_2020/fragment_tree/hoisted_shared_fragment.rs
@@ -56,16 +56,12 @@ pub(crate) enum AbsoluteBoxOffsets {
 
 impl AbsoluteBoxOffsets {
     pub(crate) fn both_specified(&self) -> bool {
-        match self {
-            AbsoluteBoxOffsets::Both { .. } => true,
-            _ => false,
-        }
+        matches!(self, AbsoluteBoxOffsets::Both { .. })
     }
 
     pub(crate) fn adjust_offset(&mut self, new_offset: Length) {
-        match *self {
-            AbsoluteBoxOffsets::StaticStart { ref mut start } => *start = new_offset,
-            _ => (),
+        if let AbsoluteBoxOffsets::StaticStart { ref mut start } = *self {
+            *start = new_offset
         }
     }
 }

--- a/components/layout_2020/fragment_tree/mod.rs
+++ b/components/layout_2020/fragment_tree/mod.rs
@@ -6,6 +6,7 @@ mod base_fragment;
 mod box_fragment;
 mod containing_block;
 mod fragment;
+#[allow(clippy::module_inception)]
 mod fragment_tree;
 mod hoisted_shared_fragment;
 mod positioning_fragment;

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -505,12 +505,9 @@ fn process_offset_parent_query_inner(
             // "If any of the following holds true return null and terminate
             // this algorithm: [...] The element’s computed value of the
             // `position` property is `fixed`."
-            let is_fixed = match fragment {
-                Fragment::Box(fragment) if fragment.style.get_box().position == Position::Fixed => {
-                    true
-                },
-                _ => false,
-            };
+            let is_fixed = matches!(
+                fragment, Fragment::Box(fragment) if fragment.style.get_box().position == Position::Fixed
+            );
 
             if is_body_element {
                 // "If the element is the HTML body element or [...] return zero

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -88,6 +88,7 @@ pub(crate) enum DisplayInside {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 /// <https://drafts.csswg.org/css-display-3/#layout-specific-display>
 pub(crate) enum DisplayLayoutInternal {
     TableCaption,

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -704,8 +704,7 @@ where
                     });
 
                     let previous_text_decoration_line = self.current_text_decoration_line;
-                    self.current_text_decoration_line =
-                        self.current_text_decoration_line | info.style.clone_text_decoration_line();
+                    self.current_text_decoration_line |= info.style.clone_text_decoration_line();
 
                     let new_row_group_index = self.builder.table.row_groups.len() - 1;
                     self.current_row_group_index = Some(new_row_group_index);
@@ -953,6 +952,7 @@ where
         contents: Contents,
         box_slot: BoxSlot<'dom>,
     ) {
+        #[allow(clippy::collapsible_match)] //// TODO: Remove once the other cases are handled
         match display {
             DisplayGeneratingBox::LayoutInternal(internal) => match internal {
                 DisplayLayoutInternal::TableCell => {

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -374,7 +374,7 @@ impl<'a> TableLayout<'a> {
         // >   * 100% minus the sum of the intrinsic percentage width of all prior columns in
         // >     the table (further left when direction is "ltr" (right for "rtl"))
         let mut total_intrinsic_percentage_width = 0.;
-        for column_measure in column_measures.iter_mut().take(self.table.size.width) {
+        for column_measure in column_measures.iter_mut() {
             let final_intrinsic_percentage_width = column_measure
                 .percentage
                 .0
@@ -970,8 +970,8 @@ impl<'a> TableLayout<'a> {
         for row_index in 0..self.table.slots.len() {
             let row = &self.table.slots[row_index];
             let mut cells_laid_out_row = Vec::new();
-            for (column_index, column_value) in row.iter().enumerate() {
-                let cell = match column_value {
+            for (column_index, slot) in row.iter().enumerate() {
+                let cell = match slot {
                     TableSlot::Cell(cell) => cell,
                     _ => {
                         cells_laid_out_row.push(None);


### PR DESCRIPTION
Continuation to #31500, fixes all clippy warnings in `components/layout_2020`.

It includes a few ignores that I think are reasonable, but please give any feedback in this regard:
- `enum_variant_names`: allows it for `DisplayLayoutInternal::Table*` in `style_ext.rs` because it follows the spec names, and for `UpdatePoint` in `flow/root.rs` since moving AbsolutelyPositioned to the title seems less clear and conflicts with the base names it is wrapping.
- `module_inception`: since it would require renaming `fragment_tree/fragment_tree.rs` or the base module, and I can't think of a good enough replacement that justifies it
- `collapsible_match`: in `table/construct.rs`, this is only there until the corresponding todo is completed, and it is marked as so
- `needless_range_loop`: in `table/layout.rs` it is iterating between columns and rows of a table, and it uses the index for multiple things. the solution provided obfuscates the function.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.