### PR TITLE
Rework “visible” to “throttled” in embedder-to-constellation + jniapi

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -103,8 +103,8 @@ pub enum EmbedderEvent {
     /// Sent when the user triggers a media action through the UA exposed media UI
     /// (play, pause, seek, etc.).
     MediaSessionAction(MediaSessionActionType),
-    /// The visibility of the webview has changed.
-    WebViewVisibilityChanged(TopLevelBrowsingContextId, bool),
+    /// Set whether to use less resources, by stopping animations and running timers at a heavily limited rate.
+    SetWebViewThrottled(TopLevelBrowsingContextId, bool),
     /// Virtual keyboard was dismissed
     IMEDismissed,
     /// Sent on platforms like Android where the native widget surface can be
@@ -148,7 +148,7 @@ impl Debug for EmbedderEvent {
             EmbedderEvent::ToggleSamplingProfiler(..) => write!(f, "ToggleSamplingProfiler"),
             EmbedderEvent::ExitFullScreen(..) => write!(f, "ExitFullScreen"),
             EmbedderEvent::MediaSessionAction(..) => write!(f, "MediaSessionAction"),
-            EmbedderEvent::WebViewVisibilityChanged(..) => write!(f, "WebViewVisibilityChanged"),
+            EmbedderEvent::SetWebViewThrottled(..) => write!(f, "SetWebViewThrottled"),
             EmbedderEvent::IMEDismissed => write!(f, "IMEDismissed"),
             EmbedderEvent::ClearCache => write!(f, "ClearCache"),
             EmbedderEvent::InvalidateNativeSurface => write!(f, "InvalidateNativeSurface"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1535,8 +1535,8 @@ where
             FromCompositorMsg::MediaSessionAction(action) => {
                 self.handle_media_session_action_msg(action);
             },
-            FromCompositorMsg::WebViewVisibilityChanged(webview_id, visible) => {
-                self.notify_webview_visibility(webview_id, visible);
+            FromCompositorMsg::SetWebViewThrottled(webview_id, throttled) => {
+                self.notify_webview_visibility(webview_id, !throttled);
             },
             FromCompositorMsg::ReadyToPresent(top_level_browsing_context_id) => {
                 self.embedder_proxy.send((

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -86,7 +86,7 @@ mod from_compositor {
                 Self::DisableProfiler => target!("DisableProfiler"),
                 Self::ExitFullScreen(_) => target!("ExitFullScreen"),
                 Self::MediaSessionAction(_) => target!("MediaSessionAction"),
-                Self::WebViewVisibilityChanged(_, _) => target!("WebViewVisibilityChanged"),
+                Self::SetWebViewThrottled(_, _) => target!("SetWebViewThrottled"),
                 Self::IMEDismissed => target!("IMEDismissed"),
                 Self::ReadyToPresent(_) => target!("ReadyToPresent"),
                 Self::Gamepad(_) => target!("Gamepad"),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -783,11 +783,11 @@ where
                 }
             },
 
-            EmbedderEvent::WebViewVisibilityChanged(webview_id, visible) => {
-                let msg = ConstellationMsg::WebViewVisibilityChanged(webview_id, visible);
+            EmbedderEvent::SetWebViewThrottled(webview_id, throttled) => {
+                let msg = ConstellationMsg::SetWebViewThrottled(webview_id, throttled);
                 if let Err(e) = self.constellation_chan.send(msg) {
                     warn!(
-                        "Sending WebViewVisibilityChanged to constellation failed ({:?}).",
+                        "Sending SetWebViewThrottled to constellation failed ({:?}).",
                         e
                     );
                 }

--- a/components/shared/compositing/constellation_msg.rs
+++ b/components/shared/compositing/constellation_msg.rs
@@ -76,8 +76,8 @@ pub enum ConstellationMsg {
     ExitFullScreen(TopLevelBrowsingContextId),
     /// Media session action.
     MediaSessionAction(MediaSessionActionType),
-    /// The visibility of the webview has changed.
-    WebViewVisibilityChanged(TopLevelBrowsingContextId, bool),
+    /// Set whether to use less resources, by stopping animations and running timers at a heavily limited rate.
+    SetWebViewThrottled(TopLevelBrowsingContextId, bool),
     /// Virtual keyboard was dismissed
     IMEDismissed,
     /// Compositing done, but external code needs to present.
@@ -115,7 +115,7 @@ impl fmt::Debug for ConstellationMsg {
             DisableProfiler => "DisableProfiler",
             ExitFullScreen(..) => "ExitFullScreen",
             MediaSessionAction(..) => "MediaSessionAction",
-            WebViewVisibilityChanged(..) => "WebViewVisibilityChanged",
+            SetWebViewThrottled(..) => "SetWebViewThrottled",
             IMEDismissed => "IMEDismissed",
             ClearCache => "ClearCache",
             ReadyToPresent(..) => "ReadyToPresent",

--- a/ports/jniapi/src/simpleservo.rs
+++ b/ports/jniapi/src/simpleservo.rs
@@ -601,10 +601,10 @@ impl ServoGlue {
         self.process_event(EmbedderEvent::MediaSessionAction(action))
     }
 
-    pub fn change_visibility(&mut self, visible: bool) -> Result<(), &'static str> {
-        info!("change_visibility");
+    pub fn set_throttled(&mut self, throttled: bool) -> Result<(), &'static str> {
+        info!("set_throttled");
         if let Ok(id) = self.get_browser_id() {
-            let event = EmbedderEvent::WebViewVisibilityChanged(id, visible);
+            let event = EmbedderEvent::SetWebViewThrottled(id, throttled);
             self.process_event(event)
         } else {
             // Ignore visibility change if no browser has been created yet.

--- a/ports/servoshell/tracing.rs
+++ b/ports/servoshell/tracing.rs
@@ -218,7 +218,7 @@ mod to_servo {
                 Self::ClearCache => target!("ClearCache"),
                 Self::ToggleSamplingProfiler(_, _) => target!("ToggleSamplingProfiler"),
                 Self::MediaSessionAction(_) => target!("MediaSessionAction"),
-                Self::WebViewVisibilityChanged(_, _) => target!("WebViewVisibilityChanged"),
+                Self::SetWebViewThrottled(_, _) => target!("SetWebViewThrottled"),
                 Self::IMEDismissed => target!("IMEDismissed"),
                 Self::InvalidateNativeSurface => target!("InvalidateNativeSurface"),
                 Self::ReplaceNativeSurface(_, _) => target!("ReplaceNativeSurface"),


### PR DESCRIPTION
Servo has a pervasive but confusing concept of webviews or pipelines being “visible”, which actually controls whether script runs timers at a heavily limited rate and the compositor pauses animations. Let’s replace this with a more concrete concept of a webview or pipeline being “throttled” (with the meanings of true and false inverted).

embedder → constellation

- SetWebViewThrottled (was WebViewVisibilityChanged) has been inverted and its concrete effects documented

jniapi

- set_throttled (was change_visibility) has been inverted

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes