### PR TITLE
script: Add pre element obsolete width attribute support

### DIFF
--- a/components/script/dom/htmlpreelement.rs
+++ b/components/script/dom/htmlpreelement.rs
@@ -3,13 +3,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix};
+use html5ever::{local_name, LocalName, Prefix};
 use js::rust::HandleObject;
+use style::attr::AttrValue;
 
+use crate::dom::bindings::codegen::Bindings::HTMLPreElementBinding::HTMLPreElementMethods;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::Node;
+use crate::dom::virtualmethods::VirtualMethods;
 
 #[dom_struct]
 pub struct HTMLPreElement {
@@ -40,4 +45,28 @@ impl HTMLPreElement {
             proto,
         )
     }
+}
+
+impl VirtualMethods for HTMLPreElement {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
+    }
+
+    fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
+        match *name {
+            local_name!("width") => AttrValue::from_limited_i32(value.into(), 0),
+            _ => self
+                .super_type()
+                .unwrap()
+                .parse_plain_attribute(name, value),
+        }
+    }
+}
+
+impl HTMLPreElementMethods for HTMLPreElement {
+    // https://html.spec.whatwg.org/multipage/#dom-pre-width
+    make_int_getter!(Width, "width", 0);
+
+    // https://html.spec.whatwg.org/multipage/#dom-pre-width
+    make_int_setter!(SetWidth, "width", 0);
 }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -40,6 +40,7 @@ use crate::dom::htmlobjectelement::HTMLObjectElement;
 use crate::dom::htmloptgroupelement::HTMLOptGroupElement;
 use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmloutputelement::HTMLOutputElement;
+use crate::dom::htmlpreelement::HTMLPreElement;
 use crate::dom::htmlscriptelement::HTMLScriptElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
 use crate::dom::htmlsourceelement::HTMLSourceElement;
@@ -232,6 +233,9 @@ pub fn vtable_for(node: &Node) -> &dyn VirtualMethods {
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLOutputElement)) => {
             node.downcast::<HTMLOutputElement>().unwrap() as &dyn VirtualMethods
+        },
+        NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLPreElement)) => {
+            node.downcast::<HTMLPreElement>().unwrap() as &dyn VirtualMethods
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLScriptElement)) => {
             node.downcast::<HTMLScriptElement>().unwrap() as &dyn VirtualMethods

--- a/components/script/dom/webidls/HTMLPreElement.webidl
+++ b/components/script/dom/webidls/HTMLPreElement.webidl
@@ -12,6 +12,5 @@ interface HTMLPreElement : HTMLElement {
 
 // https://html.spec.whatwg.org/multipage/#HTMLPreElement-partial
 partial interface HTMLPreElement {
-  // [CEReactions]
-  //         attribute long width;
+  [CEReactions] attribute long width;
 };

--- a/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
@@ -2823,9 +2823,6 @@
   [HTMLAllCollection interface: existence and properties of interface prototype object]
     expected: FAIL
 
-  [HTMLPreElement interface: document.createElement("listing") must inherit property "width" with the proper type]
-    expected: FAIL
-
   [HTMLHRElement interface: document.createElement("hr") must inherit property "noShade" with the proper type]
     expected: FAIL
 
@@ -3867,9 +3864,6 @@
   [HTMLAreaElement interface: attribute referrerPolicy]
     expected: FAIL
 
-  [HTMLPreElement interface: attribute width]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("week") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -4272,9 +4266,6 @@
   [HTMLParamElement interface: attribute type]
     expected: FAIL
 
-  [HTMLPreElement interface: document.createElement("xmp") must inherit property "width" with the proper type]
-    expected: FAIL
-
   [HTMLTableRowElement interface: document.createElement("tr") must inherit property "ch" with the proper type]
     expected: FAIL
 
@@ -4564,9 +4555,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("week") must inherit property "autofocus" with the proper type]
-    expected: FAIL
-
-  [HTMLPreElement interface: document.createElement("pre") must inherit property "width" with the proper type]
     expected: FAIL
 
   [HTMLOptGroupElement interface: attribute label]

--- a/tests/wpt/meta-legacy-layout/html/dom/reflection-grouping.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/reflection-grouping.html.ini
@@ -2265,12 +2265,6 @@
   [pre.tabIndex: IDL set to -2147483648 followed by getAttribute()]
     expected: FAIL
 
-  [pre.width: typeof IDL attribute]
-    expected: FAIL
-
-  [pre.width: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [pre.width: setAttribute() to -36 followed by IDL get]
     expected: FAIL
 
@@ -14622,172 +14616,10 @@
   [pre.width: setAttribute() to -1]
     expected: FAIL
 
-  [pre.width: setAttribute() to 0]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 1]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 2147483647]
-    expected: FAIL
-
   [pre.width: setAttribute() to -2147483648]
     expected: FAIL
 
-  [pre.width: setAttribute() to 2147483648]
-    expected: FAIL
-
-  [pre.width: setAttribute() to -2147483649]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 4294967295]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 4294967296]
-    expected: FAIL
-
-  [pre.width: setAttribute() to ""]
-    expected: FAIL
-
   [pre.width: setAttribute() to "-1"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "-0"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "0"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "1"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\t7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\f7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "﻿7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\n7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\r7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "᠎7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "　7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to undefined]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 1.5]
-    expected: FAIL
-
-  [pre.width: setAttribute() to true]
-    expected: FAIL
-
-  [pre.width: setAttribute() to false]
-    expected: FAIL
-
-  [pre.width: setAttribute() to object "[object Object\]"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to NaN]
-    expected: FAIL
-
-  [pre.width: setAttribute() to Infinity]
-    expected: FAIL
-
-  [pre.width: setAttribute() to -Infinity]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\0"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to object "2"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to object "3"]
-    expected: FAIL
-
-  [pre.width: IDL set to -36]
-    expected: FAIL
-
-  [pre.width: IDL set to -1]
-    expected: FAIL
-
-  [pre.width: IDL set to 0]
-    expected: FAIL
-
-  [pre.width: IDL set to 1]
-    expected: FAIL
-
-  [pre.width: IDL set to 2147483647]
-    expected: FAIL
-
-  [pre.width: IDL set to -2147483648]
     expected: FAIL
 
   [blockquote.accessKey: setAttribute() to ""]
@@ -17454,9 +17286,6 @@
   [blockquote.cite: IDL set to "5%"]
     expected: FAIL
 
-  [pre.width: setAttribute() to "5%"]
-    expected: FAIL
-
   [ol.start: setAttribute() to "᠎7"]
     expected: FAIL
 
@@ -17508,9 +17337,6 @@
   [ol.start: setAttribute() to " 7"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [hr.size: setAttribute() to "5%"]
     expected: FAIL
 
@@ -17520,19 +17346,7 @@
   [hr.tabIndex: setAttribute() to "5%"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [li.accessKey: setAttribute() to "5%"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [ul.accessKey: IDL set to "5%"]
@@ -17547,16 +17361,10 @@
   [ol.start: setAttribute() to "﻿7"]
     expected: FAIL
 
-  [pre.width: setAttribute() to "﻿7"]
-    expected: FAIL
-
   [p.accessKey: IDL set to "5%"]
     expected: FAIL
 
   [ol.type: setAttribute() to "5%"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [figure.accessKey: IDL set to "5%"]
@@ -17568,13 +17376,7 @@
   [dl.accessKey: setAttribute() to "5%"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [figcaption.tabIndex: setAttribute() to "5%"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [dt.tabIndex: setAttribute() to "5%"]
@@ -17637,9 +17439,6 @@
   [li.type: IDL set to "5%"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [dl.compact: setAttribute() to "5%"]
     expected: FAIL
 
@@ -17647,12 +17446,6 @@
     expected: FAIL
 
   [ol.start: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "᠎7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "　7"]
     expected: FAIL
 
   [p.align: IDL set to "5%"]
@@ -17688,18 +17481,6 @@
   [hr.size: IDL set to "5%"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [figure.tabIndex: setAttribute() to "5%"]
     expected: FAIL
 
@@ -17731,15 +17512,6 @@
     expected: FAIL
 
   [p.accessKey: setAttribute() to "5%"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [ol.reversed: IDL set to "5%"]
@@ -17859,9 +17631,6 @@
   [ol.reversed: setAttribute() to "+100"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [ul.accessKey: IDL set to "+100"]
     expected: FAIL
 
@@ -17895,22 +17664,10 @@
   [dd.accessKey: setAttribute() to ".5"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [div.accessKey: IDL set to "+100"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [hr.tabIndex: setAttribute() to "+100"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [main.accessKey: setAttribute() to ".5"]
@@ -17934,9 +17691,6 @@
   [ul.type: setAttribute() to ".5"]
     expected: FAIL
 
-  [pre.width: setAttribute() to "﻿7"]
-    expected: FAIL
-
   [pre.tabIndex: setAttribute() to "+100"]
     expected: FAIL
 
@@ -17949,16 +17703,10 @@
   [ol.start: setAttribute() to ".5"]
     expected: FAIL
 
-  [pre.width: setAttribute() to ".5"]
-    expected: FAIL
-
   [p.tabIndex: setAttribute() to "+100"]
     expected: FAIL
 
   [figcaption.tabIndex: setAttribute() to "+100"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [ol.compact: setAttribute() to "+100"]
@@ -17968,15 +17716,6 @@
     expected: FAIL
 
   [ol.start: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "+100"]
     expected: FAIL
 
   [ol.compact: IDL set to "+100"]
@@ -18045,19 +17784,10 @@
   [main.tabIndex: setAttribute() to "+100"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [hr.size: setAttribute() to ".5"]
     expected: FAIL
 
   [ol.start: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "᠎7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "　7"]
     expected: FAIL
 
   [ol.compact: IDL set to ".5"]
@@ -18129,19 +17859,7 @@
   [hr.noShade: IDL set to "+100"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [li.type: setAttribute() to "+100"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [figure.accessKey: setAttribute() to "+100"]
@@ -18180,16 +17898,7 @@
   [ul.type: IDL set to ".5"]
     expected: FAIL
 
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
   [main.accessKey: setAttribute() to "+100"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
     expected: FAIL
 
   [p.accessKey: IDL set to ".5"]
@@ -19843,30 +19552,6 @@
     expected: FAIL
 
   [pre.tabIndex: setAttribute() to object "3"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "-"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "+"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\t\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\n\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\f\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\r\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " \\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "7\\v"]
     expected: FAIL
 
   [blockquote.tabIndex: setAttribute() to "7\\v"]

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -2982,9 +2982,6 @@
   [HTMLMarqueeElement interface: document.createElement("marquee") must inherit property "behavior" with the proper type]
     expected: FAIL
 
-  [HTMLPreElement interface: document.createElement("listing") must inherit property "width" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("file") must inherit property "align" with the proper type]
     expected: FAIL
 
@@ -3690,9 +3687,6 @@
   [HTMLAreaElement interface: attribute referrerPolicy]
     expected: FAIL
 
-  [HTMLPreElement interface: attribute width]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("week") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -4077,9 +4071,6 @@
   [HTMLParamElement interface: attribute type]
     expected: FAIL
 
-  [HTMLPreElement interface: document.createElement("xmp") must inherit property "width" with the proper type]
-    expected: FAIL
-
   [HTMLTableRowElement interface: document.createElement("tr") must inherit property "ch" with the proper type]
     expected: FAIL
 
@@ -4360,9 +4351,6 @@
     expected: FAIL
 
   [HTMLTableCellElement interface: document.createElement("td") must inherit property "headers" with the proper type]
-    expected: FAIL
-
-  [HTMLPreElement interface: document.createElement("pre") must inherit property "width" with the proper type]
     expected: FAIL
 
   [HTMLOptGroupElement interface: attribute label]

--- a/tests/wpt/meta/html/dom/reflection-grouping.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-grouping.html.ini
@@ -1259,193 +1259,16 @@
   [pre.tabIndex: IDL set to -2147483648]
     expected: FAIL
 
-  [pre.width: typeof IDL attribute]
-    expected: FAIL
-
-  [pre.width: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [pre.width: setAttribute() to -36]
     expected: FAIL
 
   [pre.width: setAttribute() to -1]
     expected: FAIL
 
-  [pre.width: setAttribute() to 0]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 1]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 2147483647]
-    expected: FAIL
-
   [pre.width: setAttribute() to -2147483648]
     expected: FAIL
 
-  [pre.width: setAttribute() to 2147483648]
-    expected: FAIL
-
-  [pre.width: setAttribute() to -2147483649]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 4294967295]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 4294967296]
-    expected: FAIL
-
-  [pre.width: setAttribute() to ""]
-    expected: FAIL
-
   [pre.width: setAttribute() to "-1"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "-0"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "0"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "1"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\t7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\f7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "﻿7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\n7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\r7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "᠎7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " 7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "　7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to undefined]
-    expected: FAIL
-
-  [pre.width: setAttribute() to 1.5]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "5%"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "+100"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to ".5"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to true]
-    expected: FAIL
-
-  [pre.width: setAttribute() to false]
-    expected: FAIL
-
-  [pre.width: setAttribute() to object "[object Object\]"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to NaN]
-    expected: FAIL
-
-  [pre.width: setAttribute() to Infinity]
-    expected: FAIL
-
-  [pre.width: setAttribute() to -Infinity]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\0"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to object "2"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to object "3"]
-    expected: FAIL
-
-  [pre.width: IDL set to -36]
-    expected: FAIL
-
-  [pre.width: IDL set to -1]
-    expected: FAIL
-
-  [pre.width: IDL set to 0]
-    expected: FAIL
-
-  [pre.width: IDL set to 1]
-    expected: FAIL
-
-  [pre.width: IDL set to 2147483647]
-    expected: FAIL
-
-  [pre.width: IDL set to -2147483648]
     expected: FAIL
 
   [blockquote.autofocus: typeof IDL attribute]
@@ -5949,30 +5772,6 @@
     expected: FAIL
 
   [pre.tabIndex: setAttribute() to object "3"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "-"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "+"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\t\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\n\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\f\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "\\r\\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to " \\v7"]
-    expected: FAIL
-
-  [pre.width: setAttribute() to "7\\v"]
     expected: FAIL
 
   [blockquote.tabIndex: setAttribute() to "7\\v"]


### PR DESCRIPTION
This pr implements the `pre` element obsolete width attribute, it's quite a small change but also my first in the servo project 🎉

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

~~I can't find a wpt test that tests the this obsolete attribute, maybe I should add one?~~