### PR TITLE
clippy: Fix warnings in generated code

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -420,14 +420,14 @@ class CGMethodCall(CGThing):
                 caseBody.append(CGGeneric("if %s.get().is_object() {" %
                                           (distinguishingArg)))
                 for idx, sig in enumerate(interfacesSigs):
-                    caseBody.append(CGIndenter(CGGeneric("loop {")))
+                    caseBody.append(CGIndenter(CGGeneric("'_block: {")))
                     type = sig[1][distinguishingIndex].type
 
                     # The argument at index distinguishingIndex can't possibly
                     # be unset here, because we've already checked that argc is
                     # large enough that we can examine this argument.
                     info = getJSToNativeConversionInfo(
-                        type, descriptor, failureCode="break;", isDefinitelyObject=True)
+                        type, descriptor, failureCode="break '_block;", isDefinitelyObject=True)
                     template = info.template
                     declType = info.declType
 
@@ -2173,9 +2173,11 @@ class CGImports(CGWrapper):
                 'unused_variables',
                 'unused_assignments',
                 'unused_mut',
+                'clippy::approx_constant',
                 'clippy::let_unit_value',
                 'clippy::needless_return',
-                'clippy::unnecessary_cast'
+                'clippy::too_many_arguments',
+                'clippy::unnecessary_cast',
             ]
 
         def componentTypes(type):
@@ -7624,9 +7626,9 @@ class CallbackMember(CGNativeMember):
             # Check for variadic arguments
             lastArg = args[self.argCount - 1]
             if lastArg.variadic:
+                argCount = "0" if self.argCount == 1 else f"({self.argCount} - 1)"
                 self.argCountStr = (
-                    "(%d - 1) + %s.len()" % (self.argCount,
-                                             lastArg.identifier.name))
+                    "%s + %s.len()" % (argCount, lastArg.identifier.name))
             else:
                 self.argCountStr = "%d" % self.argCount
         self.needThisHandling = needThisHandling

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2015,7 +2015,7 @@ class AttrDefiner(PropertyDefiner):
             if m["name"] == "@@toStringTag":
                 return """    JSPropertySpec {
                     name: JSPropertySpec_Name { symbol_: SymbolCode::%s as usize + 1 },
-                    attributes_: (%s) as u8,
+                    attributes_: (%s),
                     kind_: (%s),
                     u: JSPropertySpec_AccessorsOrValue {
                         value: JSPropertySpec_ValueWrapper {
@@ -2029,7 +2029,7 @@ class AttrDefiner(PropertyDefiner):
 """
             return """    JSPropertySpec {
                     name: JSPropertySpec_Name { string_: %s as *const u8 as *const libc::c_char },
-                    attributes_: (%s) as u8,
+                    attributes_: (%s),
                     kind_: (%s),
                     u: JSPropertySpec_AccessorsOrValue {
                         accessors: JSPropertySpec_AccessorsOrValue_Accessors {
@@ -2800,7 +2800,7 @@ class CGAbstractMethod(CGThing):
                 )
                 post = (
                     "\n})());\n"
-                    "return result"
+                    "result"
                 )
             body = CGWrapper(CGIndenter(body), pre=pre, post=post)
 
@@ -3268,7 +3268,7 @@ let global = incumbent_global.reflector().get_jsobject();\n"""
                     }
                     """,
                     name=name, nameAsArray=str_to_const_array(name), conditions=ret_conditions)
-        ret += 'return true;\n'
+        ret += 'true\n'
         return CGGeneric(ret)
 
 
@@ -3381,14 +3381,14 @@ assert!(!prototype_proto.is_null());""" % name))
         code.append(CGGeneric("""
 rooted!(in(*cx) let mut prototype = ptr::null_mut::<JSObject>());
 create_interface_prototype_object(cx,
-                                  global.into(),
-                                  prototype_proto.handle().into(),
+                                  global,
+                                  prototype_proto.handle(),
                                   &PrototypeClass,
                                   %(methods)s,
                                   %(attrs)s,
                                   %(consts)s,
                                   %(unscopables)s,
-                                  prototype.handle_mut().into());
+                                  prototype.handle_mut());
 assert!(!prototype.is_null());
 assert!((*cache)[PrototypeList::ID::%(id)s as usize].is_null());
 (*cache)[PrototypeList::ID::%(id)s as usize] = prototype.get();
@@ -3416,7 +3416,7 @@ assert!(!interface_proto.is_null());
 
 rooted!(in(*cx) let mut interface = ptr::null_mut::<JSObject>());
 create_noncallback_interface_object(cx,
-                                    global.into(),
+                                    global,
                                     interface_proto.handle(),
                                     &INTERFACE_OBJECT_CLASS,
                                     %(static_methods)s,
@@ -3972,7 +3972,7 @@ class CGSetterCall(CGPerSignatureCall):
 
     def wrap_return_value(self):
         # We have no return value
-        return "\nreturn true;"
+        return "\ntrue"
 
     def getArgc(self):
         return "1"
@@ -4090,7 +4090,7 @@ class CGDefaultToJSONMethod(CGSpecializedMethod):
             parents -= 1
         ret += fill(form, parentclass="")
         ret += ('(*args).rval().set(ObjectValue(*result));\n'
-                'return true;\n')
+                'true\n')
         return CGGeneric(ret)
 
 
@@ -5645,7 +5645,7 @@ if !expando.is_null() {
     }
 }
 """ + namedGet + """\
-return true;"""
+true"""
 
     def definition_body(self):
         return CGGeneric(self.getBody())
@@ -5803,7 +5803,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
                 return false;
             }
 
-            return true;
+            true
             """)
 
         return body
@@ -5862,7 +5862,7 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
                 return false;
             }
 
-            return true;
+            true
             """)
 
         return body
@@ -5937,7 +5937,7 @@ if !expando.is_null() {
 }
 """ + named + """\
 *bp = false;
-return true;"""
+true"""
 
     def definition_body(self):
         return CGGeneric(self.getBody())
@@ -6038,7 +6038,7 @@ if found {
 }
 %s
 vp.set(UndefinedValue());
-return true;""" % (maybeCrossOriginGet, getIndexedOrExpando, getNamed)
+true""" % (maybeCrossOriginGet, getIndexedOrExpando, getNamed)
 
     def definition_body(self):
         return CGGeneric(self.getBody())

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1672,11 +1672,11 @@ class PropertyDefiner:
                 prefableSpecs.append(
                     prefableTemplate % (cond, name + "_specs", len(specs) - 1))
 
-        specsArray = ("const %s_specs: &'static [&'static[%s]] = &[\n"
+        specsArray = ("const %s_specs: &[&[%s]] = &[\n"
                       + ",\n".join(specs) + "\n"
                       + "];\n") % (name, specType)
 
-        prefArray = ("const %s: &'static [Guard<&'static [%s]>] = &[\n"
+        prefArray = ("const %s: &[Guard<&[%s]>] = &[\n"
                      + ",\n".join(prefableSpecs) + "\n"
                      + "];\n") % (name, specType)
         return specsArray + prefArray
@@ -4666,7 +4666,7 @@ use js::rust::HandleValue;
 use js::rust::MutableHandleValue;
 use js::jsval::JSVal;
 
-pub const pairs: &'static [(&'static str, super::${ident})] = &[
+pub const pairs: &[(&str, super::${ident})] = &[
     ${pairs},
 ];
 
@@ -6309,9 +6309,9 @@ class CGInterfaceTrait(CGThing):
         methods = []
         for name, arguments, rettype in members():
             arguments = list(arguments)
-            methods.append(CGGeneric("%sfn %s(&self%s) -> %s;\n" % (
+            methods.append(CGGeneric("%sfn %s(&self%s)%s;\n" % (
                 'unsafe ' if contains_unsafe_arg(arguments) else '',
-                name, fmt(arguments), rettype))
+                name, fmt(arguments), f" -> {rettype}" if rettype != '()' else ''))
             )
 
         if methods:
@@ -6772,7 +6772,7 @@ class CGDescriptor(CGThing):
             if unscopableNames:
                 haveUnscopables = True
                 cgThings.append(
-                    CGList([CGGeneric("const unscopable_names: &'static [&'static [u8]] = &["),
+                    CGList([CGGeneric("const unscopable_names: &[&[u8]] = &["),
                             CGIndenter(CGList([CGGeneric(str_to_const_array(name)) for
                                                name in unscopableNames], ",\n")),
                             CGGeneric("];\n")], "\n"))
@@ -6791,7 +6791,7 @@ class CGDescriptor(CGThing):
         haveLegacyWindowAliases = len(legacyWindowAliases) != 0
         if haveLegacyWindowAliases:
             cgThings.append(
-                CGList([CGGeneric("const legacy_window_aliases: &'static [&'static [u8]] = &["),
+                CGList([CGGeneric("const legacy_window_aliases: &[&[u8]] = &["),
                         CGIndenter(CGList([CGGeneric(str_to_const_array(name)) for
                                            name in legacyWindowAliases], ",\n")),
                         CGGeneric("];\n")], "\n"))


### PR DESCRIPTION
Fixes some clippy warnings from the code generated by `CodegenRust.py`. It specifically gets rids of all _errors_ from these files.

Due to the nature of the generated code, some allowances had to be made, sometimes because of false positives, and sometimes because "fixing" the warning would be very inefficient or require changing how everything generates. The allows and their reasoning are the following:

- `approx_constant`: Values defined in `.webidl` files could be related to constants such as pi. In rust it would be better to use defined types such as `f64::consts::PI`, but because these are taken from other files they should stay as numeric values.
- `let_unit_value`: In `CGCallGenerator` the value of `result` can take the `()` type. This is intended, and while specific allows could be placed for every let binding easily, this generates too many lines so it may be better to allow it for the entire file. There is also discussion regarding this lint in https://github.com/rust-lang/rust-clippy/issues/9048.
- `needless_return`: In `CGPerSignatureCall`, the call to `wrap_return_value` can be straightforward, so a simple `true` at the end could suffice, but it could also contain nested matches, so `return true;` becomes necessary. Distinguishing between all the possible cases seems overly complicated when `return true;` works and isn't much more verbose. The other instances of returning were addressed.
- `too_many_arguments`: Like in other cases, some functions generate with too many arguments. It seems counterproductive to check every function to know if it has more than x arguments and add an allow for it automatically when it can be permitted for every file.
- `unnecessary_cast`: This is specifically for `MethodDefiner::generateArray`. There is a comment specifying that it's not easy to tell whether the methodinfo is a `JSJitInfo` or a `JSTypedMethodJitInfo`, so we cast them both to `JSJitInfo` and rely on the compiler doing the conversion. This creates many `unnecessary_cast` warnings for `JSJitInfo`, but it is documented and not trivial to fix.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500 
- [x] These changes do not require tests because they do not change functionality, only fix warnings