### PR TITLE
Fix clippy warnings in `components/third_party`

### DIFF
--- a/components/background_hang_monitor/sampler_mac.rs
+++ b/components/background_hang_monitor/sampler_mac.rs
@@ -4,8 +4,6 @@
 
 use std::{panic, process};
 
-use {libc, mach2};
-
 use crate::sampler::{Address, NativeStack, Registers, Sampler};
 
 type MonitoredThreadId = mach2::mach_types::thread_act_t;

--- a/third_party/blurmac/src/adapter.rs
+++ b/third_party/blurmac/src/adapter.rs
@@ -28,10 +28,7 @@ impl BluetoothAdapter {
         trace!("BluetoothAdapter::init");
         let delegate = bm::delegate();
         let manager = cb::centralmanager(delegate);
-        let adapter = BluetoothAdapter {
-            manager: manager,
-            delegate: delegate,
-        };
+        let adapter = BluetoothAdapter { manager, delegate };
 
         // NOTE: start discovery at once, servo leaves close to no time to do a proper discovery
         // in a BluetoothDiscoverySession

--- a/third_party/blurmac/src/delegate.rs
+++ b/third_party/blurmac/src/delegate.rs
@@ -18,7 +18,7 @@ pub mod bm {
 
     // BlurMacDelegate : CBCentralManagerDelegate, CBPeripheralDelegate
 
-    const DELEGATE_PERIPHERALS_IVAR: &'static str = "_peripherals";
+    const DELEGATE_PERIPHERALS_IVAR: &str = "_peripherals";
 
     fn delegate_class() -> &'static Class {
         trace!("delegate_class");
@@ -181,13 +181,12 @@ pub mod bm {
             }
 
             // Notify BluetoothDevice::get_gatt_services that discovery was successful.
-            match bmx::peripheralevents(delegate, peripheral) {
-                Ok(events) => ns::mutabledictionary_setobject_forkey(
+            if let Ok(events) = bmx::peripheralevents(delegate, peripheral) {
+                ns::mutabledictionary_setobject_forkey(
                     events,
                     wait::now(),
                     nsx::string_from_str(PERIPHERALEVENT_SERVICESDISCOVEREDKEY),
-                ),
-                Err(_) => {},
+                );
             }
         }
     }
@@ -213,13 +212,12 @@ pub mod bm {
             }
 
             // Notify BluetoothGATTService::get_includes that discovery was successful.
-            match bmx::peripheralevents(delegate, peripheral) {
-                Ok(events) => ns::mutabledictionary_setobject_forkey(
+            if let Ok(events) = bmx::peripheralevents(delegate, peripheral) {
+                ns::mutabledictionary_setobject_forkey(
                     events,
                     wait::now(),
                     bmx::includedservicesdiscoveredkey(service),
-                ),
-                Err(_) => {},
+                );
             }
         }
     }
@@ -245,13 +243,12 @@ pub mod bm {
             }
 
             // Notify BluetoothGATTService::get_gatt_characteristics that discovery was successful.
-            match bmx::peripheralevents(delegate, peripheral) {
-                Ok(events) => ns::mutabledictionary_setobject_forkey(
+            if let Ok(events) = bmx::peripheralevents(delegate, peripheral) {
+                ns::mutabledictionary_setobject_forkey(
                     events,
                     wait::now(),
                     bmx::characteristicsdiscoveredkey(service),
-                ),
-                Err(_) => {},
+                );
             }
         }
     }
@@ -271,13 +268,12 @@ pub mod bm {
         );
         if error == nil {
             // Notify BluetoothGATTCharacteristic::read_value that read was successful.
-            match bmx::peripheralevents(delegate, peripheral) {
-                Ok(events) => ns::mutabledictionary_setobject_forkey(
+            if let Ok(events) = bmx::peripheralevents(delegate, peripheral) {
+                ns::mutabledictionary_setobject_forkey(
                     events,
                     wait::now(),
                     bmx::valueupdatedkey(characteristic),
-                ),
-                Err(_) => {},
+                );
             }
         }
     }
@@ -297,13 +293,12 @@ pub mod bm {
         );
         if error == nil {
             // Notify BluetoothGATTCharacteristic::write_value that write was successful.
-            match bmx::peripheralevents(delegate, peripheral) {
-                Ok(events) => ns::mutabledictionary_setobject_forkey(
+            if let Ok(events) = bmx::peripheralevents(delegate, peripheral) {
+                ns::mutabledictionary_setobject_forkey(
                     events,
                     wait::now(),
                     bmx::valuewrittenkey(characteristic),
-                ),
-                Err(_) => {},
+                );
             }
         }
     }
@@ -368,16 +363,16 @@ pub mod bm {
 
     // "BlurMacPeripheralData" = NSMutableDictionary<NSString*, id>
 
-    pub const PERIPHERALDATA_PERIPHERALKEY: &'static str = "peripheral";
-    pub const PERIPHERALDATA_RSSIKEY: &'static str = "rssi";
-    pub const PERIPHERALDATA_UUIDSKEY: &'static str = "uuids";
-    pub const PERIPHERALDATA_EVENTSKEY: &'static str = "events";
+    pub const PERIPHERALDATA_PERIPHERALKEY: &str = "peripheral";
+    pub const PERIPHERALDATA_RSSIKEY: &str = "rssi";
+    pub const PERIPHERALDATA_UUIDSKEY: &str = "uuids";
+    pub const PERIPHERALDATA_EVENTSKEY: &str = "events";
 
-    pub const PERIPHERALEVENT_SERVICESDISCOVEREDKEY: &'static str = "services";
-    pub const PERIPHERALEVENT_INCLUDEDSERVICESDISCOVEREDKEYSUFFIX: &'static str = ":includes";
-    pub const PERIPHERALEVENT_CHARACTERISTICSDISCOVEREDKEYSUFFIX: &'static str = ":characteristics";
-    pub const PERIPHERALEVENT_VALUEUPDATEDKEYSUFFIX: &'static str = ":updated";
-    pub const PERIPHERALEVENT_VALUEWRITTENKEYSUFFIX: &'static str = ":written";
+    pub const PERIPHERALEVENT_SERVICESDISCOVEREDKEY: &str = "services";
+    pub const PERIPHERALEVENT_INCLUDEDSERVICESDISCOVEREDKEYSUFFIX: &str = ":includes";
+    pub const PERIPHERALEVENT_CHARACTERISTICSDISCOVEREDKEYSUFFIX: &str = ":characteristics";
+    pub const PERIPHERALEVENT_VALUEUPDATEDKEYSUFFIX: &str = ":updated";
+    pub const PERIPHERALEVENT_VALUEWRITTENKEYSUFFIX: &str = ":written";
 }
 
 pub mod bmx {

--- a/third_party/blurmac/src/device.rs
+++ b/third_party/blurmac/src/device.rs
@@ -36,7 +36,7 @@ impl BluetoothDevice {
 
         BluetoothDevice {
             adapter: adapter.clone(),
-            peripheral: peripheral,
+            peripheral,
         }
     }
 
@@ -58,7 +58,7 @@ impl BluetoothDevice {
 
     pub fn get_id(&self) -> String {
         trace!("BluetoothDevice::get_id -> get_address");
-        self.get_address().unwrap_or(String::new())
+        self.get_address().unwrap_or_default()
     }
 
     pub fn get_address(&self) -> Result<String, Box<dyn Error>> {

--- a/third_party/blurmac/src/gatt_characteristic.rs
+++ b/third_party/blurmac/src/gatt_characteristic.rs
@@ -39,7 +39,7 @@ impl BluetoothGATTCharacteristic {
 
         BluetoothGATTCharacteristic {
             service: service.clone(),
-            characteristic: characteristic,
+            characteristic,
         }
     }
 
@@ -58,7 +58,7 @@ impl BluetoothGATTCharacteristic {
 
     pub fn get_id(&self) -> String {
         trace!("BluetoothGATTCharacteristic::get_id");
-        self.get_uuid().unwrap_or(String::new())
+        self.get_uuid().unwrap_or_default()
     }
 
     pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {

--- a/third_party/blurmac/src/gatt_service.rs
+++ b/third_party/blurmac/src/gatt_service.rs
@@ -38,7 +38,7 @@ impl BluetoothGATTService {
 
         BluetoothGATTService {
             device: device.clone(),
-            service: service,
+            service,
         }
     }
 
@@ -59,7 +59,7 @@ impl BluetoothGATTService {
 
     pub fn get_id(&self) -> String {
         trace!("BluetoothGATTService::get_id");
-        self.get_uuid().unwrap_or(String::new())
+        self.get_uuid().unwrap_or_default()
     }
 
     pub fn get_uuid(&self) -> Result<String, Box<dyn Error>> {

--- a/third_party/blurmac/src/utils.rs
+++ b/third_party/blurmac/src/utils.rs
@@ -13,10 +13,10 @@ use std::{thread, time};
 use framework::{cb, nil, ns};
 use objc::runtime::Object;
 
-pub const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported by blurmac!";
-pub const NO_PERIPHERAL_FOUND: &'static str = "Error! No peripheral found!";
-pub const NO_SERVICE_FOUND: &'static str = "Error! No service found!";
-pub const NO_CHARACTERISTIC_FOUND: &'static str = "Error! No characteristic found!";
+pub const NOT_SUPPORTED_ERROR: &str = "Error! Not supported by blurmac!";
+pub const NO_PERIPHERAL_FOUND: &str = "Error! No peripheral found!";
+pub const NO_SERVICE_FOUND: &str = "Error! No service found!";
+pub const NO_CHARACTERISTIC_FOUND: &str = "Error! No characteristic found!";
 
 pub mod nsx {
     use super::*;


### PR DESCRIPTION
Fixing Clippy linter errors in components/third_party folder


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
