### PR TITLE
clippy: Fix some warnings in `gfx`, `layout_2020`, and `script`

### DIFF
--- a/components/gfx/text/text_run.rs
+++ b/components/gfx/text/text_run.rs
@@ -227,7 +227,7 @@ impl<'a> TextRun {
 
         let mut push_range = |range: &std::ops::Range<usize>, options: &ShapingOptions| {
             glyphs.push(GlyphRun {
-                glyph_store: font.shape_text(&text[range.clone()], &options),
+                glyph_store: font.shape_text(&text[range.clone()], options),
                 range: Range::new(
                     ByteIndex(range.start as isize),
                     ByteIndex(range.len() as isize),

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1081,7 +1081,7 @@ impl<'a> FlexItem<'a> {
                             box_size,
                             &pbm,
                         );
-                        let cross_size = flex_context.vec2_to_flex_relative(size.clone()).cross;
+                        let cross_size = flex_context.vec2_to_flex_relative(size).cross;
                         let fragments = replaced.contents.make_fragments(&replaced.style, size);
                         FlexItemLayoutResult {
                             hypothetical_cross_size: cross_size.into(),

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -975,7 +975,7 @@ impl FloatBox {
                             .into();
                         children = replaced
                             .contents
-                            .make_fragments(&replaced.style, content_size.clone().into());
+                            .make_fragments(&replaced.style, content_size.into());
                     },
                 };
 

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -1122,7 +1122,6 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
                 .placement_among_floats
                 .get_or_init(|| self.place_line_among_floats(potential_line_size))
                 .size
-                .clone()
         } else {
             LogicalVec2 {
                 inline: self.containing_block.inline_size.into(),
@@ -1991,9 +1990,7 @@ impl IndependentFormattingContext {
                     None,
                     &pbm,
                 );
-                let fragments = replaced
-                    .contents
-                    .make_fragments(&replaced.style, size.clone());
+                let fragments = replaced.contents.make_fragments(&replaced.style, size);
                 let content_rect = LogicalRect {
                     start_corner: pbm_sums.start_offset(),
                     size,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -989,7 +989,7 @@ impl NonReplacedFormattingContext {
                 &collapsed_margin_block_start,
                 containing_block,
                 &pbm,
-                &content_size + &pbm.padding_border_sums.clone().into(),
+                &content_size + &pbm.padding_border_sums.into(),
                 &self.style,
             );
         } else {
@@ -1179,7 +1179,7 @@ fn layout_in_flow_replaced_block_level(
     let margin_inline_end;
     let effective_margin_inline_start;
     let (margin_block_start, margin_block_end) = solve_block_margins_for_in_flow_block_level(&pbm);
-    let fragments = replaced.make_fragments(style, content_size.clone());
+    let fragments = replaced.make_fragments(style, content_size);
 
     let clearance;
     if let Some(ref mut sequential_layout_state) = sequential_layout_state {
@@ -1204,7 +1204,7 @@ fn layout_in_flow_replaced_block_level(
             &collapsed_margin_block_start,
             containing_block,
             &pbm,
-            size.clone().into(),
+            size.into(),
             style,
         );
 
@@ -1498,7 +1498,7 @@ fn solve_clearance_and_inline_margins_avoiding_floats(
             style.get_box().clear,
             block_start_margin,
             pbm,
-            size.clone().into(),
+            size.into(),
         );
     let (inline_margins, effective_margin_inline_start) = solve_inline_margins_avoiding_floats(
         sequential_layout_state,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -250,13 +250,13 @@ impl PositioningContext {
         new_fragment: &mut BoxFragment,
     ) {
         let padding_rect = LogicalRect {
-            size: new_fragment.content_rect.size.clone(),
+            size: new_fragment.content_rect.size,
             // Ignore the content rect’s position in its own containing block:
             start_corner: LogicalVec2::zero(),
         }
         .inflate(&new_fragment.padding);
         let containing_block = DefiniteContainingBlock {
-            size: padding_rect.size.clone().into(),
+            size: padding_rect.size.into(),
             style: &new_fragment.style,
         };
 
@@ -539,9 +539,7 @@ impl HoistedAbsolutelyPositionedBox {
                     // https://drafts.csswg.org/css2/visudet.html#abs-replaced-height
                     let style = &replaced.style;
                     content_size = computed_size.auto_is(|| unreachable!()).into();
-                    fragments = replaced
-                        .contents
-                        .make_fragments(style, content_size.clone());
+                    fragments = replaced.contents.make_fragments(style, content_size);
                 },
                 IndependentFormattingContext::NonReplaced(non_replaced) => {
                     // https://drafts.csswg.org/css2/#min-max-widths

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1478,7 +1478,7 @@ impl<'a> TableLayout<'a> {
                 baselines.last = Some(row_end);
             }
 
-            let column_indices = 0..self.table.size.width.clone();
+            let column_indices = 0..self.table.size.width;
             row_fragment_layout.fragments.reserve(self.table.size.width);
             for column_index in column_indices {
                 // The PositioningContext for cells is, in order or preference, the PositioningContext of the row,

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -91,7 +91,7 @@ impl TransmitBodyConnectHandler {
         source: BodySource,
     ) -> TransmitBodyConnectHandler {
         TransmitBodyConnectHandler {
-            stream: stream,
+            stream,
             task_source,
             canceller,
             bytes_sender: None,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -175,8 +175,8 @@ pub fn handle_get_layout(
             paddingRight: String::from(computed_style.PaddingRight()),
             paddingBottom: String::from(computed_style.PaddingBottom()),
             paddingLeft: String::from(computed_style.PaddingLeft()),
-            width: width,
-            height: height,
+            width,
+            height,
         }))
         .unwrap();
 }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -86,7 +86,7 @@ impl DocumentLoader {
         let initial_loads = initial_load.into_iter().map(LoadType::PageSource).collect();
 
         DocumentLoader {
-            resource_threads: resource_threads,
+            resource_threads,
             blocking_loads: initial_loads,
             events_inhibited: false,
             cancellers: Vec::new(),

--- a/components/script/dom/abstractworker.rs
+++ b/components/script/dom/abstractworker.rs
@@ -26,6 +26,6 @@ pub struct SimpleWorkerErrorHandler<T: DomObject> {
 
 impl<T: DomObject> SimpleWorkerErrorHandler<T> {
     pub fn new(addr: Trusted<T>) -> SimpleWorkerErrorHandler<T> {
-        SimpleWorkerErrorHandler { addr: addr }
+        SimpleWorkerErrorHandler { addr }
     }
 }

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -76,7 +76,7 @@ where
 {
     let heap_buffer_source = match init {
         HeapTypedArrayInit::Buffer(buffer_source) => HeapBufferSource {
-            buffer_source: buffer_source,
+            buffer_source,
             phantom: PhantomData::default(),
         },
         HeapTypedArrayInit::Info { len, cx } => {

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -253,9 +253,9 @@ impl CallSetup {
         let ais = callback.incumbent().map(AutoIncumbentScript::new);
         CallSetup {
             exception_global: global,
-            cx: cx,
+            cx,
             old_realm: unsafe { EnterRealm(*cx, callback.callback()) },
-            handling: handling,
+            handling,
             entry_script: Some(aes),
             incumbent_script: ais,
         }

--- a/components/script/dom/bindings/guard.rs
+++ b/components/script/dom/bindings/guard.rs
@@ -22,10 +22,7 @@ pub struct Guard<T: Clone + Copy> {
 impl<T: Clone + Copy> Guard<T> {
     /// Construct a new guarded value.
     pub const fn new(condition: Condition, value: T) -> Self {
-        Guard {
-            condition: condition,
-            value: value,
-        }
+        Guard { condition, value }
     }
 
     /// Expose the value if the condition is satisfied.

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -76,8 +76,8 @@ impl NonCallbackInterfaceObjectClass {
                 ext: 0 as *const _,
                 oOps: &OBJECT_OPS,
             },
-            proto_id: proto_id,
-            proto_depth: proto_depth,
+            proto_id,
+            proto_depth,
             representation: string_rep,
         }
     }
@@ -649,10 +649,8 @@ pub fn get_desired_proto(
             let global = GetNonCCWObjectGlobal(*new_target);
             let proto_or_iface_cache = get_proto_or_iface_array(global);
             desired_proto.set((*proto_or_iface_cache)[proto_id as usize]);
-            if &*new_target != &*original_new_target {
-                if !JS_WrapObject(*cx, desired_proto.into()) {
-                    return Err(());
-                }
+            if &*new_target != &*original_new_target && !JS_WrapObject(*cx, desired_proto.into()) {
+                return Err(());
             }
             return Ok(());
         }

--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -68,7 +68,7 @@ impl<T: DomObjectIteratorWrap + JSTraceable + Iterable> IterableIterator<T> {
     pub fn new(iterable: &T, type_: IteratorType) -> DomRoot<Self> {
         let iterator = Box::new(IterableIterator {
             reflector: Reflector::new(),
-            type_: type_,
+            type_,
             iterable: Dom::from_ref(iterable),
             index: Cell::new(0),
         });

--- a/components/script/dom/bindings/record.rs
+++ b/components/script/dom/bindings/record.rs
@@ -163,7 +163,7 @@ where
             map.insert(key, property);
         }
 
-        Ok(ConversionResult::Success(Record { map: map }))
+        Ok(ConversionResult::Success(Record { map }))
     }
 }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -6,8 +6,8 @@
 macro_rules! make_getter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self) -> DOMString {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.get_string_attribute(&html5ever::local_name!($htmlname))
         }
@@ -18,8 +18,8 @@ macro_rules! make_getter(
 macro_rules! make_bool_getter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self) -> bool {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.has_attribute(&html5ever::local_name!($htmlname))
         }
@@ -30,8 +30,8 @@ macro_rules! make_bool_getter(
 macro_rules! make_limited_int_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self, value: i32) -> $crate::dom::bindings::error::ErrorResult {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
 
             let value = if value < 0 {
                 return Err($crate::dom::bindings::error::Error::IndexSize);
@@ -50,8 +50,8 @@ macro_rules! make_limited_int_setter(
 macro_rules! make_int_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self, value: i32) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
 
             let element = self.upcast::<Element>();
             element.set_int_attribute(&html5ever::local_name!($htmlname), value)
@@ -66,8 +66,8 @@ macro_rules! make_int_setter(
 macro_rules! make_int_getter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self) -> i32 {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.get_int_attribute(&html5ever::local_name!($htmlname), $default)
         }
@@ -82,8 +82,8 @@ macro_rules! make_int_getter(
 macro_rules! make_uint_getter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self) -> u32 {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.get_uint_attribute(&html5ever::local_name!($htmlname), $default)
         }
@@ -97,8 +97,8 @@ macro_rules! make_uint_getter(
 macro_rules! make_url_getter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self) -> USVString {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.get_url_attribute(&html5ever::local_name!($htmlname))
         }
@@ -109,8 +109,8 @@ macro_rules! make_url_getter(
 macro_rules! make_url_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: USVString) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.set_url_attribute(&html5ever::local_name!($htmlname),
                                          value);
@@ -122,8 +122,8 @@ macro_rules! make_url_setter(
 macro_rules! make_form_action_getter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self) -> DOMString {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             let doc = crate::dom::node::document_from_node(self);
             let attr = element.get_attribute(&html5ever::ns!(), &html5ever::local_name!($htmlname));
@@ -144,8 +144,8 @@ macro_rules! make_form_action_getter(
 macro_rules! make_labels_getter(
     ( $attr:ident, $memo:ident ) => (
         fn $attr(&self) -> DomRoot<NodeList> {
-            use crate::dom::htmlelement::HTMLElement;
-            use crate::dom::nodelist::NodeList;
+            use $crate::dom::htmlelement::HTMLElement;
+            use $crate::dom::nodelist::NodeList;
             self.$memo.or_init(|| NodeList::new_labels_list(
                 self.upcast::<Node>().owner_doc().window(),
                 self.upcast::<HTMLElement>()
@@ -159,8 +159,8 @@ macro_rules! make_labels_getter(
 macro_rules! make_enumerated_getter(
     ( $attr:ident, $htmlname:tt, $default:expr, $($choices: pat)|+) => (
         fn $attr(&self) -> DOMString {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             let mut val = element.get_string_attribute(&html5ever::local_name!($htmlname));
             val.make_ascii_lowercase();
@@ -179,8 +179,8 @@ macro_rules! make_enumerated_getter(
 macro_rules! make_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.set_string_attribute(&html5ever::local_name!($htmlname), value)
         }
@@ -191,8 +191,8 @@ macro_rules! make_setter(
 macro_rules! make_bool_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: bool) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.set_bool_attribute(&html5ever::local_name!($htmlname), value)
         }
@@ -203,8 +203,8 @@ macro_rules! make_bool_setter(
 macro_rules! make_uint_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self, value: u32) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             use crate::dom::values::UNSIGNED_LONG_MAX;
             let value = if value > UNSIGNED_LONG_MAX {
                 $default
@@ -224,8 +224,8 @@ macro_rules! make_uint_setter(
 macro_rules! make_limited_uint_setter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self, value: u32) -> $crate::dom::bindings::error::ErrorResult {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             use crate::dom::values::UNSIGNED_LONG_MAX;
             let value = if value == 0 {
                 return Err($crate::dom::bindings::error::Error::IndexSize);
@@ -248,8 +248,8 @@ macro_rules! make_limited_uint_setter(
 macro_rules! make_atomic_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             element.set_atomic_attribute(&html5ever::local_name!($htmlname), value)
         }
@@ -260,8 +260,8 @@ macro_rules! make_atomic_setter(
 macro_rules! make_legacy_color_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             use style::attr::AttrValue;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_legacy_color(value.into());
@@ -274,8 +274,8 @@ macro_rules! make_legacy_color_setter(
 macro_rules! make_dimension_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_dimension(value.into());
             element.set_attribute(&html5ever::local_name!($htmlname), value)
@@ -287,8 +287,8 @@ macro_rules! make_dimension_setter(
 macro_rules! make_nonzero_dimension_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {
-            use crate::dom::bindings::inheritance::Castable;
-            use crate::dom::element::Element;
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             let value = AttrValue::from_nonzero_dimension(value.into());
             element.set_attribute(&html5ever::local_name!($htmlname), value)

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3369,7 +3369,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn DeleteQuery(&self, query: Option<&WebGLQuery>) {
         if let Some(query) = query {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
@@ -3431,7 +3431,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn BeginQuery(&self, target: u32, query: &WebGLQuery) {
         handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
 
@@ -3460,7 +3460,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn EndQuery(&self, target: u32) {
         let active_query = match target {
             constants::ANY_SAMPLES_PASSED |
@@ -3487,7 +3487,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn GetQuery(&self, target: u32, pname: u32) -> Option<DomRoot<WebGLQuery>> {
         if pname != constants::CURRENT_QUERY {
             self.base.webgl_error(InvalidEnum);
@@ -3515,7 +3515,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12>
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn GetQueryParameter(&self, _cx: JSContext, query: &WebGLQuery, pname: u32) -> JSVal {
         handle_potential_webgl_error!(
             self.base,

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -144,7 +144,7 @@ impl WebGLQuery {
         self.query_result_available.set(Some(is_available));
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     pub fn get_parameter(
         &self,
         context: &WebGLRenderingContext,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -528,9 +528,9 @@ impl JsTimers {
         let oneshot_handle = global.schedule_callback(callback, duration);
 
         // step 3
-        let entry = active_timers.entry(handle).or_insert(JsTimerEntry {
-            oneshot_handle: oneshot_handle,
-        });
+        let entry = active_timers
+            .entry(handle)
+            .or_insert(JsTimerEntry { oneshot_handle });
         entry.oneshot_handle = oneshot_handle;
     }
 }

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -19,7 +19,6 @@ use js::rust::{
     Handle as RustHandle, HandleObject as RustHandleObject, IntoHandle,
     MutableHandle as RustMutableHandle, MutableHandleObject as RustMutableHandleObject,
 };
-use libc;
 
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::proxyhandler::set_property_descriptor;

--- a/third_party/blurmac/src/delegate.rs
+++ b/third_party/blurmac/src/delegate.rs
@@ -356,7 +356,7 @@ pub mod bm {
     pub fn delegate_peripherals(delegate: *mut Object) -> *mut Object {
         unsafe {
             let peripherals: *mut Object =
-                *(&mut *delegate).get_ivar::<*mut Object>(DELEGATE_PERIPHERALS_IVAR);
+                *(*delegate).get_ivar::<*mut Object>(DELEGATE_PERIPHERALS_IVAR);
             peripherals
         }
     }


### PR DESCRIPTION
Fixes several clippy warnings in several components.

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 

<!-- Either: -->
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

 <!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
