### PR TITLE
rustdoc: Fix warning in `components/layout_2020`

### DIFF
--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -477,7 +477,7 @@ impl TableBuilder {
 
     /// When not in the process of filling a cell, make sure any incoming rowspans are
     /// filled so that the next specified cell comes after them. Should have been called before
-    /// [`Self::handle_cell`].
+    /// [`Self::add_cell`]
     ///
     /// if `stop_at_cell_opportunity` is set, this will stop at the first slot with
     /// `incoming_rowspans` equal to zero. If not, it will insert [`TableSlot::Empty`] and


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed the unresolved links present in components/layout_2020 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31575 (GitHub issue number if applicable)
- [X] These changes do not require tests because they only change documentation and no functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
