### PR TITLE
Add wpt-report output & continue if filtering failed

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -107,7 +107,7 @@ jobs:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}
           pattern: wpt-full-logs-linux-${{ inputs.wpt-layout }}-*
           delete-merged: true
-      - name: Merge logs (full)
+      - name: Merge logs (wptreport)
         uses: actions/upload-artifact/merge@v4
         with:
           name: wptreport-linux-${{ inputs.wpt-layout }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -71,7 +71,7 @@ jobs:
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
-            --log-wptreport wptreport/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
+            --log-wptreport wptreport/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json \
             --log-raw-unexpected wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
         env:
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: wptreport-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
+          name: wptreport-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}.json
           path: wptreport/*/
 
   report-test-results:

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -101,12 +101,6 @@ jobs:
     if: ${{ always() }}
     needs: linux-wpt
     steps:
-      - name: Merge logs (filtered)
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}
-          pattern: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}-*
-          delete-merged: true
       - name: Merge logs (full)
         uses: actions/upload-artifact/merge@v4
         with:
@@ -118,6 +112,13 @@ jobs:
         with:
           name: wptreport-linux-${{ inputs.wpt-layout }}
           pattern: wptreport-linux-${{ inputs.wpt-layout }}-*
+          delete-merged: true
+      # These need to be last so we still merge others if filtered do not exists
+      - name: Merge logs (filtered)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}
+          pattern: wpt-filtered-logs-linux-${{ inputs.wpt-layout }}-*
           delete-merged: true
       - uses: actions/checkout@v4
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -70,8 +70,8 @@ jobs:
             ${{ inputs.wpt-tests-to-run }} \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
-            --log-wptreport wptreport/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json \
+            --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/raw/${{ matrix.chunk_id }}.log \
+            --log-wptreport wpt-full-logs/linux-${{ inputs.wpt-layout }}/wptreport/wptreport.${{ matrix.chunk_id }}.json \
             --log-raw-unexpected wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
         env:
@@ -88,12 +88,6 @@ jobs:
         with:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
           path: wpt-full-logs/*/
-      - name: Archive wptreport
-        uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with:
-          name: wptreport-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}.json
-          path: wptreport/*/
 
   report-test-results:
     name: Process WPT Results
@@ -106,12 +100,6 @@ jobs:
         with:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}
           pattern: wpt-full-logs-linux-${{ inputs.wpt-layout }}-*
-          delete-merged: true
-      - name: Merge logs (wptreport)
-        uses: actions/upload-artifact/merge@v4
-        with:
-          name: wptreport-linux-${{ inputs.wpt-layout }}
-          pattern: wptreport-linux-${{ inputs.wpt-layout }}-*
           delete-merged: true
       # These need to be last so we still merge others if filtered do not exists
       - name: Merge logs (filtered)

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -71,6 +71,7 @@ jobs:
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
+            --log-wptreport wptreport/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --log-raw-unexpected wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
         env:
@@ -87,6 +88,12 @@ jobs:
         with:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
           path: wpt-full-logs/*/
+      - name: Archive wptreport
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: wptreport-linux-${{ inputs.wpt-layout }}-${{ matrix.chunk_id }}
+          path: wptreport/*/
 
   report-test-results:
     name: Process WPT Results
@@ -105,6 +112,12 @@ jobs:
         with:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}
           pattern: wpt-full-logs-linux-${{ inputs.wpt-layout }}-*
+          delete-merged: true
+      - name: Merge logs (full)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wptreport-linux-${{ inputs.wpt-layout }}
+          pattern: wptreport-linux-${{ inputs.wpt-layout }}-*
           delete-merged: true
       - uses: actions/checkout@v4
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -71,7 +71,7 @@ jobs:
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/raw/${{ matrix.chunk_id }}.log \
-            --log-wptreport wpt-full-logs/linux-${{ inputs.wpt-layout }}/wptreport/wptreport.${{ matrix.chunk_id }}.json \
+            --log-wptreport wpt-full-logs/linux-${{ inputs.wpt-layout }}/wptreport/${{ matrix.chunk_id }}.json \
             --log-raw-unexpected wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
         env:
@@ -101,7 +101,7 @@ jobs:
           name: wpt-full-logs-linux-${{ inputs.wpt-layout }}
           pattern: wpt-full-logs-linux-${{ inputs.wpt-layout }}-*
           delete-merged: true
-      # These need to be last so we still merge others if filtered do not exists
+      # This job needs to be last. If no filtered results were uploaded, it will fail, but we want to merge other archives in that case.
       - name: Merge logs (filtered)
         uses: actions/upload-artifact/merge@v4
         with:


### PR DESCRIPTION
Split off from https://github.com/servo/servo/pull/31194.

Ths PR adds wptreports output in addition to other outputs. Wptreports are needed for moz-webgpu-cts, but they are also generally useful. I believe they can be feed into `./mach update-wpt` too and in comparison to raw logs they are more lightweight (raw logs have a lot of useless stuff eg.: server start, server end, ...).

WebGPU CTS failures are very spammy (a lot of printing), so we often hit "Message to long" errors in filtering phase, so no filter logs are made. Instead of failing when no filter logs are available this PR continues so all other logs still get merged.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
