### PR TITLE
Don't trim leading whitespace of anonymous table cells

### DIFF
--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-199.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-199.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-199.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-200.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-200.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-200.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-201.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-201.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-201.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-202.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-202.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-202.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-203.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-203.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-203.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-204.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-204.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-204.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-211.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/table-anonymous-objects-211.xht.ini
@@ -1,2 +1,0 @@
-[table-anonymous-objects-211.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/anonymous-table-ws-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/anonymous-table-ws-001.html.ini
@@ -1,2 +1,0 @@
-[anonymous-table-ws-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-model-fixup.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup.html.ini
@@ -14,8 +14,5 @@
   [2.2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-grouping box which are not table-row boxes. (3/3)]
     expected: FAIL
 
-  [1.4. Anonymous inline boxes which contains only white space and are between two immediate siblings *each* of which is a table-non-root element, are treated as if they had display: none.]
-    expected: FAIL
-
   [2.3 happens after 2.1. and 2.2. (1/2)]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/whitespace-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/whitespace-001.html.ini
@@ -1,2 +1,0 @@
-[whitespace-001.html]
-  expected: FAIL


### PR DESCRIPTION
A sequence of whitespace shouldn't generate an anonymous table row/cell, but we can't just throw away the leading whitespace, because afterwards we may encounter some other content, and then the leading whitespace should appear in the cell (noticeable with e.g. `white-space: pre`).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
