### PR TITLE
dom: Abort media element load on decode errors

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1551,11 +1551,29 @@ impl HTMLMediaElement {
             },
             PlayerEvent::Error(ref error) => {
                 error!("Player error: {:?}", error);
+                // https://html.spec.whatwg.org/multipage/#loading-the-media-resource:media-data-13
+                // 1. The user agent should cancel the fetching process.
+                if let Some(ref mut current_fetch_context) =
+                    *self.current_fetch_context.borrow_mut()
+                {
+                    current_fetch_context.cancel(CancelReason::Error);
+                }
+                // 2. Set the error attribute to the result of creating a MediaError with MEDIA_ERR_DECODE.
                 self.error.set(Some(&*MediaError::new(
                     &*window_from_node(self),
                     MEDIA_ERR_DECODE,
                 )));
+
+                // 3. Set the element's networkState attribute to the NETWORK_IDLE value.
+                self.network_state.set(NetworkState::Idle);
+
+                // 4. Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
+                self.delay_load_event(false);
+
+                // 5. Fire an event named error at the media element.
                 self.upcast::<EventTarget>().fire_event(atom!("error"));
+
+                // TODO: 6. Abort the overall resource selection algorithm.
             },
             PlayerEvent::VideoFrameUpdated => {
                 self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);


### PR DESCRIPTION
Previously, when a `PlayerEvent::Error` was encountered, an `error` Event was fired on the element, but the "delaying-the-load-event" flag was never set to false, so the document was loading until the end of the media source was received in `process_response_eof`:

https://github.com/servo/servo/blob/d6d903c5a11bafe7a23d15c7fd94d87dff6e3ac6/components/script/dom/htmlmediaelement.rs#L2811

I think the issue was that the `PlayerEvent::Error` was not handled according to spec. I believe the relevant portion is "[The media data processing steps list is as follows: ... If the media is corrupted](https://html.spec.whatwg.org/multipage/media.html#loading-the-media-resource%3Amedia-data-13)".

I've implemented most of the steps but am unsure about "6. Abort the overall resource selection algorithm." Is this even applicable here, or is it "automatically" aborted by cancelling the fetch event?

With this patch, the `LoadComplete` event is triggered immediately after a media decode error:

```
[2024-03-18T22:02:48Z ERROR script::dom::htmlmediaelement] Player error: "Error from element /GstPlayBin:playbin/GstURIDecodeBin:uridecodebin0: Your GStreamer installation is missing a plug-in.\nYour GStreamer installation is missing a plug-in.\n../gst/playback/gsturidecodebin.c(1049): no_more_pads_full (): /GstPlayBin:playbin/GstURIDecodeBin:uridecodebin0:\nno suitable plugins found:\n../gst/playback/gstdecodebin2.c(4704): gst_decode_bin_expose (): /GstPlayBin:playbin/GstURIDecodeBin:uridecodebin0/GstDecodeBin:decodebin0:\nno suitable plugins found:\nMissing decoder: WebM (video/webm)\n"
[2024-03-18T22:02:48Z DEBUG script::dom::document] Document got finish_load: Media
[2024-03-18T22:02:48Z DEBUG script::dom::document] Document loads are complete.
[2024-03-18T22:02:48Z DEBUG script::dom::document] About to dispatch load for "data:text/html,<video autoplay src=\"http... (f8a72f128b37adab)"
[2024-03-18T22:02:48Z TRACE servoshell<servo@LoadComplete] TopLevelBrowsingContext(0,1) LoadComplete
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31688
- [X] These changes are hard to test becuase WPT currently only tests this through a MediaSource, which is not yet implemented in servo.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
