### PR TITLE
clippy: Fix warnings in `components/layout`

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1761,7 +1761,7 @@ impl BlockFlow {
         // If you remove the might_have_floats_in conditional, this will go off.
         // TODO(servo#30572) revert to debug_assert!() once underlying bug is fixed
         #[cfg(debug_assertions)]
-        if !(!self.is_inline_flex_item()) {
+        if self.is_inline_flex_item() {
             log::warn!("debug assertion failed! !self.is_inline_flex_item()");
         }
 

--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -199,7 +199,7 @@ impl InlineBlockSplit {
                 fragment_accumulator,
                 InlineFragmentsAccumulator::from_inline_node(node, style_context),
             )
-            .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(style_context),
+            .get_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(style_context),
             flow,
         };
 
@@ -305,7 +305,7 @@ impl InlineFragmentsAccumulator {
             .push_descendants(fragments.absolute_descendants);
     }
 
-    fn to_intermediate_inline_fragments<'dom, N>(
+    fn get_intermediate_inline_fragments<'dom, N>(
         self,
         context: &SharedStyleContext,
     ) -> IntermediateInlineFragments
@@ -482,7 +482,9 @@ where
         node: &ConcreteThreadSafeLayoutNode,
     ) {
         let mut fragments = fragment_accumulator
-            .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(self.style_context());
+            .get_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(
+                self.style_context(),
+            );
         if fragments.is_empty() {
             return;
         };
@@ -1079,7 +1081,7 @@ where
                 ConstructionItem::InlineFragments(InlineFragmentsConstructionResult {
                     splits: opt_inline_block_splits,
                     fragments: fragment_accumulator
-                        .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(
+                        .get_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(
                             self.style_context(),
                         ),
                 });
@@ -1196,7 +1198,7 @@ where
             ConstructionItem::InlineFragments(InlineFragmentsConstructionResult {
                 splits: LinkedList::new(),
                 fragments: fragment_accumulator
-                    .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(context),
+                    .get_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(context),
             });
         ConstructionResult::ConstructionItem(construction_item)
     }
@@ -1246,7 +1248,7 @@ where
             ConstructionItem::InlineFragments(InlineFragmentsConstructionResult {
                 splits: LinkedList::new(),
                 fragments: fragment_accumulator
-                    .to_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(
+                    .get_intermediate_inline_fragments::<ConcreteThreadSafeLayoutNode>(
                         style_context,
                     ),
             });

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -55,6 +55,9 @@ pub fn malloc_size_of_persistent_local_context(ops: &mut MallocSizeOfOps) -> usi
     })
 }
 
+type WebrenderImageCache =
+    HashMap<(ServoUrl, UsePlaceholder), WebRenderImageInfo, BuildHasherDefault<FnvHasher>>;
+
 /// Layout information shared among all workers. This must be thread-safe.
 pub struct LayoutContext<'a> {
     /// The pipeline id of this LayoutContext.
@@ -73,11 +76,7 @@ pub struct LayoutContext<'a> {
     pub font_cache_thread: Mutex<FontCacheThread>,
 
     /// A cache of WebRender image info.
-    pub webrender_image_cache: Arc<
-        RwLock<
-            HashMap<(ServoUrl, UsePlaceholder), WebRenderImageInfo, BuildHasherDefault<FnvHasher>>,
-        >,
-    >,
+    pub webrender_image_cache: Arc<RwLock<WebrenderImageCache>>,
 
     /// Paint worklets
     pub registered_painters: &'a dyn RegisteredPainters,

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![allow(clippy::too_many_arguments)]
+
 use app_units::Au;
 use euclid::default::{Point2D, Rect, SideOffsets2D, Size2D};
 use style::computed_values::background_attachment::single_value::T as BackgroundAttachment;

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -8,6 +8,8 @@
 //! list building, as the actual painting does not happen here—only deciding *what* we're going to
 //! paint.
 
+#![allow(clippy::too_many_arguments)]
+
 use std::default::Default;
 use std::sync::Arc;
 use std::{f32, mem};
@@ -443,7 +445,7 @@ impl<'a> DisplayListBuildState<'a> {
         let mut list = Vec::new();
         let root_context = mem::replace(&mut self.root_stacking_context, StackingContext::root());
 
-        self.to_display_list_for_stacking_context(&mut list, root_context);
+        self.move_to_display_list_for_stacking_context(&mut list, root_context);
 
         DisplayList {
             list,
@@ -451,7 +453,7 @@ impl<'a> DisplayListBuildState<'a> {
         }
     }
 
-    fn to_display_list_for_stacking_context(
+    fn move_to_display_list_for_stacking_context(
         &mut self,
         list: &mut Vec<DisplayItem>,
         stacking_context: StackingContext,
@@ -473,7 +475,7 @@ impl<'a> DisplayListBuildState<'a> {
                     .into_iter()
                     .map(|index| index.to_define_item()),
             );
-            self.to_display_list_for_items(list, child_items, info.children);
+            self.move_to_display_list_for_items(list, child_items, info.children);
         } else {
             let (push_item, pop_item) = stacking_context.to_display_list_items();
             list.push(push_item);
@@ -482,12 +484,12 @@ impl<'a> DisplayListBuildState<'a> {
                     .into_iter()
                     .map(|index| index.to_define_item()),
             );
-            self.to_display_list_for_items(list, child_items, info.children);
+            self.move_to_display_list_for_items(list, child_items, info.children);
             list.push(pop_item);
         }
     }
 
-    fn to_display_list_for_items(
+    fn move_to_display_list_for_items(
         &mut self,
         list: &mut Vec<DisplayItem>,
         mut child_items: Vec<DisplayItem>,
@@ -509,7 +511,7 @@ impl<'a> DisplayListBuildState<'a> {
             .map_or(false, |child| child.z_index < 0)
         {
             let context = child_stacking_contexts.next().unwrap();
-            self.to_display_list_for_stacking_context(list, context);
+            self.move_to_display_list_for_stacking_context(list, context);
         }
 
         // Step 4: Block backgrounds and borders.
@@ -524,7 +526,7 @@ impl<'a> DisplayListBuildState<'a> {
             child.context_type == StackingContextType::PseudoFloat
         }) {
             let context = child_stacking_contexts.next().unwrap();
-            self.to_display_list_for_stacking_context(list, context);
+            self.move_to_display_list_for_stacking_context(list, context);
         }
 
         // Step 6 & 7: Content and inlines that generate stacking contexts.
@@ -536,7 +538,7 @@ impl<'a> DisplayListBuildState<'a> {
 
         // Step 8 & 9: Positioned descendants with nonnegative, numeric z-indices.
         for child in child_stacking_contexts {
-            self.to_display_list_for_stacking_context(list, child);
+            self.move_to_display_list_for_stacking_context(list, child);
         }
 
         // Step 10: Outlines.
@@ -2642,10 +2644,10 @@ impl BlockFlow {
         // The margins control which edges have sticky behavior.
         let sticky_frame_data = StickyFrameData {
             margins: SideOffsets2D::new(
-                sticky_position.top.to_option().map(|v| v.to_f32_px()),
-                sticky_position.right.to_option().map(|v| v.to_f32_px()),
-                sticky_position.bottom.to_option().map(|v| v.to_f32_px()),
-                sticky_position.left.to_option().map(|v| v.to_f32_px()),
+                sticky_position.top.as_option().map(|v| v.to_f32_px()),
+                sticky_position.right.as_option().map(|v| v.to_f32_px()),
+                sticky_position.bottom.as_option().map(|v| v.to_f32_px()),
+                sticky_position.left.as_option().map(|v| v.to_f32_px()),
             ),
             vertical_offset_bounds,
             horizontal_offset_bounds,

--- a/components/layout/display_list/items.rs
+++ b/components/layout/display_list/items.rs
@@ -12,6 +12,8 @@
 //! They are therefore not exactly analogous to constructs like Skia pictures, which consist of
 //! low-level drawing primitives.
 
+#![allow(clippy::too_many_arguments)]
+
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::{f32, fmt};

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -250,7 +250,7 @@ pub trait Flow: HasBaseFlow + fmt::Debug + Sync + Send + 'static {
     fn collect_stacking_contexts(&mut self, state: &mut StackingContextCollectionState);
 
     /// If this is a float, places it. The default implementation does nothing.
-    fn place_float_if_applicable<'a>(&mut self) {}
+    fn place_float_if_applicable(&mut self) {}
 
     /// Assigns block-sizes in-order; or, if this is a float, places the float. The default
     /// implementation simply assigns block-sizes if this flow might have floats in. Returns true
@@ -505,6 +505,7 @@ pub trait Flow: HasBaseFlow + fmt::Debug + Sync + Send + 'static {
     }
 }
 
+#[allow(clippy::wrong_self_convention)]
 pub trait ImmutableFlowUtils {
     // Convenience functions
 
@@ -603,18 +604,18 @@ pub enum FlowClass {
 
 impl FlowClass {
     fn is_block_like(self) -> bool {
-        match self {
+        matches!(
+            self,
             FlowClass::Block |
-            FlowClass::ListItem |
-            FlowClass::Table |
-            FlowClass::TableRowGroup |
-            FlowClass::TableRow |
-            FlowClass::TableCaption |
-            FlowClass::TableCell |
-            FlowClass::TableWrapper |
-            FlowClass::Flex => true,
-            _ => false,
-        }
+                FlowClass::ListItem |
+                FlowClass::Table |
+                FlowClass::TableRowGroup |
+                FlowClass::TableRow |
+                FlowClass::TableCaption |
+                FlowClass::TableCell |
+                FlowClass::TableWrapper |
+                FlowClass::Flex
+        )
     }
 }
 
@@ -1232,50 +1233,32 @@ impl<'a> ImmutableFlowUtils for &'a dyn Flow {
 
     /// Returns true if this flow is a table row flow.
     fn is_table_row(self) -> bool {
-        match self.class() {
-            FlowClass::TableRow => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::TableRow)
     }
 
     /// Returns true if this flow is a table cell flow.
     fn is_table_cell(self) -> bool {
-        match self.class() {
-            FlowClass::TableCell => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::TableCell)
     }
 
     /// Returns true if this flow is a table colgroup flow.
     fn is_table_colgroup(self) -> bool {
-        match self.class() {
-            FlowClass::TableColGroup => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::TableColGroup)
     }
 
     /// Returns true if this flow is a table flow.
     fn is_table(self) -> bool {
-        match self.class() {
-            FlowClass::Table => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::Table)
     }
 
     /// Returns true if this flow is a table caption flow.
     fn is_table_caption(self) -> bool {
-        match self.class() {
-            FlowClass::TableCaption => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::TableCaption)
     }
 
     /// Returns true if this flow is a table rowgroup flow.
     fn is_table_rowgroup(self) -> bool {
-        match self.class() {
-            FlowClass::TableRowGroup => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::TableRowGroup)
     }
 
     /// Returns the number of children that this flow possesses.
@@ -1285,18 +1268,12 @@ impl<'a> ImmutableFlowUtils for &'a dyn Flow {
 
     /// Returns true if this flow is a block flow.
     fn is_block_flow(self) -> bool {
-        match self.class() {
-            FlowClass::Block => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::Block)
     }
 
     /// Returns true if this flow is an inline flow.
     fn is_inline_flow(self) -> bool {
-        match self.class() {
-            FlowClass::Inline => true,
-            _ => false,
-        }
+        matches!(self.class(), FlowClass::Inline)
     }
 
     /// Dumps the flow tree for debugging.
@@ -1392,7 +1369,7 @@ impl MutableOwnedFlowUtils for FlowRef {
         for descendant_link in abs_descendants.descendant_links.iter_mut() {
             // TODO(servo#30573) revert to debug_assert!() once underlying bug is fixed
             #[cfg(debug_assertions)]
-            if !(!descendant_link.has_reached_containing_block) {
+            if descendant_link.has_reached_containing_block {
                 log::warn!("debug assertion failed! !descendant_link.has_reached_containing_block");
             }
             let descendant_base = FlowRef::deref_mut(&mut descendant_link.flow).mut_base();

--- a/components/layout/flow_ref.rs
+++ b/components/layout/flow_ref.rs
@@ -49,6 +49,7 @@ impl FlowRef {
     /// See <https://github.com/servo/servo/issues/6503>.
     /// Use Arc::get_mut instead when possible (e.g. on an Arc that was just created).
     #[allow(unsafe_code)]
+    #[allow(clippy::should_implement_trait)]
     pub fn deref_mut(this: &mut FlowRef) -> &mut dyn Flow {
         let ptr: *const dyn Flow = &*this.0;
         unsafe { &mut *(ptr as *mut dyn Flow) }

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -307,7 +307,7 @@ impl<'a, 'b> ResolveGeneratedContentFragmentMutator<'a, 'b> {
         }
 
         // Truncate down counters.
-        for (_, counter) in &mut self.traversal.counters {
+        for counter in self.traversal.counters.values_mut() {
             counter.truncate_to_level(self.level);
         }
         self.traversal.list_item.truncate_to_level(self.level);

--- a/components/layout/model.rs
+++ b/components/layout/model.rs
@@ -478,7 +478,7 @@ impl MaybeAuto {
     }
 
     #[inline]
-    pub fn to_option(&self) -> Option<Au> {
+    pub fn as_option(&self) -> Option<Au> {
         match *self {
             MaybeAuto::Specified(value) => Some(value),
             MaybeAuto::Auto => None,

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -35,8 +35,9 @@ pub struct UnsafeFlow(*const dyn Flow);
 unsafe impl Sync for UnsafeFlow {}
 unsafe impl Send for UnsafeFlow {}
 impl PartialEq for UnsafeFlow {
+    #[allow(clippy::ptr_eq)]
     fn eq(&self, other: &Self) -> bool {
-        // Compare the pointers explicitly to avoid clippy lint
+        // Compare the pointers explicitly to avoid a clippy error
         self.0 as *const u8 == other.0 as *const u8
     }
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -988,10 +988,10 @@ fn process_resolved_style_request_internal<'dom>(
         },
     };
 
-    let positioned = match style.get_box().position {
-        Position::Relative | Position::Sticky | Position::Fixed | Position::Absolute => true,
-        _ => false,
-    };
+    let positioned = matches!(
+        style.get_box().position,
+        Position::Relative | Position::Sticky | Position::Fixed | Position::Absolute
+    );
 
     //TODO: determine whether requested property applies to the element.
     //      eg. width does not apply to non-replaced inline elements.

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -37,7 +37,7 @@ use crate::fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use crate::model::{IntrinsicISizes, IntrinsicISizesContribution, MaybeAuto};
 use crate::table_cell::TableCellFlow;
 use crate::table_row::{
-    self, CellIntrinsicInlineSize, CollapsedBorder, CollapsedBorderProvenance, TableRowFlow,
+    self, CellIntrinsicInlineSize, CollapsedBorder, CollapsedBorderFrom, TableRowFlow,
     TableRowSizeData,
 };
 use crate::table_wrapper::TableLayout;
@@ -339,11 +339,11 @@ impl Flow for TableFlow {
             Some(TableInlineCollapsedBorders {
                 start: CollapsedBorder::inline_start(
                     &self.block_flow.fragment.style,
-                    CollapsedBorderProvenance::FromTable,
+                    CollapsedBorderFrom::Table,
                 ),
                 end: CollapsedBorder::inline_end(
                     &self.block_flow.fragment.style,
-                    CollapsedBorderProvenance::FromTable,
+                    CollapsedBorderFrom::Table,
                 ),
             })
         } else {
@@ -354,7 +354,7 @@ impl Flow for TableFlow {
         let mut previous_collapsed_block_end_borders =
             PreviousBlockCollapsedBorders::FromTable(CollapsedBorder::block_start(
                 &self.block_flow.fragment.style,
-                CollapsedBorderProvenance::FromTable,
+                CollapsedBorderFrom::Table,
             ));
         let mut first_row = true;
         let (border_padding, _) = self.block_flow.fragment.surrounding_intrinsic_inline_size();
@@ -381,7 +381,7 @@ impl Flow for TableFlow {
                         ),
                         None => NextBlockCollapsedBorders::FromTable(CollapsedBorder::block_end(
                             &self.block_flow.fragment.style,
-                            CollapsedBorderProvenance::FromTable,
+                            CollapsedBorderFrom::Table,
                         )),
                     };
                     perform_border_collapse_for_row(

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -27,7 +27,7 @@ use crate::display_list::{
 use crate::flow::{Flow, FlowClass, FlowFlags, GetBaseFlow, OpaqueFlow};
 use crate::fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use crate::table::InternalTable;
-use crate::table_row::{CollapsedBorder, CollapsedBorderProvenance};
+use crate::table_row::{CollapsedBorder, CollapsedBorderFrom};
 use crate::{layout_debug, layout_debug_scope};
 
 #[allow(unsafe_code)]
@@ -406,19 +406,19 @@ impl CollapsedBordersForCell {
     }
 
     fn should_paint_inline_start_border(&self) -> bool {
-        self.inline_start_border.provenance != CollapsedBorderProvenance::FromPreviousTableCell
+        self.inline_start_border.provenance != CollapsedBorderFrom::PreviousTableCell
     }
 
     fn should_paint_inline_end_border(&self) -> bool {
-        self.inline_end_border.provenance != CollapsedBorderProvenance::FromNextTableCell
+        self.inline_end_border.provenance != CollapsedBorderFrom::NextTableCell
     }
 
     fn should_paint_block_start_border(&self) -> bool {
-        self.block_start_border.provenance != CollapsedBorderProvenance::FromPreviousTableCell
+        self.block_start_border.provenance != CollapsedBorderFrom::PreviousTableCell
     }
 
     fn should_paint_block_end_border(&self) -> bool {
-        self.block_end_border.provenance != CollapsedBorderProvenance::FromNextTableCell
+        self.block_end_border.provenance != CollapsedBorderFrom::NextTableCell
     }
 
     pub fn adjust_border_widths_for_painting(&self, border_widths: &mut LogicalMargin<Au>) {

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -485,7 +485,8 @@ impl TextRunScanner {
                 );
 
                 let is_last_mapping_of_this_old_fragment = !matches!(
-                mappings.peek(), Some(mapping) if mapping.old_fragment_index == logical_offset
+                    mappings.peek(),
+                    Some(mapping) if mapping.old_fragment_index == logical_offset
                 );
 
                 if let Some(ref mut context) = new_fragment.inline_context {

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Text layout.
+#![allow(clippy::too_many_arguments)]
 
 use std::borrow::ToOwned;
 use std::collections::LinkedList;
@@ -483,10 +484,9 @@ impl TextRunScanner {
                     SpecificFragmentInfo::ScannedText(new_text_fragment_info),
                 );
 
-                let is_last_mapping_of_this_old_fragment = match mappings.peek() {
-                    Some(mapping) if mapping.old_fragment_index == logical_offset => false,
-                    _ => true,
-                };
+                let is_last_mapping_of_this_old_fragment = !matches!(
+                mappings.peek(), Some(mapping) if mapping.old_fragment_index == logical_offset
+                );
 
                 if let Some(ref mut context) = new_fragment.inline_context {
                     for node in &mut context.nodes {


### PR DESCRIPTION
Continuation to #31500, fixes all clippy warnings in `components/layout` (excluding safety comments).

It includes a few allows that I think are reasonable, but please give any feedback in this regard:

- `wrong_self_convention`: in `flow.rs` the trait `ImmutableFlowUtils` contains many `is_*(self)` functions. These usually take `self` by reference, but they are used extensively in the code already. I think the name is appropriate and should not be changed. They can be changed to take it by reference, but I'm not sure if that is an improvement, and it will for sure be a big change across some files.
- `should_implement_trait`: in `flow_ref.rs` this warning indicates that `deref_mut` should come from a trait, but in this case we are using a custom unsafe function
- `ptr_eq`: in `parallel.rs` `PartialEq` has to be implemented manually to avoid a clippy _error_. this still generates a warning, telling us to go back to the non manual implementation (which generated the error).

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.
