### PR TITLE
Cleanup UA styles for anonymous table rows and cells

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -236,18 +236,10 @@ svg > * {
 
 *|*::-servo-anonymous-table-row {
     display: table-row;
-    position: static;
-    border: none;
-    counter-increment: none;
-    overflow: visible;
 }
 
 *|*::-servo-anonymous-table-cell {
     display: table-cell;
-    position: static;
-    border: none;
-    counter-increment: none;
-    overflow: visible;
 }
 
 *|*::-servo-legacy-anonymous-block {


### PR DESCRIPTION
These properties were being set to their initial value, this wasn't needed because they are non-inherited properties and there isn't anything else setting them.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
