### PR TITLE
crown: Do not warn about crown for rustdoc or clippy

### DIFF
--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -5,9 +5,11 @@
 #![feature(register_tool)]
 #![deny(unsafe_code)]
 #![doc = "The script crate contains all matters DOM."]
+// Register the linter `crown`, which is the Servo-specific linter for the script
+// crate. Issue a warning if `crown` is not being used to compile, but not when
+// building rustdoc or running clippy.
 #![register_tool(crown)]
-// Issue a warning if `crown` cannot be found.
-#![warn(unknown_lints)]
+#![cfg_attr(any(doc, clippy, feature = "cargo-clippy"), allow(unknown_lints))]
 #![deny(crown_is_not_used)]
 
 // These are used a lot so let's keep them for now


### PR DESCRIPTION
This is important because tools like clippy and rustdoc cannot use crown
and should not issue warnings.

Fixes #31804.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31804
- [x] These changes do not require tests because they just eliminate some build warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
