### PR TITLE
bootstrap: Make unknown distro instructions more helpful

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -146,8 +146,9 @@ class Linux(Base):
             'void',
             'fedora linux asahi remix'
         ]:
-            raise NotImplementedError("mach bootstrap does not support "
-                                      f"{self.distro}, please file a bug")
+            raise NotImplementedError(f"mach bootstrap does not support {self.distro}."
+                                      " You may be able to install dependencies manually."
+                                      " See https://github.com/servo/servo/wiki/Building.")
 
         installed_something = self.install_non_gstreamer_dependencies(force)
         return installed_something


### PR DESCRIPTION
It doesn't make sense to ask everyone to file a bug if their
distribution is unsupported. We have manual build instructions for some
distributions and we can add instructions for more easily.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just update mach output.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
