### PR TITLE
Obey white-space when intrinsically sizing an IFC

### DIFF
--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -150,7 +150,7 @@ impl TextRunSegment {
             // If this whitespace forces a line break, queue up a hard line break the next time we
             // see any content. We don't line break immediately, because we'd like to finish processing
             // any ongoing inline boxes before ending the line.
-            if text_run.glyph_run_is_whitespace_ending_with_preserved_newline(run) {
+            if text_run.glyph_run_is_preserved_newline(run) {
                 ifc.defer_forced_line_break();
                 continue;
             }
@@ -426,11 +426,8 @@ impl TextRun {
             self.prevent_soft_wrap_opportunity_at_end;
     }
 
-    pub(super) fn glyph_run_is_whitespace_ending_with_preserved_newline(
-        &self,
-        run: &GlyphRun,
-    ) -> bool {
-        if !run.glyph_store.is_whitespace() {
+    pub(super) fn glyph_run_is_preserved_newline(&self, run: &GlyphRun) -> bool {
+        if !run.glyph_store.is_whitespace() || run.range.length() != ByteIndex(1) {
             return false;
         }
         if !self
@@ -442,8 +439,8 @@ impl TextRun {
             return false;
         }
 
-        let last_byte = self.text.as_bytes().get(run.range.end().to_usize() - 1);
-        last_byte == Some(&b'\n')
+        let byte = self.text.as_bytes().get(run.range.begin().to_usize());
+        byte == Some(&b'\n')
     }
 }
 

--- a/tests/wpt/meta/css/CSS2/generated-content/content-175.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/content-175.xht.ini
@@ -1,2 +1,0 @@
-[content-175.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-009.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-010.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-010.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-011.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-011.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-011.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-012.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-197.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-197.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-197.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-198.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-198.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-198.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/white-space-pre-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-pre-001.xht.ini
@@ -1,2 +1,0 @@
-[white-space-pre-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-lists/inline-list.html.ini
+++ b/tests/wpt/meta/css/css-lists/inline-list.html.ini
@@ -1,2 +1,0 @@
-[inline-list.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-001.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-001.html.ini
@@ -1,0 +1,2 @@
+[tab-size-integer-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-002.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-002.html.ini
@@ -1,0 +1,2 @@
+[tab-size-integer-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-003.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-003.html.ini
@@ -1,0 +1,2 @@
+[tab-size-integer-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-length-001.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-length-001.html.ini
@@ -1,0 +1,2 @@
+[tab-size-length-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-length-002.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-length-002.html.ini
@@ -1,0 +1,2 @@
+[tab-size-length-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-percent-001.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-percent-001.html.ini
@@ -1,0 +1,2 @@
+[tab-size-percent-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-015.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-015.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-016.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-016.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-017.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-017.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-017.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-018.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-018.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-018.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-002.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-pre-wrap-trailing-spaces-002.html.ini
@@ -1,2 +1,0 @@
-[white-space-pre-wrap-trailing-spaces-002.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/white-space-pre-wrap.htm.ini
+++ b/tests/wpt/mozilla/meta/css/white-space-pre-wrap.htm.ini
@@ -1,0 +1,2 @@
+[white-space-pre-wrap.htm]
+  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The old logic was assuming that all whitespace was a break opportunity,
and that no newlines would be preserved.

Note that text shaping considers the advance of a newline to be the same
as a space. This was problematic because if we have a segment with a
preserved space and newline, only the advance of the space should
contrinute to the size of the block container. Therefore, I'm changing
the breaker logic in other to have newline characters in their own
segment.

Then glyph_run_is_whitespace_ending_with_preserved_newline can just be
renamed to glyph_run_is_preserved_newline.

This patch is still not perfect because it doesn't check allow_wrap(),
so `nowrap` is treated like `normal`, and `pre-wrap` like `pre`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31652
- [X] There are tests for these changes
  - Some tests in `/css/css-text/tab-size/` fail because the `tab-size` is not enabled on Servo.
  - `/_mozilla/css/white-space-pre-wrap.htm` fails because of #31667

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
