### PR TITLE
rustdoc: Fix warnings in `components/script/dom`

### DIFF
--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -222,7 +222,7 @@ unsafe fn html_constructor(
 }
 
 /// Returns the constructor object for the element associated with the given local name.
-/// This list should only include elements marked with the [HTMLConstructor] extended attribute.
+/// This list should only include elements marked with the \[HTMLConstructor\] extended attribute.
 pub fn get_constructor_object_from_local_name(
     name: LocalName,
     cx: JSContext,

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -222,7 +222,7 @@ unsafe fn html_constructor(
 }
 
 /// Returns the constructor object for the element associated with the
-/// given local name. This list should only include elements marked with the 
+/// given local name. This list should only include elements marked with the
 /// [HTMLConstructor](https://html.spec.whatwg.org/multipage/#htmlconstructor)
 /// extended attribute.
 pub fn get_constructor_object_from_local_name(

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -222,7 +222,7 @@ unsafe fn html_constructor(
 }
 
 /// Returns the constructor object for the element associated with the given local name.
-/// This list should only include elements marked with the \[HTMLConstructor\] extended attribute.
+/// This list should only include elements marked with the [HTMLConstructor](https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor) extended attribute.
 pub fn get_constructor_object_from_local_name(
     name: LocalName,
     cx: JSContext,

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -221,8 +221,10 @@ unsafe fn html_constructor(
     Ok(())
 }
 
-/// Returns the constructor object for the element associated with the given local name.
-/// This list should only include elements marked with the [HTMLConstructor](https://html.spec.whatwg.org/multipage/#htmlconstructor) extended attribute.
+/// Returns the constructor object for the element associated with the
+/// given local name. This list should only include elements marked with the 
+/// [HTMLConstructor](https://html.spec.whatwg.org/multipage/#htmlconstructor)
+/// extended attribute.
 pub fn get_constructor_object_from_local_name(
     name: LocalName,
     cx: JSContext,

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -222,7 +222,7 @@ unsafe fn html_constructor(
 }
 
 /// Returns the constructor object for the element associated with the given local name.
-/// This list should only include elements marked with the [HTMLConstructor](https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor) extended attribute.
+/// This list should only include elements marked with the [HTMLConstructor](https://html.spec.whatwg.org/multipage/#htmlconstructor) extended attribute.
 pub fn get_constructor_object_from_local_name(
     name: LocalName,
     cx: JSContext,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1281,7 +1281,7 @@ impl TreeSink for Sink {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#html-integration-point>
-    /// Specifically, the <annotation-xml> cases.
+    /// Specifically, the `<annotation-xml>` cases.
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Dom<Node>) -> bool {
         let elem = handle.downcast::<Element>().unwrap();
         elem.get_attribute(&ns!(), &local_name!("encoding"))


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixed unclosed HTML tag warning
Fixed unresolved link warning 

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31575

<!-- Either: -->
- [x] These changes do not require tests because they do not modify any functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
