### PR TITLE
rustdoc: Fix warnings in `components/layout_2020`

### DIFF
--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -38,7 +38,7 @@ pub(super) struct LineMetrics {
     /// The block size of this line.
     pub block_size: Length,
 
-    /// The block offset of this line's baseline from [`Self:block_offset`].
+    /// The block offset of this line's baseline from [`Self::block_offset`].
     pub baseline_block_offset: Au,
 }
 

--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -51,7 +51,7 @@ pub(super) struct LineItemLayoutState<'a> {
     pub parent_offset: LogicalVec2<Length>,
 
     /// The block offset of the parent's baseline relative to the block start of the line. This
-    /// is often the same as [`Self::block_offset_of_parent`], but can be different for the root
+    /// is often the same as [`Self::parent_offset`], but can be different for the root
     /// element.
     pub baseline_offset: Au,
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1) Fixed the syntax to make it a clickable link. Added ":".
2) Added a variant named parent_offset instead of "block offset of parent" to fix the documentation.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31575  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [X] These changes do not require tests because they don't change the functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
