### PR TITLE
gfx: Rename cache_total_advance_and_word_seperators to cache_total_advance_and_word_separators

### DIFF
--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -482,11 +482,11 @@ impl<'a> GlyphStore {
 
     pub fn finalize_changes(&mut self) {
         self.detail_store.ensure_sorted();
-        self.cache_total_advance_and_word_seperators()
+        self.cache_total_advance_and_word_separators()
     }
 
     #[inline(never)]
-    fn cache_total_advance_and_word_seperators(&mut self) {
+    fn cache_total_advance_and_word_separators(&mut self) {
         let mut total_advance = Au(0);
         let mut total_word_separators = 0;
         for glyph in self.iter_glyphs_for_byte_range(&Range::new(ByteIndex(0), self.len())) {


### PR DESCRIPTION
This PR addresses issue #31653 by renaming `cache_total_advance_and_word_seperators` to `cache_total_advance_and_word_separators` in the `components/gfx/text/glyph.rs` file.

The correct spelling of the word is "separator," not "seperator." This change ensures consistency and accuracy in the variable naming, improving readability and maintainability of the codebase.
