### PR TITLE
clippy: Fix dereferenced warnings in `components/script`

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1039,7 +1039,7 @@ impl CanvasState {
         };
         let node = canvas.upcast::<Node>();
         let window = window_from_node(&*canvas);
-        let resolved_font_style = match window.resolved_font_style_query(&node, value.to_string()) {
+        let resolved_font_style = match window.resolved_font_style_query(node, value.to_string()) {
             Some(value) => value,
             None => return, // syntax error
         };

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -308,7 +308,7 @@ impl HTMLLinkElement {
             None => "",
         };
 
-        let mut input = ParserInput::new(&mq_str);
+        let mut input = ParserInput::new(mq_str);
         let mut css_parser = CssParser::new(&mut input);
         let document_url_data = &UrlExtraData(document.url().get_arc());
         let window = document.window();
@@ -317,7 +317,7 @@ impl HTMLLinkElement {
         // much sense.
         let context = CssParserContext::new(
             Origin::Author,
-            &document_url_data,
+            document_url_data,
             Some(CssRuleType::Media),
             ParsingMode::DEFAULT,
             document.quirks_mode(),

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1952,7 +1952,7 @@ impl HTMLMediaElement {
         let global = self.global();
         let media_session = global.as_window().Navigator().MediaSession();
 
-        media_session.register_media_instance(&self);
+        media_session.register_media_instance(self);
 
         media_session.send_event(event);
     }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -300,7 +300,7 @@ impl ScriptOrigin {
 
     pub fn text(&self) -> Rc<DOMString> {
         match &self.code {
-            SourceCode::Text(text) => Rc::clone(&text),
+            SourceCode::Text(text) => Rc::clone(text),
             SourceCode::Compiled(compiled_script) => Rc::clone(&compiled_script.original_text),
         }
     }
@@ -319,11 +319,11 @@ fn finish_fetching_a_classic_script(
     let document = document_from_node(&*elem);
 
     match script_kind {
-        ExternalScriptKind::Asap => document.asap_script_loaded(&elem, load),
-        ExternalScriptKind::AsapInOrder => document.asap_in_order_script_loaded(&elem, load),
-        ExternalScriptKind::Deferred => document.deferred_script_loaded(&elem, load),
+        ExternalScriptKind::Asap => document.asap_script_loaded(elem, load),
+        ExternalScriptKind::AsapInOrder => document.asap_in_order_script_loaded(elem, load),
+        ExternalScriptKind::Deferred => document.deferred_script_loaded(elem, load),
         ExternalScriptKind::ParsingBlocking => {
-            document.pending_parsing_blocking_script_loaded(&elem, load)
+            document.pending_parsing_blocking_script_loaded(elem, load)
         },
     }
 
@@ -645,7 +645,7 @@ impl HTMLScriptElement {
         // Step 15.
         if !element.has_attribute(&local_name!("src")) &&
             doc.should_elements_inline_type_behavior_be_blocked(
-                &element,
+                element,
                 csp::InlineCheckType::Script,
                 &text,
             ) == csp::CheckResult::Blocked
@@ -1085,7 +1085,7 @@ impl HTMLScriptElement {
         // Step 4
         let window = window_from_node(self);
         let global = window.upcast::<GlobalScope>();
-        let _aes = AutoEntryScript::new(&global);
+        let _aes = AutoEntryScript::new(global);
 
         let tree = if script.external {
             global.get_module_map().borrow().get(&script.url).cloned()
@@ -1103,7 +1103,7 @@ impl HTMLScriptElement {
                 let module_error = module_tree.get_rethrow_error().borrow();
                 let network_error = module_tree.get_network_error().borrow();
                 if module_error.is_some() && network_error.is_none() {
-                    module_tree.report_error(&global);
+                    module_tree.report_error(global);
                     return;
                 }
             }
@@ -1117,11 +1117,11 @@ impl HTMLScriptElement {
             if let Some(record) = record {
                 rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
                 let evaluated =
-                    module_tree.execute_module(&global, record, rval.handle_mut().into());
+                    module_tree.execute_module(global, record, rval.handle_mut().into());
 
                 if let Err(exception) = evaluated {
                     module_tree.set_rethrow_error(exception);
-                    module_tree.report_error(&global);
+                    module_tree.report_error(global);
                     return;
                 }
             }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -456,7 +456,7 @@ impl HTMLTextAreaElement {
 
     #[allow(crown::unrooted_must_root)]
     fn selection(&self) -> TextControlSelection<Self> {
-        TextControlSelection::new(&self, &self.textinput)
+        TextControlSelection::new(self, &self.textinput)
     }
 }
 
@@ -656,7 +656,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     .task_manager()
                     .user_interaction_task_source()
                     .queue_event(
-                        &self.upcast(),
+                        self.upcast(),
                         atom!("input"),
                         EventBubbles::Bubbles,
                         EventCancelable::NotCancelable,

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -45,7 +45,7 @@ impl HTMLTrackElement {
         HTMLTrackElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
             ready_state: ReadyState::None,
-            track: Dom::from_ref(&track),
+            track: Dom::from_ref(track),
         }
     }
 
@@ -56,7 +56,7 @@ impl HTMLTrackElement {
         proto: Option<HandleObject>,
     ) -> DomRoot<HTMLTrackElement> {
         let track = TextTrack::new(
-            &document.window(),
+            document.window(),
             Default::default(),
             Default::default(),
             Default::default(),

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -148,7 +148,7 @@ impl HTMLVideoElement {
         }
 
         // Step 3.
-        let poster_url = match document_from_node(self).url().join(&poster_url) {
+        let poster_url = match document_from_node(self).url().join(poster_url) {
             Ok(url) => url,
             Err(_) => return,
         };

--- a/components/script/dom/mediametadata.rs
+++ b/components/script/dom/mediametadata.rs
@@ -65,7 +65,7 @@ impl MediaMetadata {
     }
 
     pub fn set_session(&self, session: &MediaSession) {
-        self.session.set(Some(&session));
+        self.session.set(Some(session));
     }
 }
 

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -133,7 +133,7 @@ impl MediaSessionMethods for MediaSession {
             init.artist = DOMString::from_string(metadata.artist.clone());
             init.album = DOMString::from_string(metadata.album.clone());
             let global = self.global();
-            Some(MediaMetadata::new(&global.as_window(), &init))
+            Some(MediaMetadata::new(global.as_window(), &init))
         } else {
             None
         }

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -154,7 +154,7 @@ impl MediaStream {
     fn clone_with_proto(&self, proto: Option<HandleObject>) -> DomRoot<MediaStream> {
         let new = MediaStream::new_with_proto(&self.global(), proto);
         for track in &*self.tracks.borrow() {
-            new.add_track(&track)
+            new.add_track(track)
         }
         new
     }

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -43,7 +43,7 @@ impl MediaStreamAudioDestinationNode {
         );
         let node = AudioNode::new_inherited(
             AudioNodeInit::MediaStreamDestinationNode(socket),
-            &context.upcast(),
+            context.upcast(),
             node_options,
             1, // inputs
             0, // outputs

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -39,14 +39,14 @@ impl MediaStreamAudioSourceNode {
             .id();
         let node = AudioNode::new_inherited(
             AudioNodeInit::MediaStreamSourceNode(track),
-            &context.upcast(),
+            context.upcast(),
             Default::default(),
             0, // inputs
             1, // outputs
         )?;
         Ok(MediaStreamAudioSourceNode {
             node,
-            stream: Dom::from_ref(&stream),
+            stream: Dom::from_ref(stream),
         })
     }
 

--- a/components/script/dom/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/mediastreamtrackaudiosourcenode.rs
@@ -30,14 +30,14 @@ impl MediaStreamTrackAudioSourceNode {
     ) -> Fallible<MediaStreamTrackAudioSourceNode> {
         let node = AudioNode::new_inherited(
             AudioNodeInit::MediaStreamSourceNode(track.id()),
-            &context.upcast(),
+            context.upcast(),
             Default::default(),
             0, // inputs
             1, // outputs
         )?;
         Ok(MediaStreamTrackAudioSourceNode {
             node,
-            track: Dom::from_ref(&track),
+            track: Dom::from_ref(track),
         })
     }
 

--- a/components/script/dom/messagechannel.rs
+++ b/components/script/dom/messagechannel.rs
@@ -31,10 +31,10 @@ impl MessageChannel {
     /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
     fn new(incumbent: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<MessageChannel> {
         // Step 1
-        let port1 = MessagePort::new(&incumbent);
+        let port1 = MessagePort::new(incumbent);
 
         // Step 2
-        let port2 = MessagePort::new(&incumbent);
+        let port2 = MessagePort::new(incumbent);
 
         incumbent.track_message_port(&*port1, None);
         incumbent.track_message_port(&*port2, None);

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -214,8 +214,7 @@ impl NavigatorMethods for Navigator {
 
     /// <https://immersive-web.github.io/webxr/#dom-navigator-xr>
     fn Xr(&self) -> DomRoot<XRSystem> {
-        self.xr
-            .or_init(|| XRSystem::new(&self.global().as_window()))
+        self.xr.or_init(|| XRSystem::new(self.global().as_window()))
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-navigator-mediadevices>

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -242,7 +242,7 @@ impl Node {
                     },
                     Some(ref prev_sibling) => {
                         prev_sibling.next_sibling.set(Some(new_child));
-                        new_child.prev_sibling.set(Some(&prev_sibling));
+                        new_child.prev_sibling.set(Some(prev_sibling));
                     },
                 }
                 before.prev_sibling.set(Some(new_child));
@@ -255,7 +255,7 @@ impl Node {
                     Some(ref last_child) => {
                         assert!(last_child.next_sibling.get().is_none());
                         last_child.next_sibling.set(Some(new_child));
-                        new_child.prev_sibling.set(Some(&last_child));
+                        new_child.prev_sibling.set(Some(last_child));
                     },
                 }
 
@@ -282,7 +282,7 @@ impl Node {
             node.set_flag(NodeFlags::IS_CONNECTED, parent_is_connected);
             // Out-of-document elements never have the descendants flag set.
             debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-            vtable_for(&&*node).bind_to_tree(&BindContext {
+            vtable_for(&*node).bind_to_tree(&BindContext {
                 tree_connected: parent_is_connected,
                 tree_in_doc: parent_in_doc,
             });
@@ -313,7 +313,7 @@ impl Node {
             // This needs to be in its own loop, because unbind_from_tree may
             // rely on the state of IS_IN_DOC of the context node's descendants,
             // e.g. when removing a <form>.
-            vtable_for(&&*node).unbind_from_tree(&context);
+            vtable_for(&*node).unbind_from_tree(context);
             // https://dom.spec.whatwg.org/#concept-node-remove step 14
             if let Some(element) = node.as_custom_element() {
                 ScriptThread::enqueue_callback_reaction(
@@ -2046,7 +2046,7 @@ impl Node {
                 Node::remove(kid, node, SuppressObserver::Suppressed);
             }
             // Step 5.
-            vtable_for(&node).children_changed(&ChildrenMutation::replace_all(new_nodes.r(), &[]));
+            vtable_for(node).children_changed(&ChildrenMutation::replace_all(new_nodes.r(), &[]));
 
             let mutation = Mutation::ChildList {
                 added: None,
@@ -2054,7 +2054,7 @@ impl Node {
                 prev: None,
                 next: None,
             };
-            MutationObserver::queue_a_mutation_record(&node, mutation);
+            MutationObserver::queue_a_mutation_record(node, mutation);
 
             new_nodes.r()
         } else {
@@ -2772,7 +2772,7 @@ impl NodeMethods for Node {
             next: reference_child,
         };
 
-        MutationObserver::queue_a_mutation_record(&self, mutation);
+        MutationObserver::queue_a_mutation_record(self, mutation);
 
         // Step 15.
         Ok(DomRoot::from_ref(child))
@@ -2958,7 +2958,7 @@ impl NodeMethods for Node {
             attr1 = Some(a);
             attr1owner = a.GetOwnerElement();
             node1 = match attr1owner {
-                Some(ref e) => Some(&e.upcast()),
+                Some(ref e) => Some(e.upcast()),
                 None => None,
             }
         }
@@ -3468,7 +3468,7 @@ impl UniqueId {
             if (*ptr).is_none() {
                 *ptr = Some(Box::new(Uuid::new_v4()));
             }
-            &(&*ptr).as_ref().unwrap()
+            (&*ptr).as_ref().unwrap()
         }
     }
 }

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -180,7 +180,7 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
                             processed_audio.resize(this.length as usize, Vec::new())
                         }
                         let buffer = AudioBuffer::new(
-                            &this.global().as_window(),
+                            this.global().as_window(),
                             this.channel_count,
                             this.length,
                             *this.context.SampleRate(),
@@ -188,7 +188,7 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
                         (*this.pending_rendering_promise.borrow_mut()).take().unwrap().resolve_native(&buffer);
                         let global = &this.global();
                         let window = global.as_window();
-                        let event = OfflineAudioCompletionEvent::new(&window,
+                        let event = OfflineAudioCompletionEvent::new(window,
                                                                      atom!("complete"),
                                                                      EventBubbles::DoesNotBubble,
                                                                      EventCancelable::NotCancelable,

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -469,7 +469,7 @@ impl PerformanceMethods for Performance {
         // Steps 2 to 6.
         let entry = PerformanceMark::new(&global, mark_name, self.now(), 0.);
         // Steps 7 and 8.
-        self.queue_entry(&entry.upcast::<PerformanceEntry>());
+        self.queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 9.
         Ok(())
@@ -516,7 +516,7 @@ impl PerformanceMethods for Performance {
         );
 
         // Step 9 and 10.
-        self.queue_entry(&entry.upcast::<PerformanceEntry>());
+        self.queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 11.
         Ok(())

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -200,7 +200,7 @@ impl Range {
         }
         if &self.start.node != node {
             if self.start.node == self.end.node {
-                node.ranges().push(WeakRef::new(&self));
+                node.ranges().push(WeakRef::new(self));
             } else if &self.end.node == node {
                 self.StartContainer().ranges().remove(self);
             } else {
@@ -218,7 +218,7 @@ impl Range {
         }
         if &self.end.node != node {
             if self.end.node == self.start.node {
-                node.ranges().push(WeakRef::new(&self));
+                node.ranges().push(WeakRef::new(self));
             } else if &self.start.node == node {
                 self.EndContainer().ranges().remove(self);
             } else {

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -103,7 +103,7 @@ impl ReadableStream {
     /// Build a stream backed by a Rust source that has already been read into memory.
     pub fn new_from_bytes(global: &GlobalScope, bytes: Vec<u8>) -> DomRoot<ReadableStream> {
         let stream = ReadableStream::new_with_external_underlying_source(
-            &global,
+            global,
             ExternalUnderlyingSource::Memory(bytes.len()),
         );
         stream.enqueue_native(bytes);
@@ -123,7 +123,7 @@ impl ReadableStream {
 
         let source = Rc::new(ExternalUnderlyingSourceController::new(source));
 
-        let stream = ReadableStream::new(&global, Some(source.clone()));
+        let stream = ReadableStream::new(global, Some(source.clone()));
 
         unsafe {
             let js_wrapper = CreateReadableStreamUnderlyingSource(

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -86,7 +86,7 @@ impl Request {
             // Step 5
             RequestInfo::USVString(USVString(ref usv_string)) => {
                 // Step 5.1
-                let parsed_url = base_url.join(&usv_string);
+                let parsed_url = base_url.join(usv_string);
                 // Step 5.2
                 if parsed_url.is_err() {
                     return Err(Error::Type("Url could not be parsed".to_string()));
@@ -266,11 +266,11 @@ impl Request {
 
         // Step 25.1
         if let Some(init_method) = init.method.as_ref() {
-            if !is_method(&init_method) {
+            if !is_method(init_method) {
                 return Err(Error::Type("Method is not a method".to_string()));
             }
             // Step 25.2
-            if is_forbidden_method(&init_method) {
+            if is_forbidden_method(init_method) {
                 return Err(Error::Type("Method is forbidden".to_string()));
             }
             // Step 25.3

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -155,7 +155,7 @@ impl Response {
         } else {
             // Reset FetchResponse to an in-memory stream with empty byte sequence here for
             // no-init-body case
-            let stream = ReadableStream::new_from_bytes(&global, Vec::with_capacity(0));
+            let stream = ReadableStream::new_from_bytes(global, Vec::with_capacity(0));
             r.body_stream.set(Some(&*stream));
         }
 

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -75,7 +75,7 @@ impl RTCDataChannel {
         let channel = RTCDataChannel {
             eventtarget: EventTarget::new_inherited(),
             servo_media_id,
-            peer_connection: Dom::from_ref(&peer_connection),
+            peer_connection: Dom::from_ref(peer_connection),
             label,
             ordered: options.ordered,
             max_packet_life_time: options.maxPacketLifeTime,

--- a/components/script/dom/rtcdatachannelevent.rs
+++ b/components/script/dom/rtcdatachannelevent.rs
@@ -52,7 +52,7 @@ impl RTCDataChannelEvent {
         channel: &RTCDataChannel,
     ) -> DomRoot<RTCDataChannelEvent> {
         let event = reflect_dom_object_with_proto(
-            Box::new(RTCDataChannelEvent::new_inherited(&channel)),
+            Box::new(RTCDataChannelEvent::new_inherited(channel)),
             global,
             proto,
         );

--- a/components/script/dom/rtcerrorevent.rs
+++ b/components/script/dom/rtcerrorevent.rs
@@ -52,7 +52,7 @@ impl RTCErrorEvent {
         error: &RTCError,
     ) -> DomRoot<RTCErrorEvent> {
         let event = reflect_dom_object_with_proto(
-            Box::new(RTCErrorEvent::new_inherited(&error)),
+            Box::new(RTCErrorEvent::new_inherited(error)),
             global,
             proto,
         );

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -307,7 +307,7 @@ impl RTCPeerConnection {
             DataChannelEvent::NewChannel => {
                 let channel = RTCDataChannel::new(
                     &self.global(),
-                    &self,
+                    self,
                     USVString::from("".to_owned()),
                     &RTCDataChannelInit::empty(),
                     Some(channel_id),
@@ -357,7 +357,7 @@ impl RTCPeerConnection {
     }
 
     pub fn unregister_data_channel(&self, id: &DataChannelId) {
-        self.data_channels.borrow_mut().remove(&id);
+        self.data_channels.borrow_mut().remove(id);
     }
 
     /// <https://www.w3.org/TR/webrtc/#update-ice-gathering-state>
@@ -648,7 +648,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
                             let this = this.root();
                             let desc = desc.into();
                             let desc = RTCSessionDescription::Constructor(
-                                &this.global().as_window(),
+                                this.global().as_window(),
                                 None,
                                 &desc,
                             ).unwrap();
@@ -688,7 +688,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
                             let this = this.root();
                             let desc = desc.into();
                             let desc = RTCSessionDescription::Constructor(
-                                &this.global().as_window(),
+                                this.global().as_window(),
                                 None,
                                 &desc,
                             ).unwrap();
@@ -764,7 +764,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         label: USVString,
         init: &RTCDataChannelInit,
     ) -> DomRoot<RTCDataChannel> {
-        RTCDataChannel::new(&self.global(), &self, label, init, None)
+        RTCDataChannel::new(&self.global(), self, label, init, None)
     }
 
     /// <https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addtransceiver>

--- a/components/script/dom/rtctrackevent.rs
+++ b/components/script/dom/rtctrackevent.rs
@@ -52,7 +52,7 @@ impl RTCTrackEvent {
         track: &MediaStreamTrack,
     ) -> DomRoot<RTCTrackEvent> {
         let trackevent = reflect_dom_object_with_proto(
-            Box::new(RTCTrackEvent::new_inherited(&track)),
+            Box::new(RTCTrackEvent::new_inherited(track)),
             global,
             proto,
         );

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -27,7 +27,7 @@ impl Screen {
     fn new_inherited(window: &Window) -> Screen {
         Screen {
             reflector_: Reflector::new(),
-            window: Dom::from_ref(&window),
+            window: Dom::from_ref(window),
         }
     }
 

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -47,7 +47,7 @@ impl ServiceWorkerContainer {
 
     #[allow(crown::unrooted_must_root)]
     pub fn new(global: &GlobalScope) -> DomRoot<ServiceWorkerContainer> {
-        let client = Client::new(&global.as_window());
+        let client = Client::new(global.as_window());
         let container = ServiceWorkerContainer::new_inherited(&*client);
         reflect_dom_object(Box::new(container), global)
     }

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -70,7 +70,7 @@ impl QueuedTaskConversion for ServiceWorkerScriptMsg {
         };
         match script_msg {
             CommonScriptMsg::Task(_category, _boxed, _pipeline_id, task_source) => {
-                Some(&task_source)
+                Some(task_source)
             },
             _ => None,
         }

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -119,7 +119,7 @@ impl ServiceWorkerRegistration {
 
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
-        let init = prepare_workerscope_init(&global, None, None);
+        let init = prepare_workerscope_init(global, None, None);
         ScopeThings {
             script_url: script_url,
             init: init,
@@ -197,6 +197,6 @@ impl ServiceWorkerRegistrationMethods for ServiceWorkerRegistration {
     // https://w3c.github.io/ServiceWorker/#service-worker-registration-navigationpreload
     fn NavigationPreload(&self) -> DomRoot<NavigationPreloadManager> {
         self.navigation_preload
-            .or_init(|| NavigationPreloadManager::new(&self.global(), &self))
+            .or_init(|| NavigationPreloadManager::new(&self.global(), self))
     }
 }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -433,7 +433,7 @@ impl Tokenizer {
             },
             ParseOperation::CreateComment { text, node } => {
                 let comment = Comment::new(DOMString::from(text), document, None);
-                self.insert_node(node, Dom::from_ref(&comment.upcast()));
+                self.insert_node(node, Dom::from_ref(comment.upcast()));
             },
             ParseOperation::AppendBeforeSibling { sibling, node } => {
                 self.append_before_sibling(sibling, node);

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -228,13 +228,13 @@ impl<'a> Serialize for &'a Node {
                 },
 
                 SerializationCommand::CloseElement(n) => {
-                    end_element(&&n, serializer)?;
+                    end_element(&n, serializer)?;
                 },
 
                 SerializationCommand::SerializeNonelement(n) => match n.type_id() {
                     NodeTypeId::DocumentType => {
                         let doctype = n.downcast::<DocumentType>().unwrap();
-                        serializer.write_doctype(&doctype.name())?;
+                        serializer.write_doctype(doctype.name())?;
                     },
 
                     NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => {
@@ -250,7 +250,7 @@ impl<'a> Serialize for &'a Node {
                     NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
                         let pi = n.downcast::<ProcessingInstruction>().unwrap();
                         let data = pi.upcast::<CharacterData>().data();
-                        serializer.write_processing_instruction(&pi.target(), &data)?;
+                        serializer.write_processing_instruction(pi.target(), &data)?;
                     },
 
                     NodeTypeId::DocumentFragment(_) => {},

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -656,7 +656,7 @@ impl WorkletThread {
         let script = load_whole_resource(
             request,
             &resource_fetcher,
-            &global_scope.upcast::<GlobalScope>(),
+            global_scope.upcast::<GlobalScope>(),
         )
         .ok()
         .and_then(|(_, bytes)| String::from_utf8(bytes).ok());

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -100,7 +100,7 @@ impl XRInputSourceMethods for XRInputSource {
     fn TargetRaySpace(&self) -> DomRoot<XRSpace> {
         self.target_ray_space.or_init(|| {
             let global = self.global();
-            XRSpace::new_inputspace(&global, &self.session, &self, false)
+            XRSpace::new_inputspace(&global, &self.session, self, false)
         })
     }
 

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -542,7 +542,7 @@ impl XRSession {
         match event {
             FrameUpdateEvent::HitTestSourceAdded(id) => {
                 if let Some(promise) = self.pending_hit_test_promises.borrow_mut().remove(&id) {
-                    promise.resolve_native(&XRHitTestSource::new(&self.global(), id, &self));
+                    promise.resolve_native(&XRHitTestSource::new(&self.global(), id, self));
                 } else {
                     warn!(
                         "received hit test add request for unknown hit test {:?}",

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -84,7 +84,7 @@ impl XRTestMethods for XRTest {
         };
 
         let floor_origin = if let Some(ref o) = init.floorOrigin {
-            match get_origin(&o) {
+            match get_origin(o) {
                 Ok(origin) => Some(origin),
                 Err(e) => {
                     p.reject_error(e);

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -346,7 +346,7 @@ pub fn load_whole_resource(
             FetchResponseMsg::ProcessResponseEOF(Ok(_)) => {
                 let metadata = metadata.unwrap();
                 if let Some(timing) = &metadata.timing {
-                    submit_timing_data(global, url, InitiatorType::Other, &timing);
+                    submit_timing_data(global, url, InitiatorType::Other, timing);
                 }
                 return Ok((metadata, buf));
             },

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -59,7 +59,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ::style::dom::TShadowRoot
     where
         Self: 'a,
     {
-        Some(&self.shadow_root.get_style_data_for_layout())
+        Some(self.shadow_root.get_style_data_for_layout())
     }
 }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -79,7 +79,7 @@ use crate::task_source::TaskSourceName;
 #[allow(unsafe_code)]
 unsafe fn gen_type_error(global: &GlobalScope, string: String) -> RethrowError {
     rooted!(in(*GlobalScope::get_cx()) let mut thrown = UndefinedValue());
-    Error::Type(string).to_jsval(*GlobalScope::get_cx(), &global, thrown.handle_mut());
+    Error::Type(string).to_jsval(*GlobalScope::get_cx(), global, thrown.handle_mut());
 
     return RethrowError(RootedTraceableBox::from_box(Heap::boxed(thrown.get())));
 }
@@ -329,7 +329,7 @@ impl ModuleTree {
         let module_map = global.get_module_map().borrow();
         let mut discovered_urls = HashSet::new();
 
-        ModuleTree::recursive_check_descendants(&self, &module_map.0, &mut discovered_urls)
+        ModuleTree::recursive_check_descendants(self, &module_map.0, &mut discovered_urls)
     }
 
     // We just leverage the power of Promise to run the task for `finish` the owner.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3747,7 +3747,7 @@ impl ScriptThread {
         global_scope.evaluate_js_on_global_with_result(
             &script_source,
             jsval.handle_mut(),
-            ScriptFetchOptions::default_classic_script(&global_scope),
+            ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),
         );
 
@@ -3803,7 +3803,7 @@ impl ScriptThread {
                 DOMString::from("resize"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::NotCancelable,
-                Some(&window),
+                Some(window),
                 0i32,
             );
             uievent.upcast::<Event>().fire(window.upcast());

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -461,7 +461,7 @@ pub fn handle_find_element_link_text(
                 .find_document(pipeline)
                 .ok_or(ErrorStatus::UnknownError)
                 .and_then(|document| {
-                    first_matching_link(&document.upcast::<Node>(), selector.clone(), partial)
+                    first_matching_link(document.upcast::<Node>(), selector.clone(), partial)
                 }),
         )
         .unwrap();
@@ -528,7 +528,7 @@ pub fn handle_find_elements_link_text(
                 .find_document(pipeline)
                 .ok_or(ErrorStatus::UnknownError)
                 .and_then(|document| {
-                    all_matching_links(&document.upcast::<Node>(), selector.clone(), partial)
+                    all_matching_links(document.upcast::<Node>(), selector.clone(), partial)
                 }),
         )
         .unwrap();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Delete needless borrows (`&`) to fix the dereferenced clippy warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
