### PR TITLE
clippy: Fix `needless_borrow` warnings in `components/script`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -453,7 +453,7 @@ impl Extractable for BodyInit {
             BodyInit::ArrayBuffer(ref typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
-                let stream = ReadableStream::new_from_bytes(&global, bytes);
+                let stream = ReadableStream::new_from_bytes(global, bytes);
                 Ok(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -464,7 +464,7 @@ impl Extractable for BodyInit {
             BodyInit::ArrayBufferView(ref typedarray) => {
                 let bytes = typedarray.to_vec();
                 let total_bytes = bytes.len();
-                let stream = ReadableStream::new_from_bytes(&global, bytes);
+                let stream = ReadableStream::new_from_bytes(global, bytes);
                 Ok(ExtractedBody {
                     stream,
                     total_bytes: Some(total_bytes),
@@ -497,7 +497,7 @@ impl Extractable for Vec<u8> {
     fn extract(&self, global: &GlobalScope) -> Fallible<ExtractedBody> {
         let bytes = self.clone();
         let total_bytes = self.len();
-        let stream = ReadableStream::new_from_bytes(&global, bytes);
+        let stream = ReadableStream::new_from_bytes(global, bytes);
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -531,7 +531,7 @@ impl Extractable for DOMString {
         let bytes = self.as_bytes().to_owned();
         let total_bytes = bytes.len();
         let content_type = Some(DOMString::from("text/plain;charset=UTF-8"));
-        let stream = ReadableStream::new_from_bytes(&global, bytes);
+        let stream = ReadableStream::new_from_bytes(global, bytes);
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -550,7 +550,7 @@ impl Extractable for FormData {
             "multipart/form-data;boundary={}",
             boundary
         )));
-        let stream = ReadableStream::new_from_bytes(&global, bytes);
+        let stream = ReadableStream::new_from_bytes(global, bytes);
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),
@@ -567,7 +567,7 @@ impl Extractable for URLSearchParams {
         let content_type = Some(DOMString::from(
             "application/x-www-form-urlencoded;charset=UTF-8",
         ));
-        let stream = ReadableStream::new_from_bytes(&global, bytes);
+        let stream = ReadableStream::new_from_bytes(global, bytes);
         Ok(ExtractedBody {
             stream,
             total_bytes: Some(total_bytes),

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -46,7 +46,7 @@ pub fn handle_evaluate_js(global: &GlobalScope, eval: String, reply: IpcSender<E
             "<eval>",
             rval.handle_mut(),
             1,
-            ScriptFetchOptions::default_classic_script(&global),
+            ScriptFetchOptions::default_classic_script(global),
             global.api_base_url(),
         );
 

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -206,7 +206,7 @@ impl Attr {
             (Some(old), None) => {
                 // Already gone from the list of attributes of old owner.
                 assert!(
-                    old.get_attribute(&ns, &self.identifier.local_name)
+                    old.get_attribute(ns, &self.identifier.local_name)
                         .as_deref() !=
                         Some(self)
                 )

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -58,7 +58,7 @@ impl AudioBufferSourceNode {
         )?;
         let node_id = source_node.node().node_id();
         let playback_rate = AudioParam::new(
-            &window,
+            window,
             context,
             node_id,
             AudioNodeType::AudioBufferSourceNode,
@@ -69,7 +69,7 @@ impl AudioBufferSourceNode {
             f32::MAX,
         );
         let detune = AudioParam::new(
-            &window,
+            window,
             context,
             node_id,
             AudioNodeType::AudioBufferSourceNode,

--- a/components/script/dom/audioscheduledsourcenode.rs
+++ b/components/script/dom/audioscheduledsourcenode.rs
@@ -86,7 +86,7 @@ impl AudioScheduledSourceNodeMethods for AudioScheduledSourceNode {
                     window.task_manager().dom_manipulation_task_source().queue_simple_event(
                         this.upcast(),
                         atom!("ended"),
-                        &window
+                        window
                         );
                 }),
                 &canceller,

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -331,7 +331,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
     fn Listener(&self) -> DomRoot<AudioListener> {
         let global = self.global();
         let window = global.as_window();
-        self.listener.or_init(|| AudioListener::new(&window, self))
+        self.listener.or_init(|| AudioListener::new(window, self))
     }
 
     // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange
@@ -339,33 +339,29 @@ impl BaseAudioContextMethods for BaseAudioContext {
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createoscillator>
     fn CreateOscillator(&self) -> Fallible<DomRoot<OscillatorNode>> {
-        OscillatorNode::new(
-            &self.global().as_window(),
-            &self,
-            &OscillatorOptions::empty(),
-        )
+        OscillatorNode::new(self.global().as_window(), self, &OscillatorOptions::empty())
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-creategain>
     fn CreateGain(&self) -> Fallible<DomRoot<GainNode>> {
-        GainNode::new(&self.global().as_window(), &self, &GainOptions::empty())
+        GainNode::new(self.global().as_window(), self, &GainOptions::empty())
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createpanner>
     fn CreatePanner(&self) -> Fallible<DomRoot<PannerNode>> {
-        PannerNode::new(&self.global().as_window(), &self, &PannerOptions::empty())
+        PannerNode::new(self.global().as_window(), self, &PannerOptions::empty())
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createanalyser>
     fn CreateAnalyser(&self) -> Fallible<DomRoot<AnalyserNode>> {
-        AnalyserNode::new(&self.global().as_window(), &self, &AnalyserOptions::empty())
+        AnalyserNode::new(self.global().as_window(), self, &AnalyserOptions::empty())
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbiquadfilter>
     fn CreateBiquadFilter(&self) -> Fallible<DomRoot<BiquadFilterNode>> {
         BiquadFilterNode::new(
-            &self.global().as_window(),
-            &self,
+            self.global().as_window(),
+            self,
             &BiquadFilterOptions::empty(),
         )
     }
@@ -373,8 +369,8 @@ impl BaseAudioContextMethods for BaseAudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createstereopanner>
     fn CreateStereoPanner(&self) -> Fallible<DomRoot<StereoPannerNode>> {
         StereoPannerNode::new(
-            &self.global().as_window(),
-            &self,
+            self.global().as_window(),
+            self,
             &StereoPannerOptions::empty(),
         )
     }
@@ -382,8 +378,8 @@ impl BaseAudioContextMethods for BaseAudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createconstantsource>
     fn CreateConstantSource(&self) -> Fallible<DomRoot<ConstantSourceNode>> {
         ConstantSourceNode::new(
-            &self.global().as_window(),
-            &self,
+            self.global().as_window(),
+            self,
             &ConstantSourceOptions::empty(),
         )
     }
@@ -392,14 +388,14 @@ impl BaseAudioContextMethods for BaseAudioContext {
     fn CreateChannelMerger(&self, count: u32) -> Fallible<DomRoot<ChannelMergerNode>> {
         let mut opts = ChannelMergerOptions::empty();
         opts.numberOfInputs = count;
-        ChannelMergerNode::new(&self.global().as_window(), &self, &opts)
+        ChannelMergerNode::new(self.global().as_window(), self, &opts)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createchannelsplitter>
     fn CreateChannelSplitter(&self, count: u32) -> Fallible<DomRoot<ChannelSplitterNode>> {
         let mut opts = ChannelSplitterOptions::empty();
         opts.numberOfOutputs = count;
-        ChannelSplitterNode::new(&self.global().as_window(), &self, &opts)
+        ChannelSplitterNode::new(self.global().as_window(), self, &opts)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer>
@@ -417,7 +413,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
             return Err(Error::NotSupported);
         }
         Ok(AudioBuffer::new(
-            &self.global().as_window(),
+            self.global().as_window(),
             number_of_channels,
             length,
             *sample_rate,
@@ -428,8 +424,8 @@ impl BaseAudioContextMethods for BaseAudioContext {
     // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffersource
     fn CreateBufferSource(&self) -> Fallible<DomRoot<AudioBufferSourceNode>> {
         AudioBufferSourceNode::new(
-            &self.global().as_window(),
-            &self,
+            self.global().as_window(),
+            self,
             &AudioBufferSourceOptions::empty(),
         )
     }
@@ -507,7 +503,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
                                 0
                             };
                             let buffer = AudioBuffer::new(
-                                &this.global().as_window(),
+                                this.global().as_window(),
                                 decoded_audio.len() as u32 /* number of channels */,
                                 length as u32,
                                 this.sample_rate,

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -145,7 +145,7 @@ unsafe fn html_constructor(
 
     // Step 6
     rooted!(in(*cx) let mut prototype = ptr::null_mut::<JSObject>());
-    get_desired_proto(cx, &call_args, proto_id, creator, prototype.handle_mut())?;
+    get_desired_proto(cx, call_args, proto_id, creator, prototype.handle_mut())?;
 
     let entry = definition.construction_stack.borrow().last().cloned();
     let result = match entry {

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -121,7 +121,7 @@ where
                 if self.0.reflector().get_jsobject().is_null() {
                     self.0.trace(tracer);
                 } else {
-                    trace_reflector(tracer, "on stack", &self.0.reflector());
+                    trace_reflector(tracer, "on stack", self.0.reflector());
                 }
             }
         }
@@ -718,7 +718,7 @@ where
         F: FnOnce() -> DomRoot<T>,
     {
         assert_in_script();
-        &self.ptr.get_or_init(|| Dom::from_ref(&cb()))
+        self.ptr.get_or_init(|| Dom::from_ref(&cb()))
     }
 }
 

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -65,7 +65,7 @@ unsafe fn read_blob(
         &mut index as *mut u32
     ));
     let storage_key = StorageKey { index, name_space };
-    if <Blob as Serializable>::deserialize(&owner, &mut sc_holder, storage_key.clone()).is_ok() {
+    if <Blob as Serializable>::deserialize(owner, sc_holder, storage_key.clone()).is_ok() {
         let blobs = match sc_holder {
             StructuredDataHolder::Read { blobs, .. } => blobs,
             _ => panic!("Unexpected variant of StructuredDataHolder"),
@@ -171,7 +171,7 @@ unsafe extern "C" fn read_transfer_callback(
         let owner = GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof));
         if let Ok(_) = <MessagePort as Transferable>::transfer_receive(
             &owner,
-            &mut sc_holder,
+            sc_holder,
             extra_data,
             return_object,
         ) {
@@ -195,7 +195,7 @@ unsafe extern "C" fn write_transfer_callback(
         *tag = StructuredCloneTags::MessagePort as u32;
         *ownership = TransferableOwnership::SCTAG_TMO_CUSTOM;
         let mut sc_holder = &mut *(closure as *mut StructuredDataHolder);
-        if let Ok(data) = port.transfer(&mut sc_holder) {
+        if let Ok(data) = port.transfer(sc_holder) {
             *extra_data = data;
             return true;
         }

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -178,7 +178,7 @@ impl Bluetooth {
             // Step 2.4.
             for filter in filters {
                 // Step 2.4.1.
-                match canonicalize_filter(&filter) {
+                match canonicalize_filter(filter) {
                     // Step 2.4.2.
                     Ok(f) => uuid_filters.push(f),
                     Err(e) => {
@@ -576,7 +576,7 @@ impl AsyncBluetoothListener for Bluetooth {
                     &self.global(),
                     DOMString::from(device.id.clone()),
                     device.name.map(DOMString::from),
-                    &self,
+                    self,
                 );
                 device_instance_map.insert(device.id.clone(), Dom::from_ref(&bt_device));
 
@@ -667,7 +667,7 @@ impl PermissionAlgorithm for Bluetooth {
 
                 // Step 6.2.1.
                 for filter in filters {
-                    match canonicalize_filter(&filter) {
+                    match canonicalize_filter(filter) {
                         Ok(f) => scan_filters.push(f),
                         Err(error) => return promise.reject_error(error),
                     }

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -99,7 +99,7 @@ impl BluetoothDevice {
         let (ref service_map_ref, _, _) = self.attribute_instance_map;
         let mut service_map = service_map_ref.borrow_mut();
         if let Some(existing_service) = service_map.get(&service.instance_id) {
-            return DomRoot::from_ref(&existing_service);
+            return DomRoot::from_ref(existing_service);
         }
         let bt_service = BluetoothRemoteGATTService::new(
             &server.global(),
@@ -120,7 +120,7 @@ impl BluetoothDevice {
         let (_, ref characteristic_map_ref, _) = self.attribute_instance_map;
         let mut characteristic_map = characteristic_map_ref.borrow_mut();
         if let Some(existing_characteristic) = characteristic_map.get(&characteristic.instance_id) {
-            return DomRoot::from_ref(&existing_characteristic);
+            return DomRoot::from_ref(existing_characteristic);
         }
         let properties = BluetoothCharacteristicProperties::new(
             &service.global(),
@@ -167,7 +167,7 @@ impl BluetoothDevice {
         let (_, _, ref descriptor_map_ref) = self.attribute_instance_map;
         let mut descriptor_map = descriptor_map_ref.borrow_mut();
         if let Some(existing_descriptor) = descriptor_map.get(&descriptor.instance_id) {
-            return DomRoot::from_ref(&existing_descriptor);
+            return DomRoot::from_ref(existing_descriptor);
         }
         let bt_descriptor = BluetoothRemoteGATTDescriptor::new(
             &characteristic.global(),

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -105,7 +105,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 if let Some(ref existing_device) = device_instance_map.get(&device.id) {
                     // https://webbluetoothcg.github.io/web-bluetooth/#request-the-bluetooth-permission
                     // Step 3.
-                    self.set_devices(vec![Dom::from_ref(&*existing_device)]);
+                    self.set_devices(vec![Dom::from_ref(*existing_device)]);
 
                     // https://w3c.github.io/permissions/#dom-permissions-request
                     // Step 8.

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -294,13 +294,13 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
             BluetoothResponse::GetDescriptors(descriptors_vec, single) => {
                 if single {
                     promise.resolve_native(
-                        &device.get_or_create_descriptor(&descriptors_vec[0], &self),
+                        &device.get_or_create_descriptor(&descriptors_vec[0], self),
                     );
                     return;
                 }
                 let mut descriptors = vec![];
                 for descriptor in descriptors_vec {
-                    let bt_descriptor = device.get_or_create_descriptor(&descriptor, &self);
+                    let bt_descriptor = device.get_or_create_descriptor(&descriptor, self);
                     descriptors.push(bt_descriptor);
                 }
                 promise.resolve_native(&descriptors);

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -162,12 +162,12 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
             BluetoothResponse::GetPrimaryServices(services_vec, single) => {
                 let device = self.Device();
                 if single {
-                    promise.resolve_native(&device.get_or_create_service(&services_vec[0], &self));
+                    promise.resolve_native(&device.get_or_create_service(&services_vec[0], self));
                     return;
                 }
                 let mut services = vec![];
                 for service in services_vec {
-                    let bt_service = device.get_or_create_service(&service, &self);
+                    let bt_service = device.get_or_create_service(&service, self);
                     services.push(bt_service);
                 }
                 promise.resolve_native(&services);

--- a/components/script/dom/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetoothremotegattservice.rs
@@ -157,14 +157,14 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
             BluetoothResponse::GetCharacteristics(characteristics_vec, single) => {
                 if single {
                     promise.resolve_native(
-                        &device.get_or_create_characteristic(&characteristics_vec[0], &self),
+                        &device.get_or_create_characteristic(&characteristics_vec[0], self),
                     );
                     return;
                 }
                 let mut characteristics = vec![];
                 for characteristic in characteristics_vec {
                     let bt_characteristic =
-                        device.get_or_create_characteristic(&characteristic, &self);
+                        device.get_or_create_characteristic(&characteristic, self);
                     characteristics.push(bt_characteristic);
                 }
                 promise.resolve_native(&characteristics);

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -44,17 +44,17 @@ impl CharacterData {
     pub fn clone_with_data(&self, data: DOMString, document: &Document) -> DomRoot<Node> {
         match self.upcast::<Node>().type_id() {
             NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => {
-                DomRoot::upcast(Comment::new(data, &document, None))
+                DomRoot::upcast(Comment::new(data, document, None))
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
                 let pi = self.downcast::<ProcessingInstruction>().unwrap();
-                DomRoot::upcast(ProcessingInstruction::new(pi.Target(), data, &document))
+                DomRoot::upcast(ProcessingInstruction::new(pi.Target(), data, document))
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::CDATASection)) => {
-                DomRoot::upcast(CDATASection::new(data, &document))
+                DomRoot::upcast(CDATASection::new(data, document))
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
-                DomRoot::upcast(Text::new(data, &document))
+                DomRoot::upcast(Text::new(data, document))
             },
             _ => unreachable!(),
         }

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -55,7 +55,7 @@ impl CryptoMethods for Crypto {
             if data.len() > 65536 {
                 return Err(Error::QuotaExceeded);
             }
-            self.rng.borrow_mut().fill_bytes(&mut data);
+            self.rng.borrow_mut().fill_bytes(data);
             let underlying_object = unsafe { input.underlying_object() };
             TypedArray::<ArrayBufferViewU8, *mut JSObject>::from(*underlying_object)
                 .map_err(|_| Error::JSFailed)

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -128,7 +128,7 @@ impl CSSRuleList {
         )?;
 
         let parent_stylesheet = &*self.parent_stylesheet;
-        let dom_rule = CSSRule::new_specific(&window, parent_stylesheet, new_rule);
+        let dom_rule = CSSRule::new_specific(window, parent_stylesheet, new_rule);
         self.dom_rules
             .borrow_mut()
             .insert(index, MutNullableDom::new(Some(&*dom_rule)));

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -73,7 +73,7 @@ impl CSSStyleOwner {
                     let lock = attr.as_ref().unwrap();
                     let mut guard = shared_lock.write();
                     let mut pdb = lock.write_with(&mut guard);
-                    let result = f(&mut pdb, &mut changed);
+                    let result = f(pdb, &mut changed);
                     result
                 } else {
                     let mut pdb = PropertyDeclarationBlock::new();

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -433,7 +433,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         // Step 1
         if !is_valid_custom_element_name(&name) {
             let promise = Promise::new_in_current_realm(comp);
-            promise.reject_native(&DOMException::new(&global_scope, DOMErrorName::SyntaxError));
+            promise.reject_native(&DOMException::new(global_scope, DOMErrorName::SyntaxError));
             return promise;
         }
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -121,7 +121,7 @@ impl QueuedTaskConversion for DedicatedWorkerScriptMsg {
         };
         match script_msg {
             CommonScriptMsg::Task(_category, _boxed, _pipeline_id, source_name) => {
-                Some(&source_name)
+                Some(source_name)
             },
             _ => None,
         }
@@ -218,7 +218,7 @@ impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
     }
 
     fn handle_worker_post_event(&self, worker: &TrustedWorkerAddress) -> Option<AutoWorkerReset> {
-        let ar = AutoWorkerReset::new(&self, worker.clone());
+        let ar = AutoWorkerReset::new(self, worker.clone());
         Some(ar)
     }
 
@@ -431,7 +431,7 @@ impl DedicatedWorkerGlobalScope {
                 let (metadata, bytes) = match load_whole_resource(
                     request,
                     &global_scope.resource_threads().sender(),
-                    &global_scope,
+                    global_scope,
                 ) {
                     Err(_) => {
                         println!("error loading script {}", serialized_worker_url);

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -229,7 +229,7 @@ impl DissimilarOriginWindow {
         let target_origin = match target_origin.0[..].as_ref() {
             "*" => None,
             "/" => Some(source_origin.clone()),
-            url => match ServoUrl::parse(&url) {
+            url => match ServoUrl::parse(url) {
                 Ok(url) => Some(url.origin().clone()),
                 Err(_) => return Err(Error::Syntax),
             },

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -715,7 +715,7 @@ impl Document {
                     event.set_trusted(true);
                     // FIXME(nox): Why are errors silenced here?
                     let _ = window.dispatch_event_with_target_override(
-                        &event,
+                        event,
                     );
                 }),
                 self.window.upcast(),
@@ -1920,7 +1920,7 @@ impl Document {
             .and_then(DomRoot::downcast::<HTMLBodyElement>)
         {
             let body = body.upcast::<Element>();
-            let value = body.parse_attribute(&ns!(), &local_name, value);
+            let value = body.parse_attribute(&ns!(), local_name, value);
             body.set_attribute(local_name, value);
         }
     }
@@ -2162,7 +2162,7 @@ impl Document {
         event.set_trusted(true);
         let event_target = self.window.upcast::<EventTarget>();
         let has_listeners = event_target.has_listeners_for(&atom!("beforeunload"));
-        self.window.dispatch_event_with_target_override(&event);
+        self.window.dispatch_event_with_target_override(event);
         // TODO: Step 6, decrease the event loop's termination nesting level by 1.
         // Step 7
         if has_listeners {
@@ -2218,13 +2218,13 @@ impl Document {
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);
-            let _ = self.window.dispatch_event_with_target_override(&event);
+            let _ = self.window.dispatch_event_with_target_override(event);
             // TODO Step 6, document visibility steps.
         }
         // Step 7
         if !self.fired_unload.get() {
             let event = Event::new(
-                &self.window.upcast(),
+                self.window.upcast(),
                 atom!("unload"),
                 EventBubbles::Bubbles,
                 EventCancelable::Cancelable,
@@ -2373,7 +2373,7 @@ impl Document {
 
                         // FIXME(nox): Why are errors silenced here?
                         let _ = window.dispatch_event_with_target_override(
-                            &event,
+                            event,
                         );
                     }),
                     self.window.upcast(),
@@ -3441,7 +3441,7 @@ impl Document {
         maybe_node
             .iter()
             .flat_map(|node| node.traverse_preorder(ShadowIncluding::No))
-            .filter(|node| callback(&node))
+            .filter(|node| callback(node))
             .count() as u32
     }
 
@@ -3455,7 +3455,7 @@ impl Document {
         maybe_node
             .iter()
             .flat_map(|node| node.traverse_preorder(ShadowIncluding::No))
-            .filter(|node| callback(&node))
+            .filter(|node| callback(node))
             .nth(index as usize)
             .map(|n| DomRoot::from_ref(&*n))
     }
@@ -3538,7 +3538,7 @@ impl Document {
     pub fn get_element_by_id(&self, id: &Atom) -> Option<DomRoot<Element>> {
         self.id_map
             .borrow()
-            .get(&id)
+            .get(id)
             .map(|ref elements| DomRoot::from_ref(&*(*elements)[0]))
     }
 
@@ -4292,7 +4292,7 @@ impl DocumentMethods for Document {
         let value = AttrValue::String("".to_owned());
 
         Ok(Attr::new(
-            &self,
+            self,
             name.clone(),
             value,
             name,
@@ -4312,7 +4312,7 @@ impl DocumentMethods for Document {
         let value = AttrValue::String("".to_owned());
         let qualified_name = LocalName::from(qualified_name);
         Ok(Attr::new(
-            &self,
+            self,
             local_name,
             value,
             qualified_name,
@@ -4425,7 +4425,7 @@ impl DocumentMethods for Document {
             // FIXME(#25136): devicemotionevent, deviceorientationevent
             // FIXME(#7529): dragevent
             "events" | "event" | "htmlevents" | "svgevents" => {
-                Ok(Event::new_uninitialized(&self.window.upcast()))
+                Ok(Event::new_uninitialized(self.window.upcast()))
             },
             "focusevent" => Ok(DomRoot::upcast(FocusEvent::new_uninitialized(&self.window))),
             "hashchangeevent" => Ok(DomRoot::upcast(HashChangeEvent::new_uninitialized(
@@ -4986,7 +4986,7 @@ impl DocumentMethods for Document {
             if a.1 == b.1 {
                 // This can happen if an img has an id different from its name,
                 // spec does not say which string to put first.
-                a.0.cmp(&b.0)
+                a.0.cmp(b.0)
             } else if a.1.upcast::<Node>().is_before(b.1.upcast::<Node>()) {
                 Ordering::Less
             } else {

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -259,7 +259,7 @@ impl DocumentOrShadowRoot {
             self, to_unregister, id
         );
         let mut id_map = id_map.borrow_mut();
-        let is_empty = match id_map.get_mut(&id) {
+        let is_empty = match id_map.get_mut(id) {
             None => false,
             Some(elements) => {
                 let position = elements
@@ -271,7 +271,7 @@ impl DocumentOrShadowRoot {
             },
         };
         if is_empty {
-            id_map.remove(&id);
+            id_map.remove(id);
         }
     }
 

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -85,7 +85,7 @@ impl DOMMatrix {
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-frommatrix
     pub fn FromMatrix(global: &GlobalScope, other: &DOMMatrixInit) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(&other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
     }
 
     pub fn from_readonly(global: &GlobalScope, ro: &DOMMatrixReadOnly) -> DomRoot<Self> {
@@ -347,7 +347,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .multiply_self(other)
             // Step 4.
-            .and(Ok(DomRoot::from_ref(&self)))
+            .and(Ok(DomRoot::from_ref(self)))
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-premultiplyself
@@ -356,7 +356,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .pre_multiply_self(other)
             // Step 4.
-            .and(Ok(DomRoot::from_ref(&self)))
+            .and(Ok(DomRoot::from_ref(self)))
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-translateself
@@ -365,7 +365,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .translate_self(tx, ty, tz);
         // Step 3.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-scaleself
@@ -382,7 +382,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .scale_self(scaleX, scaleY, scaleZ, originX, originY, originZ);
         // Step 7.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-scale3dself
@@ -397,7 +397,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .scale_3d_self(scale, originX, originY, originZ);
         // Step 5.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotateself
@@ -406,7 +406,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .rotate_self(rotX, rotY, rotZ);
         // Step 8.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotatefromvectorself
@@ -415,7 +415,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .rotate_from_vector_self(x, y);
         // Step 2.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotateaxisangleself
@@ -424,7 +424,7 @@ impl DOMMatrixMethods for DOMMatrix {
         self.upcast::<DOMMatrixReadOnly>()
             .rotate_axis_angle_self(x, y, z, angle);
         // Step 3.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-skewxself
@@ -432,7 +432,7 @@ impl DOMMatrixMethods for DOMMatrix {
         // Step 1.
         self.upcast::<DOMMatrixReadOnly>().skew_x_self(sx);
         // Step 2.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-skewyself
@@ -440,7 +440,7 @@ impl DOMMatrixMethods for DOMMatrix {
         // Step 1.
         self.upcast::<DOMMatrixReadOnly>().skew_y_self(sy);
         // Step 2.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-invertself
@@ -448,6 +448,6 @@ impl DOMMatrixMethods for DOMMatrix {
         // Steps 1-2.
         self.upcast::<DOMMatrixReadOnly>().invert_self();
         // Step 3.
-        DomRoot::from_ref(&self)
+        DomRoot::from_ref(self)
     }
 }

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -102,7 +102,7 @@ impl DOMMatrixReadOnly {
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-frommatrix
     pub fn FromMatrix(global: &GlobalScope, other: &DOMMatrixInit) -> Fallible<DomRoot<Self>> {
-        dommatrixinit_to_matrix(&other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
+        dommatrixinit_to_matrix(other).map(|(is2D, matrix)| Self::new(global, is2D, matrix))
     }
 
     pub fn matrix(&self) -> Ref<Transform3D<f64>> {
@@ -196,7 +196,7 @@ impl DOMMatrixReadOnly {
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-multiplyself
     pub fn multiply_self(&self, other: &DOMMatrixInit) -> Fallible<()> {
         // Step 1.
-        dommatrixinit_to_matrix(&other).map(|(is2D, other_matrix)| {
+        dommatrixinit_to_matrix(other).map(|(is2D, other_matrix)| {
             // Step 2.
             let mut matrix = self.matrix.borrow_mut();
             *matrix = other_matrix.then(&matrix);
@@ -211,7 +211,7 @@ impl DOMMatrixReadOnly {
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-premultiplyself
     pub fn pre_multiply_self(&self, other: &DOMMatrixInit) -> Fallible<()> {
         // Step 1.
-        dommatrixinit_to_matrix(&other).map(|(is2D, other_matrix)| {
+        dommatrixinit_to_matrix(other).map(|(is2D, other_matrix)| {
             // Step 2.
             let mut matrix = self.matrix.borrow_mut();
             *matrix = matrix.then(&other_matrix);
@@ -631,7 +631,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-multiply
     fn Multiply(&self, other: &DOMMatrixInit) -> Fallible<DomRoot<DOMMatrix>> {
-        DOMMatrix::from_readonly(&self.global(), self).MultiplySelf(&other)
+        DOMMatrix::from_readonly(&self.global(), self).MultiplySelf(other)
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-flipx
@@ -731,9 +731,9 @@ fn create_3d_matrix(entries: &[f64]) -> Transform3D<f64> {
 // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-dommatrixreadonly-numbersequence
 pub fn entries_to_matrix(entries: &[f64]) -> Fallible<(bool, Transform3D<f64>)> {
     if entries.len() == 6 {
-        Ok((true, create_2d_matrix(&entries)))
+        Ok((true, create_2d_matrix(entries)))
     } else if entries.len() == 16 {
-        Ok((false, create_3d_matrix(&entries)))
+        Ok((false, create_3d_matrix(entries)))
     } else {
         let err_msg = format!("Expected 6 or 16 entries, but found {}.", entries.len());
         Err(error::Error::Type(err_msg.to_owned()))

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -133,7 +133,7 @@ impl DOMTokenListMethods for DOMTokenList {
     fn Add(&self, tokens: Vec<DOMString>) -> ErrorResult {
         let mut atoms = self.element.get_tokenlist_attribute(&self.local_name);
         for token in &tokens {
-            let token = self.check_token_exceptions(&token)?;
+            let token = self.check_token_exceptions(token)?;
             if !atoms.iter().any(|atom| *atom == token) {
                 atoms.push(token);
             }
@@ -146,7 +146,7 @@ impl DOMTokenListMethods for DOMTokenList {
     fn Remove(&self, tokens: Vec<DOMString>) -> ErrorResult {
         let mut atoms = self.element.get_tokenlist_attribute(&self.local_name);
         for token in &tokens {
-            let token = self.check_token_exceptions(&token)?;
+            let token = self.check_token_exceptions(token)?;
             atoms
                 .iter()
                 .position(|atom| *atom == token)

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1585,7 +1585,7 @@ impl Element {
             .attrs
             .borrow()
             .iter()
-            .find(|attr| find(&attr))
+            .find(|attr| find(attr))
             .map(|js| DomRoot::from_ref(&**js));
         if let Some(attr) = attr {
             attr.set_value(value, self);
@@ -1625,7 +1625,7 @@ impl Element {
     where
         F: Fn(&Attr) -> bool,
     {
-        let idx = self.attrs.borrow().iter().position(|attr| find(&attr));
+        let idx = self.attrs.borrow().iter().position(|attr| find(attr));
         idx.map(|idx| {
             let attr = DomRoot::from_ref(&*(*self.attrs.borrow())[idx]);
             self.will_mutate_attr(&attr);
@@ -1803,9 +1803,9 @@ impl Element {
                 }
             },
             AdjacentPosition::AfterBegin => {
-                Node::pre_insert(node, &self_node, self_node.GetFirstChild().as_deref()).map(Some)
+                Node::pre_insert(node, self_node, self_node.GetFirstChild().as_deref()).map(Some)
             },
-            AdjacentPosition::BeforeEnd => Node::pre_insert(node, &self_node, None).map(Some),
+            AdjacentPosition::BeforeEnd => Node::pre_insert(node, self_node, None).map(Some),
             AdjacentPosition::AfterEnd => {
                 if let Some(parent) = self_node.GetParentNode() {
                     Node::pre_insert(node, &parent, self_node.GetNextSibling().as_deref()).map(Some)
@@ -2222,7 +2222,7 @@ impl ElementMethods for Element {
             self.attrs.borrow_mut()[position] = Dom::from_ref(attr);
             old_attr.set_owner(None);
             if attr.namespace() == &ns!() {
-                vtable.attribute_mutated(&attr, AttributeMutation::Set(Some(&old_attr.value())));
+                vtable.attribute_mutated(attr, AttributeMutation::Set(Some(&old_attr.value())));
             }
 
             // Step 6.
@@ -3076,7 +3076,7 @@ impl VirtualMethods for Element {
         let doc = document_from_node(self);
 
         if let Some(ref shadow_root) = self.shadow_root() {
-            doc.register_shadow_root(&shadow_root);
+            doc.register_shadow_root(shadow_root);
             let shadow_root = shadow_root.upcast::<Node>();
             shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
             for node in shadow_root.children() {
@@ -3124,7 +3124,7 @@ impl VirtualMethods for Element {
         let doc = document_from_node(self);
 
         if let Some(ref shadow_root) = self.shadow_root() {
-            doc.unregister_shadow_root(&shadow_root);
+            doc.unregister_shadow_root(shadow_root);
             let shadow_root = shadow_root.upcast::<Node>();
             shadow_root.set_flag(NodeFlags::IS_CONNECTED, false);
             for node in shadow_root.children() {
@@ -3358,7 +3358,7 @@ impl<'a> SelectorsElement for DomRoot<Element> {
     }
 
     fn has_class(&self, name: &AtomIdent, case_sensitivity: CaseSensitivity) -> bool {
-        Element::has_class(&**self, &name, case_sensitivity)
+        Element::has_class(&**self, name, case_sensitivity)
     }
 
     fn is_html_element_in_html_document(&self) -> bool {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -214,7 +214,7 @@ impl Event {
         // related to shadow DOM requirements that aren't otherwise
         // implemented right now. The path also needs to contain
         // various flags instead of just bare event targets.
-        let path = self.construct_event_path(&target);
+        let path = self.construct_event_path(target);
         rooted_vec!(let event_path <- path.into_iter());
 
         // Step 5.4
@@ -333,7 +333,7 @@ impl Event {
         if !self.DefaultPrevented() {
             if let Some(target) = self.GetTarget() {
                 if let Some(node) = target.downcast::<Node>() {
-                    let vtable = vtable_for(&node);
+                    let vtable = vtable_for(node);
                     vtable.handle_event(self);
                 }
             }
@@ -712,7 +712,7 @@ fn inner_invoke(
 
         // Step 2.5.
         if let CompiledEventListener::Listener(event_listener) = listener {
-            object.remove_listener_if_once(&event.type_(), &event_listener);
+            object.remove_listener_if_once(&event.type_(), event_listener);
         }
 
         // Step 2.6

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -258,7 +258,7 @@ impl EventSourceContext {
             task!(dispatch_the_event_source_event: move || {
                 let event_source = event_source.root();
                 if event_source.ready_state.get() != ReadyState::Closed {
-                    event.root().upcast::<Event>().fire(&event_source.upcast());
+                    event.root().upcast::<Event>().fire(event_source.upcast());
                 }
             }),
             &global,
@@ -387,7 +387,7 @@ impl FetchResponseListener for EventSourceContext {
         }
 
         while !input.is_empty() {
-            match utf8::decode(&input) {
+            match utf8::decode(input) {
                 Ok(s) => {
                     self.parse(s.chars());
                     return;

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -207,7 +207,7 @@ impl Gamepad {
     }
 
     pub fn notify_event(&self, event_type: GamepadEventType) {
-        let event = GamepadEvent::new_with_type(&self.global(), event_type, &self);
+        let event = GamepadEvent::new_with_type(&self.global(), event_type, self);
         event
             .upcast::<Event>()
             .fire(self.global().as_window().upcast::<EventTarget>());

--- a/components/script/dom/gamepadevent.rs
+++ b/components/script/dom/gamepadevent.rs
@@ -57,7 +57,7 @@ impl GamepadEvent {
         gamepad: &Gamepad,
     ) -> DomRoot<GamepadEvent> {
         let ev = reflect_dom_object_with_proto(
-            Box::new(GamepadEvent::new_inherited(&gamepad)),
+            Box::new(GamepadEvent::new_inherited(gamepad)),
             global,
             proto,
         );
@@ -78,7 +78,7 @@ impl GamepadEvent {
             GamepadEventType::Disconnected => "gamepaddisconnected",
         };
 
-        GamepadEvent::new(&global, name.into(), false, false, &gamepad)
+        GamepadEvent::new(global, name.into(), false, false, gamepad)
     }
 
     // https://w3c.github.io/gamepad/#gamepadevent-interface

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1085,7 +1085,7 @@ impl GlobalScope {
                             let target_global = this.root();
                             target_global.route_task_to_port(port_id, task);
                         }),
-                        &self,
+                        self,
                     );
                 }
             }
@@ -1259,7 +1259,7 @@ impl GlobalScope {
                                     MessageEvent::dispatch_error(&*destination.upcast(), &global);
                                 }
                             }),
-                            &self,
+                            self,
                         );
                     });
             }
@@ -1300,7 +1300,7 @@ impl GlobalScope {
                 // Substep 6
                 // Dispatch the event, using the dom message-port.
                 MessageEvent::dispatch_jsval(
-                    &dom_port.upcast(),
+                    dom_port.upcast(),
                     self,
                     message_clone.handle(),
                     Some(&origin.ascii_serialization()),
@@ -1309,7 +1309,7 @@ impl GlobalScope {
                 );
             } else {
                 // Step 4, fire messageerror event.
-                MessageEvent::dispatch_error(&dom_port.upcast(), self);
+                MessageEvent::dispatch_error(dom_port.upcast(), self);
             }
         }
     }
@@ -1531,7 +1531,7 @@ impl GlobalScope {
                         let target_global = this.root();
                         target_global.maybe_add_pending_ports();
                     }),
-                    &self,
+                    self,
                 );
             } else {
                 // If this is a newly-created port, let the constellation immediately know.
@@ -1671,7 +1671,7 @@ impl GlobalScope {
             let blob_state = self.blob_state.borrow();
             if let BlobState::Managed(blobs_map) = &*blob_state {
                 let blob_info = blobs_map
-                    .get(&blob_id)
+                    .get(blob_id)
                     .expect("get_blob_bytes for an unknown blob.");
                 match blob_info.blob_impl.blob_data() {
                     BlobData::Sliced(ref parent, ref rel_pos) => {
@@ -1698,7 +1698,7 @@ impl GlobalScope {
         let blob_state = self.blob_state.borrow();
         if let BlobState::Managed(blobs_map) = &*blob_state {
             let blob_info = blobs_map
-                .get(&blob_id)
+                .get(blob_id)
                 .expect("get_blob_bytes_non_sliced called for a unknown blob.");
             match blob_info.blob_impl.blob_data() {
                 BlobData::File(ref f) => {
@@ -1736,7 +1736,7 @@ impl GlobalScope {
             let blob_state = self.blob_state.borrow();
             if let BlobState::Managed(blobs_map) = &*blob_state {
                 let blob_info = blobs_map
-                    .get(&blob_id)
+                    .get(blob_id)
                     .expect("get_blob_bytes_or_file_id for an unknown blob.");
                 match blob_info.blob_impl.blob_data() {
                     BlobData::Sliced(ref parent, ref rel_pos) => {
@@ -1772,7 +1772,7 @@ impl GlobalScope {
         let blob_state = self.blob_state.borrow();
         if let BlobState::Managed(blobs_map) = &*blob_state {
             let blob_info = blobs_map
-                .get(&blob_id)
+                .get(blob_id)
                 .expect("get_blob_bytes_non_sliced_or_file_id called for a unknown blob.");
             match blob_info.blob_impl.blob_data() {
                 BlobData::File(ref f) => match f.get_cache() {
@@ -1794,7 +1794,7 @@ impl GlobalScope {
         let blob_state = self.blob_state.borrow();
         if let BlobState::Managed(blobs_map) = &*blob_state {
             let blob_info = blobs_map
-                .get(&blob_id)
+                .get(blob_id)
                 .expect("get_blob_type_string called for a unknown blob.");
             blob_info.blob_impl.type_string()
         } else {
@@ -1808,7 +1808,7 @@ impl GlobalScope {
         if let BlobState::Managed(blobs_map) = &*blob_state {
             let parent = {
                 let blob_info = blobs_map
-                    .get(&blob_id)
+                    .get(blob_id)
                     .expect("get_blob_size called for a unknown blob.");
                 match blob_info.blob_impl.blob_data() {
                     BlobData::Sliced(ref parent, ref rel_pos) => {
@@ -1830,9 +1830,7 @@ impl GlobalScope {
                     rel_pos.to_abs_range(parent_size as usize).len() as u64
                 },
                 None => {
-                    let blob_info = blobs_map
-                        .get(&blob_id)
-                        .expect("Blob whose size is unknown.");
+                    let blob_info = blobs_map.get(blob_id).expect("Blob whose size is unknown.");
                     match blob_info.blob_impl.blob_data() {
                         BlobData::File(ref f) => f.get_size(),
                         BlobData::Memory(ref v) => v.len() as u64,
@@ -1852,7 +1850,7 @@ impl GlobalScope {
         if let BlobState::Managed(blobs_map) = &mut *blob_state {
             let parent = {
                 let blob_info = blobs_map
-                    .get_mut(&blob_id)
+                    .get_mut(blob_id)
                     .expect("get_blob_url_id called for a unknown blob.");
 
                 // Keep track of blobs with outstanding URLs.
@@ -1878,13 +1876,13 @@ impl GlobalScope {
                     };
                     let parent_size = rel_pos.to_abs_range(parent_size as usize).len() as u64;
                     let blob_info = blobs_map
-                        .get_mut(&blob_id)
+                        .get_mut(blob_id)
                         .expect("Blob whose url is requested is unknown.");
                     self.create_sliced_url_id(blob_info, &parent_file_id, &rel_pos, parent_size)
                 },
                 None => {
                     let blob_info = blobs_map
-                        .get_mut(&blob_id)
+                        .get_mut(blob_id)
                         .expect("Blob whose url is requested is unknown.");
                     self.promote(blob_info, /* set_valid is */ true)
                 },
@@ -2797,7 +2795,7 @@ impl GlobalScope {
                         .map(|data| data.to_vec())
                         .unwrap_or_else(|| vec![0; size.area() as usize * 4]);
 
-                    let image_bitmap = ImageBitmap::new(&self, size.width, size.height).unwrap();
+                    let image_bitmap = ImageBitmap::new(self, size.width, size.height).unwrap();
 
                     image_bitmap.set_bitmap_data(data);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
@@ -2817,7 +2815,7 @@ impl GlobalScope {
                         .map(|data| data.to_vec())
                         .unwrap_or_else(|| vec![0; size.area() as usize * 4]);
 
-                    let image_bitmap = ImageBitmap::new(&self, size.width, size.height).unwrap();
+                    let image_bitmap = ImageBitmap::new(self, size.width, size.height).unwrap();
                     image_bitmap.set_bitmap_data(data);
                     image_bitmap.set_origin_clean(canvas.origin_is_clean());
                     p.resolve_native(&(image_bitmap));

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -248,7 +248,7 @@ impl AsyncWGPUListener for GPUAdapter {
                     let device = GPUDevice::new(
                         &self.global(),
                         self.channel.clone(),
-                        &self,
+                        self,
                         Heap::default(),
                         descriptor.features,
                         descriptor.limits,

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -146,7 +146,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
         GPUComputePassEncoder::new(
             &self.global(),
             self.channel.clone(),
-            &self,
+            self,
             compute_pass,
             descriptor.parent.label.clone().unwrap_or_default(),
         )
@@ -245,7 +245,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             &self.global(),
             self.channel.clone(),
             render_pass,
-            &self,
+            self,
             descriptor.parent.label.clone().unwrap_or_default(),
         )
     }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -418,7 +418,7 @@ impl GPUDeviceMethods for GPUDevice {
             &self.global(),
             self.channel.clone(),
             buffer,
-            &self,
+            self,
             state,
             descriptor.size,
             map_info,
@@ -733,7 +733,7 @@ impl GPUDeviceMethods for GPUDevice {
             compute_pipeline,
             descriptor.parent.parent.label.clone().unwrap_or_default(),
             bgls,
-            &self,
+            self,
         )
     }
 
@@ -776,7 +776,7 @@ impl GPUDeviceMethods for GPUDevice {
         GPUCommandEncoder::new(
             &self.global(),
             self.channel.clone(),
-            &self,
+            self,
             encoder,
             descriptor.parent.label.clone().unwrap_or_default(),
         )
@@ -836,7 +836,7 @@ impl GPUDeviceMethods for GPUDevice {
         GPUTexture::new(
             &self.global(),
             texture,
-            &self,
+            self,
             self.channel.clone(),
             size,
             descriptor.mipLevelCount,
@@ -1047,7 +1047,7 @@ impl GPUDeviceMethods for GPUDevice {
             render_pipeline,
             descriptor.parent.parent.label.clone().unwrap_or_default(),
             bgls,
-            &self,
+            self,
         )
     }
 
@@ -1095,7 +1095,7 @@ impl GPUDeviceMethods for GPUDevice {
         GPURenderBundleEncoder::new(
             &self.global(),
             render_bundle_encoder,
-            &self,
+            self,
             self.channel.clone(),
             descriptor.parent.parent.label.clone().unwrap_or_default(),
         )

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -185,7 +185,7 @@ impl GPUTextureMethods for GPUTexture {
         GPUTextureView::new(
             &self.global(),
             texture_view,
-            &self,
+            self,
             descriptor.parent.label.clone().unwrap_or_default(),
         )
     }

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -54,7 +54,7 @@ impl History {
         state.set(NullValue());
         History {
             reflector_: Reflector::new(),
-            window: Dom::from_ref(&window),
+            window: Dom::from_ref(window),
             state,
             state_id: Cell::new(None),
         }
@@ -121,7 +121,7 @@ impl History {
                 };
                 let global_scope = self.window.upcast::<GlobalScope>();
                 rooted!(in(*GlobalScope::get_cx()) let mut state = UndefinedValue());
-                if let Err(_) = structuredclone::read(&global_scope, data, state.handle_mut()) {
+                if let Err(_) = structuredclone::read(global_scope, data, state.handle_mut()) {
                     warn!("Error reading structuredclone data");
                 }
                 self.state.set(state.get());
@@ -270,7 +270,7 @@ impl History {
         // Step 11
         let global_scope = self.window.upcast::<GlobalScope>();
         rooted!(in(*cx) let mut state = UndefinedValue());
-        if let Err(_) = structuredclone::read(&global_scope, serialized_data, state.handle_mut()) {
+        if let Err(_) = structuredclone::read(global_scope, serialized_data, state.handle_mut()) {
             warn!("Error reading structuredclone data");
         }
 

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -295,7 +295,7 @@ impl HTMLCanvasElement {
             match WebGLContextAttributes::new(cx, options) {
                 Ok(ConversionResult::Success(ref attrs)) => Some(From::from(attrs)),
                 Ok(ConversionResult::Failure(ref error)) => {
-                    throw_type_error(*cx, &error);
+                    throw_type_error(*cx, error);
                     None
                 },
                 _ => {

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -292,7 +292,7 @@ impl HTMLCollection {
         after
             .following_nodes(&self.root)
             .filter_map(DomRoot::downcast)
-            .filter(move |element| self.filter.filter(&element, &self.root))
+            .filter(move |element| self.filter.filter(element, &self.root))
     }
 
     pub fn elements_iter<'a>(&'a self) -> impl Iterator<Item = DomRoot<Element>> + 'a {
@@ -308,7 +308,7 @@ impl HTMLCollection {
         before
             .preceding_nodes(&self.root)
             .filter_map(DomRoot::downcast)
-            .filter(move |element| self.filter.filter(&element, &self.root))
+            .filter(move |element| self.filter.filter(element, &self.root))
     }
 
     pub fn root_node(&self) -> DomRoot<Node> {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -492,7 +492,7 @@ impl HTMLElementMethods for HTMLElement {
                     }
 
                     let br = HTMLBRElement::new(local_name!("br"), None, &document, None);
-                    fragment.upcast::<Node>().AppendChild(&br.upcast()).unwrap();
+                    fragment.upcast::<Node>().AppendChild(br.upcast()).unwrap();
                 },
                 _ => {
                     text.push(ch);
@@ -550,7 +550,7 @@ fn append_text_node_to_fragment(document: &Document, fragment: &DocumentFragment
     let text = Text::new(DOMString::from(text), document);
     fragment
         .upcast::<Node>()
-        .AppendChild(&text.upcast())
+        .AppendChild(text.upcast())
         .unwrap();
 }
 
@@ -691,7 +691,7 @@ impl HTMLElement {
             .iter()
             .filter_map(|attr| {
                 let raw_name = attr.local_name();
-                to_camel_case(&raw_name)
+                to_camel_case(raw_name)
             })
             .collect()
     }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -178,7 +178,7 @@ impl HTMLFormElement {
         self.controls
             .borrow()
             .iter()
-            .filter(|n| HTMLFormElement::filter_for_radio_list(mode, &*n, name))
+            .filter(|n| HTMLFormElement::filter_for_radio_list(mode, *n, name))
             .nth(index as usize)
             .and_then(|n| Some(DomRoot::from_ref(n.upcast::<Node>())))
     }
@@ -281,12 +281,12 @@ impl HTMLFormElementMethods for HTMLFormElement {
 
                 let submit_button = match element {
                     HTMLElementTypeId::HTMLInputElement => FormSubmitter::InputElement(
-                        &submitter_element
+                        submitter_element
                             .downcast::<HTMLInputElement>()
                             .expect("Failed to downcast submitter elem to HTMLInputElement."),
                     ),
                     HTMLElementTypeId::HTMLButtonElement => FormSubmitter::ButtonElement(
-                        &submitter_element
+                        submitter_element
                             .downcast::<HTMLButtonElement>()
                             .expect("Failed to downcast submitter elem to HTMLButtonElement."),
                     ),
@@ -317,7 +317,7 @@ impl HTMLFormElementMethods for HTMLFormElement {
             },
             None => {
                 // Step 2
-                FormSubmitter::FormElement(&self)
+                FormSubmitter::FormElement(self)
             },
         };
         // Step 3
@@ -849,7 +849,7 @@ impl HTMLFormElement {
                 load_data
                     .headers
                     .typed_insert(ContentType::from(mime::APPLICATION_WWW_FORM_URLENCODED));
-                self.mutate_action_url(&mut form_data, load_data, encoding, &target_window);
+                self.mutate_action_url(&mut form_data, load_data, encoding, target_window);
             },
             // https://html.spec.whatwg.org/multipage/#submit-body
             ("http", FormMethod::FormPost) | ("https", FormMethod::FormPost) => {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR fixes the `needless_borrow` warnings by deleting the address of operations (`&`), which the compiler will dereferenced immediately.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
