### PR TITLE
Make `Cargo.toml` a little friendlier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3464,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5075,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "nodrop",
  "serde",
@@ -5373,7 +5373,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5579,7 +5579,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "static_assertions",
 ]
@@ -5705,7 +5705,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 
 [[package]]
 name = "str-buf"
@@ -5748,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "lazy_static",
 ]
@@ -5815,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "darling",
  "derive_common",
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "app_units",
  "bitflags 1.3.2",
@@ -6189,7 +6189,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6202,7 +6202,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo.git?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#3d41c54f18ace2bc3708fe3b5c032c5341a331ed"
 dependencies = [
  "darling",
  "derive_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ keyboard-types = "0.6"
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-malloc_size_of = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01", features = ["servo"] }
+malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
 malloc_size_of_derive = "0.1"
 mime = "0.3.13"
 mime_guess = "2.0.3"
@@ -87,31 +87,31 @@ rustls = { version = "0.21.10", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
 serde = "1.0.197"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01" }
-servo_atoms = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01" }
-size_of_test = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+servo_atoms = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+size_of_test = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 sparkle = "0.1.26"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01" }
-style_traits = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+style_traits = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
 # NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
 surfman = { version = "0.9", features = ["chains", "sm-angle", "sm-angle-default"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
-to_shmem = { git = "https://github.com/servo/stylo.git", branch = "2023-09-01" }
+to_shmem = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
 tokio = "1"
 tokio-rustls = "0.24"
 tungstenite = "0.20"
@@ -151,21 +151,21 @@ debug-assertions = false
 #
 # Or for Stylo:
 #
-#     [patch."https://github.com/servo/stylo.git"]
-#     derive_common = { path = "../stylo/derive_common" }
-#     malloc_size_of = { path = "../stylo/malloc_size_of" }
-#     selectors = { path = "../stylo/selectors" }
-#     servo_arc = { path = "../stylo/servo_arc" }
-#     servo_atoms = { path = "../stylo/atoms" }
-#     size_of_test = { path = "../stylo/size_of_test" }
-#     static_prefs = { path = "../stylo/style_static_prefs" }
-#     style_config = { path = "../stylo/style_config" }
-#     style_derive = { path = "../stylo/style_derive" }
-#     style = { path = "../stylo/style" }
-#     style_traits = { path = "../stylo/style_traits" }
-#     to_shmem = { path = "../stylo/to_shmem" }
+# [patch."https://github.com/servo/stylo"]
+# derive_common = { path = "../stylo/derive_common" }
+# malloc_size_of = { path = "../stylo/malloc_size_of" }
+# selectors = { path = "../stylo/selectors" }
+# servo_arc = { path = "../stylo/servo_arc" }
+# servo_atoms = { path = "../stylo/atoms" }
+# size_of_test = { path = "../stylo/size_of_test" }
+# static_prefs = { path = "../stylo/style_static_prefs" }
+# style_config = { path = "../stylo/style_config" }
+# style_derive = { path = "../stylo/style_derive" }
+# style = { path = "../stylo/style" }
+# style_traits = { path = "../stylo/style_traits" }
+# to_shmem = { path = "../stylo/to_shmem" }
 #
 # Or for another git dependency:
 #
-#     [patch."https://github.com/servo/<repository>"]
-#     <crate> = { path = "/path/to/local/checkout" }
+# [patch."https://github.com/servo/<repository>"]
+# <crate> = { path = "/path/to/local/checkout" }


### PR DESCRIPTION
Instead of using a strange number of spaces (5) for the example
override, use a single space. This makes it much easier to undo changes
to this file when switching between overriding a dependency and not
overriding a dependency.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
