### PR TITLE
android: add support for x86_64 images

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: ['armv7-linux-androideabi', 'i686-linux-android']
+        arch: ['armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -146,6 +146,8 @@ class PackageCommands(CommandBase):
                 arch_string = "Armv7"
             elif "i686" in android_target:
                 arch_string = "x86"
+            elif "x86_64" in android_target:
+                arch_string = "x64"
             else:
                 arch_string = "Arm"
 

--- a/support/android/apk/build.gradle
+++ b/support/android/apk/build.gradle
@@ -27,7 +27,8 @@ ext.getRustTarget = { String arch ->
     switch (arch.toLowerCase()) {
         case 'armv7' : return 'armv7-linux-androideabi'
         case 'arm64' : return 'aarch64-linux-android'
-        case 'x86' : return 'i686-linux-android'
+        case 'x86': return 'i686-linux-android'
+        case 'x64': return 'x86_64-linux-android'
         default: throw new GradleException("Invalid target architecture " + arch)
     }
 }
@@ -36,7 +37,8 @@ ext.getNDKAbi = { String arch ->
     switch (arch.toLowerCase()) {
         case 'armv7' : return 'armeabi-v7a'
         case 'arm64' : return 'arm64-v8a'
-        case 'x86' : return 'x86'
+        case 'x86': return 'x86'
+        case 'x64': return 'x86_64'
         default: throw new GradleException("Invalid target architecture " + arch)
     }
 }

--- a/support/android/apk/jni/Application.mk
+++ b/support/android/apk/jni/Application.mk
@@ -2,4 +2,7 @@ NDK_TOOLCHAIN_VERSION := clang
 APP_MODULES := c++_shared servojni
 APP_PLATFORM := android-30
 APP_STL := c++_shared
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a x86 x86_64
+ifeq ($(NDK_DEBUG),1)
+  APP_STRIP_MODE := none
+endif

--- a/support/android/apk/servoapp/build.gradle
+++ b/support/android/apk/servoapp/build.gradle
@@ -97,6 +97,18 @@ android {
                 abiFilters getNDKAbi('x86')
             }
         }
+        x64Debug {
+            initWith(debug)
+            ndk {
+                abiFilters getNDKAbi('x64')
+            }
+        }
+        x64Release {
+            initWith(release)
+            ndk {
+                abiFilters getNDKAbi('x64')
+            }
+        }
     }
 
     // Ignore default 'debug' and 'release' build types

--- a/support/android/apk/servoview/build.gradle
+++ b/support/android/apk/servoview/build.gradle
@@ -76,6 +76,12 @@ android {
         x86Release {
             initWith(release)
         }
+        x64Debug {
+            initWith(debug)
+        }
+        x64Release {
+            initWith(release)
+        }
     }
 
     sourceSets {
@@ -98,6 +104,12 @@ android {
         }
         x86Release {
             jniLibs.srcDirs = [getJniLibsPath(false, 'x86')]
+        }
+        x64Debug {
+            jniLibs.srcDirs = [getJniLibsPath(true, 'x64')]
+        }
+        x64Release {
+            jniLibs.srcDirs = [getJniLibsPath(false, 'x64')]
         }
     }
 
@@ -183,7 +195,7 @@ dependencies {
     ]
     // Iterate all build types and dependencies
     // For each dependency call the proper implementation command and set the correct dependency path
-    def list = ['armv7', 'arm64', 'x86']
+    def list = ['armv7', 'arm64', 'x86', 'x64']
     for (arch in list) {
         for (debug in [true, false]) {
             String basePath = getTargetDir(debug, arch) + "/build"


### PR DESCRIPTION
I've retained the 32 bit x86 build since I expect that will be useful when investigating the SpiderMonkey JIT crash.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only introduce support for new emulator and CI still doesn't have support for running the build via emulator.

