### PR TITLE
rustdoc: Add some basic Safety sections to unsafe functions

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -16,6 +16,10 @@ mod platform {
     pub use jemallocator::Jemalloc as Allocator;
 
     /// Get the size of a heap block.
+    ///
+    /// # Safety
+    ///
+    /// Passing a non-heap allocated pointer to this function results in undefined behavior.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {
         jemallocator::usable_size(ptr)
     }
@@ -35,6 +39,10 @@ mod platform {
     use std::os::raw::c_void;
 
     /// Get the size of a heap block.
+    ///
+    /// # Safety
+    ///
+    /// Passing a non-heap allocated pointer to this function results in undefined behavior.
     pub unsafe extern "C" fn usable_size(ptr: *const c_void) -> usize {
         #[cfg(target_vendor = "apple")]
         return libc::malloc_size(ptr);
@@ -56,6 +64,10 @@ mod platform {
     use winapi::um::heapapi::{GetProcessHeap, HeapSize, HeapValidate};
 
     /// Get the size of a heap block.
+    ///
+    /// # Safety
+    ///
+    /// Passing a non-heap allocated pointer to this function results in undefined behavior.
     pub unsafe extern "C" fn usable_size(mut ptr: *const c_void) -> usize {
         let heap = GetProcessHeap();
 

--- a/components/gfx/text/shaping/harfbuzz.rs
+++ b/components/gfx/text/shaping/harfbuzz.rs
@@ -47,6 +47,11 @@ pub struct ShapedGlyphEntry {
 }
 
 impl ShapedGlyphData {
+    /// Create a new [`SharedGlyphData`] from the given HarfBuzz buffer.
+    ///
+    /// # Safety
+    ///
+    /// Passing an invalid buffer pointer to this function results in undefined behavior.
     pub unsafe fn new(buffer: *mut hb_buffer_t) -> ShapedGlyphData {
         let mut glyph_count = 0;
         let glyph_infos = hb_buffer_get_glyph_infos(buffer, &mut glyph_count);

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -546,6 +546,11 @@ macro_rules! define_resource_id {
         impl $name {
             #[allow(unsafe_code)]
             #[inline]
+            /// Create a new $name.
+            ///
+            /// # Safety
+            ///
+            /// Using an invalid OpenGL id may result in undefined behavior.
             pub unsafe fn new(id: $type) -> Self {
                 $name(<nonzero_type!($type)>::new_unchecked(id))
             }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500.
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
