### PR TITLE
clippy: Fix assorted warnings in `components/`

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -114,6 +114,7 @@ pub trait GenericPathBuilder {
         control_point3: &Point2D<f32>,
     );
     fn close(&mut self);
+    #[allow(clippy::too_many_arguments)]
     fn ellipse(
         &mut self,
         origin: Point2D<f32>,
@@ -195,6 +196,7 @@ impl<'a> PathBuilderRef<'a> {
             .arc(center, radius, start_angle, end_angle, ccw);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn ellipse(
         &mut self,
         center: &Point2D<f32>,
@@ -978,6 +980,7 @@ impl<'a> CanvasData<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn ellipse(
         &mut self,
         center: &Point2D<f32>,

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -670,7 +670,7 @@ impl GenericDrawTarget for raqote::DrawTarget {
 }
 
 impl Filter {
-    fn to_raqote(&self) -> raqote::FilterMode {
+    fn to_raqote(self) -> raqote::FilterMode {
         match self {
             Filter::Bilinear => raqote::FilterMode::Bilinear,
             Filter::Nearest => raqote::FilterMode::Nearest,
@@ -847,7 +847,7 @@ pub trait ToRaqotePattern<'a> {
 }
 
 pub trait ToRaqoteGradientStop {
-    fn to_raqote(&self) -> raqote::GradientStop;
+    fn to_raqote(self) -> raqote::GradientStop;
 }
 
 /// Clamp a 0..1 number to a 0..255 range to u8.
@@ -878,7 +878,7 @@ pub fn clamp_floor_256_f32(val: f32) -> u8 {
 }
 
 impl ToRaqoteGradientStop for CanvasGradientStop {
-    fn to_raqote(&self) -> raqote::GradientStop {
+    fn to_raqote(self) -> raqote::GradientStop {
         let color = raqote::Color::new(
             self.color.alpha.map(clamp_unit_f32).unwrap_or(0),
             self.color.red.unwrap_or(0),
@@ -890,7 +890,7 @@ impl ToRaqoteGradientStop for CanvasGradientStop {
     }
 }
 
-impl<'a> ToRaqotePattern<'_> for FillOrStrokeStyle {
+impl ToRaqotePattern<'_> for FillOrStrokeStyle {
     #[allow(unsafe_code)]
     fn to_raqote_pattern(self) -> Option<Pattern<'static>> {
         use canvas_traits::canvas::FillOrStrokeStyle::*;

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -2514,8 +2514,8 @@ fn to_name_in_compiled_shader(s: &str) -> String {
 
 fn from_name_in_compiled_shader(s: &str) -> String {
     map_dot_separated(s, |s, mapped| {
-        mapped.push_str(if s.starts_with(ANGLE_NAME_PREFIX) {
-            &s[ANGLE_NAME_PREFIX.len()..]
+        mapped.push_str(if let Some(stripped) = s.strip_prefix(ANGLE_NAME_PREFIX) {
+            stripped
         } else {
             s
         })
@@ -2533,6 +2533,7 @@ fn map_dot_separated<F: Fn(&str, &mut String)>(s: &str, f: F) -> String {
     mapped
 }
 
+#[allow(clippy::too_many_arguments)]
 fn prepare_pixels(
     internal_format: TexFormat,
     data_type: TexDataType,
@@ -3100,7 +3101,8 @@ impl WebXRBridge {
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
         context_id: WebXRContextId,
     ) {
-        for (_, manager) in &mut self.managers {
+        for manager in self.managers.values_mut() {
+            #[allow(clippy::unnecessary_to_owned)] // Needs mutable borrow later in destroy
             for (other_id, layer_id) in manager.layers().to_vec() {
                 if other_id == context_id {
                     manager.destroy_layer(device, contexts, context_id, layer_id);

--- a/components/compositing/gl.rs
+++ b/components/compositing/gl.rs
@@ -132,7 +132,7 @@ impl RenderTargetInfo {
             let dst_start = y * stride;
             let src_start = (height - y - 1) * stride;
             let src_slice = &orig_pixels[src_start..src_start + stride];
-            (&mut pixels[dst_start..dst_start + stride]).clone_from_slice(&src_slice[..stride]);
+            pixels[dst_start..dst_start + stride].clone_from_slice(&src_slice[..stride]);
         }
 
         RgbImage::from_raw(width as u32, height as u32, pixels).expect("Flipping image failed!")

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -25,10 +25,7 @@ pub struct TouchPoint {
 
 impl TouchPoint {
     pub fn new(id: TouchId, point: Point2D<f32, DevicePixel>) -> Self {
-        TouchPoint {
-            id: id,
-            point: point,
-        }
+        TouchPoint { id, point }
     }
 }
 

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -218,7 +218,7 @@ impl EmbedderCoordinates {
     /// to the framebuffer with OpenGL commands.
     pub fn get_flipped_viewport(&self) -> DeviceIntRect {
         let fb_height = self.framebuffer.height;
-        let mut view = self.viewport.clone();
+        let mut view = self.viewport;
         view.origin.y = fb_height - view.origin.y - view.size.height;
         DeviceIntRect::from_untyped(&view.to_untyped())
     }

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -28,6 +28,7 @@ use crate::pipeline::UnprivilegedPipelineContent;
 use crate::serviceworker::ServiceWorkerUnprivilegedContent;
 
 #[derive(Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum UnprivilegedContent {
     Pipeline(UnprivilegedPipelineContent),
     ServiceWorker(ServiceWorkerUnprivilegedContent),

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -521,7 +521,7 @@ impl FontCacheThread {
         };
 
         let mut number_loading = 0;
-        stylesheet.effective_font_face_rules(&device, guard, |rule| {
+        stylesheet.effective_font_face_rules(device, guard, |rule| {
             let font_face = match rule.font_face() {
                 Some(font_face) => font_face,
                 None => return,

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -75,13 +75,7 @@ fn set_metric<U: ProgressiveWebMetric>(
     pwm.send_queued_constellation_msg(metric_type, time);
 
     // Send the metric to the time profiler.
-    send_profile_data(
-        category,
-        metadata,
-        &pwm.get_time_profiler_chan(),
-        time,
-        time,
-    );
+    send_profile_data(category, metadata, pwm.get_time_profiler_chan(), time, time);
 
     // Print the metric to console if the print-pwm option was given.
     if opts::get().print_pwm {
@@ -119,13 +113,15 @@ pub struct InteractiveWindow {
     start: SystemTime,
 }
 
-impl InteractiveWindow {
-    pub fn new() -> InteractiveWindow {
-        InteractiveWindow {
+impl Default for InteractiveWindow {
+    fn default() -> Self {
+        Self {
             start: SystemTime::now(),
         }
     }
+}
 
+impl InteractiveWindow {
     // We need to either start or restart the 10s window
     //   start: we've added a new document
     //   restart: there was a task > 50ms
@@ -163,7 +159,7 @@ impl InteractiveMetrics {
             dom_content_loaded: Cell::new(None),
             main_thread_available: Cell::new(None),
             time_to_interactive: Cell::new(None),
-            time_profiler_chan: time_profiler_chan,
+            time_profiler_chan,
             url,
         }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3547,7 +3547,7 @@ impl Document {
         RefMut::map(map, |m| {
             &mut m
                 .entry(Dom::from_ref(el))
-                .or_insert_with(|| NoTrace(PendingRestyle::default()))
+                .or_insert_with(|| NoTrace(PendingRestyle::new()))
                 .0
         })
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3200,7 +3200,7 @@ impl Document {
             fullscreen_element: MutNullableDom::new(None),
             form_id_listener_map: Default::default(),
             interactive_time: DomRefCell::new(interactive_time),
-            tti_window: DomRefCell::new(InteractiveWindow::new()),
+            tti_window: DomRefCell::new(InteractiveWindow::default()),
             canceller: canceller,
             throw_on_dynamic_markup_insertion_counter: Cell::new(0),
             page_showing: Cell::new(false),
@@ -3547,7 +3547,7 @@ impl Document {
         RefMut::map(map, |m| {
             &mut m
                 .entry(Dom::from_ref(el))
-                .or_insert_with(|| NoTrace(PendingRestyle::new()))
+                .or_insert_with(|| NoTrace(PendingRestyle::default()))
                 .0
         })
     }

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -211,7 +211,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> LayoutNode<'dom>
     unsafe fn initialize_data(&self) {
         if self.get_style_and_opaque_layout_data().is_none() {
             let opaque = StyleAndOpaqueLayoutData::new(
-                StyleData::new(),
+                StyleData::default(),
                 AtomicRefCell::new(LayoutDataType::default()),
             );
             self.init_style_and_opaque_layout_data(opaque);

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -211,7 +211,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> LayoutNode<'dom>
     unsafe fn initialize_data(&self) {
         if self.get_style_and_opaque_layout_data().is_none() {
             let opaque = StyleAndOpaqueLayoutData::new(
-                StyleData::default(),
+                StyleData::new(),
                 AtomicRefCell::new(LayoutDataType::default()),
             );
             self.init_style_and_opaque_layout_data(opaque);

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -101,8 +101,8 @@ impl Handler {
         actions_by_tick: &[ActionSequence],
     ) -> Result<(), ErrorStatus> {
         for tick_actions in actions_by_tick.iter() {
-            let tick_duration = compute_tick_duration(&tick_actions);
-            self.dispatch_tick_actions(&tick_actions, tick_duration)?;
+            let tick_duration = compute_tick_duration(tick_actions);
+            self.dispatch_tick_actions(tick_actions, tick_duration)?;
         }
         Ok(())
     }
@@ -144,10 +144,10 @@ impl Handler {
                                 .or_insert(InputSourceState::Key(KeyInputState::new()));
                             match action {
                                 KeyAction::Down(action) => {
-                                    self.dispatch_keydown_action(&source_id, &action)
+                                    self.dispatch_keydown_action(source_id, action)
                                 },
                                 KeyAction::Up(action) => {
-                                    self.dispatch_keyup_action(&source_id, &action)
+                                    self.dispatch_keyup_action(source_id, action)
                                 },
                             };
                         },
@@ -174,15 +174,15 @@ impl Handler {
                             match action {
                                 PointerAction::Cancel => (),
                                 PointerAction::Down(action) => {
-                                    self.dispatch_pointerdown_action(&source_id, &action)
+                                    self.dispatch_pointerdown_action(source_id, action)
                                 },
                                 PointerAction::Move(action) => self.dispatch_pointermove_action(
-                                    &source_id,
-                                    &action,
+                                    source_id,
+                                    action,
                                     tick_duration,
                                 )?,
                                 PointerAction::Up(action) => {
-                                    self.dispatch_pointerup_action(&source_id, &action)
+                                    self.dispatch_pointerup_action(source_id, action)
                                 },
                             }
                         },
@@ -435,6 +435,7 @@ impl Handler {
     }
 
     // https://w3c.github.io/webdriver/#dfn-perform-a-pointer-move
+    #[allow(clippy::too_many_arguments)]
     fn perform_pointer_move(
         &mut self,
         source_id: &str,
@@ -470,11 +471,7 @@ impl Handler {
             };
 
             // Step 3
-            let last = if 1.0 - duration_ratio < 0.001 {
-                true
-            } else {
-                false
-            };
+            let last = 1.0 - duration_ratio < 0.001;
 
             // Step 4
             let (x, y) = if last {

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -54,6 +54,7 @@ const DEVICE_POLL_INTERVAL: u64 = 100;
 pub const PRESENTATION_BUFFER_COUNT: usize = 10;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum WebGPUResponse {
     RequestAdapter {
         adapter_info: wgt::AdapterInfo,
@@ -330,6 +331,12 @@ impl WebGPU {
     }
 }
 
+type WGPUBufferMaps<'a> =
+    HashMap<id::BufferId, Rc<BufferMapInfo<'a, Option<WebGPUResponseResult>>>>;
+type WGPUPresentBufferMaps<'a> =
+    HashMap<id::BufferId, Rc<BufferMapInfo<'a, (Option<ErrorScopeId>, WebGPURequest)>>>;
+
+#[allow(clippy::upper_case_acronyms)] // Name of the library
 struct WGPU<'a> {
     receiver: IpcReceiver<(Option<ErrorScopeId>, WebGPURequest)>,
     sender: IpcSender<(Option<ErrorScopeId>, WebGPURequest)>,
@@ -340,10 +347,9 @@ struct WGPU<'a> {
     // Track invalid adapters https://gpuweb.github.io/gpuweb/#invalid
     _invalid_adapters: Vec<WebGPUAdapter>,
     // Buffers with pending mapping
-    buffer_maps: HashMap<id::BufferId, Rc<BufferMapInfo<'a, Option<WebGPUResponseResult>>>>,
+    buffer_maps: WGPUBufferMaps<'a>,
     // Presentation Buffers with pending mapping
-    present_buffer_maps:
-        HashMap<id::BufferId, Rc<BufferMapInfo<'a, (Option<ErrorScopeId>, WebGPURequest)>>>,
+    present_buffer_maps: WGPUPresentBufferMaps<'a>,
     //TODO: Remove this (https://github.com/gfx-rs/wgpu/issues/867)
     error_command_encoders: RefCell<HashMap<id::CommandEncoderId, String>>,
     webrender_api: RenderApi,

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -331,9 +331,9 @@ impl WebGPU {
     }
 }
 
-type WGPUBufferMaps<'a> =
+type WebGPUBufferMaps<'a> =
     HashMap<id::BufferId, Rc<BufferMapInfo<'a, Option<WebGPUResponseResult>>>>;
-type WGPUPresentBufferMaps<'a> =
+type WebGPUPresentBufferMaps<'a> =
     HashMap<id::BufferId, Rc<BufferMapInfo<'a, (Option<ErrorScopeId>, WebGPURequest)>>>;
 
 #[allow(clippy::upper_case_acronyms)] // Name of the library
@@ -347,9 +347,9 @@ struct WGPU<'a> {
     // Track invalid adapters https://gpuweb.github.io/gpuweb/#invalid
     _invalid_adapters: Vec<WebGPUAdapter>,
     // Buffers with pending mapping
-    buffer_maps: WGPUBufferMaps<'a>,
+    buffer_maps: WebGPUBufferMaps<'a>,
     // Presentation Buffers with pending mapping
-    present_buffer_maps: WGPUPresentBufferMaps<'a>,
+    present_buffer_maps: WebGPUPresentBufferMaps<'a>,
     //TODO: Remove this (https://github.com/gfx-rs/wgpu/issues/867)
     error_command_encoders: RefCell<HashMap<id::CommandEncoderId, String>>,
     webrender_api: RenderApi,


### PR DESCRIPTION
Continuation to #31500, fixes clippy warnings in the rest of `components/` modules (excluding all those in `script` and the ones about safety comments and result types).

It includes the following allows that seem to be reasonable:
- `upper_case_acronyms`: in the case of `WGPU` I think it looks better and more correct than `Wgpu`.
- `wrong_self_convention`: in `compositing/compositor.rs`, a function named `from_webrender` is used to turn `WebRenderPipelineId` into `PipelineId`. I can't think of a name that better represents this conversion, if anyone has ideas for this please do say them.
- `large_enum_variant`: same as in #31610

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
- [x] These changes do not require tests because they do not modify functionality, they only fix lint errors.