### PR TITLE
Add gstreamer plugins good/ugly for better codec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,10 @@ Run Servo with the command:
 #### Linux
 
 * `GStreamer` >=1.18
+* `gst-plugins-base` >=1.18
+* `gst-plugins-good` >=1.18
 * `gst-plugins-bad` >=1.18
+* `gst-plugins-ugly` >=1.18
 * `libXcursor`
 * `libXrandr`
 * `libXi`

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -71,7 +71,9 @@ stdenv.mkDerivation (androidEnvironment // rec {
 
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
 
     rustup
     taplo

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -54,7 +54,8 @@ DNF_PKGS = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
             'dbus-devel', 'ncurses-devel', 'harfbuzz-devel', 'ccache',
             'clang', 'clang-libs', 'llvm', 'python3-devel',
             'gstreamer1-devel', 'gstreamer1-plugins-base-devel',
-            'gstreamer1-plugins-bad-free-devel', 'libjpeg-turbo-devel',
+            'gstreamer1-plugins-good', 'gstreamer1-plugins-bad-free-devel',
+            'gstreamer1-plugins-ugly-free', 'libjpeg-turbo-devel',
             'zlib', 'libjpeg', 'vulkan-loader']
 
 # https://voidlinux.org/packages/
@@ -68,8 +69,9 @@ XBPS_PKGS = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
              'fontconfig-devel', 'cabextract', 'expat-devel', 'cmake',
              'cmake', 'libXcursor-devel', 'libXmu-devel', 'dbus-devel',
              'ncurses-devel', 'harfbuzz-devel', 'ccache', 'glu-devel',
-             'clang', 'gstreamer1-devel',
-             'gst-plugins-base1-devel', 'gst-plugins-bad1-devel', 'vulkan-loader']
+             'clang', 'gstreamer1-devel', 'gst-plugins-base1-devel',
+             'gst-plugins-good1', 'gst-plugins-bad1-devel',
+             'gst-plugins-ugly1', 'vulkan-loader']
 
 GSTREAMER_URL = \
     "https://github.com/servo/servo-build-deps/releases/download/linux/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz"


### PR DESCRIPTION
Currently we only tell users to install gstreamer plugins base/bad, so if you install only what we ask, you won’t be able to play webm videos with av1.

This patch adds the good and ugly plugins to all of our dependency lists, including in the README and mach bootstrap. I have also updated the deps for all of the Linux distros [on the wiki](https://github.com/servo/servo/wiki/Building/_compare/d03e40a56f4ea27bae9692ca01c7aff705b08685...e04d7a194b59fad65fbd3eefb7aab12ae3a60eba).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31686

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect our runtime dep lists