### PR TITLE
clippy: Fix warnings in `components/net`

### DIFF
--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -192,9 +192,9 @@ impl CookieStorage {
             (match acc.len() {
                 0 => acc,
                 _ => acc + "; ",
-            }) + &c.cookie.name() +
+            }) + c.cookie.name() +
                 "=" +
-                &c.cookie.value()
+                c.cookie.value()
         };
         let result = url_cookies.iter_mut().fold("".to_owned(), reducer);
 
@@ -253,7 +253,7 @@ fn evict_one_cookie(is_secure_cookie: bool, cookies: &mut Vec<Cookie>) -> bool {
     true
 }
 
-fn get_oldest_accessed(is_secure_cookie: bool, cookies: &mut Vec<Cookie>) -> Option<(usize, Tm)> {
+fn get_oldest_accessed(is_secure_cookie: bool, cookies: &mut [Cookie]) -> Option<(usize, Tm)> {
     let mut oldest_accessed: Option<(usize, Tm)> = None;
     for (i, c) in cookies.iter().enumerate() {
         if (c.cookie.secure().unwrap_or(false) == is_secure_cookie) &&

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -248,7 +248,7 @@ fn poll_with_read(reader: &mut dyn Read, buf: &mut BytesMut) -> Poll<Option<Resu
     };
 
     match read {
-        Ok(read) if read == 0 => Poll::Ready(None),
+        Ok(0) => Poll::Ready(None),
         Ok(read) => {
             unsafe { buf.advance_mut(read) };
             let chunk = buf.split_to(read).freeze();

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -869,16 +869,13 @@ async fn scheme_fetch(
 }
 
 fn is_null_body_status(status: &Option<(StatusCode, String)>) -> bool {
-    match *status {
-        Some((status, _)) => matches!(
-            status,
-            StatusCode::SWITCHING_PROTOCOLS |
-                StatusCode::NO_CONTENT |
-                StatusCode::RESET_CONTENT |
-                StatusCode::NOT_MODIFIED
-        ),
-        _ => false,
-    }
+    matches!(
+        status,
+        Some((StatusCode::SWITCHING_PROTOCOLS, ..)) |
+            Some((StatusCode::NO_CONTENT, ..)) |
+            Some((StatusCode::RESET_CONTENT, ..)) |
+            Some((StatusCode::NOT_MODIFIED, ..))
+    )
 }
 
 /// <https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?>

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -440,10 +440,7 @@ pub async fn main_fetch(
         let not_network_error = !response_is_network_error && !internal_response.is_network_error();
         if not_network_error &&
             (is_null_body_status(&internal_response.status) ||
-                match request.method {
-                    Method::HEAD | Method::CONNECT => true,
-                    _ => false,
-                })
+                matches!(request.method, Method::HEAD | Method::CONNECT))
         {
             // when Fetch is used only asynchronously, we will need to make sure
             // that nothing tries to write to the body at this point
@@ -487,7 +484,7 @@ pub async fn main_fetch(
     if request.synchronous {
         // process_response is not supposed to be used
         // by sync fetch, but we overload it here for simplicity
-        target.process_response(&mut response);
+        target.process_response(&response);
         if !response_loaded {
             wait_for_response(&mut response, target, done_chan).await;
         }
@@ -873,13 +870,13 @@ async fn scheme_fetch(
 
 fn is_null_body_status(status: &Option<(StatusCode, String)>) -> bool {
     match *status {
-        Some((status, _)) => match status {
+        Some((status, _)) => matches!(
+            status,
             StatusCode::SWITCHING_PROTOCOLS |
-            StatusCode::NO_CONTENT |
-            StatusCode::RESET_CONTENT |
-            StatusCode::NOT_MODIFIED => true,
-            _ => false,
-        },
+                StatusCode::NO_CONTENT |
+                StatusCode::RESET_CONTENT |
+                StatusCode::NOT_MODIFIED
+        ),
         _ => false,
     }
 }

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -125,6 +125,7 @@ impl FileManager {
     // Read a file for the Fetch implementation.
     // It gets the required headers synchronously and reads the actual content
     // in a separate thread.
+    #[allow(clippy::too_many_arguments)]
     pub fn fetch_file(
         &self,
         done_sender: &mut TokioSender<Data>,
@@ -278,6 +279,7 @@ impl FileManager {
             });
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn fetch_blob_buf(
         &self,
         done_sender: &mut TokioSender<Data>,
@@ -824,21 +826,18 @@ impl FileManagerStore {
     }
 
     fn promote_memory(&self, id: Uuid, blob_buf: BlobBuf, set_valid: bool, origin: FileOrigin) {
-        match Url::parse(&origin) {
-            // parse to check sanity
-            Ok(_) => {
-                self.insert(
-                    id,
-                    FileStoreEntry {
-                        origin,
-                        file_impl: FileImpl::Memory(blob_buf),
-                        refs: AtomicUsize::new(1),
-                        is_valid_url: AtomicBool::new(set_valid),
-                        outstanding_tokens: Default::default(),
-                    },
-                );
-            },
-            Err(_) => {},
+        // parse to check sanity
+        if Url::parse(&origin).is_ok() {
+            self.insert(
+                id,
+                FileStoreEntry {
+                    origin,
+                    file_impl: FileImpl::Memory(blob_buf),
+                    refs: AtomicUsize::new(1),
+                    is_valid_url: AtomicBool::new(set_valid),
+                    outstanding_tokens: Default::default(),
+                },
+            );
         }
     }
 

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -827,18 +827,19 @@ impl FileManagerStore {
 
     fn promote_memory(&self, id: Uuid, blob_buf: BlobBuf, set_valid: bool, origin: FileOrigin) {
         // parse to check sanity
-        if Url::parse(&origin).is_ok() {
-            self.insert(
-                id,
-                FileStoreEntry {
-                    origin,
-                    file_impl: FileImpl::Memory(blob_buf),
-                    refs: AtomicUsize::new(1),
-                    is_valid_url: AtomicBool::new(set_valid),
-                    outstanding_tokens: Default::default(),
-                },
-            );
+        if Url::parse(&origin).is_err() {
+            return;
         }
+        self.insert(
+            id,
+            FileStoreEntry {
+                origin,
+                file_impl: FileImpl::Memory(blob_buf),
+                refs: AtomicUsize::new(1),
+                is_valid_url: AtomicBool::new(set_valid),
+                outstanding_tokens: Default::default(),
+            },
+        );
     }
 
     fn set_blob_url_validity(

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -134,10 +134,10 @@ pub struct HttpCache {
 
 /// Determine if a response is cacheable by default <https://tools.ietf.org/html/rfc7231#section-6.1>
 fn is_cacheable_by_default(status_code: u16) -> bool {
-    match status_code {
-        200 | 203 | 204 | 206 | 300 | 301 | 404 | 405 | 410 | 414 | 501 => true,
-        _ => false,
-    }
+    matches!(
+        status_code,
+        200 | 203 | 204 | 206 | 300 | 301 | 404 | 405 | 410 | 414 | 501
+    )
 }
 
 /// Determine if a given response is cacheable.

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -63,6 +63,7 @@ fn load_root_cert_store_from_file(file_path: String) -> io::Result<RootCertStore
 }
 
 /// Returns a tuple of (public, private) senders to the new threads.
+#[allow(clippy::too_many_arguments)]
 pub fn new_resource_threads(
     user_agent: Cow<'static, str>,
     devtools_sender: Option<Sender<DevtoolsControlMsg>>,
@@ -102,6 +103,7 @@ pub fn new_resource_threads(
 }
 
 /// Create a CoreResourceThread
+#[allow(clippy::too_many_arguments)]
 pub fn new_core_resource_thread(
     user_agent: Cow<'static, str>,
     devtools_sender: Option<Sender<DevtoolsControlMsg>>,
@@ -225,9 +227,8 @@ impl ResourceChannelManager {
         loop {
             for receiver in rx_set.select().unwrap().into_iter() {
                 // Handles case where profiler thread shuts down before resource thread.
-                match receiver {
-                    ipc::IpcSelectionResult::ChannelClosed(..) => continue,
-                    _ => {},
+                if let ipc::IpcSelectionResult::ChannelClosed(..) = receiver {
+                    continue;
                 }
                 let (id, data) = receiver.unwrap();
                 // If message is memory report, get the size_of of public and private http caches

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -132,10 +132,10 @@ fn apply_algorithm_to_response<S: ArrayLength<u8>, D: Digest<OutputSize = S>>(
 
 /// <https://w3c.github.io/webappsec-subresource-integrity/#is-response-eligible>
 fn is_eligible_for_integrity_validation(response: &Response) -> bool {
-    match response.response_type {
-        ResponseType::Basic | ResponseType::Default | ResponseType::Cors => true,
-        _ => false,
-    }
+    matches!(
+        response.response_type,
+        ResponseType::Basic | ResponseType::Default | ResponseType::Cors
+    )
 }
 
 /// <https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist>


### PR DESCRIPTION
Continuation to #31500, fixes all clippy warnings in `components/net` (excluding safety comments).

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.