### PR TITLE
rustdoc: Fix `StackingContextFragment` error in `components/layout_2020/display_list`

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -93,13 +93,13 @@ impl DisplayList {
 pub(crate) struct DisplayListBuilder<'a> {
     /// The current [ScrollTreeNodeId] for this [DisplayListBuilder]. This
     /// allows only passing the builder instead passing the containing
-    /// [stacking_context::StackingContextFragment] as an argument to display
+    /// [stacking_context::StackingContextContent::Fragment] as an argument to display
     /// list building functions.
     current_scroll_node_id: ScrollTreeNodeId,
 
     /// The current [wr::ClipId] for this [DisplayListBuilder]. This allows
     /// only passing the builder instead passing the containing
-    /// [stacking_context::StackingContextFragment] as an argument to display
+    /// [stacking_context::StackingContextContent::Fragment] as an argument to display
     /// list building functions.
     current_clip_chain_id: ClipChainId,
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace `[stacking_context::StackingContextFragment]` with `[stacking_context::StackingContextContent::Fragment]`.

**ref:** https://github.com/servo/servo/commit/afe4faa09a8db16bf04ae6c7fd58a2c81d7b3aad#diff-82520938a024f875c789f7314111aaeb3f11a47fd9b956a3a90fef8399ddaea1L195

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31575
<!-- Either: -->
- [X] These changes do not require tests because they are documentation fixes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
