### PR TITLE
rustdoc: Fix broken link to `FontFace` in `components/gfx`

### DIFF
--- a/components/gfx/platform/windows/font_template.rs
+++ b/components/gfx/platform/windows/font_template.rs
@@ -79,11 +79,8 @@ impl FontTemplateData {
         self.font_data.read().unwrap().as_ref().cloned()
     }
 
-    /// Get a [`FontFace`] for this font if it is a local font or return `None` if it's a
-    /// web font.
-    ///
-    /// [`FontFace`]: https://developer.mozilla.org/en-US/docs/Web/API/FontFace
-    ///
+    /// Get a [`Font`] for this font if it is a local font or return `None`
+    /// if it's a web font.
     pub fn get_font(&self) -> Option<Font> {
         let font_descriptor = match &self.identifier {
             FontIdentifier::Local(local_identifier) => local_identifier.font_descriptor.clone(),

--- a/components/gfx/platform/windows/font_template.rs
+++ b/components/gfx/platform/windows/font_template.rs
@@ -79,8 +79,8 @@ impl FontTemplateData {
         self.font_data.read().unwrap().as_ref().cloned()
     }
 
-    /// Get a [`Font`] for this font if it is a local font or return `None`
-    /// if it's a web font.
+    /// Get a [`Font`] for this font if it is a local font or return `None` if it's a
+    /// web font.
     pub fn get_font(&self) -> Option<Font> {
         let font_descriptor = match &self.identifier {
             FontIdentifier::Local(local_identifier) => local_identifier.font_descriptor.clone(),

--- a/components/gfx/platform/windows/font_template.rs
+++ b/components/gfx/platform/windows/font_template.rs
@@ -81,6 +81,9 @@ impl FontTemplateData {
 
     /// Get a [`FontFace`] for this font if it is a local font or return `None` if it's a
     /// web font.
+    ///
+    /// [`FontFace`]: https://developer.mozilla.org/en-US/docs/Web/API/FontFace
+    ///
     pub fn get_font(&self) -> Option<Font> {
         let font_descriptor = match &self.identifier {
             FontIdentifier::Local(local_identifier) => local_identifier.font_descriptor.clone(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add the MDN documentation link referenced in the [rustwasm](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.FontFace.html#) doc to resolve the `FontFace` broken link warning.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31575 (GitHub issue number if applicable)
- [X] These changes do not require tests because they are documentation fixes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
