### PR TITLE
layout: IFCs should not always be marked as containing floats

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -971,7 +971,9 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
             match text_align {
                 TextAlign::Start => text_indent,
                 TextAlign::End => (available_space - line_length).max(text_indent),
-                TextAlign::Center => (available_space - line_length + text_indent) / 2.,
+                TextAlign::Center => {
+                    ((available_space - line_length + text_indent) / 2.).max(text_indent)
+                },
             };
 
         // Calculate the justification adjustment. This is simply the remaining space on the line,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -64,7 +64,7 @@ impl BlockContainer {
             BlockContainer::BlockLevelBoxes(boxes) => boxes
                 .iter()
                 .any(|block_level_box| block_level_box.borrow().contains_floats()),
-            BlockContainer::InlineFormattingContext { .. } => true,
+            BlockContainer::InlineFormattingContext(context) => context.contains_floats,
         }
     }
 }


### PR DESCRIPTION
Marking all IFCs as containing floats shouldn't change layout results,
but does prevent parallel layout in some cases. This change fixes an
issue where we were marking all IFCs as containing floats.

Fixes #31540.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not result in easily observable changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
