### PR TITLE
Add CoC and Security Policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+The Servo Project follows the [**Rust Code of Conduct**](https://www.rust-lang.org/policies/code-of-conduct), with two differences.
+
+Our code of conduct applies to the [Servo Zulip channels](https://servo.zulipchat.com/), [GitHub repositories](https://github.com/servo), and all official Servo venues, rather than the Rust project.
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify one of our designated contacts:
+* Delan Azabani (she/her) <dazabani@igalia.com>
+* Martin Robinson (he/him) <mrobinson@igalia.com>
+* Manuel Rego Casasnovas (he/him) <rego@igalia.com>
+
+*Note: If you modify this file, please keep this file in sync with <https://servo.org/coc/>.*
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+Given that Servo does not yet have customers or products, we are comfortable accepting the security related vulnerabilities as a [new GitHub issue](https://github.com/servo/servo/issues/new) for now.
+


### PR DESCRIPTION
CoC is the same than we have at <https://servo.org/coc/>.

Security Policy is based on the agreement on the last TSC meeting: https://github.com/servo/project/blob/main/governance/tsc/tsc-2024-02-26.md#security-policy

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19118

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they just add some docs.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
