### PR TITLE
Wrap aggregate reports in code blocks

### DIFF
--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -37,7 +37,7 @@ class Item:
     def from_result(cls, result: dict, title: Optional[str] = None, print_stack=True):
         expected = result["expected"]
         actual = result["actual"]
-        title = title if title else result["path"]
+        title = title if title else f'`{result["path"]}`'
         if expected != actual:
             title = f"{actual} [expected {expected}] {title}"
         else:
@@ -51,12 +51,15 @@ class Item:
 
         stack = result["stack"] if result["stack"] and print_stack else ""
         body = f"{result['message']}\n{stack}".strip()
+        if body:
+            body = f"\n```\n{body}\n```\n"
 
         subtest_results = result.get("unexpected_subtest_results", [])
         children = [
             cls.from_result(
                 subtest_result,
-                f"subtest: {subtest_result['subtest']} {subtest_result.get('message', '')}",
+                f"subtest: `{subtest_result['subtest']}`"
+                + (f" \n```\n{subtest_result['message']}\n```\n" if subtest_result['message'] else ""),
                 False)
             for subtest_result in subtest_results
         ]
@@ -69,7 +72,7 @@ class Item:
                                       " " * len(indent + bullet))
         output += "\n".join([child.to_string("• ", indent + "  ")
                              for child in self.children])
-        return output.rstrip()
+        return output.rstrip().replace("`", "")
 
     def to_html(self, level: int = 0) -> ElementTree.Element:
         if level == 0:


### PR DESCRIPTION
This is to prevent random ping and to prevent markdown to misinterpret symbols (webgpu test names includes `*`).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30103
- [x] These changes do not require tests because it's just CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
