### PR TITLE
ci: Fix artifact path in WPT import workflow after #31616

### DIFF
--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -54,8 +54,8 @@ jobs:
           export CURRENT_DATE=$(date +"%d-%m-%Y")
           echo $CURRENT_DATE
           echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
-          ./mach update-wpt linux-layout-2013/*.log --legacy-layout
-          ./mach update-wpt linux-layout-2020/*.log
+          ./mach update-wpt linux-layout-2013/raw/*.log --legacy-layout
+          ./mach update-wpt linux-layout-2020/raw/*.log
           git add tests/wpt/meta tests/wpt/meta-legacy-layout
           git commit -a --amend --no-edit
       - name: Push changes


### PR DESCRIPTION
I forgot to do this in #31616


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
