### PR TITLE
rustdoc: Fix two warnings in `components/layout_2020`

### DIFF
--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -32,7 +32,7 @@ use crate::style_ext::PaddingBorderMargin;
 use crate::ContainingBlock;
 
 pub(super) struct LineMetrics {
-    /// The block offset of the line start in the containing 
+    /// The block offset of the line start in the containing
     /// [`crate::flow::InlineFormattingContext`].
     pub block_offset: Length,
 

--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -32,7 +32,8 @@ use crate::style_ext::PaddingBorderMargin;
 use crate::ContainingBlock;
 
 pub(super) struct LineMetrics {
-    /// The block offset of the line start in the containing [`crate::flow::InlineFormattingContext`].
+    /// The block offset of the line start in the containing 
+    /// [`crate::flow::InlineFormattingContext`].
     pub block_offset: Length,
 
     /// The block size of this line.

--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -32,7 +32,7 @@ use crate::style_ext::PaddingBorderMargin;
 use crate::ContainingBlock;
 
 pub(super) struct LineMetrics {
-    /// The block offset of the line start in the containing [`InlineFormattingContext`].
+    /// The block offset of the line start in the containing [`crate::flow::InlineFormattingContext`].
     pub block_offset: Length,
 
     /// The block size of this line.

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -59,7 +59,7 @@ pub(crate) enum NonReplacedFormattingContextContents {
     // Other layout modes go here
 }
 
-/// The baselines of a layout or a [`BoxFragment`]. Some layout uses the first and some layout uses
+/// The baselines of a layout or a [`crate::fragment_tree::BoxFragment`]. Some layout uses the first and some layout uses
 /// the last.
 #[derive(Debug, Default, Serialize)]
 pub(crate) struct Baselines {

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -59,8 +59,8 @@ pub(crate) enum NonReplacedFormattingContextContents {
     // Other layout modes go here
 }
 
-/// The baselines of a layout or a [`crate::fragment_tree::BoxFragment`]. Some layout uses the first and some layout uses
-/// the last.
+/// The baselines of a layout or a [`crate::fragment_tree::BoxFragment`]. Some layout
+/// uses the first and some layout uses the last.
 #[derive(Debug, Default, Serialize)]
 pub(crate) struct Baselines {
     pub first: Option<Au>,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix two docs references.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31575
- [X] These changes do not require tests because I only change the documentation

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
