### PR TITLE
rustdoc: Fix `bare_urls` warning in `components/script`

### DIFF
--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -748,7 +748,7 @@ impl GPUDeviceMethods for GPUDevice {
         promise
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder>
     fn CreateCommandEncoder(
         &self,
         descriptor: &GPUCommandEncoderDescriptor,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Convert URL text to an anchor link to fix the `bare_urls` rustdoc warning.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31575
- [X] These changes do not require tests because they are documentation fixes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
