### PR TITLE
Net: fold websocket and http tokio runtime into one

### DIFF
--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -1,0 +1,8 @@
+use std::sync::Mutex;
+
+use lazy_static::lazy_static;
+use tokio::runtime::Runtime;
+
+lazy_static! {
+    pub static ref HANDLE: Mutex<Option<Runtime>> = Mutex::new(Some(Runtime::new().unwrap()));
+}

--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::sync::Mutex;
 
 use lazy_static::lazy_static;

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -18,8 +18,8 @@ use log::warn;
 use rustls::client::WebPkiVerifier;
 use rustls::{Certificate, ClientConfig, OwnedTrustAnchor, RootCertStore, ServerName};
 
+use crate::async_runtime::HANDLE;
 use crate::hosts::replace_host;
-use crate::http_loader::HANDLE;
 
 pub const BUF_SIZE: usize = 32768;
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -31,7 +31,6 @@ use hyper::{Body, Client, Response as HyperResponse};
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
-use lazy_static::lazy_static;
 use log::{debug, error, info, log_enabled, warn};
 use msg::constellation_msg::{HistoryStateId, PipelineId};
 use net_traits::pub_domains::reg_suffix;
@@ -50,13 +49,13 @@ use net_traits::{
 };
 use servo_arc::Arc;
 use servo_url::{ImmutableOrigin, ServoUrl};
-use tokio::runtime::Runtime;
 use tokio::sync::mpsc::{
     channel, unbounded_channel, Receiver as TokioReceiver, Sender as TokioSender,
     UnboundedReceiver, UnboundedSender,
 };
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::async_runtime::HANDLE;
 use crate::connector::{
     create_http_client, create_tls_config, CACertificates, CertificateErrorOverrideManager,
     Connector,
@@ -69,10 +68,6 @@ use crate::fetch::methods::{main_fetch, Data, DoneChannel, FetchContext, Target}
 use crate::hsts::HstsList;
 use crate::http_cache::{CacheKey, HttpCache};
 use crate::resource_thread::AuthCache;
-
-lazy_static! {
-    pub static ref HANDLE: Mutex<Option<Runtime>> = Mutex::new(Some(Runtime::new().unwrap()));
-}
 
 /// The various states an entry of the HttpCache can be in.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(unsafe_code)]
 
+pub mod async_runtime;
 pub mod connector;
 pub mod cookie;
 pub mod cookie_storage;

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -39,6 +39,7 @@ use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
 
+use crate::async_runtime::HANDLE;
 use crate::connector::{
     create_http_client, create_tls_config, CACertificates, CertificateErrorOverrideManager,
 };
@@ -48,7 +49,7 @@ use crate::fetch::methods::{fetch, CancellationListener, FetchContext};
 use crate::filemanager_thread::FileManager;
 use crate::hsts::HstsList;
 use crate::http_cache::HttpCache;
-use crate::http_loader::{http_redirect_fetch, HttpState, HANDLE};
+use crate::http_loader::{http_redirect_fetch, HttpState};
 use crate::storage_thread::StorageThreadFactory;
 use crate::{cookie, websocket_loader};
 

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -37,12 +37,12 @@ use tungstenite::protocol::CloseFrame;
 use tungstenite::Message;
 use url::Url;
 
+use crate::async_runtime::HANDLE;
 use crate::connector::{create_tls_config, CACertificates, TlsConfig};
 use crate::cookie::Cookie;
 use crate::fetch::methods::should_be_blocked_due_to_bad_port;
 use crate::hosts::replace_host;
-use crate::http_loader::{HttpState, HANDLE};
-
+use crate::http_loader::HttpState;
 /// Create a tungstenite Request object for the initial HTTP request.
 /// This request contains `Origin`, `Sec-WebSocket-Protocol`, `Authorization`,
 /// and `Cookie` headers as appropriate.

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -12,7 +12,7 @@
 //! the need for a dedicated thread per websocket.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use async_tungstenite::tokio::{client_async_tls_with_connector_and_config, ConnectStream};
 use async_tungstenite::WebSocketStream;
@@ -23,13 +23,11 @@ use futures::stream::StreamExt;
 use http::header::{self, HeaderName, HeaderValue};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
-use lazy_static::lazy_static;
 use log::{debug, trace, warn};
 use net_traits::request::{RequestBuilder, RequestMode};
 use net_traits::{CookieSource, MessageData, WebSocketDomAction, WebSocketNetworkEvent};
 use servo_url::ServoUrl;
 use tokio::net::TcpStream;
-use tokio::runtime::Runtime;
 use tokio::select;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio_rustls::TlsConnector;
@@ -43,14 +41,7 @@ use crate::connector::{create_tls_config, CACertificates, TlsConfig};
 use crate::cookie::Cookie;
 use crate::fetch::methods::should_be_blocked_due_to_bad_port;
 use crate::hosts::replace_host;
-use crate::http_loader::HttpState;
-
-// Websockets get their own tokio runtime that's independent of the one used for
-// HTTP connections, otherwise a large number of websockets could occupy all workers
-// and starve other network traffic.
-lazy_static! {
-    pub static ref HANDLE: Mutex<Option<Runtime>> = Mutex::new(Some(Runtime::new().unwrap()));
-}
+use crate::http_loader::{HttpState, HANDLE};
 
 /// Create a tungstenite Request object for the initial HTTP request.
 /// This request contains `Origin`, `Sec-WebSocket-Protocol`, `Authorization`,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Share the same tokio runtime between http loader and websocket loader.
Since tokio 0.2.14, long running tasks can be preempted.

https://tokio.rs/blog/2020-04-preemption
https://github.com/tokio-rs/tokio/pull/2160

https://github.com/servo/servo/commit/76198e40a8921bfa6ef4e8e8d259ebdc3814e426#diff-82827a4300a35d539615e071a6daff34e5791d11a66f7930bcc25f36442ee292R61

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31648

<!-- Either: -->
- [x] These changes do not require tests because there is no behavior changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
