### PR TITLE
Update fontsan to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,15 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,10 +1690,11 @@ dependencies = [
 
 [[package]]
 name = "fontsan"
-version = "0.5.0"
-source = "git+https://github.com/servo/fontsan#36de30730c14af97c5545b957b125a6ce94a4ea3"
+version = "0.5.2"
+source = "git+https://github.com/servo/fontsan#cf5d0035486ac2c23e778b78ff081e0bbc791a82"
 dependencies = [
- "cmake",
+ "cc",
+ "glob",
  "libc",
  "miniz-sys",
 ]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- Removes the depndency on `cmake-rs`. 
- Fixes build-issues, e.g. when clang is used on Linux, where previously the wrong c++ stdlib implementation would be linked against.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
