### PR TITLE
android: fix broken rendering in emulators

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -331,6 +331,11 @@ where
                 webrender_gl.clone(),
                 render_notifier,
                 webrender::WebRenderOptions {
+                    // We force the use of optimized shaders here because rendering is broken
+                    // on Android emulators with unoptimized shaders. This is due to a known
+                    // issue in the emulator's OpenGL emulation layer.
+                    // See: https://github.com/servo/servo/issues/31726
+                    use_optimized_shaders: true,
                     resource_override_path: opts.shaders_dir.clone(),
                     enable_aa: !opts.debug.disable_text_antialiasing,
                     debug_flags: debug_flags,


### PR DESCRIPTION
Android's OpenGL emulation layer (goldfish-opengl) has pre-processing logic that looks for samplers of the type `samplerExternalOES` and does a simple textual [replacement to change the type][1] to `sampler2D` before compilation. It also [marks the sampler][2] as 'replaced' so it can emulate the correct type at runtime.

However, this logic can lead to false positives when the sampler is declared inside conditional macros. Hence, the sampler's type can be incorrectly marked as `samplerExternalOES` even though the #if, #ifdef conditional logic would have declared the type as `sampler2D`. This seems to be a [known limitation][3].

WebRender (in particular the shared.glsl include) has such conditional declaration of the texture units used from the shaders. In particular, the sampler [sColor0 here][4] is declared within ifdefs to have different types depending on the flags enabled, to allow the shader to work with different image target kinds.

WebRender also maintain two versions of the compiled shaders in its cache:
  1. An unoptimized version with all the conditional logic preserved in the source until the shader is compiled at runtime on Android, when the shader is actually used.
  2. Multiple optimized versions for combinations of features required These versions are produced during Servo [build][5]. Thus the optimized versions eliminate most of the conditional declarations at build time.

The bug in Servo with current code is because, [by default][6], WebRender uses the *unoptimized* versions of the shaders. This means the conditional GLSL source is evaluated at runtime by the Android emulator and thus ends up with the incorrect type for the sColor0 sampler unit, which breaks the [texture sampling in the fragment shader][7], causing it to always return Vec4(0, 0, 0, 1) and rendering all elements on the page black.

This change forces WebRender to use the *optimized* version as a workaround - the optimized versions have unconditional code for the sampler declarations so are not susceptible to the emulator issue.

[1]: https://android.googlesource.com/device/generic/goldfish-opengl/+/refs/tags/android-platform-11.0.0_r40/system/GLESv2_enc/GL2Encoder.cpp#1644
[2]: https://android.googlesource.com/device/generic/goldfish-opengl/+/refs/tags/android-platform-11.0.0_r40/system/GLESv2_enc/GL2Encoder.cpp#1673
[3]: https://android.googlesource.com/device/generic/goldfish-opengl/+/refs/tags/android-platform-11.0.0_r40/system/GLESv2_enc/GL2Encoder.cpp#1571
[4]: https://github.com/servo/webrender/blob/b36399019cadcadeeed53759c96870577d4da136/webrender/res/shared.glsl#L206
[5]: https://github.com/servo/webrender/blob/b36399019cadcadeeed53759c96870577d4da136/webrender/build.rs#L289
[6]: https://github.com/servo/webrender/blob/b36399019cadcadeeed53759c96870577d4da136/webrender/src/renderer/init.rs#L214
[7]: https://github.com/servo/webrender/blob/b36399019cadcadeeed53759c96870577d4da136/webrender/res/composite.glsl#L189

Fixes #31726.

![android fixed](https://github.com/servo/servo/assets/251518/257c3c23-8a56-4e69-b43e-39aa94cfafa0)

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31726 