### PR TITLE
servoshell: allow event tracing to be configured with RUST_LOG

### DIFF
--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -140,7 +140,7 @@ impl App {
         let ev_waker = events_loop.create_event_loop_waker();
         events_loop.run_forever(move |event, w, control_flow| {
             let now = Instant::now();
-            trace_from_winit!(event, "@{:?} (+{:?}) {:?}", now - t_start, now - t, event);
+            trace_from_winit!(event, "@{:?} (+{:?}) {event:?}", now - t_start, now - t);
             t = now;
             match event {
                 winit::event::Event::NewEvents(winit::event::StartCause::Init) => {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -140,7 +140,7 @@ impl App {
         let ev_waker = events_loop.create_event_loop_waker();
         events_loop.run_forever(move |event, w, control_flow| {
             let now = Instant::now();
-            trace_from_winit!(event, "@{:?} (+{:?}) {event:?}", now - t_start, now - t);
+            trace_winit_event!(event, "@{:?} (+{:?}) {event:?}", now - t_start, now - t);
             t = now;
             match event {
                 winit::event::Event::NewEvents(winit::event::StartCause::Init) => {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -27,7 +27,6 @@ use crate::embedder::EmbedderCallbacks;
 use crate::events_loop::{EventsLoop, WakerEvent};
 use crate::minibrowser::Minibrowser;
 use crate::parser::get_default_url;
-use crate::tracing::LogTarget as _;
 use crate::webview::WebViewManager;
 use crate::window_trait::WindowPortsMethods;
 use crate::{headed_window, headless_window};

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -27,6 +27,7 @@ use crate::embedder::EmbedderCallbacks;
 use crate::events_loop::{EventsLoop, WakerEvent};
 use crate::minibrowser::Minibrowser;
 use crate::parser::get_default_url;
+use crate::tracing::LogTarget as _;
 use crate::webview::WebViewManager;
 use crate::window_trait::WindowPortsMethods;
 use crate::{headed_window, headless_window};
@@ -140,19 +141,18 @@ impl App {
         let ev_waker = events_loop.create_event_loop_waker();
         events_loop.run_forever(move |event, w, control_flow| {
             let now = Instant::now();
-            match event {
-                // Uncomment to filter out logging of common events, which can be very noisy.
-                // winit::event::Event::DeviceEvent { .. } => {},
-                // winit::event::Event::WindowEvent {
-                //     event: WindowEvent::CursorMoved { .. },
-                //     ..
-                // } => {},
-                // winit::event::Event::MainEventsCleared => {},
-                // winit::event::Event::RedrawEventsCleared => {},
-                // winit::event::Event::UserEvent(..) => {},
-                // winit::event::Event::NewEvents(..) => {},
-                _ => trace!("@{:?} (+{:?}) {:?}", now - t_start, now - t, event),
-            }
+            // To disable tracing: RUST_LOG='servoshell<winit@=off'
+            // To enable tracing: RUST_LOG='servoshell<winit@'
+            // Recommended filters when tracing is enabled:
+            // - servoshell<winit@DeviceEvent=off
+            // - servoshell<winit@MainEventsCleared=off
+            // - servoshell<winit@NewEvents(WaitCancelled)=off
+            // - servoshell<winit@RedrawEventsCleared=off
+            // - servoshell<winit@RedrawRequested=off
+            // - servoshell<winit@UserEvent(WakerEvent)=off
+            // - servoshell<winit@WindowEvent(AxisMotion)=off
+            // - servoshell<winit@WindowEvent(CursorMoved)=off
+            trace!(target: event.log_target(), "@{:?} (+{:?}) {:?}", now - t_start, now - t, event);
             t = now;
             match event {
                 winit::event::Event::NewEvents(winit::event::StartCause::Init) => {

--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -141,18 +141,7 @@ impl App {
         let ev_waker = events_loop.create_event_loop_waker();
         events_loop.run_forever(move |event, w, control_flow| {
             let now = Instant::now();
-            // To disable tracing: RUST_LOG='servoshell<winit@=off'
-            // To enable tracing: RUST_LOG='servoshell<winit@'
-            // Recommended filters when tracing is enabled:
-            // - servoshell<winit@DeviceEvent=off
-            // - servoshell<winit@MainEventsCleared=off
-            // - servoshell<winit@NewEvents(WaitCancelled)=off
-            // - servoshell<winit@RedrawEventsCleared=off
-            // - servoshell<winit@RedrawRequested=off
-            // - servoshell<winit@UserEvent(WakerEvent)=off
-            // - servoshell<winit@WindowEvent(AxisMotion)=off
-            // - servoshell<winit@WindowEvent(CursorMoved)=off
-            trace!(target: event.log_target(), "@{:?} (+{:?}) {:?}", now - t_start, now - t, event);
+            trace_from_winit!(event, "@{:?} (+{:?}) {:?}", now - t_start, now - t, event);
             t = now;
             match event {
                 winit::event::Event::NewEvents(winit::event::StartCause::Init) => {

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -26,6 +26,7 @@ mod minibrowser;
 mod parser;
 mod prefs;
 mod resources;
+mod tracing;
 mod webview;
 mod window_trait;
 

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -9,6 +9,9 @@
 #[macro_use]
 extern crate sig;
 
+#[macro_use]
+mod tracing;
+
 #[cfg(test)]
 mod test;
 
@@ -26,7 +29,6 @@ mod minibrowser;
 mod parser;
 mod prefs;
 mod resources;
-mod tracing;
 mod webview;
 mod window_trait;
 

--- a/ports/servoshell/tracing.rs
+++ b/ports/servoshell/tracing.rs
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/// Get the log target for an event, as a static string.
+pub(crate) trait LogTarget {
+    fn log_target(&self) -> &'static str;
+}
+
+mod from_winit {
+    use super::LogTarget;
+    use crate::events_loop::WakerEvent;
+
+    macro_rules! target {
+        ($($name:literal)+) => {
+            concat!("servoshell<winit@", $($name),+)
+        };
+    }
+
+    impl LogTarget for winit::event::Event<'_, WakerEvent> {
+        fn log_target(&self) -> &'static str {
+            use winit::event::StartCause;
+            match self {
+                Self::NewEvents(start_cause) => match start_cause {
+                    StartCause::ResumeTimeReached { .. } => target!("NewEvents(ResumeTimeReached)"),
+                    StartCause::WaitCancelled { .. } => target!("NewEvents(WaitCancelled)"),
+                    StartCause::Poll => target!("NewEvents(Poll)"),
+                    StartCause::Init => target!("NewEvents(Init)"),
+                },
+                Self::WindowEvent { event, .. } => event.log_target(),
+                Self::DeviceEvent { .. } => target!("DeviceEvent"),
+                Self::UserEvent(WakerEvent) => target!("UserEvent(WakerEvent)"),
+                Self::Suspended => target!("Suspended"),
+                Self::Resumed => target!("Resumed"),
+                Self::MainEventsCleared => target!("MainEventsCleared"),
+                Self::RedrawRequested(_) => target!("RedrawRequested"),
+                Self::RedrawEventsCleared => target!("RedrawEventsCleared"),
+                Self::LoopDestroyed => target!("LoopDestroyed"),
+            }
+        }
+    }
+
+    impl LogTarget for winit::event::WindowEvent<'_> {
+        fn log_target(&self) -> &'static str {
+            macro_rules! target_variant {
+                ($name:literal) => {
+                    target!("WindowEvent(" $name ")")
+                };
+            }
+            match self {
+                Self::Resized(_) => target_variant!("Resized"),
+                Self::Moved(_) => target_variant!("Moved"),
+                Self::CloseRequested => target_variant!("CloseRequested"),
+                Self::Destroyed => target_variant!("Destroyed"),
+                Self::DroppedFile(_) => target_variant!("DroppedFile"),
+                Self::HoveredFile(_) => target_variant!("HoveredFile"),
+                Self::HoveredFileCancelled => target_variant!("HoveredFileCancelled"),
+                Self::ReceivedCharacter(_) => target_variant!("ReceivedCharacter"),
+                Self::Focused(_) => target_variant!("Focused"),
+                Self::KeyboardInput { .. } => target_variant!("KeyboardInput"),
+                Self::ModifiersChanged(_) => target_variant!("ModifiersChanged"),
+                Self::Ime(_) => target_variant!("Ime"),
+                Self::CursorMoved { .. } => target_variant!("CursorMoved"),
+                Self::CursorEntered { .. } => target_variant!("CursorEntered"),
+                Self::CursorLeft { .. } => target_variant!("CursorLeft"),
+                Self::MouseWheel { .. } => target_variant!("MouseWheel"),
+                Self::MouseInput { .. } => target_variant!("MouseInput"),
+                Self::TouchpadMagnify { .. } => target_variant!("TouchpadMagnify"),
+                Self::SmartMagnify { .. } => target_variant!("SmartMagnify"),
+                Self::TouchpadRotate { .. } => target_variant!("TouchpadRotate"),
+                Self::TouchpadPressure { .. } => target_variant!("TouchpadPressure"),
+                Self::AxisMotion { .. } => target_variant!("AxisMotion"),
+                Self::Touch(_) => target_variant!("Touch"),
+                Self::ScaleFactorChanged { .. } => target_variant!("ScaleFactorChanged"),
+                Self::ThemeChanged(_) => target_variant!("ThemeChanged"),
+                Self::Occluded(_) => target_variant!("Occluded"),
+            }
+        }
+    }
+}
+
+mod from_servo {
+    use super::LogTarget;
+
+    macro_rules! target {
+        ($($name:literal)+) => {
+            concat!("servoshell<servo@", $($name),+)
+        };
+    }
+
+    impl LogTarget for servo::embedder_traits::EmbedderMsg {
+        fn log_target(&self) -> &'static str {
+            match self {
+                Self::Status(_) => target!("Status"),
+                Self::ChangePageTitle(_) => target!("ChangePageTitle"),
+                Self::MoveTo(_) => target!("MoveTo"),
+                Self::ResizeTo(_) => target!("ResizeTo"),
+                Self::Prompt(_, _) => target!("Prompt"),
+                Self::ShowContextMenu(_, _, _) => target!("ShowContextMenu"),
+                Self::AllowNavigationRequest(_, _) => target!("AllowNavigationRequest"),
+                Self::AllowOpeningWebView(_) => target!("AllowOpeningWebView"),
+                Self::WebViewOpened(_) => target!("WebViewOpened"),
+                Self::WebViewClosed(_) => target!("WebViewClosed"),
+                Self::WebViewFocused(_) => target!("WebViewFocused"),
+                Self::WebViewBlurred => target!("WebViewBlurred"),
+                Self::AllowUnload(_) => target!("AllowUnload"),
+                Self::Keyboard(_) => target!("Keyboard"),
+                Self::GetClipboardContents(_) => target!("GetClipboardContents"),
+                Self::SetClipboardContents(_) => target!("SetClipboardContents"),
+                Self::SetCursor(_) => target!("SetCursor"),
+                Self::NewFavicon(_) => target!("NewFavicon"),
+                Self::HeadParsed => target!("HeadParsed"),
+                Self::HistoryChanged(_, _) => target!("HistoryChanged"),
+                Self::SetFullscreenState(_) => target!("SetFullscreenState"),
+                Self::LoadStart => target!("LoadStart"),
+                Self::LoadComplete => target!("LoadComplete"),
+                Self::Panic(_, _) => target!("Panic"),
+                Self::GetSelectedBluetoothDevice(_, _) => target!("GetSelectedBluetoothDevice"),
+                Self::SelectFiles(_, _, _) => target!("SelectFiles"),
+                Self::PromptPermission(_, _) => target!("PromptPermission"),
+                Self::ShowIME(_, _, _, _) => target!("ShowIME"),
+                Self::HideIME => target!("HideIME"),
+                Self::Shutdown => target!("Shutdown"),
+                Self::ReportProfile(_) => target!("ReportProfile"),
+                Self::MediaSessionEvent(_) => target!("MediaSessionEvent"),
+                Self::OnDevtoolsStarted(_, _) => target!("OnDevtoolsStarted"),
+                Self::ReadyToPresent => target!("ReadyToPresent"),
+                Self::EventDelivered(_) => target!("EventDelivered"),
+            }
+        }
+    }
+}
+
+mod to_servo {
+    use super::LogTarget;
+
+    macro_rules! target {
+        ($($name:literal)+) => {
+            concat!("servoshell>servo@", $($name),+)
+        };
+    }
+
+    impl LogTarget for servo::compositing::windowing::EmbedderEvent {
+        fn log_target(&self) -> &'static str {
+            match self {
+                Self::Idle => target!("Idle"),
+                Self::Refresh => target!("Refresh"),
+                Self::Resize => target!("Resize"),
+                Self::AllowNavigationResponse(_, _) => target!("AllowNavigationResponse"),
+                Self::LoadUrl(_, _) => target!("LoadUrl"),
+                Self::MouseWindowEventClass(_) => target!("MouseWindowEventClass"),
+                Self::MouseWindowMoveEventClass(_) => target!("MouseWindowMoveEventClass"),
+                Self::Touch(_, _, _) => target!("Touch"),
+                Self::Wheel(_, _) => target!("Wheel"),
+                Self::Scroll(_, _, _) => target!("Scroll"),
+                Self::Zoom(_) => target!("Zoom"),
+                Self::PinchZoom(_) => target!("PinchZoom"),
+                Self::ResetZoom => target!("ResetZoom"),
+                Self::Navigation(_, _) => target!("Navigation"),
+                Self::Quit => target!("Quit"),
+                Self::ExitFullScreen(_) => target!("ExitFullScreen"),
+                Self::Keyboard(_) => target!("Keyboard"),
+                Self::Reload(_) => target!("Reload"),
+                Self::NewWebView(_, _) => target!("NewWebView"),
+                Self::CloseWebView(_) => target!("CloseWebView"),
+                Self::SendError(_, _) => target!("SendError"),
+                Self::FocusWebView(_) => target!("FocusWebView"),
+                Self::ToggleWebRenderDebug(_) => target!("ToggleWebRenderDebug"),
+                Self::CaptureWebRender => target!("CaptureWebRender"),
+                Self::ClearCache => target!("ClearCache"),
+                Self::ToggleSamplingProfiler(_, _) => target!("ToggleSamplingProfiler"),
+                Self::MediaSessionAction(_) => target!("MediaSessionAction"),
+                Self::WebViewVisibilityChanged(_, _) => target!("WebViewVisibilityChanged"),
+                Self::IMEDismissed => target!("IMEDismissed"),
+                Self::InvalidateNativeSurface => target!("InvalidateNativeSurface"),
+                Self::ReplaceNativeSurface(_, _) => target!("ReplaceNativeSurface"),
+                Self::Gamepad(_) => target!("Gamepad"),
+            }
+        }
+    }
+}

--- a/ports/servoshell/tracing.rs
+++ b/ports/servoshell/tracing.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/// Log an event from winit at trace level.
+/// Log an event from winit ([winit::event::Event]) at trace level.
 /// - To disable tracing: RUST_LOG='servoshell<winit@=off'
 /// - To enable tracing: RUST_LOG='servoshell<winit@'
 /// - Recommended filters when tracing is enabled:
@@ -14,7 +14,7 @@
 ///   - servoshell<winit@UserEvent(WakerEvent)=off
 ///   - servoshell<winit@WindowEvent(AxisMotion)=off
 ///   - servoshell<winit@WindowEvent(CursorMoved)=off
-macro_rules! trace_from_winit {
+macro_rules! trace_winit_event {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {
@@ -22,13 +22,13 @@ macro_rules! trace_from_winit {
     };
 }
 
-/// Log an event from servo at trace level.
+/// Log an event from servo ([servo::embedder_traits::EmbedderMsg]) at trace level.
 /// - To disable tracing: RUST_LOG='servoshell<servo@=off'
 /// - To enable tracing: RUST_LOG='servoshell<servo@'
 /// - Recommended filters when tracing is enabled:
 ///   - servoshell<servo@EventDelivered=off
 ///   - servoshell<servo@ReadyToPresent=off
-macro_rules! trace_from_servo {
+macro_rules! trace_embedder_msg {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {
@@ -36,13 +36,13 @@ macro_rules! trace_from_servo {
     };
 }
 
-/// Log an event to servo at trace level.
+/// Log an event to servo ([servo::compositing::windowing::EmbedderEvent]) at trace level.
 /// - To disable tracing: RUST_LOG='servoshell>servo@=off'
 /// - To enable tracing: RUST_LOG='servoshell>servo@'
 /// - Recommended filters when tracing is enabled:
 ///   - servoshell>servo@Idle=off
 ///   - servoshell>servo@MouseWindowMoveEventClass=off
-macro_rules! trace_to_servo {
+macro_rules! trace_embedder_event {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {

--- a/ports/servoshell/tracing.rs
+++ b/ports/servoshell/tracing.rs
@@ -18,7 +18,7 @@ macro_rules! trace_from_winit {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {
-        ::log::trace!(target: $event.log_target(), $($rest)+)
+        ::log::trace!(target: $crate::tracing::LogTarget::log_target(&$event), $($rest)+)
     };
 }
 
@@ -32,7 +32,7 @@ macro_rules! trace_from_servo {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {
-        ::log::trace!(target: $event.log_target(), $($rest)+)
+        ::log::trace!(target: $crate::tracing::LogTarget::log_target(&$event), $($rest)+)
     };
 }
 
@@ -46,7 +46,7 @@ macro_rules! trace_to_servo {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {
-        ::log::trace!(target: $event.log_target(), $($rest)+)
+        ::log::trace!(target: $crate::tracing::LogTarget::log_target(&$event), $($rest)+)
     };
 }
 

--- a/ports/servoshell/tracing.rs
+++ b/ports/servoshell/tracing.rs
@@ -2,6 +2,54 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+/// Log an event from winit at trace level.
+/// - To disable tracing: RUST_LOG='servoshell<winit@=off'
+/// - To enable tracing: RUST_LOG='servoshell<winit@'
+/// - Recommended filters when tracing is enabled:
+///   - servoshell<winit@DeviceEvent=off
+///   - servoshell<winit@MainEventsCleared=off
+///   - servoshell<winit@NewEvents(WaitCancelled)=off
+///   - servoshell<winit@RedrawEventsCleared=off
+///   - servoshell<winit@RedrawRequested=off
+///   - servoshell<winit@UserEvent(WakerEvent)=off
+///   - servoshell<winit@WindowEvent(AxisMotion)=off
+///   - servoshell<winit@WindowEvent(CursorMoved)=off
+macro_rules! trace_from_winit {
+    // This macro only exists to put the docs in the same file as the target prefix,
+    // so the macro definition is always the same.
+    ($event:expr, $($rest:tt)+) => {
+        ::log::trace!(target: $event.log_target(), $($rest)+)
+    };
+}
+
+/// Log an event from servo at trace level.
+/// - To disable tracing: RUST_LOG='servoshell<servo@=off'
+/// - To enable tracing: RUST_LOG='servoshell<servo@'
+/// - Recommended filters when tracing is enabled:
+///   - servoshell<servo@EventDelivered=off
+///   - servoshell<servo@ReadyToPresent=off
+macro_rules! trace_from_servo {
+    // This macro only exists to put the docs in the same file as the target prefix,
+    // so the macro definition is always the same.
+    ($event:expr, $($rest:tt)+) => {
+        ::log::trace!(target: $event.log_target(), $($rest)+)
+    };
+}
+
+/// Log an event to servo at trace level.
+/// - To disable tracing: RUST_LOG='servoshell>servo@=off'
+/// - To enable tracing: RUST_LOG='servoshell>servo@'
+/// - Recommended filters when tracing is enabled:
+///   - servoshell>servo@Idle=off
+///   - servoshell>servo@MouseWindowMoveEventClass=off
+macro_rules! trace_to_servo {
+    // This macro only exists to put the docs in the same file as the target prefix,
+    // so the macro definition is always the same.
+    ($event:expr, $($rest:tt)+) => {
+        ::log::trace!(target: $event.log_target(), $($rest)+)
+    };
+}
+
 /// Get the log target for an event, as a static string.
 pub(crate) trait LogTarget {
     fn log_target(&self) -> &'static str;

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -112,7 +112,7 @@ where
 
     pub fn handle_window_events(&mut self, events: Vec<EmbedderEvent>) {
         for event in events {
-            trace_to_servo!(event, "{event:?}");
+            trace_embedder_event!(event, "{event:?}");
             match event {
                 EmbedderEvent::Keyboard(key_event) => {
                     self.handle_key_from_window(key_event);
@@ -413,9 +413,9 @@ where
         let mut history_changed = false;
         for (webview_id, msg) in events {
             if let Some(webview_id) = webview_id {
-                trace_from_servo!(msg, "{webview_id} {msg:?}");
+                trace_embedder_msg!(msg, "{webview_id} {msg:?}");
             } else {
-                trace_from_servo!(msg, "{msg:?}");
+                trace_embedder_msg!(msg, "{msg:?}");
             }
             match msg {
                 EmbedderMsg::Status(_status) => {

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -113,12 +113,7 @@ where
 
     pub fn handle_window_events(&mut self, events: Vec<EmbedderEvent>) {
         for event in events {
-            // To disable tracing: RUST_LOG='servoshell>servo@=off'
-            // To enable tracing: RUST_LOG='servoshell>servo@'
-            // Recommended filters when tracing is enabled:
-            // - servoshell>servo@Idle=off
-            // - servoshell>servo@MouseWindowMoveEventClass=off
-            trace!(target: event.log_target(), "{event:?}");
+            trace_to_servo!(event, "{event:?}");
             match event {
                 EmbedderEvent::Keyboard(key_event) => {
                     self.handle_key_from_window(key_event);
@@ -418,15 +413,10 @@ where
         let mut need_present = false;
         let mut history_changed = false;
         for (webview_id, msg) in events {
-            // To disable tracing: RUST_LOG='servoshell<servo@=off'
-            // To enable tracing: RUST_LOG='servoshell<servo@'
-            // Recommended filters when tracing is enabled:
-            // - servoshell<servo@EventDelivered=off
-            // - servoshell<servo@ReadyToPresent=off
             if let Some(webview_id) = webview_id {
-                trace!(target: msg.log_target(), "{webview_id} {msg:?}");
+                trace_from_servo!(msg, "{webview_id} {msg:?}");
             } else {
-                trace!(target: msg.log_target(), "{msg:?}");
+                trace_from_servo!(msg, "{msg:?}");
             }
             match msg {
                 EmbedderMsg::Status(_status) => {

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -31,7 +31,6 @@ use tinyfiledialogs::{self, MessageBoxIcon, OkCancel, YesNo};
 
 use crate::keyutils::{CMD_OR_ALT, CMD_OR_CONTROL};
 use crate::parser::location_bar_input_to_url;
-use crate::tracing::LogTarget as _;
 use crate::window_trait::{WindowPortsMethods, LINE_HEIGHT};
 
 pub struct WebViewManager<Window: WindowPortsMethods + ?Sized> {


### PR DESCRIPTION
To make debugging easier, servoshell logs events from winit, from servo, and to servo, but the output of these logs can be so noisy as to be unusable, unless we reconfigure which event types are logged [at compile time](https://github.com/servo/servo/blob/f3a73dbed39c38c6581fc356d3d4f2d38c906e93/ports/servoshell/app.rs#L143-L155).

We use [log](https://crates.io/crates/log) and [env_logger](https://crates.io/crates/env_logger), which allows runtime configuration with RUST_LOG, but by default, while you can filter logs by module path or filter them to only messages that match a regex, you can’t filter them to *exclude* messages by regex. Custom targets allow us to key our logs on an arbitrary string (as long as it doesn’t contain `,=/`).

This patch sets custom targets on servoshell’s event tracing logs, allowing them to be filtered by RUST_LOG. The targets are of the form “servoshell&lt;[source]@[event]” or “servoshell>[destination]@[event]”. For example:

- to trace only events from servo:<br>`RUST_LOG='servoshell<=off,servoshell>=off,servoshell<servo@'`
- to trace all events except for AxisMotion events: <br>`RUST_LOG='servoshell<,servoshell>,servoshell<winit@WindowEvent(AxisMotion)=off'`
- to trace only winit window moved events:<br>`RUST_LOG='servoshell<=off,servoshell>=off,servoshell<winit@WindowEvent(Moved)'`

You can get a very usable setup that traces most unusual events with:

RUST_LOG='warn,servoshell&lt;,servoshell>,servoshell&lt;winit@DeviceEvent=off,servoshell&lt;winit@MainEventsCleared=off,servoshell&lt;winit@NewEvents(WaitCancelled)=off,servoshell&lt;winit@RedrawEventsCleared=off,servoshell&lt;winit@RedrawRequested=off,servoshell&lt;winit@UserEvent(WakerEvent)=off,servoshell&lt;winit@WindowEvent(CursorMoved)=off,servoshell&lt;winit@WindowEvent(AxisMotion)=off,servoshell&lt;servo@EventDelivered=off,servoshell&lt;servo@ReadyToPresent=off,servoshell>servo@Idle=off,servoshell>servo@MouseWindowMoveEventClass=off'

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect debug logging