### PR TITLE
gfx: Derive `line-through` metrics for fonts on MacOS

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -410,7 +410,6 @@ impl Fragment {
         {
             let mut rect = rect;
             rect.origin.y += Length::from(font_metrics.ascent - font_metrics.strikeout_offset);
-            // XXX(ferjm) This does not work on MacOS #942
             rect.size.height = Length::new(font_metrics.strikeout_size.to_nearest_pixel(dppx));
             self.build_display_list_for_text_decoration(fragment, builder, &rect, &color);
         }


### PR DESCRIPTION
There is no platform-specific way to get metrics for `line-through` on
MacOS and currently striking through simply does not work. The correct
approach here is likely to first search for these metrics in font tables
and then fall back to deriving them. Searching the font tables is a
larger change, so this change adds the fallback mechanism first. This at
least makes sure that strike through renders at all on Mac.

In a followup change we can add support for getting metrics via HarfBuzz
in a platform-independent way, which is what Gecko does.

Fixes #942.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #942.
- [x] These changes do not require tests because this fixes the rendering of strikethrough but it's very hard to test and also we don't run automated tests yet for MacOS.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
