### PR TITLE
layout: Add very basic support for showing text in input boxes

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 use html5ever::{local_name, LocalName};
 use log::warn;
 use script_layout_interface::wrapper_traits::{ThreadSafeLayoutElement, ThreadSafeLayoutNode};
+use script_layout_interface::{LayoutElementType, LayoutNodeType};
 use servo_arc::Arc as ServoArc;
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
@@ -163,6 +164,15 @@ fn traverse_children_of<'dom, Node>(
         } else if child.is_element() {
             traverse_element(child, context, handler);
         }
+    }
+
+    if matches!(
+        parent_element.type_id(),
+        LayoutNodeType::Element(LayoutElementType::HTMLInputElement) |
+            LayoutNodeType::Element(LayoutElementType::HTMLTextAreaElement)
+    ) {
+        let info = NodeAndStyleInfo::new(parent_element, parent_element.style(context));
+        handler.handle_text(&info, parent_element.to_threadsafe().node_text_content());
     }
 
     traverse_pseudo_element(WhichPseudoElement::After, parent_element, context, handler);


### PR DESCRIPTION
This is lacking many things. Notably:

1. There is no painting of selection or caret.
2. The size of the input box is wrong if it contains no text.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
