### PR TITLE
rusdoc: Fix `idl` warning in components/script/dom/bindings

### DIFF
--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -151,7 +151,7 @@ pub fn is_token(s: &[u8]) -> bool {
 
 /// A DOMString.
 ///
-/// This type corresponds to the [`DOMString`](idl) type in WebIDL.
+/// This type corresponds to the [`DOMString`](https://webidl.spec.whatwg.org/#idl-DOMString) type in WebIDL.
 ///
 /// [idl]: https://heycam.github.io/webidl/#idl-DOMString
 ///

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -151,9 +151,9 @@ pub fn is_token(s: &[u8]) -> bool {
 
 /// A DOMString.
 ///
-/// This type corresponds to the [`DOMString`](https://webidl.spec.whatwg.org/#idl-DOMString) type in WebIDL.
+/// This type corresponds to the [`DOMString`] type in WebIDL.
 ///
-/// [idl]: https://heycam.github.io/webidl/#idl-DOMString
+/// [`DOMString`]: https://webidl.spec.whatwg.org/#idl-DOMString
 ///
 /// Conceptually, a DOMString has the same value space as a JavaScript String,
 /// i.e., an array of 16-bit *code units* representing UTF-16, potentially with


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix unresolved link to `idl` warning

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31575 (GitHub issue number if applicable)
- [X] These changes do not require tests because they are documentation fixes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
