### PR TITLE
Fix rustdoc errors in `components/script/dom`

### DIFF
--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -44,7 +44,7 @@ pub struct AudioBuffer {
     #[ignore_malloc_size_of = "mozjs"]
     js_channels: DomRefCell<Vec<HeapBufferSource<Float32>>>,
     /// Aggregates the data from js_channels.
-    /// This is `Some<T>` if the buffers in js_channels are detached.
+    /// This is `Some<T>` iff the buffers in js_channels are detached.
     #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
     shared_channels: DomRefCell<Option<ServoMediaAudioBuffer>>,

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -44,7 +44,7 @@ pub struct AudioBuffer {
     #[ignore_malloc_size_of = "mozjs"]
     js_channels: DomRefCell<Vec<HeapBufferSource<Float32>>>,
     /// Aggregates the data from js_channels.
-    /// This is Some<T> iff the buffers in js_channels are detached.
+    /// This is `Some<T>` if the buffers in js_channels are detached.
     #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
     shared_channels: DomRefCell<Option<ServoMediaAudioBuffer>>,

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -68,7 +68,7 @@ impl TrustedReference {
 /// A safe wrapper around a DOM Promise object that can be shared among threads for use
 /// in asynchronous operations. The underlying DOM object is guaranteed to live at least
 /// as long as the last outstanding `TrustedPromise` instance. These values cannot be cloned,
-/// only created from existing Rc<Promise> values.
+/// only created from existing `Rc<Promise>` values.
 pub struct TrustedPromise {
     dom_object: *const Promise,
     owner_thread: *const libc::c_void,

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -135,7 +135,7 @@ pub trait DomObjectWrap: Sized + DomObject {
 /// A trait to provide a function pointer to wrap function for
 /// DOM iterator interfaces.
 pub trait DomObjectIteratorWrap: DomObjectWrap + JSTraceable + Iterable {
-    /// Function pointer to the wrap function for IterableIterator<T>
+    /// Function pointer to the wrap function for `IterableIterator<T>`
     const ITER_WRAP: unsafe fn(
         JSContext,
         &GlobalScope,

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -53,7 +53,7 @@ pub struct Promise {
     permanent_js_root: Heap<JSVal>,
 }
 
-/// Private helper to enable adding new methods to Rc<Promise>.
+/// Private helper to enable adding new methods to `Rc<Promise>`.
 trait PromiseHelper {
     fn initialize(&self, cx: SafeJSContext);
 }


### PR DESCRIPTION
Fixing rustdoc errors in components/script/dom



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31575 
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
