### PR TITLE
clippy: Fix `needless_return` warnings in `components/script`

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -524,7 +524,7 @@ impl HTMLInputElement {
                 return Some(min);
             }
         }
-        return self.default_minimum();
+        self.default_minimum()
     }
 
     // https://html.spec.whatwg.org/multipage#concept-input-max
@@ -538,7 +538,7 @@ impl HTMLInputElement {
                 return Some(max);
             }
         }
-        return self.default_maximum();
+        self.default_maximum()
     }
 
     // when allowed_value_step and minumum both exist, this is the smallest
@@ -2789,7 +2789,7 @@ impl Activatable for HTMLInputElement {
             },
             _ => (),
         }
-        return None;
+        None
     }
 
     // https://dom.spec.whatwg.org/#eventtarget-legacy-canceled-activation-behavior

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1930,7 +1930,7 @@ impl HTMLMediaElement {
     pub fn get_current_frame(&self) -> Option<VideoFrame> {
         match self.video_renderer.lock().unwrap().current_frame_holder {
             Some(ref holder) => Some(holder.get_frame()),
-            None => return None,
+            None => None,
         }
     }
 

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -111,7 +111,7 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-output-type
     fn Type(&self) -> DOMString {
-        return DOMString::from("output");
+        DOMString::from("output")
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1122,7 +1122,6 @@ impl HTMLScriptElement {
                 if let Err(exception) = evaluated {
                     module_tree.set_rethrow_error(exception);
                     module_tree.report_error(global);
-                    return;
                 }
             }
         }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -190,7 +190,7 @@ impl HTMLTextAreaElement {
 
     pub fn auto_directionality(&self) -> String {
         let value: String = self.Value().to_string();
-        return HTMLInputElement::directionality_from_value(&value);
+        HTMLInputElement::directionality_from_value(&value)
     }
 
     fn update_placeholder_shown_state(&self) {

--- a/components/script/dom/mediametadata.rs
+++ b/components/script/dom/mediametadata.rs
@@ -59,9 +59,7 @@ impl MediaMetadata {
     }
 
     fn queue_update_metadata_algorithm(&self) {
-        if self.session.get().is_none() {
-            return;
-        }
+        if self.session.get().is_none() {}
     }
 
     pub fn set_session(&self, session: &MediaSession) {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3016,15 +3016,15 @@ impl NodeMethods for Node {
         match (node1, node2) {
             (None, _) => {
                 // node1 is null
-                return NodeConstants::DOCUMENT_POSITION_FOLLOWING +
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING +
                     NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
             },
             (_, None) => {
                 // node2 is null
-                return NodeConstants::DOCUMENT_POSITION_PRECEDING +
+                NodeConstants::DOCUMENT_POSITION_PRECEDING +
                     NodeConstants::DOCUMENT_POSITION_DISCONNECTED +
-                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+                    NodeConstants::DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
             },
             (Some(node1), Some(node2)) => {
                 // still step 6, testing if node1 and 2 share a root
@@ -3080,13 +3080,13 @@ impl NodeMethods for Node {
                 // contained in the other.
                 //
                 // If we're the container, return that `other` is contained by us.
-                return if self_and_ancestors.len() < other_and_ancestors.len() {
+                if self_and_ancestors.len() < other_and_ancestors.len() {
                     NodeConstants::DOCUMENT_POSITION_FOLLOWING +
                         NodeConstants::DOCUMENT_POSITION_CONTAINED_BY
                 } else {
                     NodeConstants::DOCUMENT_POSITION_PRECEDING +
                         NodeConstants::DOCUMENT_POSITION_CONTAINS
-                };
+                }
             },
         }
     }

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -171,7 +171,7 @@ impl OffscreenCanvasMethods for OffscreenCanvas {
 
     // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-width
     fn Width(&self) -> u64 {
-        return self.width.get();
+        self.width.get()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-width
@@ -189,7 +189,7 @@ impl OffscreenCanvasMethods for OffscreenCanvas {
 
     // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-height
     fn Height(&self) -> u64 {
-        return self.height.get();
+        self.height.get()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-height

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -143,7 +143,7 @@ impl OscillatorNodeMethods for OscillatorNode {
             .message(AudioNodeMessage::OscillatorNode(
                 OscillatorNodeMessage::SetOscillatorType(type_.into()),
             ));
-        return Ok(());
+        Ok(())
     }
 }
 

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -244,6 +244,6 @@ impl PerformanceObserverMethods for PerformanceObserver {
             .map(|entry| DomRoot::from_ref(&**entry))
             .collect();
         entries.clear();
-        return taken;
+        taken
     }
 }

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -299,7 +299,7 @@ impl ResponseMethods for Response {
         match *self.status.borrow() {
             Some(s) => {
                 let status_num = s.as_u16();
-                return status_num >= 200 && status_num <= 299;
+                status_num >= 200 && status_num <= 299
             },
             None => false,
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -359,7 +359,7 @@ impl SelectionMethods for Selection {
             // Step 2
             return Err(Error::InvalidState);
         }
-        return Ok(());
+        Ok(())
     }
 
     // https://w3c.github.io/selection-api/#dom-selection-setbaseandextent
@@ -447,7 +447,7 @@ impl SelectionMethods for Selection {
             // selectionchange event as it would if if mutated any other way
             return range.DeleteContents();
         }
-        return Ok(());
+        Ok(())
     }
 
     // https://w3c.github.io/selection-api/#dom-selection-containsnode
@@ -478,7 +478,7 @@ impl SelectionMethods for Selection {
                 if node == end_node {
                     return range.EndOffset() > 0;
                 }
-                return true;
+                true
             } else {
                 if node.is_before(start_node) {
                     return false;
@@ -493,11 +493,11 @@ impl SelectionMethods for Selection {
                 if node == end_node {
                     return range.EndOffset() == node.len();
                 }
-                return true;
+                true
             }
         } else {
             // No range
-            return false;
+            false
         }
     }
 

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -892,8 +892,7 @@ impl WebGL2RenderingContext {
 
         handle_potential_webgl_error!(
             self.base,
-            texture.storage(target, levels, internal_format, width, height, depth),
-            return
+            texture.storage(target, levels, internal_format, width, height, depth)
         );
     }
 }
@@ -4197,8 +4196,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
         handle_potential_webgl_error!(
             self.base,
-            program.bind_uniform_block(block_index, block_binding),
-            return
+            program.bind_uniform_block(block_index, block_binding)
         )
     }
 

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -312,7 +312,7 @@ impl WebGLTexture {
             },
             constants::TEXTURE_MAG_FILTER => match int_value as u32 {
                 constants::NEAREST | constants::LINEAR => update_filter(&self.mag_filter),
-                _ => return Err(WebGLError::InvalidEnum),
+                _ => Err(WebGLError::InvalidEnum),
             },
             constants::TEXTURE_WRAP_S | constants::TEXTURE_WRAP_T => match int_value as u32 {
                 constants::CLAMP_TO_EDGE | constants::MIRRORED_REPEAT | constants::REPEAT => {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -537,7 +537,7 @@ impl WindowProxy {
             return Ok(None);
         }
         // Step 17.
-        return Ok(target_document.browsing_context());
+        Ok(target_document.browsing_context())
     }
 
     // https://html.spec.whatwg.org/multipage/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
@@ -840,7 +840,7 @@ fn parse_open_feature_boolean(tokenized_features: &IndexMap<String, String>, nam
         }
     }
     // Step 5
-    return false;
+    false
 }
 
 // This is only called from extern functions,

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -357,8 +357,8 @@ impl<'dom, LayoutDataType: LayoutDataTrait> style::dom::TElement
 
     fn has_animations(&self, context: &SharedStyleContext) -> bool {
         // This is not used for pseudo elements currently so we can pass None.
-        return self.has_css_animations(context, /* pseudo_element = */ None) ||
-            self.has_css_transitions(context, /* pseudo_element = */ None);
+        self.has_css_animations(context, /* pseudo_element = */ None) ||
+            self.has_css_transitions(context, /* pseudo_element = */ None)
     }
 
     fn has_css_animations(

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -81,7 +81,7 @@ unsafe fn gen_type_error(global: &GlobalScope, string: String) -> RethrowError {
     rooted!(in(*GlobalScope::get_cx()) let mut thrown = UndefinedValue());
     Error::Type(string).to_jsval(*GlobalScope::get_cx(), global, thrown.handle_mut());
 
-    return RethrowError(RootedTraceableBox::from_box(Heap::boxed(thrown.get())));
+    RethrowError(RootedTraceableBox::from_box(Heap::boxed(thrown.get())))
 }
 
 #[derive(JSTraceable)]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2469,7 +2469,6 @@ impl ScriptThread {
         if let Some(document) = document {
             let _ac = enter_realm(&*document);
             document.exit_fullscreen();
-            return;
         }
     }
 

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -364,7 +364,6 @@ impl ServiceWorkerManager {
                         active_worker: registration.active_worker.as_ref().map(|worker| worker.id),
                     },
                 ));
-                return;
             }
         } else {
             // Step 6: we do not have a registration.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove unneeded `return` statements to fix `needless_return` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
