### PR TITLE
webgpu: Implement onSubmittedWorkDone

### DIFF
--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -208,7 +208,7 @@ impl GPUQueueMethods for GPUQueue {
                 queue_id: self.queue.0,
             },
         )) {
-            todo!("QueueOnSubmittedWorkDone failed with {e}")
+            warn!("QueueOnSubmittedWorkDone failed with {e}")
         }
         promise
     }

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
 use webgpu::identity::WebGPUOpResult;
-use webgpu::{wgt, WebGPU, WebGPUQueue, WebGPURequest, WebGPUResponse, WebGPUResponseResult};
+use webgpu::{wgt, WebGPU, WebGPUQueue, WebGPURequest, WebGPUResponse};
 
 use super::bindings::codegen::Bindings::WebGPUBinding::{GPUImageCopyTexture, GPUImageDataLayout};
 use super::gpu::{response_async, AsyncWGPUListener};
@@ -196,7 +196,7 @@ impl GPUQueueMethods for GPUQueue {
         Ok(())
     }
 
-    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone>
     fn OnSubmittedWorkDone(&self) -> Rc<Promise> {
         let global = self.global();
         let promise = Promise::new(&global);
@@ -208,14 +208,13 @@ impl GPUQueueMethods for GPUQueue {
                 queue_id: self.queue.0,
             },
         )) {
-            todo!("QueueOnSubmittedWorkDone failed")
+            todo!("QueueOnSubmittedWorkDone failed with {e}")
         }
         promise
     }
 }
 
 impl AsyncWGPUListener for GPUQueue {
-    #[allow(unsafe_code)]
     fn handle_response(
         &self,
         response: Option<Result<webgpu::WebGPUResponse, String>>,

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -2,19 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
 use webgpu::identity::WebGPUOpResult;
-use webgpu::{wgt, WebGPU, WebGPUQueue, WebGPURequest};
+use webgpu::{wgt, WebGPU, WebGPUQueue, WebGPURequest, WebGPUResponse, WebGPUResponseResult};
 
 use super::bindings::codegen::Bindings::WebGPUBinding::{GPUImageCopyTexture, GPUImageDataLayout};
+use super::gpu::{response_async, AsyncWGPUListener};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUExtent3D, GPUQueueMethods, GPUSize64,
 };
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer as BufferSource;
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
@@ -25,6 +28,7 @@ use crate::dom::gpuconvert::{
     convert_texture_size_to_wgt,
 };
 use crate::dom::gpudevice::GPUDevice;
+use crate::dom::promise::Promise;
 
 #[dom_struct]
 pub struct GPUQueue {
@@ -190,5 +194,41 @@ impl GPUQueueMethods for GPUQueue {
         }
 
         Ok(())
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone
+    fn OnSubmittedWorkDone(&self) -> Rc<Promise> {
+        let global = self.global();
+        let promise = Promise::new(&global);
+        let sender = response_async(&promise, self);
+        if let Err(e) = self.channel.0.send((
+            self.device.borrow().as_ref().unwrap().use_current_scope(),
+            WebGPURequest::QueueOnSubmittedWorkDone {
+                sender,
+                queue_id: self.queue.0,
+            },
+        )) {
+            todo!("QueueOnSubmittedWorkDone failed")
+        }
+        promise
+    }
+}
+
+impl AsyncWGPUListener for GPUQueue {
+    #[allow(unsafe_code)]
+    fn handle_response(
+        &self,
+        response: Option<Result<webgpu::WebGPUResponse, String>>,
+        promise: &Rc<Promise>,
+    ) {
+        match response {
+            Some(Ok(WebGPUResponse::SubmittedWorkDone)) => {
+                promise.resolve_native(&());
+            },
+            _ => {
+                warn!("GPUQueue received wrong WebGPUResponse");
+                promise.reject_error(Error::Operation);
+            },
+        }
     }
 }

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -991,8 +991,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
 interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> buffers);
 
-    //TODO:
-    //Promise<undefined> onSubmittedWorkDone();
+    Promise<undefined> onSubmittedWorkDone();
 
     [Throws]
     undefined writeBuffer(

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use log::{error, warn};
-use wgpu::device::queue::{SubmittedWorkDoneClosure, SubmittedWorkDoneClosureC};
+use wgpu::device::queue::SubmittedWorkDoneClosure;
 use wgpu::gfx_select;
 pub use {wgpu_core as wgpu, wgpu_types as wgt};
 

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use log::{error, warn};
+use wgpu::device::queue::{SubmittedWorkDoneClosure, SubmittedWorkDoneClosureC};
 use wgpu::gfx_select;
 pub use {wgpu_core as wgpu, wgpu_types as wgt};
 
@@ -69,6 +70,7 @@ pub enum WebGPUResponse {
         descriptor: wgt::DeviceDescriptor<Option<String>>,
     },
     BufferMapAsync(IpcSharedMemory),
+    SubmittedWorkDone,
 }
 
 pub type WebGPUResponseResult = Result<WebGPUResponse, String>;
@@ -257,6 +259,10 @@ pub enum WebGPURequest {
         size: wgt::Extent3d,
         data: IpcSharedMemory,
     },
+    QueueOnSubmittedWorkDone {
+        sender: IpcSender<Option<WebGPUResponseResult>>,
+        queue_id: id::QueueId,
+    },
 }
 
 struct BufferMapInfo<'a, T> {
@@ -350,6 +356,8 @@ struct WGPU<'a> {
     buffer_maps: WebGPUBufferMaps<'a>,
     // Presentation Buffers with pending mapping
     present_buffer_maps: WebGPUPresentBufferMaps<'a>,
+    /// Queues with pending submitted work
+    queue_submitted_work: HashMap<id::QueueId, Rc<IpcSender<Option<WebGPUResponseResult>>>>,
     //TODO: Remove this (https://github.com/gfx-rs/wgpu/issues/867)
     error_command_encoders: RefCell<HashMap<id::CommandEncoderId, String>>,
     webrender_api: RenderApi,
@@ -391,6 +399,7 @@ impl<'a> WGPU<'a> {
             _invalid_adapters: Vec::new(),
             buffer_maps: HashMap::new(),
             present_buffer_maps: HashMap::new(),
+            queue_submitted_work: HashMap::new(),
             error_command_encoders: RefCell::new(HashMap::new()),
             webrender_api: webrender_api_sender.create_api(),
             webrender_document,
@@ -1247,6 +1256,32 @@ impl<'a> WGPU<'a> {
                             &data_layout,
                             &size
                         ));
+                        self.send_result(queue_id, scope_id, result);
+                    },
+                    WebGPURequest::QueueOnSubmittedWorkDone { sender, queue_id } => {
+                        let global = &self.global;
+                        self.queue_submitted_work
+                            .insert(queue_id, Rc::new(sender.clone()));
+                        unsafe extern "C" fn callback(userdata: *mut u8) {
+                            let sender = Rc::from_raw(
+                                userdata as *const IpcSender<Option<WebGPUResponseResult>>,
+                            );
+                            if let Err(e) = sender.send(Some(Ok(WebGPUResponse::SubmittedWorkDone)))
+                            {
+                                warn!("Could not send SubmittedWorkDone Response ({})", e);
+                            }
+                        }
+
+                        // TODO(sagudev): use rust closure
+                        let callback_c = unsafe {
+                            SubmittedWorkDoneClosure::from_c(SubmittedWorkDoneClosureC {
+                                callback,
+                                user_data: convert_to_pointer(
+                                    self.queue_submitted_work.get(&queue_id).unwrap().clone(),
+                                ),
+                            })
+                        };
+                        let result = gfx_select!(queue_id => global.queue_on_submitted_work_done(queue_id, callback_c));
                         self.send_result(queue_id, scope_id, result);
                     },
                 }

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -2373,8 +2373,6 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:rw:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2389,12 +2387,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2409,8 +2403,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2561,8 +2553,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2577,16 +2567,10 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2601,12 +2585,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2795,8 +2775,6 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:wr:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2811,12 +2789,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2831,8 +2805,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2983,8 +2955,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -2999,16 +2969,10 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -3023,12 +2987,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3217,8 +3177,6 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:ww:*]
   [:boundary="command-buffer";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -3233,8 +3191,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
     expected:
@@ -3265,8 +3221,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -3281,8 +3235,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
     expected:
@@ -3293,8 +3245,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -3309,12 +3259,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","write-buffer"\];contexts=["command-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
     expected:
@@ -3357,8 +3303,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -3373,16 +3317,10 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","write-buffer"\];contexts=["command-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","b2b-copy"\];contexts=["queue","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","compute-pass-encoder"\]]
     expected:
@@ -3397,18 +3335,12 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","t2b-copy"\];contexts=["queue","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","write-buffer"\];contexts=["queue","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:rw:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -3423,12 +3355,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -3443,8 +3371,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3595,32 +3521,20 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -3635,12 +3549,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3663,8 +3573,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3799,8 +3707,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3823,8 +3729,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:two_dispatches_in_the_same_compute_pass:*]
@@ -3847,8 +3751,6 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:wr:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -3863,12 +3765,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -3883,8 +3781,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -4035,32 +3931,20 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
     expected:
@@ -4075,12 +3959,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -4103,8 +3983,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -4239,8 +4117,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -4263,14 +4139,10 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:ww:*]
   [:boundary="command-buffer";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -4285,8 +4157,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
     expected:
@@ -4317,8 +4187,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -4333,8 +4201,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
     expected:
@@ -4345,8 +4211,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -4361,12 +4225,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","write-buffer"\];contexts=["command-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
     expected:
@@ -4409,8 +4269,6 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
     expected:
@@ -4425,36 +4283,22 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","write-buffer"\];contexts=["command-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","b2b-copy"\];contexts=["queue","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","render-bundle-encoder"\]]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","t2b-copy"\];contexts=["queue","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","write-buffer"\];contexts=["queue","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:*]
@@ -4975,32 +4819,22 @@
 
 [cts.https.html?q=webgpu:api,operation,onSubmittedWorkDone:many,parallel:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,onSubmittedWorkDone:many,parallel_order:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,onSubmittedWorkDone:many,serial:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,onSubmittedWorkDone:with_work:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,onSubmittedWorkDone:without_work:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,pipeline,default_layout:getBindGroupLayout_js_object:*]
@@ -15451,11 +15285,11 @@
 
   [:limitTest="overMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="overMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: TIMEOUT
 
   [:limitTest="overMaximum";testValueName="atLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false]
     expected:
@@ -19010,7 +18844,34 @@
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,limits,maxTextureArrayLayers:createTexture,at_over:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: [TIMEOUT, CRASH]
+  [:limitTest="atDefault";testValueName="atLimit"]
+
+  [:limitTest="atDefault";testValueName="overLimit"]
+
+  [:limitTest="atMaximum";testValueName="atLimit"]
+
+  [:limitTest="atMaximum";testValueName="overLimit"]
+
+  [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit"]
+
+  [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit"]
+
+  [:limitTest="overMaximum";testValueName="atLimit"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
+
+  [:limitTest="overMaximum";testValueName="overLimit"]
+    expected:
+      if os == "linux" and not debug: [PASS, TIMEOUT]
+
+  [:limitTest="underDefault";testValueName="atLimit"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
+
+  [:limitTest="underDefault";testValueName="overLimit"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,limits,maxTextureDimension1D:createTexture,at_over:*]
@@ -68793,8 +68654,6 @@
 
 [cts.https.html?q=webgpu:examples:gpu,async:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:examples:gpu,buffers:*]
@@ -68932,30 +68791,30 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:scalar_vector:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68970,19 +68829,17 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:equals:*]
@@ -69058,6 +68915,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:less_than:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69094,6 +68953,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_division:scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69142,110 +69003,106 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_matrix_addition:matrix:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_matrix_subtraction:matrix:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:scalar:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69260,19 +69117,17 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar:*]
@@ -69282,6 +69137,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69296,6 +69153,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -69324,27 +69183,23 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:vector:*]
@@ -69362,811 +69217,773 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_and:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_and_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_exclusive_or:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_exclusive_or_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_or:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_or_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_left_concrete:*]
@@ -70176,8 +69993,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_left_concrete_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70195,380 +70010,364 @@
       if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_right_concrete:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_right_concrete_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:type="i32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:and:*]
@@ -70589,8 +70388,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -70605,8 +70402,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -70621,8 +70416,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -70655,8 +70448,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -70671,8 +70462,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -70687,8 +70476,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -70709,16 +70496,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:equals:*]
@@ -70739,8 +70520,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -70755,8 +70534,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -70771,8 +70548,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -70805,8 +70580,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -70821,8 +70594,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -70837,8 +70608,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -70871,8 +70640,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -70887,8 +70654,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -70903,8 +70668,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -70937,8 +70700,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -70953,8 +70714,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -70969,8 +70728,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -70991,19 +70748,15 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -71014,6 +70767,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -71126,6 +70881,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -71426,6 +71183,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -71944,6 +71703,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -72018,6 +71779,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -72462,6 +72225,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_vector_multiplication:vector_matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72558,6 +72323,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -72584,6 +72351,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72646,6 +72415,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -72880,6 +72651,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72932,143 +72705,121 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar_vector:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector:*]
@@ -73085,8 +72836,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
@@ -73097,8 +72846,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
@@ -73109,8 +72856,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
@@ -73123,106 +72868,98 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector_scalar:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";dim=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";dim=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";dim=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:equals:*]
@@ -73243,8 +72980,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73259,8 +72994,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73275,8 +73008,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73292,6 +73023,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_equals:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73309,8 +73042,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73325,8 +73056,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73341,8 +73070,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73358,6 +73085,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_than:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73375,8 +73104,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73391,8 +73118,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73407,8 +73132,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73441,8 +73164,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73457,8 +73178,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73473,8 +73192,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73507,8 +73224,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73523,8 +73238,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73539,8 +73252,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73573,8 +73284,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73589,8 +73298,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73605,8 +73312,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73622,21 +73327,17 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_compound:*]
@@ -73657,8 +73358,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -73673,8 +73372,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -73689,8 +73386,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -73706,6 +73401,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73720,7 +73417,7 @@
 
   [:inputSource="storage_r";dim=2]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";dim=3]
     expected:
@@ -73732,7 +73429,7 @@
 
   [:inputSource="storage_rw";dim=2]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";dim=3]
     expected:
@@ -73744,7 +73441,7 @@
 
   [:inputSource="uniform";dim=2]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";dim=3]
     expected:
@@ -73769,8 +73466,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
@@ -73781,8 +73476,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
@@ -73793,8 +73486,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
@@ -73806,6 +73497,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73819,8 +73512,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=3]
     expected:
@@ -73831,8 +73522,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=3]
     expected:
@@ -73843,8 +73532,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=3]
     expected:
@@ -73869,8 +73556,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=3]
     expected:
@@ -73881,8 +73566,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=3]
     expected:
@@ -73893,8 +73576,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=3]
     expected:
@@ -73906,411 +73587,371 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_addition:matrix:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_addition:matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_matrix_multiplication:matrix_matrix:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=3;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=2;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=3;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=2;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=3;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=2;y_cols=2]
     expected:
@@ -74322,11 +73963,11 @@
 
   [:inputSource="storage_r";common_dim=2;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=3;y_cols=3]
     expected:
@@ -74334,19 +73975,19 @@
 
   [:inputSource="storage_r";common_dim=2;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=2;y_cols=2]
     expected:
@@ -74358,11 +73999,11 @@
 
   [:inputSource="storage_r";common_dim=3;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=3;y_cols=3]
     expected:
@@ -74370,55 +74011,55 @@
 
   [:inputSource="storage_r";common_dim=3;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2;y_cols=2]
     expected:
@@ -74430,11 +74071,11 @@
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3;y_cols=3]
     expected:
@@ -74442,19 +74083,19 @@
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2;y_cols=2]
     expected:
@@ -74466,11 +74107,11 @@
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3;y_cols=3]
     expected:
@@ -74478,55 +74119,55 @@
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=2;y_cols=2]
     expected:
@@ -74534,15 +74175,15 @@
 
   [:inputSource="uniform";common_dim=2;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=3;y_cols=3]
     expected:
@@ -74550,19 +74191,19 @@
 
   [:inputSource="uniform";common_dim=2;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=2;y_cols=2]
     expected:
@@ -74570,15 +74211,15 @@
 
   [:inputSource="uniform";common_dim=3;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=3;y_cols=3]
     expected:
@@ -74586,95 +74227,93 @@
 
   [:inputSource="uniform";common_dim=3;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4;y_cols=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4;y_cols=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4;y_cols=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_matrix_multiplication:matrix_matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";common_dim=2;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=2;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=3;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";common_dim=4;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=2]
     expected:
@@ -74686,7 +74325,7 @@
 
   [:inputSource="storage_r";common_dim=2;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=2]
     expected:
@@ -74698,19 +74337,19 @@
 
   [:inputSource="storage_r";common_dim=3;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2]
     expected:
@@ -74722,7 +74361,7 @@
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2]
     expected:
@@ -74734,19 +74373,19 @@
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=2]
     expected:
@@ -74754,15 +74393,15 @@
 
   [:inputSource="uniform";common_dim=2;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=3]
     expected:
@@ -74770,1247 +74409,1109 @@
 
   [:inputSource="uniform";common_dim=3;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:matrix_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:matrix_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:scalar_matrix:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:matrix_vector:*]
-  expected:
-    if os == "linux" and not debug: [TIMEOUT, ERROR]
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix:*]
   expected:
-    if os == "linux" and not debug: [TIMEOUT, ERROR]
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=2;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";cols=2;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=3;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=3;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=4;rows=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=4;rows=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=4;rows=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: [TIMEOUT, ERROR]
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_vector:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector:*]
@@ -76027,8 +75528,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
@@ -76039,8 +75538,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
@@ -76051,8 +75548,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
@@ -76064,107 +75559,91 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:scalar:*]
@@ -76173,16 +75652,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:scalar_compound:*]
@@ -76203,8 +75676,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -76219,8 +75690,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -76235,8 +75704,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -76265,8 +75732,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=3]
     expected:
@@ -76277,8 +75742,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=3]
     expected:
@@ -76289,8 +75752,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=3]
     expected:
@@ -76315,8 +75776,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
@@ -76327,8 +75786,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
@@ -76339,8 +75796,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
@@ -76365,8 +75820,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=3]
     expected:
@@ -76377,8 +75830,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=3]
     expected:
@@ -76389,8 +75840,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=3]
     expected:
@@ -76415,8 +75864,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=3]
     expected:
@@ -76427,8 +75874,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=3]
     expected:
@@ -76439,8 +75884,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=3]
     expected:
@@ -76452,143 +75895,119 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector:*]
@@ -76605,8 +76024,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
@@ -76617,8 +76034,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
@@ -76629,8 +76044,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
@@ -76642,107 +76055,91 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";dim=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform";dim=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition:*]
@@ -76763,8 +76160,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -76779,8 +76174,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -76829,8 +76222,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -76845,8 +76236,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -76878,159 +76267,143 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division:*]
@@ -77166,162 +76539,160 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_vector_scalar:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77340,7 +76711,7 @@
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -77356,7 +76727,7 @@
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -77405,8 +76776,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -77421,8 +76790,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -77454,71 +76821,63 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
     expected:
@@ -77526,11 +76885,11 @@
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
     expected:
@@ -77538,75 +76897,69 @@
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder:*]
@@ -77743,158 +77096,154 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_scalar_vector:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction:*]
@@ -77915,8 +77264,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -77931,8 +77278,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -77964,6 +77309,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77982,7 +77329,7 @@
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -77998,7 +77345,7 @@
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78031,70 +77378,70 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_scalar_vector:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_rhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_rhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_rhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_vector_scalar:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT]
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=2]
     expected:
@@ -78102,11 +77449,11 @@
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=2]
     expected:
@@ -78114,75 +77461,71 @@
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_vector_scalar_compound:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:equals:*]
@@ -78203,8 +77546,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78219,8 +77560,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78235,8 +77574,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78269,8 +77606,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78285,8 +77620,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78301,8 +77634,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78335,8 +77666,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78351,8 +77680,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78367,8 +77694,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78401,8 +77726,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78417,8 +77740,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78433,8 +77754,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78467,8 +77786,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78483,8 +77800,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78499,8 +77814,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78533,8 +77846,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78549,8 +77860,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78565,8 +77874,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78599,8 +77906,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78615,8 +77920,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78631,8 +77934,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78665,8 +77966,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -78681,8 +77980,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -78697,8 +77994,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -78727,8 +78022,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
@@ -78739,8 +78032,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
@@ -78777,8 +78068,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
@@ -78789,8 +78078,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
@@ -78827,8 +78114,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
@@ -78839,8 +78124,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
@@ -79163,8 +78446,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -79179,8 +78460,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -79195,8 +78474,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -79212,6 +78489,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79229,8 +78508,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -79245,8 +78522,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -79261,8 +78536,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -79291,8 +78564,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
@@ -79303,8 +78574,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
@@ -79341,8 +78610,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
@@ -79353,8 +78620,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
@@ -79378,6 +78643,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79391,8 +78658,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
@@ -79403,8 +78668,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
@@ -79727,8 +78990,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -79743,8 +79004,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -79759,8 +79018,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -79776,6 +79033,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_compound:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79793,8 +79052,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -79809,8 +79066,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -79825,8 +79080,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -79855,8 +79108,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=3]
     expected:
@@ -79867,8 +79118,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=3]
     expected:
@@ -79905,8 +79154,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
@@ -79917,8 +79164,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
@@ -79955,8 +79200,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=3]
     expected:
@@ -79967,8 +79210,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=3]
     expected:
@@ -80009,8 +79250,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80025,8 +79264,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80041,8 +79278,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80075,8 +79310,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80091,8 +79324,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80107,8 +79338,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80141,8 +79370,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80157,8 +79384,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80173,8 +79398,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80256,6 +79479,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_than:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -80273,8 +79498,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80289,8 +79512,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80305,8 +79526,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80322,6 +79541,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:not_equals:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -80340,7 +79561,7 @@
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80356,7 +79577,7 @@
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80372,7 +79593,7 @@
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80491,8 +79712,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80507,8 +79726,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80523,8 +79740,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80557,8 +79772,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80573,8 +79786,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80589,8 +79800,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80623,8 +79832,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80639,8 +79846,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80655,8 +79860,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -80757,8 +79960,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80773,8 +79974,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80891,8 +80090,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -80907,8 +80104,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -80957,8 +80152,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="vec2"]
     expected:
@@ -80973,8 +80166,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="vec2"]
     expected:
@@ -80989,8 +80180,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="vec2"]
     expected:
@@ -81023,8 +80212,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="vec2"]
     expected:
@@ -81039,8 +80226,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="vec2"]
     expected:
@@ -81055,8 +80240,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="vec2"]
     expected:
@@ -82133,8 +81316,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -82149,8 +81330,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -82267,8 +81446,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -82283,8 +81460,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -82299,8 +81474,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -82384,8 +81557,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan2:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82403,52 +81574,48 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:abstract_float:*]
@@ -82537,8 +81704,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -82553,8 +81718,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -82671,8 +81834,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -82687,8 +81848,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -88735,8 +87894,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -88767,8 +87924,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -88865,8 +88020,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -88897,8 +88050,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -88995,8 +88146,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89027,8 +88176,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89143,8 +88290,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89175,8 +88320,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89207,8 +88350,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
     expected:
@@ -89273,8 +88414,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89305,8 +88444,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89337,8 +88474,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
     expected:
@@ -89403,8 +88538,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89435,8 +88568,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89467,8 +88598,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
     expected:
@@ -89551,8 +88680,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89583,8 +88710,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89615,8 +88740,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
     expected:
@@ -89681,8 +88804,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89713,8 +88834,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89745,8 +88864,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
     expected:
@@ -89811,8 +88928,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
     expected:
@@ -89843,8 +88958,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
     expected:
@@ -89875,8 +88988,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
     expected:
@@ -90136,6 +89247,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,ceil:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -90187,8 +89300,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -90203,8 +89314,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -90236,23 +89345,21 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:abstract_int:*]
@@ -90325,209 +89432,199 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:f32:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:i32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:u32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -90596,71 +89693,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:abstract_float:*]
@@ -90732,6 +89823,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:f32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90750,7 +89843,7 @@
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -90766,7 +89859,7 @@
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -90782,7 +89875,7 @@
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -90815,8 +89908,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -90831,8 +89922,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -90847,8 +89936,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -90881,8 +89968,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -90897,8 +89982,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -90913,8 +89996,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -90947,8 +90028,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -90963,8 +90042,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -90979,8 +90056,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -91013,8 +90088,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -91029,8 +90102,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -91045,8 +90116,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -91079,8 +90148,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -91095,8 +90162,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -91111,8 +90176,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -91145,8 +90208,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -91161,8 +90222,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -91177,8 +90236,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -91194,11 +90251,9 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [TIMEOUT, ERROR]
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:f16:*]
@@ -91212,26 +90267,20 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,degrees:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -91250,6 +90299,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,degrees:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -91301,8 +90352,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -91317,8 +90366,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -91333,8 +90380,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -91415,36 +90460,24 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
     expected:
@@ -91526,23 +90559,17 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32:*]
-  expected:
-    if os == "linux" and not debug: [TIMEOUT, ERROR]
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec2:*]
@@ -91553,16 +90580,10 @@
       if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec3:*]
@@ -91573,16 +90594,10 @@
       if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec4:*]
@@ -91593,16 +90608,10 @@
       if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot4I8Packed:basic:*]
@@ -91682,6 +90691,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec4:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -91693,65 +90704,45 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f32_vec2:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f32_vec4:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:i32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -92044,74 +91035,70 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp2:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -92146,6 +91133,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -92180,71 +91169,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,extractBits:i32:*]
@@ -92436,31 +91419,23 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,faceForward:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,faceForward:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
@@ -92472,15 +91447,13 @@
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,faceForward:f32_vec4:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
@@ -92492,7 +91465,7 @@
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,firstLeadingBit:i32:*]
@@ -92513,8 +91486,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -92529,8 +91500,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -92579,8 +91548,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -92595,8 +91562,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -92611,8 +91576,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -92645,8 +91608,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -92661,8 +91622,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -92677,8 +91636,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -92711,8 +91668,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -92727,8 +91682,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -92743,8 +91696,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -92829,8 +91780,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -92845,8 +91794,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -92878,23 +91825,21 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:f16:*]
@@ -92932,71 +91877,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fract:abstract_float:*]
@@ -93085,8 +92024,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -93101,8 +92038,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -93219,16 +92154,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_fract:*]
@@ -93237,16 +92166,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_vec2_exp:*]
@@ -93255,16 +92178,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_vec2_fract:*]
@@ -93273,16 +92190,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_vec3_exp:*]
@@ -93291,16 +92202,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_vec3_fract:*]
@@ -93309,16 +92214,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_vec4_exp:*]
@@ -93327,16 +92226,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f32_vec4_fract:*]
@@ -93345,16 +92238,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fwidth:f32:*]
@@ -93590,6 +92477,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93658,71 +92547,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,ldexp:abstract_float:*]
@@ -93811,8 +92694,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -93827,8 +92708,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -93894,6 +92773,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -93939,16 +92820,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec2:*]
@@ -93975,16 +92850,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec4:*]
@@ -93993,19 +92862,15 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log2:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -94040,6 +92905,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log2:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -94074,74 +92941,70 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log2:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -94176,6 +93039,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -94211,90 +93076,88 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f32:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:abstract_int:*]
@@ -94367,7 +93230,7 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:f32:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [TIMEOUT, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: TIMEOUT
@@ -94451,8 +93314,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -94467,8 +93328,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -94483,8 +93342,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -94567,25 +93424,27 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:abstract_float:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:abstract_int:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -94654,71 +93513,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:i32:*]
@@ -94739,8 +93592,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -94755,8 +93606,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -94771,8 +93620,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -94805,8 +93652,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -94821,8 +93666,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -94837,8 +93680,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -94854,47 +93695,41 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_matching:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec2:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec3:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec4:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_matching:*]
@@ -94932,6 +93767,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_nonmatching_vec2:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -94942,6 +93779,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_nonmatching_vec3:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -94963,22 +93802,22 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_matching:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
@@ -94986,15 +93825,15 @@
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
@@ -95002,39 +93841,37 @@
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec2:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
@@ -95046,15 +93883,13 @@
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec3:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
@@ -95066,15 +93901,13 @@
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec4:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
@@ -95086,7 +93919,7 @@
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_fract:*]
@@ -95096,6 +93929,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec2_fract:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -95114,6 +93949,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec3_whole:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -95223,16 +94060,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec2_fract:*]
@@ -95241,34 +94072,30 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec2_whole:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec3_fract:*]
@@ -95277,16 +94104,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec3_whole:*]
@@ -95295,34 +94116,24 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec4_fract:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec4_whole:*]
@@ -95331,16 +94142,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_whole:*]
@@ -95349,16 +94154,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:abstract_float:*]
@@ -95406,6 +94205,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f16_vec3:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -95431,34 +94232,24 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f32_vec3:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f32_vec4:*]
@@ -95467,24 +94258,18 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack2x16float:pack:*]
   expected:
-    if os == "linux" and not debug: ERROR
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
     expected:
@@ -95496,7 +94281,7 @@
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack2x16snorm:pack:*]
@@ -95505,16 +94290,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack2x16unorm:pack:*]
@@ -95523,56 +94302,34 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack4x8snorm:pack:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack4x8unorm:pack:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack4xI8:basic:*]
@@ -95716,74 +94473,70 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pow:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,quantizeToF16:f32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -95868,6 +94621,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,radians:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -95919,8 +94674,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -95935,8 +94688,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -95951,8 +94702,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -95968,6 +94717,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -96024,63 +94775,39 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f32_vec4:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:abstract_float:*]
@@ -96140,63 +94867,45 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec4:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="uniform"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reverseBits:i32:*]
@@ -96217,8 +94926,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -96233,8 +94940,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -96249,8 +94954,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -96283,8 +94986,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -96299,8 +95000,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -96315,8 +95014,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -96332,6 +95029,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -96350,6 +95049,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -96401,8 +95102,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -96417,8 +95116,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -96433,8 +95130,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -96468,6 +95163,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,saturate:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -96519,8 +95216,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -96535,8 +95230,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -96665,8 +95358,6 @@
   [:inputSource="storage_r";component="af";overload="vec4"]
 
   [:inputSource="storage_r";component="b";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="b";overload="vec2"]
     expected:
@@ -96745,8 +95436,6 @@
   [:inputSource="storage_rw";component="af";overload="vec4"]
 
   [:inputSource="storage_rw";component="b";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="b";overload="vec2"]
     expected:
@@ -96825,8 +95514,6 @@
   [:inputSource="uniform";component="af";overload="vec4"]
 
   [:inputSource="uniform";component="b";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="b";overload="vec2"]
     expected:
@@ -96971,8 +95658,6 @@
   [:inputSource="storage_r";component="af";overload="vec4"]
 
   [:inputSource="storage_r";component="b";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="b";overload="vec3"]
     expected:
@@ -97031,8 +95716,6 @@
   [:inputSource="storage_rw";component="af";overload="vec4"]
 
   [:inputSource="storage_rw";component="b";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="b";overload="vec3"]
     expected:
@@ -97091,8 +95774,6 @@
   [:inputSource="uniform";component="af";overload="vec4"]
 
   [:inputSource="uniform";component="b";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="b";overload="vec3"]
     expected:
@@ -97249,8 +95930,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -97265,8 +95944,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -97281,8 +95958,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -97315,8 +95990,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -97331,8 +96004,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -97347,8 +96018,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -97432,74 +96101,70 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sin:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -97568,6 +96233,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:f32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -97586,7 +96253,7 @@
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -97602,7 +96269,7 @@
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -97618,7 +96285,7 @@
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -97668,6 +96335,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,smoothstep:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -97702,71 +96371,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,smoothstep:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:abstract_float:*]
@@ -97838,6 +96501,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:f32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -97856,7 +96521,7 @@
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -97872,7 +96537,7 @@
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -97888,7 +96553,7 @@
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -97972,71 +96637,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,step:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,storageBarrier:barrier:*]
@@ -98086,6 +96745,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tan:f16:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -98120,71 +96781,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tan:f32:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tanh:abstract_float:*]
@@ -98273,8 +96928,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -98289,8 +96942,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -98305,8 +96956,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -99427,12 +98076,8 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
@@ -99443,8 +98088,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
@@ -99463,12 +98106,8 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
@@ -99479,8 +98118,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
@@ -99499,12 +98136,8 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
@@ -99515,8 +98148,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
@@ -99605,8 +98236,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -99621,8 +98250,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -99637,8 +98264,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -99659,16 +98284,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack2x16snorm:unpack:*]
@@ -99677,16 +98296,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack2x16unorm:unpack:*]
@@ -99695,34 +98308,24 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack4x8snorm:unpack:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack4x8unorm:unpack:*]
@@ -99731,16 +98334,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack4xI8:basic:*]
@@ -100074,31 +98671,27 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_arithmetic:negation:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_assignment:abstract:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_assignment:f16:*]
@@ -100112,11 +98705,9 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,ai_assignment:abstract:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,ai_assignment:i32:*]
@@ -100126,6 +98717,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,ai_assignment:u32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -100149,8 +98742,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -100165,8 +98756,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -100181,8 +98770,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -100249,8 +98836,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -100265,8 +98850,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -100281,8 +98864,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -100315,8 +98896,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -100331,8 +98910,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -100347,8 +98924,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -100364,6 +98939,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_conversion:u32:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -100381,8 +98958,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -100397,8 +98972,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -100413,8 +98986,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -100447,8 +99018,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -100463,8 +99032,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -100479,8 +99046,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -100848,71 +99413,65 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_arithmetic:negation:*]
-  expected:
-    if os == "linux" and not debug: ERROR
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:bool:*]
@@ -100933,8 +99492,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -100949,8 +99506,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -100965,8 +99520,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101107,8 +99660,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101123,8 +99674,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101139,8 +99688,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101193,12 +99740,8 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=2;rows=4]
     expected:
@@ -101209,8 +99752,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=4]
     expected:
@@ -101229,12 +99770,8 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=4]
     expected:
@@ -101245,8 +99782,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=4]
     expected:
@@ -101265,12 +99800,8 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
     expected:
@@ -101281,8 +99812,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
     expected:
@@ -101319,8 +99848,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101335,8 +99862,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101351,8 +99876,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101385,8 +99908,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101401,8 +99922,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101417,8 +99936,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101451,8 +99968,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101467,8 +99982,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101483,8 +99996,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101517,8 +100028,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101533,8 +100042,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101549,8 +100056,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101583,8 +100088,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101599,8 +100102,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101615,8 +100116,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101749,8 +100248,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101765,8 +100262,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101781,8 +100276,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101815,8 +100308,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -101831,8 +100322,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -101847,8 +100336,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -101881,8 +100368,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="u32";derefType="deref_pointer"]
     expected:
@@ -101977,8 +100462,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="u32";derefType="deref_pointer"]
     expected:
@@ -102073,8 +100556,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="u32";derefType="deref_pointer"]
     expected:
@@ -102169,8 +100650,6 @@
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
     expected:
@@ -102265,8 +100744,6 @@
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
     expected:
@@ -102361,8 +100838,6 @@
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
     expected:
@@ -102459,8 +100934,6 @@
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
     expected:
@@ -102555,8 +101028,6 @@
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
     expected:
@@ -102651,8 +101122,6 @@
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
     expected:
@@ -102751,8 +101220,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -102767,8 +101234,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -102783,8 +101248,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -102800,6 +101263,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:abstract_int:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -102851,8 +101316,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -102867,8 +101330,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -102883,8 +101344,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -103017,8 +101476,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -103033,8 +101490,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -103049,8 +101504,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -103083,8 +101536,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2]
     expected:
@@ -103099,8 +101550,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
@@ -103115,8 +101564,6 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
     expected:
@@ -108827,6 +107274,8 @@
   [:canvasType="onscreen";prevFrameCallsite="requestAnimationFrame";getCurrentTextureAgain=false]
 
   [:canvasType="onscreen";prevFrameCallsite="requestAnimationFrame";getCurrentTextureAgain=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:canvasType="onscreen";prevFrameCallsite="runInNewCanvasFrame";getCurrentTextureAgain=false]
 

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -93112,70 +93112,70 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:f32:*]
   expected:
-    if os == "linux" and not debug: [TIMEOUT, CRASH]
+    if os == "linux" and not debug: [OK, TIMEOUT, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:inputSource="const";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="const";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:i32:*]

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -68797,8 +68797,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -68813,8 +68811,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68915,8 +68911,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:less_than:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68953,8 +68947,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_division:scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69079,8 +69071,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69101,8 +69091,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69137,8 +69125,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69153,8 +69139,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -70755,8 +70739,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -70767,8 +70749,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -70881,8 +70861,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -71183,8 +71161,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -71703,8 +71679,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -71779,8 +71753,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -72225,8 +72197,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_vector_multiplication:vector_matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72323,8 +72293,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -72351,8 +72319,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72415,8 +72381,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -72651,8 +72615,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72777,8 +72739,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -72867,8 +72827,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -73023,8 +72981,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_equals:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73085,8 +73041,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_than:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73327,8 +73281,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73401,8 +73353,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73497,8 +73447,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75209,8 +75157,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -75469,8 +75415,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76313,8 +76257,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76589,8 +76531,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -76691,8 +76631,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77095,8 +77033,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77309,8 +77245,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77377,8 +77311,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -77429,8 +77361,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: [PASS, FAIL, TIMEOUT]
@@ -77481,8 +77411,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78489,8 +78417,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78643,8 +78569,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79033,8 +78957,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_compound:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79479,8 +79401,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_than:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79541,8 +79461,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:not_equals:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -89247,8 +89165,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,ceil:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89431,8 +89347,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -89623,8 +89537,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89823,8 +89735,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90279,8 +90189,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,degrees:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90299,8 +90207,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,degrees:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -90691,8 +90597,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec4:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -90703,8 +90607,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90741,8 +90643,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:i32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -91097,8 +90997,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -91133,8 +91031,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -92477,8 +92373,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -92773,8 +92667,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -92869,8 +92761,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log2:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -92905,8 +92795,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log2:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93003,8 +92891,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93039,8 +92925,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93075,8 +92959,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -93423,8 +93305,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93443,8 +93323,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:abstract_int:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93513,6 +93391,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f32:*]
+  expected:
+    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93725,8 +93605,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec4:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -93767,8 +93645,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_nonmatching_vec2:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -93779,8 +93655,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_nonmatching_vec3:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -93801,8 +93675,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_matching:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93929,8 +93801,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec2_fract:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -93949,8 +93819,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec3_whole:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94079,8 +93947,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec2_whole:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94123,8 +93989,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec4_fract:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94205,8 +94069,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f16_vec3:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -94239,8 +94101,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94265,8 +94125,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack2x16float:pack:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94535,8 +94393,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,quantizeToF16:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -94621,8 +94477,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,radians:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -94717,8 +94571,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -95029,8 +94881,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -95049,8 +94899,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -95163,8 +95011,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,saturate:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -96163,8 +96009,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -96233,8 +96077,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -96335,8 +96177,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,smoothstep:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -96501,8 +96341,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -96745,8 +96583,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tan:f16:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -98315,8 +98151,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack4x8snorm:unpack:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -98717,8 +98551,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,ai_assignment:u32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -98939,8 +98771,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_conversion:u32:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -101263,8 +101093,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:abstract_int:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: [CRASH, PASS]
+    if os == "linux" and not debug: [CRASH, PASS, FAIL]

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_opaque_draw.https.html]
   expected:
-    if os == "linux" and not debug: PASS
+    if os == "linux" and not debug: [PASS, FAIL]


### PR DESCRIPTION
All relevant test `webgpu:api,operation,onSubmittedWorkDone:` passes. There is also some more passes in shader tests. It serves as good example how to do safe callback (they key part is to use `move` closure).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
