### PR TITLE
Take spaces into account in the max-content size of an IFC

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2215,7 +2215,7 @@ struct ContentSizesComputation<'a> {
     paragraph: ContentSizes,
     current_line: ContentSizes,
     /// Size for whitepsace pending to be added to this line.
-    pending_whitespace: Length,
+    pending_whitespace: Au,
     /// Whether or not this IFC has seen any non-whitespace content.
     had_non_whitespace_content_yet: bool,
     /// Stack of ending padding, margin, and border to add to the length
@@ -2270,14 +2270,13 @@ impl<'a> ContentSizesComputation<'a> {
                     }
 
                     for run in segment.runs.iter() {
-                        let advance = Length::from(run.glyph_store.total_advance());
+                        let advance = run.glyph_store.total_advance();
 
                         if !run.glyph_store.is_whitespace() {
                             self.had_non_whitespace_content_yet = true;
-                            self.current_line.min_content += advance.into();
-                            self.current_line.max_content +=
-                                (self.pending_whitespace + advance).into();
-                            self.pending_whitespace = Length::zero();
+                            self.current_line.min_content += advance;
+                            self.current_line.max_content += self.pending_whitespace + advance;
+                            self.pending_whitespace = Au::zero();
                         } else {
                             // If this run is a forced line break, we *must* break the line
                             // and start measuring from the inline origin once more.
@@ -2307,10 +2306,9 @@ impl<'a> ContentSizesComputation<'a> {
                     self.containing_block_writing_mode,
                 );
 
-                self.current_line.min_content +=
-                    (self.pending_whitespace + outer.min_content.into()).into();
-                self.current_line.max_content += outer.max_content;
-                self.pending_whitespace = Length::zero();
+                self.current_line.min_content += self.pending_whitespace + outer.min_content;
+                self.current_line.max_content += self.pending_whitespace + outer.max_content;
+                self.pending_whitespace = Au::zero();
                 self.had_non_whitespace_content_yet = true;
             },
             _ => {},
@@ -2349,7 +2347,7 @@ impl<'a> ContentSizesComputation<'a> {
             containing_block_writing_mode,
             paragraph: ContentSizes::zero(),
             current_line: ContentSizes::zero(),
-            pending_whitespace: Length::zero(),
+            pending_whitespace: Au::zero(),
             had_non_whitespace_content_yet: false,
             ending_inline_pbm_stack: Vec::new(),
         }

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-118.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-118.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-118.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-120.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-120.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-120.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-size-quirks-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-size-quirks-002.html.ini
@@ -1,6 +1,3 @@
 [percentage-size-quirks-002.html]
   [.pct 2]
     expected: FAIL
-
-  [.pct 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/td-with-subpixel-padding-vertical-rl.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/td-with-subpixel-padding-vertical-rl.html.ini
@@ -1,0 +1,3 @@
+[td-with-subpixel-padding-vertical-rl.html]
+  [td-with-subpixel-padding-vertical-rl]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/width-distribution/td-with-subpixel-padding.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/td-with-subpixel-padding.html.ini
@@ -1,3 +1,0 @@
-[td-with-subpixel-padding.html]
-  [td-with-subpixel-padding]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

They were only considered in min-content sizes.
Also avoid some pointless conversions from Au to Length.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31605

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
