### PR TITLE
clippy: fix `result_unit_err` warnings

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -1104,9 +1104,8 @@ impl<'a> CanvasData<'a> {
                 updates.push(ImageUpdate::Update(image_key, descriptor, data));
             },
             None => {
-                let key = match self.webrender_api.generate_key() {
-                    Ok(key) => key,
-                    Err(()) => return,
+                let Some(key) = self.webrender_api.generate_key() else {
+                    return;
                 };
                 updates.push(ImageUpdate::Add(key, descriptor, data));
                 self.image_key = Some(key);

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -30,7 +30,7 @@ pub enum ImageUpdate {
 }
 
 pub trait WebrenderApi {
-    fn generate_key(&self) -> Result<ImageKey, ()>;
+    fn generate_key(&self) -> Option<ImageKey>;
     fn update_images(&self, updates: Vec<ImageUpdate>);
     fn clone(&self) -> Box<dyn WebrenderApi>;
 }

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -30,6 +30,7 @@ pub enum ImageUpdate {
 }
 
 pub trait WebrenderApi {
+    /// Attempt to generate an [`ImageKey`], returning `None` in case of failure.
     fn generate_key(&self) -> Option<ImageKey>;
     fn update_images(&self, updates: Vec<ImageUpdate>);
     fn clone(&self) -> Box<dyn WebrenderApi>;

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -3180,7 +3180,7 @@ impl WebXRLayerGrandManagerAPI<WebXRSurfman> for WebXRBridgeGrandManager {
         &self,
         factory: WebXRLayerManagerFactory<WebXRSurfman>,
     ) -> Result<WebXRLayerManager, WebXRError> {
-        let (sender, receiver) = webgl_channel().map_err(|_| WebXRError::CommunicationError)?;
+        let (sender, receiver) = webgl_channel().ok_or(WebXRError::CommunicationError)?;
         let _ = self.factory_sender.send(factory);
         let _ = self
             .sender
@@ -3221,7 +3221,7 @@ impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
         context_id: WebXRContextId,
         init: WebXRLayerInit,
     ) -> Result<WebXRLayerId, WebXRError> {
-        let (sender, receiver) = webgl_channel().map_err(|_| WebXRError::CommunicationError)?;
+        let (sender, receiver) = webgl_channel().ok_or(WebXRError::CommunicationError)?;
         let _ = self
             .sender
             .send(WebGLMsg::WebXRCommand(WebXRCommand::CreateLayer(
@@ -3264,7 +3264,7 @@ impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
         _: &mut dyn WebXRContexts<GL>,
         layers: &[(WebXRContextId, WebXRLayerId)],
     ) -> Result<Vec<WebXRSubImages>, WebXRError> {
-        let (sender, receiver) = webgl_channel().map_err(|_| WebXRError::CommunicationError)?;
+        let (sender, receiver) = webgl_channel().ok_or(WebXRError::CommunicationError)?;
         let _ = self
             .sender
             .send(WebGLMsg::WebXRCommand(WebXRCommand::BeginFrame(
@@ -3283,7 +3283,7 @@ impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
         _: &mut dyn WebXRContexts<GL>,
         layers: &[(WebXRContextId, WebXRLayerId)],
     ) -> Result<(), WebXRError> {
-        let (sender, receiver) = webgl_channel().map_err(|_| WebXRError::CommunicationError)?;
+        let (sender, receiver) = webgl_channel().ok_or(WebXRError::CommunicationError)?;
         let _ = self
             .sender
             .send(WebGLMsg::WebXRCommand(WebXRCommand::EndFrame(

--- a/components/media/media_channel/mod.rs
+++ b/components/media/media_channel/mod.rs
@@ -83,7 +83,7 @@ where
     }
 }
 
-pub fn glplayer_channel<T>() -> Result<(GLPlayerSender<T>, GLPlayerReceiver<T>), ()>
+pub fn glplayer_channel<T>() -> Option<(GLPlayerSender<T>, GLPlayerReceiver<T>)>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
@@ -91,10 +91,11 @@ where
     if true {
         ipc::glplayer_channel()
             .map(|(tx, rx)| (GLPlayerSender::Ipc(tx), GLPlayerReceiver::Ipc(rx)))
-            .map_err(|_| ())
+            .ok()
     } else {
         mpsc::glplayer_channel()
             .map(|(tx, rx)| (GLPlayerSender::Mpsc(tx), GLPlayerReceiver::Mpsc(rx)))
+            .ok()
     }
 }
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -569,17 +569,17 @@ pub enum RangeRequestBounds {
 }
 
 impl RangeRequestBounds {
-    pub fn get_final(&self, len: Option<u64>) -> Result<RelativePos, ()> {
+    pub fn get_final(&self, len: Option<u64>) -> Option<RelativePos> {
         match self {
             RangeRequestBounds::Final(pos) => {
                 if let Some(len) = len {
                     if pos.start <= len as i64 {
-                        return Ok(pos.clone());
+                        return Some(pos.clone());
                     }
                 }
-                Err(())
+                None
             },
-            RangeRequestBounds::Pending(offset) => Ok(RelativePos::from_opts(
+            RangeRequestBounds::Pending(offset) => Some(RelativePos::from_opts(
                 if let Some(len) = len {
                     Some((len - u64::min(len, *offset)) as i64)
                 } else {
@@ -750,12 +750,10 @@ async fn scheme_fetch(
 
                     let range_header = request.headers.typed_get::<Range>();
                     let is_range_request = range_header.is_some();
-                    let range = match get_range_request_bounds(range_header).get_final(file_size) {
-                        Ok(range) => range,
-                        Err(_) => {
-                            range_not_satisfiable_error(&mut response);
-                            return response;
-                        },
+                    let Some(range) = get_range_request_bounds(range_header).get_final(file_size)
+                    else {
+                        range_not_satisfiable_error(&mut response);
+                        return response;
                     };
                     let mut reader = BufReader::with_capacity(FILE_CHUNK_SIZE, file);
                     if reader.seek(SeekFrom::Start(range.start as u64)).is_err() {

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -295,7 +295,7 @@ impl FileManager {
             FileImpl::Memory(buf) => {
                 let range = range
                     .get_final(Some(buf.size))
-                    .ok_or(BlobURLStoreError::InvalidRange)?;
+                    .map_err(|_| BlobURLStoreError::InvalidRange)?;
 
                 let range = range.to_abs_range(buf.size as usize);
                 let len = range.len() as u64;
@@ -327,7 +327,7 @@ impl FileManager {
 
                 let range = range
                     .get_final(Some(metadata.size))
-                    .ok_or(BlobURLStoreError::InvalidRange)?;
+                    .map_err(|_| BlobURLStoreError::InvalidRange)?;
 
                 let mut reader = BufReader::with_capacity(FILE_CHUNK_SIZE, file);
                 if reader.seek(SeekFrom::Start(range.start as u64)).is_err() {

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -293,12 +293,9 @@ impl FileManager {
         let file_impl = self.store.get_impl(id, file_token, origin_in)?;
         match file_impl {
             FileImpl::Memory(buf) => {
-                let range = match range.get_final(Some(buf.size)) {
-                    Ok(range) => range,
-                    Err(_) => {
-                        return Err(BlobURLStoreError::InvalidRange);
-                    },
-                };
+                let range = range
+                    .get_final(Some(buf.size))
+                    .ok_or(BlobURLStoreError::InvalidRange)?;
 
                 let range = range.to_abs_range(buf.size as usize);
                 let len = range.len() as u64;
@@ -328,12 +325,9 @@ impl FileManager {
                 let file = File::open(&metadata.path)
                     .map_err(|e| BlobURLStoreError::External(e.to_string()))?;
 
-                let range = match range.get_final(Some(metadata.size)) {
-                    Ok(range) => range,
-                    Err(_) => {
-                        return Err(BlobURLStoreError::InvalidRange);
-                    },
-                };
+                let range = range
+                    .get_final(Some(metadata.size))
+                    .ok_or(BlobURLStoreError::InvalidRange)?;
 
                 let mut reader = BufReader::with_capacity(FILE_CHUNK_SIZE, file);
                 if reader.seek(SeekFrom::Start(range.start as u64)).is_err() {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -218,9 +218,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
             Some((ref mut image_key, ref mut width, ref mut height)) => {
                 self.old_frame = Some(*image_key);
 
-                let new_image_key = match self.api.generate_image_key() {
-                    Ok(key) => key,
-                    Err(()) => return,
+                let Some(new_image_key) = self.api.generate_image_key() else {
+                    return;
                 };
 
                 /* update current_frame */
@@ -251,9 +250,8 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                 updates.push(ImageUpdate::AddImage(new_image_key, descriptor, image_data));
             },
             None => {
-                let image_key = match self.api.generate_image_key() {
-                    Ok(key) => key,
-                    Err(()) => return,
+                let Some(image_key) = self.api.generate_image_key() else {
+                    return;
                 };
                 self.current_frame = Some((image_key, frame.get_width(), frame.get_height()));
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1036,14 +1036,14 @@ impl gfx_traits::WebrenderApi for FontCacheWR {
 struct CanvasWebrenderApi(CompositorProxy);
 
 impl canvas_paint_thread::WebrenderApi for CanvasWebrenderApi {
-    fn generate_key(&self) -> Result<ImageKey, ()> {
+    fn generate_key(&self) -> Option<ImageKey> {
         let (sender, receiver) = unbounded();
         let _ = self
             .0
             .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Canvas(
                 CanvasToCompositorMsg::GenerateKey(sender),
             )));
-        receiver.recv().map_err(|_| ())
+        receiver.recv().ok()
     }
     fn update_images(&self, updates: Vec<canvas_paint_thread::ImageUpdate>) {
         let _ = self

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -1227,12 +1227,12 @@ impl WebrenderIpcSender {
     }
 
     /// Create a new image key. Blocks until the key is available.
-    pub fn generate_image_key(&self) -> Result<ImageKey, ()> {
+    pub fn generate_image_key(&self) -> Option<ImageKey> {
         let (sender, receiver) = ipc::channel().unwrap();
         self.0
             .send(ScriptToCompositorMsg::GenerateImageKey(sender))
-            .map_err(|_| ())?;
-        receiver.recv().map_err(|_| ())
+            .ok()?;
+        receiver.recv().ok()
     }
 
     /// Perform a resource update operation.

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::result_unit_err)]
 #![crate_name = "servo_url"]
 #![crate_type = "rlib"]
 


### PR DESCRIPTION
This pr tackles the clippy warnings about having a function returning a `Result<_, ()>`. There are three main cases:

- The function returns a result directly from an external library (`components/url/lib.rs`). An allow is added for this case because we have no control over that.
- The `Result` type is better expressed as an `Option` (it is used to check if something is there or not, and there is no differentiation between error scenarios). The spec also says for some functions that "This will return either a TYPE, or nothing.", so using an `Option` may be more in line. I understand that for some of the cases this may be controversial, so please add a suggestion if you think a specific return should stay a `Result`.
- In cases where it made sense, added an error type to the result so it is more clear why is it failing. This was done in `components/net/cookie_storage.rs` and `components/shared/canvas/webgl_channel/mod.rs`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500
- [x] These changes do not require tests because they only fix warnings, they don't add new functionality
