### PR TITLE
clippy: Fix `needless_borrowed_reference` warnings in `components/script`

### DIFF
--- a/components/script/dom/bindings/num.rs
+++ b/components/script/dom/bindings/num.rs
@@ -39,7 +39,7 @@ impl<T: Float> Deref for Finite<T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        let &Finite(ref value) = self;
+        let Finite(value) = self;
         value
     }
 }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -253,7 +253,7 @@ pub unsafe fn find_enum_value<'a, T>(
         pairs
             .iter()
             .find(|&&(key, _)| search == *key)
-            .map(|&(_, ref ev)| ev),
+            .map(|(_, ev)| ev),
         search,
     ))
 }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -166,7 +166,7 @@ impl Bluetooth {
         // Step 2.2: There are no requiredServiceUUIDS, we scan for all devices.
         let mut uuid_filters = vec![];
 
-        if let &Some(ref filters) = filters {
+        if let Some(filters) = filters {
             // Step 2.1.
             if filters.is_empty() {
                 p.reject_error(Type(FILTER_EMPTY_ERROR.to_owned()));

--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -627,7 +627,7 @@ impl BluetoothUUID {
 impl Clone for StringOrUnsignedLong {
     fn clone(&self) -> StringOrUnsignedLong {
         match self {
-            &StringOrUnsignedLong::String(ref s) => StringOrUnsignedLong::String(s.clone()),
+            StringOrUnsignedLong::String(s) => StringOrUnsignedLong::String(s.clone()),
             &StringOrUnsignedLong::UnsignedLong(ul) => StringOrUnsignedLong::UnsignedLong(ul),
         }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1762,8 +1762,8 @@ impl Document {
         let body = self.GetBody();
 
         let target = match (&focused, &body) {
-            (&Some(ref focused), _) => focused.upcast(),
-            (&None, &Some(ref body)) => body.upcast(),
+            (Some(focused), _) => focused.upcast(),
+            (&None, Some(body)) => body.upcast(),
             (&None, &None) => self.window.upcast(),
         };
 
@@ -4640,7 +4640,7 @@ impl DocumentMethods for Document {
 
         match (self.GetDocumentElement(), &old_body) {
             // Step 3.
-            (Some(ref root), &Some(ref child)) => {
+            (Some(ref root), Some(child)) => {
                 let root = root.upcast::<Node>();
                 root.ReplaceChild(new_body.upcast(), child.upcast())
                     .unwrap();

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -138,18 +138,12 @@ impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
     fn data(self) -> HTMLCanvasData {
         let source = unsafe {
             match self.unsafe_get().context.borrow_for_layout().as_ref() {
-                Some(&CanvasContext::Context2d(ref context)) => {
+                Some(CanvasContext::Context2d(context)) => {
                     HTMLCanvasDataSource::Image(Some(context.to_layout().get_ipc_renderer()))
                 },
-                Some(&CanvasContext::WebGL(ref context)) => {
-                    context.to_layout().canvas_data_source()
-                },
-                Some(&CanvasContext::WebGL2(ref context)) => {
-                    context.to_layout().canvas_data_source()
-                },
-                Some(&CanvasContext::WebGPU(ref context)) => {
-                    context.to_layout().canvas_data_source()
-                },
+                Some(CanvasContext::WebGL(context)) => context.to_layout().canvas_data_source(),
+                Some(CanvasContext::WebGL2(context)) => context.to_layout().canvas_data_source(),
+                Some(CanvasContext::WebGPU(context)) => context.to_layout().canvas_data_source(),
                 None => HTMLCanvasDataSource::Image(None),
             }
         };
@@ -318,7 +312,7 @@ impl HTMLCanvasElement {
         }
 
         let data = match self.context.borrow().as_ref() {
-            Some(&CanvasContext::Context2d(ref context)) => {
+            Some(CanvasContext::Context2d(context)) => {
                 let (sender, receiver) =
                     ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let msg = CanvasMsg::FromScript(

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -359,7 +359,7 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     fn SelectedIndex(&self) -> i32 {
         self.list_of_options()
             .enumerate()
-            .filter(|&(_, ref opt_elem)| opt_elem.Selected())
+            .filter(|(_, opt_elem)| opt_elem.Selected())
             .map(|(i, _)| i as i32)
             .next()
             .unwrap_or(-1)

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -181,7 +181,7 @@ impl MutationObserver {
                             None
                         };
                         // Step 3.1.1
-                        let idx = interested_observers.iter().position(|&(ref o, _)| {
+                        let idx = interested_observers.iter().position(|(o, _)| {
                             &**o as *const _ == &*registered.observer as *const _
                         });
                         if let Some(idx) = idx {
@@ -202,7 +202,7 @@ impl MutationObserver {
                             None
                         };
                         // Step 3.1.1
-                        let idx = interested_observers.iter().position(|&(ref o, _)| {
+                        let idx = interested_observers.iter().position(|(o, _)| {
                             &**o as *const _ == &*registered.observer as *const _
                         });
                         if let Some(idx) = idx {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2796,7 +2796,7 @@ impl NodeMethods for Node {
                 }
                 while children
                     .peek()
-                    .map_or(false, |&(_, ref sibling)| sibling.is::<Text>())
+                    .map_or(false, |(_, sibling)| sibling.is::<Text>())
                 {
                     let (index, sibling) = children.next().unwrap();
                     sibling
@@ -3431,7 +3431,7 @@ unsafe_no_jsmanaged_fields!(UniqueId);
 impl MallocSizeOf for UniqueId {
     #[allow(unsafe_code)]
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        if let &Some(ref uuid) = unsafe { &*self.cell.get() } {
+        if let Some(uuid) = unsafe { &*self.cell.get() } {
             unsafe { ops.malloc_size_of(&**uuid) }
         } else {
             0

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -107,7 +107,7 @@ impl OffscreenCanvas {
         }
 
         let data = match self.context.borrow().as_ref() {
-            Some(&OffscreenCanvasContext::OffscreenContext2d(ref context)) => {
+            Some(OffscreenCanvasContext::OffscreenContext2d(context)) => {
                 let (sender, receiver) =
                     ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let msg = CanvasMsg::FromScript(

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -858,10 +858,10 @@ impl Into<RequestRedirect> for NetTraitsRequestRedirect {
 impl Clone for HeadersInit {
     fn clone(&self) -> HeadersInit {
         match self {
-            &HeadersInit::ByteStringSequenceSequence(ref b) => {
+            HeadersInit::ByteStringSequenceSequence(b) => {
                 HeadersInit::ByteStringSequenceSequence(b.clone())
             },
-            &HeadersInit::ByteStringByteStringRecord(ref m) => {
+            HeadersInit::ByteStringByteStringRecord(m) => {
                 HeadersInit::ByteStringByteStringRecord(m.clone())
             },
         }

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -88,7 +88,7 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
         // A: Step 4-5
         let scope = match options.scope {
             Some(ref scope) => {
-                let &USVString(ref inner_scope) = scope;
+                let USVString(inner_scope) = scope;
                 match api_base_url.join(inner_scope) {
                     Ok(url) => url,
                     Err(_) => {

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -134,7 +134,7 @@ fn start_element<S: Serializer>(node: &Element, serializer: &mut S) -> io::Resul
             (qname, value)
         })
         .collect::<Vec<_>>();
-    let attr_refs = attrs.iter().map(|&(ref qname, ref value)| {
+    let attr_refs = attrs.iter().map(|(qname, value)| {
         let ar: AttrRef = (&qname, &**value);
         ar
     });

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -118,12 +118,10 @@ impl URLSearchParamsMethods for URLSearchParams {
     // https://url.spec.whatwg.org/#dom-urlsearchparams-delete
     fn Delete(&self, name: USVString, value: Option<USVString>) {
         // Step 1.
-        self.list
-            .borrow_mut()
-            .retain(|&(ref k, ref v)| match &value {
-                Some(value) => !(k == &name.0 && v == &value.0),
-                None => k != &name.0,
-            });
+        self.list.borrow_mut().retain(|(k, v)| match &value {
+            Some(value) => !(k == &name.0 && v == &value.0),
+            None => k != &name.0,
+        });
         // Step 2.
         self.update_steps();
     }
@@ -140,7 +138,7 @@ impl URLSearchParamsMethods for URLSearchParams {
     fn GetAll(&self, name: USVString) -> Vec<USVString> {
         let list = self.list.borrow();
         list.iter()
-            .filter_map(|&(ref k, ref v)| {
+            .filter_map(|(k, v)| {
                 if k == &name.0 {
                     Some(USVString(v.clone()))
                 } else {
@@ -153,7 +151,7 @@ impl URLSearchParamsMethods for URLSearchParams {
     // https://url.spec.whatwg.org/#dom-urlsearchparams-has
     fn Has(&self, name: USVString, value: Option<USVString>) -> bool {
         let list = self.list.borrow();
-        list.iter().any(|&(ref k, ref v)| match &value {
+        list.iter().any(|(k, v)| match &value {
             Some(value) => k == &name.0 && v == &value.0,
             None => k == &name.0,
         })
@@ -166,7 +164,7 @@ impl URLSearchParamsMethods for URLSearchParams {
             let mut list = self.list.borrow_mut();
             let mut index = None;
             let mut i = 0;
-            list.retain(|&(ref k, _)| {
+            list.retain(|(k, _)| {
                 if index.is_none() {
                     if k == &name.0 {
                         index = Some(i);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Delete tuple pattern dereferencings to fix the `needless_borrowed_reference` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
