### PR TITLE
rustdoc: fix warnings in `components/layout_2020/table`

### DIFF
--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -46,8 +46,8 @@
 //! Fragment tree construction involves calculating the size and positioning of all table elements,
 //! given their style, content, and cell and row spans. This happens both during intrinsic inline
 //! size computation as well as layout into Fragments. In both of these cases, measurement and
-//! layout is done by [`layout::TableLayout`], though for intrinsic size computation only a partial
-//! layout is done.
+//! layout is done by the layout module located in components/layout_2020/table/layout.rs,
+//! though for intrinsic size computation only a partial layout is done.
 //!
 //! In general, we follow the following steps when laying out table content:
 //!
@@ -196,7 +196,8 @@ impl TableSlotCell {
         }
     }
 
-    /// Get the node id of this cell's [`BaseFragmentInfo`]. This is used for unit tests.
+    /// Get the node id of this cell's base fragment located in components/layout_2020/fragment_tree/base_fragment.rs.
+    /// This is used for unit tests.
     pub fn node_id(&self) -> usize {
         self.base_fragment_info.tag.map_or(0, |tag| tag.node.0)
     }

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+#![allow(rustdoc::private_intra_doc_links)]
 
 //! # HTML Tables (╯°□°)╯︵ ┻━┻
 //!
@@ -46,8 +47,8 @@
 //! Fragment tree construction involves calculating the size and positioning of all table elements,
 //! given their style, content, and cell and row spans. This happens both during intrinsic inline
 //! size computation as well as layout into Fragments. In both of these cases, measurement and
-//! layout is done by the layout module located in components/layout_2020/table/layout.rs,
-//! though for intrinsic size computation only a partial layout is done.
+//! layout is done by [`layout::TableLayout`], though for intrinsic size computation only a partial
+//! layout is done.
 //!
 //! In general, we follow the following steps when laying out table content:
 //!
@@ -196,8 +197,7 @@ impl TableSlotCell {
         }
     }
 
-    /// Get the node id of this cell's base fragment located in components/layout_2020/fragment_tree/base_fragment.rs.
-    /// This is used for unit tests.
+    /// Get the node id of this cell's [`BaseFragmentInfo`]. This is used for unit tests.
     pub fn node_id(&self) -> usize {
         self.base_fragment_info.tag.map_or(0, |tag| tag.node.0)
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix rustdoc warning about private intra-doc links

- Allowed private intra doc links by #![allow(rustdoc::private_intra_doc_links)]
- This resolves the warnings:
-- warning: public documentation for `node_id` links to private item `BaseFragmentInfo`
-- warning: public documentation for `table` links to private item `layout::TableLayout`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These change is part of #31575 

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
