### PR TITLE
layout: use `Au` in `BoxFragment`

### DIFF
--- a/components/layout_2020/display_list/conversions.rs
+++ b/components/layout_2020/display_list/conversions.rs
@@ -140,6 +140,18 @@ impl ToWebRender for PhysicalSides<Length> {
     }
 }
 
+impl ToWebRender for PhysicalSides<Au> {
+    type Type = units::LayoutSideOffsets;
+    fn to_webrender(&self) -> Self::Type {
+        units::LayoutSideOffsets::new(
+            self.top.to_f32_px(),
+            self.right.to_f32_px(),
+            self.bottom.to_f32_px(),
+            self.left.to_f32_px(),
+        )
+    }
+}
+
 impl ToWebRender for ComputedTextDecorationStyle {
     type Type = LineStyle;
     fn to_webrender(&self) -> Self::Type {

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -569,6 +569,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                     self.border_radius,
                     self.fragment
                         .border
+                        .map(|t| (*t).into())
                         .to_physical(self.fragment.style.writing_mode)
                         .to_webrender(),
                 ),
@@ -583,7 +584,8 @@ impl<'a> BuilderForBoxFragment<'a> {
             clip_for_radii(
                 inner_radii(
                     self.border_radius,
-                    (&self.fragment.border + &self.fragment.padding)
+                    (&self.fragment.border.map(|t| (*t).into()) +
+                        &self.fragment.padding.map(|t| (*t).into()))
                         .to_physical(self.fragment.style.writing_mode)
                         .to_webrender(),
                 ),
@@ -811,10 +813,10 @@ impl<'a> BuilderForBoxFragment<'a> {
             .border
             .to_physical(self.fragment.style.writing_mode);
         let widths = SideOffsets2D::new(
-            border_widths.top.px(),
-            border_widths.right.px(),
-            border_widths.bottom.px(),
-            border_widths.left.px(),
+            Length::from(border_widths.top).px(),
+            Length::from(border_widths.right).px(),
+            Length::from(border_widths.bottom).px(),
+            Length::from(border_widths.left).px(),
         );
         if widths == SideOffsets2D::zero() {
             return;

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -569,7 +569,6 @@ impl<'a> BuilderForBoxFragment<'a> {
                     self.border_radius,
                     self.fragment
                         .border
-                        .map(|t| (*t).into())
                         .to_physical(self.fragment.style.writing_mode)
                         .to_webrender(),
                 ),
@@ -584,8 +583,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             clip_for_radii(
                 inner_radii(
                     self.border_radius,
-                    (&self.fragment.border.map(|t| (*t).into()) +
-                        &self.fragment.padding.map(|t| (*t).into()))
+                    (&self.fragment.border + &self.fragment.padding)
                         .to_physical(self.fragment.style.writing_mode)
                         .to_webrender(),
                 ),
@@ -811,16 +809,13 @@ impl<'a> BuilderForBoxFragment<'a> {
         let border_widths = self
             .fragment
             .border
-            .to_physical(self.fragment.style.writing_mode);
-        let widths = SideOffsets2D::new(
-            Length::from(border_widths.top).px(),
-            Length::from(border_widths.right).px(),
-            Length::from(border_widths.bottom).px(),
-            Length::from(border_widths.left).px(),
-        );
-        if widths == SideOffsets2D::zero() {
+            .to_physical(self.fragment.style.writing_mode)
+            .to_webrender();
+
+        if border_widths == SideOffsets2D::zero() {
             return;
         }
+
         let common = builder.common_properties(self.border_rect, &self.fragment.style);
         let details = wr::BorderDetails::Normal(wr::NormalBorder {
             top: self.build_border_side(border.border_top_style, border.border_top_color.clone()),
@@ -837,7 +832,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         });
         builder
             .wr()
-            .push_border(&common, self.border_rect, widths, details)
+            .push_border(&common, self.border_rect, border_widths, details)
     }
 
     fn build_outline(&mut self, builder: &mut DisplayListBuilder) {

--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -63,16 +63,6 @@ impl<T> FlexRelativeSides<T> {
             cross: self.cross_start + self.cross_end,
         }
     }
-
-    // TODO(#29819): Check if this function can be removed after we convert everything to Au.
-    pub fn map<U>(&self, f: impl Fn(&T) -> U) -> FlexRelativeSides<U> {
-        FlexRelativeSides {
-            main_start: f(&self.main_start),
-            main_end: f(&self.main_end),
-            cross_start: f(&self.cross_start),
-            cross_end: f(&self.cross_end),
-        }
-    }
 }
 
 /// One of the two bits set by the `flex-direction` property

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -856,9 +856,9 @@ impl FlexLine<'_> {
                         item.box_.style().clone(),
                         item_result.fragments,
                         content_rect,
-                        flex_context.sides_to_flow_relative(item.padding.map(|t| (*t).into())),
-                        flex_context.sides_to_flow_relative(item.border.map(|t| (*t).into())),
-                        margin,
+                        flex_context.sides_to_flow_relative(item.padding),
+                        flex_context.sides_to_flow_relative(item.border),
+                        margin.into(),
                         None, /* clearance */
                         collapsed_margin,
                     ),

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -989,9 +989,9 @@ impl FloatBox {
                     style.clone(),
                     children,
                     content_rect,
-                    pbm.padding.into(),
-                    pbm.border.into(),
-                    margin.into(),
+                    pbm.padding,
+                    pbm.border,
+                    margin,
                     // Clearance is handled internally by the float placement logic, so there's no need
                     // to store it explicitly in the fragment.
                     None, // clearance
@@ -1215,7 +1215,7 @@ impl SequentialLayoutState {
 
         let pbm_sums = &(&box_fragment.padding + &box_fragment.border) + &box_fragment.margin;
         let content_rect: LogicalRect<Au> = box_fragment.content_rect.clone().into();
-        let pbm_sums_all: LogicalSides<Au> = pbm_sums.map(|length| (*length).into());
+        let pbm_sums_all: LogicalSides<Au> = pbm_sums;
         let margin_box_start_corner = self.floats.add_float(&PlacementInfo {
             size: &content_rect.size + &pbm_sums_all.sum(),
             side: FloatSide::from_style(&box_fragment.style).expect("Float box wasn't floated!"),

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -25,7 +25,7 @@ use crate::dom::NodeExt;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, CollapsedMargin, FloatFragment};
-use crate::geom::{LogicalRect, LogicalSides, LogicalVec2};
+use crate::geom::{LogicalRect, LogicalVec2};
 use crate::positioned::PositioningContext;
 use crate::style_ext::{ComputedValuesExt, DisplayInside, PaddingBorderMargin};
 use crate::ContainingBlock;
@@ -1215,9 +1215,8 @@ impl SequentialLayoutState {
 
         let pbm_sums = &(&box_fragment.padding + &box_fragment.border) + &box_fragment.margin;
         let content_rect: LogicalRect<Au> = box_fragment.content_rect.clone().into();
-        let pbm_sums_all: LogicalSides<Au> = pbm_sums;
         let margin_box_start_corner = self.floats.add_float(&PlacementInfo {
-            size: &content_rect.size + &pbm_sums_all.sum(),
+            size: &content_rect.size + &pbm_sums.sum(),
             side: FloatSide::from_style(&box_fragment.style).expect("Float box wasn't floated!"),
             clear: box_fragment.style.get_box().clear,
         });
@@ -1225,7 +1224,7 @@ impl SequentialLayoutState {
         // This is the position of the float in the float-containing block formatting context. We add the
         // existing start corner here because we may have already gotten some relative positioning offset.
         let new_position_in_bfc =
-            &(&margin_box_start_corner + &pbm_sums_all.start_offset()) + &content_rect.start_corner;
+            &(&margin_box_start_corner + &pbm_sums.start_offset()) + &content_rect.start_corner;
 
         // This is the position of the float relative to the containing block start.
         let new_position_in_containing_block = LogicalVec2 {

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -1031,7 +1031,7 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
         let margin_box = float_item
             .fragment
             .border_rect()
-            .inflate(&float_item.fragment.margin);
+            .inflate(&float_item.fragment.margin.map(|t| (*t).into()));
         let inline_size = margin_box.size.inline.max(Length::zero());
 
         let available_inline_size = match self.current_line.placement_among_floats.get() {
@@ -2001,9 +2001,9 @@ impl IndependentFormattingContext {
                     replaced.style.clone(),
                     fragments,
                     content_rect.into(),
-                    pbm.padding.into(),
-                    pbm.border.into(),
-                    margin.into(),
+                    pbm.padding,
+                    pbm.border,
+                    margin,
                     None, /* clearance */
                     CollapsedBlockMargins::zero(),
                 )
@@ -2090,9 +2090,9 @@ impl IndependentFormattingContext {
                     non_replaced.style.clone(),
                     independent_layout.fragments,
                     content_rect.into(),
-                    pbm.padding.into(),
-                    pbm.border.into(),
-                    margin.into(),
+                    pbm.padding,
+                    pbm.border,
+                    margin,
                     None,
                     CollapsedBlockMargins::zero(),
                 )

--- a/components/layout_2020/flow/line.rs
+++ b/components/layout_2020/flow/line.rs
@@ -378,9 +378,9 @@ impl InlineBoxLineItem {
             self.style.clone(),
             fragments,
             content_rect,
-            padding.into(),
-            border.into(),
-            margin.into(),
+            padding,
+            border,
+            margin,
             None, /* clearance */
             CollapsedBlockMargins::zero(),
         );

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -814,10 +814,10 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         style.clone(),
         flow_layout.fragments,
         content_rect.into(),
-        pbm.padding.into(),
-        pbm.border.into(),
-        margin,
-        clearance.map(|t| t.into()),
+        pbm.padding,
+        pbm.border,
+        margin.into(),
+        clearance,
         block_margins_collapsed_with_children,
     )
     .with_baselines(flow_layout.baselines)
@@ -900,9 +900,9 @@ impl NonReplacedFormattingContext {
             self.style.clone(),
             layout.fragments,
             content_rect.into(),
-            pbm.padding.into(),
-            pbm.border.into(),
-            margin,
+            pbm.padding,
+            pbm.border,
+            margin.into(),
             None, /* clearance */
             block_margins_collapsed_with_children,
         )
@@ -1152,10 +1152,10 @@ impl NonReplacedFormattingContext {
             self.style.clone(),
             layout.fragments,
             content_rect.into(),
-            pbm.padding.into(),
-            pbm.border.into(),
-            margin,
-            clearance,
+            pbm.padding,
+            pbm.border,
+            margin.into(),
+            clearance.map(|t| t.into()),
             block_margins_collapsed_with_children,
         )
         .with_baselines(layout.baselines)
@@ -1257,10 +1257,10 @@ fn layout_in_flow_replaced_block_level(
         style.clone(),
         fragments,
         content_rect.into(),
-        pbm.padding.into(),
-        pbm.border.into(),
-        margin,
-        clearance,
+        pbm.padding,
+        pbm.border,
+        margin.into(),
+        clearance.map(|t| t.into()),
         block_margins_collapsed_with_children,
     )
 }
@@ -1590,7 +1590,7 @@ impl PlacementState {
                 let fragment_block_margins = &fragment.block_margins_collapsed_with_children;
                 let mut fragment_block_size = fragment.padding.block_sum() +
                     fragment.border.block_sum() +
-                    fragment.content_rect.size.block;
+                    fragment.content_rect.size.block.into();
                 // We use `last_in_flow_margin_collapses_with_parent_end_margin` to implement
                 // this quote from https://drafts.csswg.org/css2/#collapsing-margins
                 // > If the top and bottom margins of an element with clearance are adjoining,
@@ -1632,12 +1632,12 @@ impl PlacementState {
                 if fragment_block_margins.collapsed_through {
                     // `fragment_block_size` is typically zero when collapsing through,
                     // but we still need to consider it in case there is clearance.
-                    self.current_block_direction_position += fragment_block_size;
+                    self.current_block_direction_position += fragment_block_size.into();
                     self.current_margin
                         .adjoin_assign(&fragment_block_margins.end);
                 } else {
                     self.current_block_direction_position +=
-                        self.current_margin.solve() + fragment_block_size;
+                        self.current_margin.solve() + fragment_block_size.into();
                     self.current_margin = fragment_block_margins.end;
                 }
             },

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -154,9 +154,10 @@ impl BoxFragment {
         let mut baselines = Baselines::default();
         if style.establishes_scroll_container() {
             baselines.last = Some(
-                (content_rect.size.block +
-                    Length::from(padding.block_end + border.block_end + margin.block_end))
-                .into(),
+                Au::from(content_rect.size.block) +
+                    padding.block_end +
+                    border.block_end +
+                    margin.block_end,
             )
         }
 

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -52,9 +52,9 @@ pub(crate) struct BoxFragment {
     /// <https://drafts.csswg.org/css-writing-modes/#orthogonal-flows>
     pub content_rect: LogicalRect<Length>,
 
-    pub padding: LogicalSides<Length>,
-    pub border: LogicalSides<Length>,
-    pub margin: LogicalSides<Length>,
+    pub padding: LogicalSides<Au>,
+    pub border: LogicalSides<Au>,
+    pub margin: LogicalSides<Au>,
 
     /// When the `clear` property is not set to `none`, it may introduce clearance.
     /// Clearance is some extra spacing that is added above the top margin,
@@ -62,7 +62,7 @@ pub(crate) struct BoxFragment {
     /// The presence of clearance prevents the top margin from collapsing with
     /// earlier margins or with the bottom margin of the parent block.
     /// <https://drafts.csswg.org/css2/#clearance>
-    pub clearance: Option<Length>,
+    pub clearance: Option<Au>,
 
     /// When this [`BoxFragment`] is for content that has a baseline, this tracks
     /// the first and last baselines of that content. This is used to propagate baselines
@@ -93,10 +93,10 @@ impl BoxFragment {
         style: ServoArc<ComputedValues>,
         children: Vec<Fragment>,
         content_rect: LogicalRect<Length>,
-        padding: LogicalSides<Length>,
-        border: LogicalSides<Length>,
-        margin: LogicalSides<Length>,
-        clearance: Option<Length>,
+        padding: LogicalSides<Au>,
+        border: LogicalSides<Au>,
+        margin: LogicalSides<Au>,
+        clearance: Option<Au>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
     ) -> BoxFragment {
         let position = style.get_box().position;
@@ -128,10 +128,10 @@ impl BoxFragment {
         style: ServoArc<ComputedValues>,
         children: Vec<Fragment>,
         content_rect: LogicalRect<Length>,
-        padding: LogicalSides<Length>,
-        border: LogicalSides<Length>,
-        margin: LogicalSides<Length>,
-        clearance: Option<Length>,
+        padding: LogicalSides<Au>,
+        border: LogicalSides<Au>,
+        margin: LogicalSides<Au>,
+        clearance: Option<Au>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
         overconstrained: PhysicalSize<bool>,
     ) -> BoxFragment {
@@ -154,8 +154,9 @@ impl BoxFragment {
         let mut baselines = Baselines::default();
         if style.establishes_scroll_container() {
             baselines.last = Some(
-                (content_rect.size.block + padding.block_end + border.block_end + margin.block_end)
-                    .into(),
+                (content_rect.size.block +
+                    Length::from(padding.block_end + border.block_end + margin.block_end))
+                .into(),
             )
         }
 
@@ -221,11 +222,13 @@ impl BoxFragment {
     }
 
     pub fn padding_rect(&self) -> LogicalRect<Length> {
-        self.content_rect.inflate(&self.padding)
+        self.content_rect
+            .inflate(&self.padding.map(|t| (*t).into()))
     }
 
     pub fn border_rect(&self) -> LogicalRect<Length> {
-        self.padding_rect().inflate(&self.border)
+        self.padding_rect()
+            .inflate(&self.border.map(|t| (*t).into()))
     }
 
     pub fn print(&self, tree: &mut PrintTree) {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -254,7 +254,7 @@ impl PositioningContext {
             // Ignore the content rect’s position in its own containing block:
             start_corner: LogicalVec2::zero(),
         }
-        .inflate(&new_fragment.padding);
+        .inflate(&new_fragment.padding.map(|t| (*t).into()));
         let containing_block = DefiniteContainingBlock {
             size: padding_rect.size.into(),
             style: &new_fragment.style,
@@ -703,9 +703,9 @@ impl HoistedAbsolutelyPositionedBox {
                 absolutely_positioned_box.context.style().clone(),
                 fragments,
                 content_rect.into(),
-                pbm.padding.into(),
-                pbm.border.into(),
-                margin.into(),
+                pbm.padding,
+                pbm.border,
+                margin,
                 None, /* clearance */
                 // We do not set the baseline offset, because absolutely positioned
                 // elements are not inflow.

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -370,14 +370,14 @@ pub fn process_resolved_style_request<'dom>(
             match longhand_id {
                 LonghandId::Width => Some(content_rect.size.width),
                 LonghandId::Height => Some(content_rect.size.height),
-                LonghandId::MarginBottom => Some(margins.bottom),
-                LonghandId::MarginTop => Some(margins.top),
-                LonghandId::MarginLeft => Some(margins.left),
-                LonghandId::MarginRight => Some(margins.right),
-                LonghandId::PaddingBottom => Some(padding.bottom),
-                LonghandId::PaddingTop => Some(padding.top),
-                LonghandId::PaddingLeft => Some(padding.left),
-                LonghandId::PaddingRight => Some(padding.right),
+                LonghandId::MarginBottom => Some(margins.bottom.into()),
+                LonghandId::MarginTop => Some(margins.top.into()),
+                LonghandId::MarginLeft => Some(margins.left.into()),
+                LonghandId::MarginRight => Some(margins.right.into()),
+                LonghandId::PaddingBottom => Some(padding.bottom.into()),
+                LonghandId::PaddingTop => Some(padding.top.into()),
+                LonghandId::PaddingLeft => Some(padding.left.into()),
+                LonghandId::PaddingRight => Some(padding.right.into()),
                 _ => None,
             }
             .map(|value| value.to_css_string())

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -2077,8 +2077,8 @@ impl TableSlotCell {
             self.style.clone(),
             vec![Fragment::Positioning(vertical_align_fragment)],
             cell_content_rect,
-            layout.padding,
-            layout.border,
+            layout.padding.into(),
+            layout.border.into(),
             LogicalSides::zero(), /* margin */
             None,                 /* clearance */
             CollapsedBlockMargins::zero(),

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -470,8 +470,8 @@ impl Drop for FloatPlacement {
 impl PlacedFloat {
     fn rect(&self) -> LogicalRect<Au> {
         LogicalRect {
-            start_corner: self.origin.clone(),
-            size: self.info.size.clone(),
+            start_corner: self.origin,
+            size: self.info.size,
         }
     }
 }


### PR DESCRIPTION
Make `pbm` and `clearance` in `BoxFragement` use app units


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
