### PR TITLE
Updated comment with 'layout_traits' to 'script_layout_interface'

### DIFF
--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -205,7 +205,7 @@ pub trait Layout {
     fn current_epoch(&self) -> Epoch;
 }
 
-/// This trait is part of `layout_traits` because it depends on both `script_traits` and also
+/// This trait is part of `script_layout_interface` because it depends on both `script_traits` and also
 /// `LayoutFactory` from this crate. If it was in `script_traits` there would be a circular
 /// dependency.
 pub trait ScriptThreadFactory {

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -206,7 +206,7 @@ pub trait Layout {
 }
 
 /// This trait is part of `script_layout_interface` because it depends on both `script_traits`
-/// and also `LayoutFactory` from this crate. If it was in `script_traits` there would be a 
+/// and also `LayoutFactory` from this crate. If it was in `script_traits` there would be a
 /// circular dependency.
 pub trait ScriptThreadFactory {
     /// Create a `ScriptThread`.

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -205,9 +205,9 @@ pub trait Layout {
     fn current_epoch(&self) -> Epoch;
 }
 
-/// This trait is part of `script_layout_interface` because it depends on both `script_traits` and also
-/// `LayoutFactory` from this crate. If it was in `script_traits` there would be a circular
-/// dependency.
+/// This trait is part of `script_layout_interface` because it depends on both `script_traits`
+/// and also `LayoutFactory` from this crate. If it was in `script_traits` there would be a 
+/// circular dependency.
 pub trait ScriptThreadFactory {
     /// Create a `ScriptThread`.
     fn create(


### PR DESCRIPTION
Corrected a comment mentioning 'layout-traits' to say 'script_layout_interface'.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31558 
- [X] These changes do not require tests because they do not touch functionality.
