### PR TITLE
rustdoc: Fix some typos in `components/layout_2020/table/mod.rs`

### DIFF
--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -92,14 +92,14 @@ pub struct Table {
     /// The column groups for this table.
     pub column_groups: Vec<TableTrackGroup>,
 
-    /// The columns of this tabled defined by `<colgroup> | display: table-column-group`
+    /// The columns of this table defined by `<colgroup> | display: table-column-group`
     /// and `<col> | display: table-column` elements as well as `display: table-column`.
     pub columns: Vec<TableTrack>,
 
-    /// The rows groups for this table deinfed by `<tbody>`, `<thead>`, and `<tfoot>`.
+    /// The rows groups for this table defined by `<tbody>`, `<thead>`, and `<tfoot>`.
     pub row_groups: Vec<TableTrackGroup>,
 
-    /// The rows of this tabled defined by `<tr>` or `display: table-row` elements.
+    /// The rows of this table defined by `<tr>` or `display: table-row` elements.
     pub rows: Vec<TableTrack>,
 
     /// The content of the slots of this table.


### PR DESCRIPTION

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they involve minor documentation adjustments that do not impact the functionality or output of the code.


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
