### PR TITLE
clippy: Fix warnings in `components/shared`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3547,7 +3547,7 @@ impl Document {
         RefMut::map(map, |m| {
             &mut m
                 .entry(Dom::from_ref(el))
-                .or_insert_with(|| NoTrace(PendingRestyle::new()))
+                .or_insert_with(|| NoTrace(PendingRestyle::default()))
                 .0
         })
     }

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -211,7 +211,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> LayoutNode<'dom>
     unsafe fn initialize_data(&self) {
         if self.get_style_and_opaque_layout_data().is_none() {
             let opaque = StyleAndOpaqueLayoutData::new(
-                StyleData::new(),
+                StyleData::default(),
                 AtomicRefCell::new(LayoutDataType::default()),
             );
             self.init_style_and_opaque_layout_data(opaque);

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -207,6 +207,7 @@ impl RequestBody {
         self.source == BodySource::Null
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> Option<usize> {
         self.total_bytes
     }

--- a/components/shared/script/compositor.rs
+++ b/components/shared/script/compositor.rs
@@ -131,7 +131,7 @@ impl ScrollTreeNode {
 
         let scrollable_width = info.scrollable_size.width;
         let scrollable_height = info.scrollable_size.height;
-        let original_layer_scroll_offset = info.offset.clone();
+        let original_layer_scroll_offset = info.offset;
 
         if scrollable_width > 0. {
             info.offset.x = (info.offset.x + delta.x).min(0.0).max(-scrollable_width);
@@ -172,10 +172,10 @@ impl ScrollTree {
             parent: parent.cloned(),
             scroll_info,
         });
-        return ScrollTreeNodeId {
+        ScrollTreeNodeId {
             index: self.nodes.len() - 1,
             spatial_id,
-        };
+        }
     }
 
     /// Get a mutable reference to the node with the given index.
@@ -198,7 +198,7 @@ impl ScrollTree {
         scroll_location: ScrollLocation,
     ) -> Option<(ExternalScrollId, LayoutVector2D)> {
         let parent = {
-            let ref mut node = self.get_node_mut(scroll_node_id);
+            let node = &mut self.get_node_mut(scroll_node_id);
             let result = node.scroll(scroll_location);
             if result.is_some() {
                 return result;

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -194,14 +194,14 @@ impl LoadData {
     ) -> LoadData {
         LoadData {
             load_origin,
-            url: url,
-            creator_pipeline_id: creator_pipeline_id,
+            url,
+            creator_pipeline_id,
             method: Method::GET,
             headers: HeaderMap::new(),
             data: None,
             js_eval_result: None,
-            referrer: referrer,
-            referrer_policy: referrer_policy,
+            referrer,
+            referrer_policy,
             srcdoc: "".to_string(),
             inherited_secure_context,
             crash: None,
@@ -977,7 +977,7 @@ impl StructuredSerializedData {
                     // Note: we insert the blob at the original id,
                     // otherwise this will not match the storage key as serialized by SM in `serialized`.
                     // The clone has it's own new Id however.
-                    blob_clones.insert(original_id.clone(), blob_clone);
+                    blob_clones.insert(*original_id, blob_clone);
                 } else {
                     // Not panicking only because this is called from the constellation.
                     warn!("Serialized blob not in memory format(should never happen).");
@@ -1263,7 +1263,7 @@ impl WebrenderIpcSender {
         }
 
         senders.into_iter().for_each(|(tx, data)| {
-            if let Err(e) = tx.send(&*data) {
+            if let Err(e) = tx.send(&data) {
                 warn!("error sending image data: {}", e);
             }
         });
@@ -1308,8 +1308,8 @@ impl SerializedImageData {
     /// Convert to ``ImageData`.
     pub fn to_image_data(&self) -> Result<ImageData, ipc::IpcError> {
         match self {
-            SerializedImageData::Raw(rx) => rx.recv().map(|data| ImageData::new(data)),
-            SerializedImageData::External(image) => Ok(ImageData::External(image.clone())),
+            SerializedImageData::Raw(rx) => rx.recv().map(ImageData::new),
+            SerializedImageData::External(image) => Ok(ImageData::External(*image)),
         }
     }
 }

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -402,6 +402,7 @@ pub enum JobError {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 /// Messages sent from Job algorithms steps running in the SW manager,
 /// in order to resolve or reject the job promise.
 pub enum JobResult {

--- a/components/shared/script/serializable.rs
+++ b/components/shared/script/serializable.rs
@@ -41,7 +41,7 @@ impl FileBlob {
 
     /// Get the size of the file.
     pub fn get_size(&self) -> u64 {
-        self.size.clone()
+        self.size
     }
 
     /// Get the cached file data, if any.
@@ -56,7 +56,7 @@ impl FileBlob {
 
     /// Get the file id.
     pub fn get_id(&self) -> Uuid {
-        self.id.clone()
+        self.id
     }
 }
 
@@ -107,7 +107,7 @@ impl BlobImpl {
             id: file_id,
             name: Some(name),
             cache: RefCell::new(None),
-            size: size,
+            size,
         });
         BlobImpl {
             blob_id,
@@ -131,7 +131,7 @@ impl BlobImpl {
 
     /// Get a clone of the blob-id
     pub fn blob_id(&self) -> BlobId {
-        self.blob_id.clone()
+        self.blob_id
     }
 
     /// Get a clone of the type-string

--- a/components/shared/script/transferable.rs
+++ b/components/shared/script/transferable.rs
@@ -63,7 +63,7 @@ impl MessagePortImpl {
 
     /// Maybe get the Id of the entangled port.
     pub fn entangled_port_id(&self) -> Option<MessagePortId> {
-        self.entangled_port.clone()
+        self.entangled_port
     }
 
     /// Entanged this port with another.
@@ -73,10 +73,7 @@ impl MessagePortImpl {
 
     /// Is this port enabled?
     pub fn enabled(&self) -> bool {
-        match self.state {
-            MessagePortState::Enabled(_) => true,
-            _ => false,
-        }
+        matches!(self.state, MessagePortState::Enabled(_))
     }
 
     /// Mark this port as having been shipped.

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -49,11 +49,11 @@ pub struct StyleData {
     pub parallel: DomParallelInfo,
 }
 
-impl StyleData {
-    pub fn new() -> Self {
+impl Default for StyleData {
+    fn default() -> Self {
         Self {
             element_data: AtomicRefCell::new(ElementData::default()),
-            parallel: DomParallelInfo::new(),
+            parallel: DomParallelInfo::default(),
         }
     }
 }
@@ -86,18 +86,10 @@ impl StyleAndOpaqueLayoutData {
 }
 
 /// Information that we need stored in each DOM node.
-#[derive(MallocSizeOf)]
+#[derive(MallocSizeOf, Default)]
 pub struct DomParallelInfo {
     /// The number of children remaining to process during bottom-up traversal.
     pub children_to_process: AtomicIsize,
-}
-
-impl DomParallelInfo {
-    pub fn new() -> DomParallelInfo {
-        DomParallelInfo {
-            children_to_process: AtomicIsize::new(0),
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -86,7 +86,7 @@ impl StyleAndOpaqueLayoutData {
 }
 
 /// Information that we need stored in each DOM node.
-#[derive(MallocSizeOf, Default)]
+#[derive(Default, MallocSizeOf)]
 pub struct DomParallelInfo {
     /// The number of children remaining to process during bottom-up traversal.
     pub children_to_process: AtomicIsize,

--- a/components/shared/script_layout/message.rs
+++ b/components/shared/script_layout/message.rs
@@ -199,11 +199,11 @@ pub struct PendingRestyle {
     pub damage: RestyleDamage,
 }
 
-impl PendingRestyle {
+impl Default for PendingRestyle {
     /// Creates a new empty pending restyle.
     #[inline]
-    pub fn new() -> Self {
-        PendingRestyle {
+    fn default() -> Self {
+        Self {
             snapshot: None,
             hint: RestyleHint::empty(),
             damage: RestyleDamage::empty(),

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -50,17 +50,11 @@ impl PseudoElementType {
     }
 
     pub fn is_before(&self) -> bool {
-        match *self {
-            PseudoElementType::Before => true,
-            _ => false,
-        }
+        matches!(*self, PseudoElementType::Before)
     }
 
     pub fn is_replaced_content(&self) -> bool {
-        match *self {
-            PseudoElementType::Before | PseudoElementType::After => true,
-            _ => false,
-        }
+        matches!(*self, PseudoElementType::Before | PseudoElementType::After)
     }
 
     pub fn style_pseudo_element(&self) -> PseudoElement {
@@ -138,9 +132,8 @@ where
     ConcreteNode: LayoutNode<'dom>,
 {
     fn new(root: ConcreteNode) -> TreeIterator<ConcreteNode> {
-        let mut stack = vec![];
-        stack.push(root);
-        TreeIterator { stack: stack }
+        let stack = vec![root];
+        TreeIterator { stack }
     }
 
     pub fn next_skipping_children(&mut self) -> Option<ConcreteNode> {
@@ -155,7 +148,9 @@ where
     type Item = ConcreteNode;
     fn next(&mut self) -> Option<ConcreteNode> {
         let ret = self.stack.pop();
-        ret.map(|node| self.stack.extend(node.rev_children()));
+        if let Some(node) = ret {
+            self.stack.extend(node.rev_children())
+        }
         ret
     }
 }


### PR DESCRIPTION
Continuation to #31500, fixes all clippy warnings in `components/shared` (excluding safety comments).

It includes the following allows that seem to be reasonable:
- `len_without_is_empty`: We would not using the `is_empty` function for anything and it is ambiguous to implement (being an optional).
- `large_enum_variant`: In a similar way to #31610, adding a box could affect performance.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.