### PR TITLE
Add RUSTC env to clippy command

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -139,7 +139,9 @@ class MachCommands(CommandBase):
 
         self.ensure_bootstrapped()
         self.ensure_clobbered()
-        return self.run_cargo_build_like_command("clippy", params, **kwargs)
+        env = self.build_env()
+        env['RUSTC'] = 'rustc'
+        return self.run_cargo_build_like_command("clippy", params, env, **kwargs)
 
     @Command('grep',
              description='`git grep` for selected directories.',

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -141,7 +141,7 @@ class MachCommands(CommandBase):
         self.ensure_clobbered()
         env = self.build_env()
         env['RUSTC'] = 'rustc'
-        return self.run_cargo_build_like_command("clippy", params, env, **kwargs)
+        return self.run_cargo_build_like_command("clippy", params, env=env, **kwargs)
 
     @Command('grep',
              description='`git grep` for selected directories.',


### PR DESCRIPTION
Adds the env override directly to the `./mach cargo-clippy` command so we can run it without `RUSTC=rustc`.

Once merged: Update the description of #31500 removing `RUSTC=rustc`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31692
- [x] These changes do not require tests because they involve a build tool, not the actual project
