### PR TITLE
minibrowser: Add loading spinner 

### DIFF
--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Instant;
 
-use egui::{CentralPanel, Frame, Key, Modifiers, PaintCallback, TopBottomPanel};
+use egui::{CentralPanel, Color32, Frame, Key, Modifiers, PaintCallback, Spinner, TopBottomPanel};
 use egui_glow::CallbackFn;
 use egui_winit::EventResponse;
 use euclid::{Length, Point2D, Scale};
@@ -24,7 +24,7 @@ use crate::egui_glue::EguiGlow;
 use crate::events_loop::EventsLoop;
 use crate::geometry::winit_position_to_euclid_point;
 use crate::parser::location_bar_input_to_url;
-use crate::webview::WebViewManager;
+use crate::webview::{LoadStatus, WebViewManager};
 use crate::window_trait::WindowPortsMethods;
 
 pub struct Minibrowser {
@@ -42,6 +42,8 @@ pub struct Minibrowser {
 
     /// Whether the location has been edited by the user without clicking Go.
     location_dirty: Cell<bool>,
+
+    load_status: LoadStatus,
 }
 
 pub enum MinibrowserEvent {
@@ -83,6 +85,7 @@ impl Minibrowser {
             last_mouse_position: None,
             location: RefCell::new(initial_url.to_string()),
             location_dirty: false.into(),
+            load_status: LoadStatus::LoadComplete,
         }
     }
 
@@ -160,6 +163,16 @@ impl Minibrowser {
                                 if ui.button("go").clicked() {
                                     event_queue.borrow_mut().push(MinibrowserEvent::Go);
                                     location_dirty.set(false);
+                                }
+
+                                match self.load_status {
+                                    LoadStatus::LoadStart => {
+                                        ui.add(Spinner::new().color(Color32::GRAY));
+                                    },
+                                    LoadStatus::HeadParsed => {
+                                        ui.add(Spinner::new().color(Color32::WHITE));
+                                    },
+                                    LoadStatus::LoadComplete => { /* No Spinner */ },
                                 }
 
                                 let location_field = ui.add_sized(
@@ -315,12 +328,27 @@ impl Minibrowser {
         }
     }
 
+    /// Updates the spinner from the given [WebViewManager], returning true iff it has changed
+    /// (needing an egui update).
+    pub fn update_spinner_in_toolbar(
+        &mut self,
+        browser: &mut WebViewManager<dyn WindowPortsMethods>,
+    ) -> bool {
+        let need_update = browser.load_status() != self.load_status;
+        self.load_status = browser.load_status();
+        return need_update;
+    }
+
     /// Updates all fields taken from the given [WebViewManager], such as the location field.
     /// Returns true iff the egui needs an update.
     pub fn update_webview_data(
         &mut self,
         browser: &mut WebViewManager<dyn WindowPortsMethods>,
     ) -> bool {
-        return self.update_location_in_toolbar(browser);
+        // Note: We must use the "bitwise OR" (|) operator here instead of "logical OR" (||)
+        //       because logical OR would short-circuit if any of the functions return true.
+        //       We want to ensure that all functions are called. The "bitwise OR" operator
+        //       does not short-circuit.
+        return self.update_location_in_toolbar(browser) | self.update_spinner_in_toolbar(browser);
     }
 }

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -314,4 +314,13 @@ impl Minibrowser {
             _ => false,
         }
     }
+
+    /// Updates all fields taken from the given [WebViewManager], such as the location field.
+    /// Returns true iff the egui needs an update.
+    pub fn update_webview_data(
+        &mut self,
+        browser: &mut WebViewManager<dyn WindowPortsMethods>,
+    ) -> bool {
+        return self.update_location_in_toolbar(browser);
+    }
 }

--- a/ports/servoshell/webview.rs
+++ b/ports/servoshell/webview.rs
@@ -63,7 +63,7 @@ pub struct WebView {}
 
 pub struct ServoEventResponse {
     pub need_present: bool,
-    pub history_changed: bool,
+    pub need_update: bool,
 }
 
 impl<Window> WebViewManager<Window>
@@ -410,7 +410,7 @@ where
         events: Drain<'_, (Option<WebViewId>, EmbedderMsg)>,
     ) -> ServoEventResponse {
         let mut need_present = false;
-        let mut history_changed = false;
+        let mut need_update = false;
         for (webview_id, msg) in events {
             if let Some(webview_id) = webview_id {
                 trace_embedder_msg!(msg, "{webview_id} {msg:?}");
@@ -599,7 +599,7 @@ where
                 EmbedderMsg::HistoryChanged(urls, current) => {
                     self.current_url = Some(urls[current].clone());
                     self.current_url_string = Some(urls[current].clone().into_string());
-                    history_changed = true;
+                    need_update = true;
                 },
                 EmbedderMsg::SetFullscreenState(state) => {
                     self.window.set_fullscreen(state);
@@ -680,7 +680,7 @@ where
 
         ServoEventResponse {
             need_present,
-            history_changed,
+            need_update,
         }
     }
 }


### PR DESCRIPTION
I've started to implement a simple spinner that indicates when a page is loading. This PR is not complete yet but I'd like to get some feedback and discuss some implementation details if that's possible.

For this "MVP", I've simply added a new bool `loading_changed` analogous to the `history_changed` field in `PumpResult::Continue`. The `WebView` then keeps track of wether or not it is loading and exposes this via `WebView::loading()`, like `WebView::shutdown_requested`. The `Minibrowser` then gets a notification from the `App` when `loading` changed and updates the spinner accordingly.

A few questions arose while implementing this:

- The comments in the code and issue indicate that `EmbedderMsg::HeadParsed` should also "influence" the loading state, but I do not understand how this should surface. In my understanding, the spinner simply shows up when the document starts loading and stops once it is complete. What is the intended "intermediary" step here?

https://github.com/servo/servo/blob/8cfc6a1898d02eb1df9c13c3c410747cb1e0b412/ports/servoshell/webview.rs#L596-L598

- It seems a bit clunky to add a `xyz_changed` for everything about the `WebView` that could be required to bubble up to the `Minibrowser`. For example, showing the Favicon might also require a `favicon_changed: bool` in the future. Perhaps it would make sense to combine all these into a `toolbar_data_changed` or `metadata_changed` or something and let the `Minibrowser` figure out what it has to do (or just refresh the entire toolbar when anything changed, that shouldn't really impact performance). Is this something I should implement in this PR?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31689 

<!-- Either: -->
- [X] These changes do not require tests because it is purely visual in the minibrowser.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
