### PR TITLE
fix: missing thread name when spawning

### DIFF
--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -49,6 +49,7 @@ impl HangMonitorRegister {
         let (tether, tether_port) = unbounded();
 
         let _ = thread::Builder::new()
+            .name("HangMonitor".to_owned())
             .spawn(move || {
                 let mut monitor = BackgroundHangMonitorWorker::new(
                     constellation_chan,

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -49,7 +49,7 @@ impl HangMonitorRegister {
         let (tether, tether_port) = unbounded();
 
         let _ = thread::Builder::new()
-            .name("HangMonitor".to_owned())
+            .name("BackgroundHangMonitor".to_owned())
             .spawn(move || {
                 let mut monitor = BackgroundHangMonitorWorker::new(
                     constellation_chan,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -526,6 +526,7 @@ pub struct CoreResourceThreadPool {
 impl CoreResourceThreadPool {
     pub fn new(num_threads: usize) -> CoreResourceThreadPool {
         let pool = rayon::ThreadPoolBuilder::new()
+            .thread_name(|i| format!("CoreResourceThread#{i}"))
             .num_threads(num_threads)
             .build()
             .unwrap();

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -467,11 +467,11 @@ impl WorkletThread {
     fn spawn(
         role: WorkletThreadRole,
         init: WorkletThreadInit,
-        index: u8,
+        thread_index: u8,
     ) -> Sender<WorkletControl> {
         let (control_sender, control_receiver) = unbounded();
         let _ = thread::Builder::new()
-            .name(format!("Worklet#{index}"))
+            .name(format!("Worklet#{thread_index}"))
             .spawn(move || {
                 // TODO: add a new IN_WORKLET thread state?
                 // TODO: set interrupt handler?

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -291,9 +291,9 @@ impl WorkletThreadPool {
             primary_sender: primary_sender,
             hot_backup_sender: hot_backup_sender,
             cold_backup_sender: cold_backup_sender,
-            control_sender_0: WorkletThread::spawn(primary_role, init.clone()),
-            control_sender_1: WorkletThread::spawn(hot_backup_role, init.clone()),
-            control_sender_2: WorkletThread::spawn(cold_backup_role, init),
+            control_sender_0: WorkletThread::spawn(primary_role, init.clone(), 0),
+            control_sender_1: WorkletThread::spawn(hot_backup_role, init.clone(), 1),
+            control_sender_2: WorkletThread::spawn(cold_backup_role, init, 2),
         }
     }
 
@@ -464,32 +464,38 @@ impl WorkletThread {
     /// Spawn a new worklet thread, returning the channel to send it control messages.
     #[allow(unsafe_code)]
     #[allow(crown::unrooted_must_root)]
-    fn spawn(role: WorkletThreadRole, init: WorkletThreadInit) -> Sender<WorkletControl> {
+    fn spawn(
+        role: WorkletThreadRole,
+        init: WorkletThreadInit,
+        index: u8,
+    ) -> Sender<WorkletControl> {
         let (control_sender, control_receiver) = unbounded();
-        // TODO: name this thread
-        thread::spawn(move || {
-            // TODO: add a new IN_WORKLET thread state?
-            // TODO: set interrupt handler?
-            // TODO: configure the JS runtime (e.g. discourage GC, encourage agressive JIT)
-            debug!("Initializing worklet thread.");
-            thread_state::initialize(ThreadState::SCRIPT | ThreadState::IN_WORKER);
-            let roots = RootCollection::new();
-            let _stack_roots = ThreadLocalStackRoots::new(&roots);
-            let mut thread = RootedTraceableBox::new(WorkletThread {
-                role: role,
-                control_receiver: control_receiver,
-                primary_sender: init.primary_sender,
-                hot_backup_sender: init.hot_backup_sender,
-                cold_backup_sender: init.cold_backup_sender,
-                global_init: init.global_init,
-                global_scopes: HashMap::new(),
-                control_buffer: None,
-                runtime: new_rt_and_cx(None),
-                should_gc: false,
-                gc_threshold: MIN_GC_THRESHOLD,
-            });
-            thread.run();
-        });
+        let _ = thread::Builder::new()
+            .name(format!("Worklet#{index}"))
+            .spawn(move || {
+                // TODO: add a new IN_WORKLET thread state?
+                // TODO: set interrupt handler?
+                // TODO: configure the JS runtime (e.g. discourage GC, encourage agressive JIT)
+                debug!("Initializing worklet thread.");
+                thread_state::initialize(ThreadState::SCRIPT | ThreadState::IN_WORKER);
+                let roots = RootCollection::new();
+                let _stack_roots = ThreadLocalStackRoots::new(&roots);
+                let mut thread = RootedTraceableBox::new(WorkletThread {
+                    role: role,
+                    control_receiver: control_receiver,
+                    primary_sender: init.primary_sender,
+                    hot_backup_sender: init.hot_backup_sender,
+                    cold_backup_sender: init.cold_backup_sender,
+                    global_init: init.global_init,
+                    global_scopes: HashMap::new(),
+                    control_buffer: None,
+                    runtime: new_rt_and_cx(None),
+                    should_gc: false,
+                    gc_threshold: MIN_GC_THRESHOLD,
+                });
+                thread.run();
+            })
+            .expect("Couldn't start worklet thread");
         control_sender
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Some threads spawn without names, making it difficult for me to monitor all of them during debugging. This PR adds missing names to them.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [x] These changes do not require tests, but the existing build should succeed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
