### PR TITLE
Rework “visible” to “throttled” in constellation + script + compositor

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -32,9 +32,9 @@ pub struct NewBrowsingContextInfo {
     /// Whether this browsing context inherits a secure context.
     pub inherited_secure_context: Option<bool>,
 
-    /// Whether this browsing context should be treated as visible for the
-    /// purposes of scheduling and resource management.
-    pub is_visible: bool,
+    /// Whether this browsing context should be throttled, using less resources
+    /// by stopping animations and running timers at a heavily limited rate.
+    pub throttled: bool,
 }
 
 /// The constellation's view of a browsing context.
@@ -62,9 +62,9 @@ pub struct BrowsingContext {
     /// Whether this browsing context inherits a secure context.
     pub inherited_secure_context: Option<bool>,
 
-    /// Whether this browsing context should be treated as visible for the
-    /// purposes of scheduling and resource management.
-    pub is_visible: bool,
+    /// Whether this browsing context should be throttled, using less resources
+    /// by stopping animations and running timers at a heavily limited rate.
+    pub throttled: bool,
 
     /// The pipeline for the current session history entry.
     pub pipeline_id: PipelineId,
@@ -90,7 +90,7 @@ impl BrowsingContext {
         size: Size2D<f32, CSSPixel>,
         is_private: bool,
         inherited_secure_context: Option<bool>,
-        is_visible: bool,
+        throttled: bool,
     ) -> BrowsingContext {
         let mut pipelines = HashSet::new();
         pipelines.insert(pipeline_id);
@@ -101,7 +101,7 @@ impl BrowsingContext {
             size,
             is_private,
             inherited_secure_context,
-            is_visible,
+            throttled,
             pipeline_id,
             parent_pipeline_id,
             pipelines,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -127,7 +127,7 @@ use msg::constellation_msg::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, BroadcastChannelRouterId,
     BrowsingContextGroupId, BrowsingContextId, HangMonitorAlert, HistoryStateId, MessagePortId,
     MessagePortRouterId, PipelineId, PipelineNamespace, PipelineNamespaceId,
-    PipelineNamespaceRequest, TopLevelBrowsingContextId, TraversalDirection,
+    PipelineNamespaceRequest, TopLevelBrowsingContextId, TraversalDirection, WebViewId,
 };
 use net_traits::pub_domains::reg_host;
 use net_traits::request::{Referrer, RequestBuilder};
@@ -956,7 +956,7 @@ where
         load_data: LoadData,
         sandbox: IFrameSandboxState,
         is_private: bool,
-        is_visible: bool,
+        throttled: bool,
     ) {
         if self.shutting_down {
             return;
@@ -1051,7 +1051,7 @@ where
             },
             event_loop,
             load_data,
-            prev_visibility: is_visible,
+            prev_throttled: throttled,
             webrender_api_sender: self.webrender_api_ipc_sender.clone(),
             webrender_image_api_sender: self.webrender_image_api_sender.clone(),
             webrender_document: self.webrender_document,
@@ -1135,7 +1135,7 @@ where
         size: Size2D<f32, CSSPixel>,
         is_private: bool,
         inherited_secure_context: Option<bool>,
-        is_visible: bool,
+        throttled: bool,
     ) {
         debug!("{}: Creating new browsing context", browsing_context_id);
         let bc_group_id = match self
@@ -1168,7 +1168,7 @@ where
             size,
             is_private,
             inherited_secure_context,
-            is_visible,
+            throttled,
         );
         self.browsing_contexts
             .insert(browsing_context_id, browsing_context);
@@ -1536,7 +1536,7 @@ where
                 self.handle_media_session_action_msg(action);
             },
             FromCompositorMsg::SetWebViewThrottled(webview_id, throttled) => {
-                self.notify_webview_visibility(webview_id, !throttled);
+                self.set_webview_throttled(webview_id, throttled);
             },
             FromCompositorMsg::ReadyToPresent(top_level_browsing_context_id) => {
                 self.embedder_proxy.send((
@@ -1712,8 +1712,8 @@ where
             FromScriptMsg::Focus => {
                 self.handle_focus_msg(source_pipeline_id);
             },
-            FromScriptMsg::VisibilityChangeComplete(is_visible) => {
-                self.handle_visibility_change_complete(source_pipeline_id, is_visible);
+            FromScriptMsg::SetThrottledComplete(throttled) => {
+                self.handle_set_throttled_complete(source_pipeline_id, throttled);
             },
             FromScriptMsg::RemoveIFrame(browsing_context_id, response_sender) => {
                 let removed_pipeline_ids = self.handle_remove_iframe_msg(browsing_context_id);
@@ -2790,7 +2790,7 @@ where
         };
         let window_size = browsing_context.size;
         let pipeline_id = browsing_context.pipeline_id;
-        let is_visible = browsing_context.is_visible;
+        let throttled = browsing_context.throttled;
 
         let pipeline = match self.pipelines.get(&pipeline_id) {
             Some(p) => p,
@@ -2837,7 +2837,7 @@ where
             new_load_data,
             sandbox,
             is_private,
-            is_visible,
+            throttled,
         );
         self.add_pending_change(SessionHistoryChange {
             top_level_browsing_context_id,
@@ -2953,7 +2953,7 @@ where
         );
         let sandbox = IFrameSandboxState::IFrameUnsandboxed;
         let is_private = false;
-        let is_visible = true;
+        let throttled = false;
 
         // Register this new top-level browsing context id as a webview and set
         // its focused browsing context to be itself.
@@ -2984,7 +2984,7 @@ where
             load_data,
             sandbox,
             is_private,
-            is_visible,
+            throttled,
         );
         self.add_pending_change(SessionHistoryChange {
             top_level_browsing_context_id,
@@ -2995,7 +2995,7 @@ where
                 parent_pipeline_id: None,
                 is_private,
                 inherited_secure_context: None,
-                is_visible,
+                throttled,
             }),
             window_size,
         });
@@ -3197,7 +3197,7 @@ where
 
         // https://github.com/rust-lang/rust/issues/59159
         let browsing_context_size = browsing_context.size;
-        let browsing_context_is_visible = browsing_context.is_visible;
+        let browsing_context_throttled = browsing_context.throttled;
         // TODO(servo#30571) revert to debug_assert_eq!() once underlying bug is fixed
         #[cfg(debug_assertions)]
         if !(browsing_context_size == load_info.window_size.initial_viewport) {
@@ -3215,7 +3215,7 @@ where
             load_info.load_data,
             load_info.sandbox,
             is_private,
-            browsing_context_is_visible,
+            browsing_context_throttled,
         );
         self.add_pending_change(SessionHistoryChange {
             top_level_browsing_context_id,
@@ -3248,9 +3248,9 @@ where
                     )
                 },
             };
-        let (is_parent_private, is_parent_visible, is_parent_secure) =
+        let (is_parent_private, is_parent_throttled, is_parent_secure) =
             match self.browsing_contexts.get(&parent_browsing_context_id) {
-                Some(ctx) => (ctx.is_private, ctx.is_visible, ctx.inherited_secure_context),
+                Some(ctx) => (ctx.is_private, ctx.throttled, ctx.inherited_secure_context),
                 None => {
                     return warn!(
                         "{}: New iframe {} loaded in closed parent browsing context",
@@ -3266,7 +3266,7 @@ where
             None,
             script_sender,
             self.compositor_proxy.clone(),
-            is_parent_visible,
+            is_parent_throttled,
             load_info.load_data,
         );
 
@@ -3282,7 +3282,7 @@ where
                 parent_pipeline_id: Some(parent_pipeline_id),
                 is_private,
                 inherited_secure_context: is_parent_secure,
-                is_visible: is_parent_visible,
+                throttled: is_parent_throttled,
             }),
             window_size: load_info.window_size.initial_viewport,
         });
@@ -3307,9 +3307,9 @@ where
                     );
                 },
             };
-        let (is_opener_private, is_opener_visible, is_opener_secure) =
+        let (is_opener_private, is_opener_throttled, is_opener_secure) =
             match self.browsing_contexts.get(&opener_browsing_context_id) {
-                Some(ctx) => (ctx.is_private, ctx.is_visible, ctx.inherited_secure_context),
+                Some(ctx) => (ctx.is_private, ctx.throttled, ctx.inherited_secure_context),
                 None => {
                     return warn!(
                         "{}: New auxiliary {} loaded in closed opener browsing context",
@@ -3324,7 +3324,7 @@ where
             Some(opener_browsing_context_id),
             script_sender,
             self.compositor_proxy.clone(),
-            is_opener_visible,
+            is_opener_throttled,
             load_data,
         );
 
@@ -3367,7 +3367,7 @@ where
                 parent_pipeline_id: None,
                 is_private: is_opener_private,
                 inherited_secure_context: is_opener_secure,
-                is_visible: is_opener_visible,
+                throttled: is_opener_throttled,
             }),
             window_size: self.window_size.initial_viewport,
         });
@@ -3470,14 +3470,14 @@ where
                 return None;
             },
         };
-        let (window_size, pipeline_id, parent_pipeline_id, is_private, is_visible) =
+        let (window_size, pipeline_id, parent_pipeline_id, is_private, is_throttled) =
             match self.browsing_contexts.get(&browsing_context_id) {
                 Some(ctx) => (
                     ctx.size,
                     ctx.pipeline_id,
                     ctx.parent_pipeline_id,
                     ctx.is_private,
-                    ctx.is_visible,
+                    ctx.throttled,
                 ),
                 None => {
                     // This should technically never happen (since `load_url` is
@@ -3553,7 +3553,7 @@ where
                     load_data,
                     sandbox,
                     is_private,
-                    is_visible,
+                    is_throttled,
                 );
                 self.add_pending_change(SessionHistoryChange {
                     top_level_browsing_context_id,
@@ -3827,7 +3827,7 @@ where
                     parent_pipeline_id,
                     window_size,
                     is_private,
-                    is_visible,
+                    throttled,
                 ) = match self.browsing_contexts.get(&browsing_context_id) {
                     Some(ctx) => (
                         ctx.top_level_id,
@@ -3835,7 +3835,7 @@ where
                         ctx.parent_pipeline_id,
                         ctx.size,
                         ctx.is_private,
-                        ctx.is_visible,
+                        ctx.throttled,
                     ),
                     None => return warn!("No browsing context to traverse!"),
                 };
@@ -3854,7 +3854,7 @@ where
                     load_data.clone(),
                     sandbox,
                     is_private,
-                    is_visible,
+                    throttled,
                 );
                 self.add_pending_change(SessionHistoryChange {
                     top_level_browsing_context_id: top_level_id,
@@ -3886,7 +3886,7 @@ where
             };
 
         if let Some(old_pipeline) = self.pipelines.get(&old_pipeline_id) {
-            old_pipeline.notify_visibility(false);
+            old_pipeline.set_throttled(true);
         }
         if let Some(new_pipeline) = self.pipelines.get(&new_pipeline_id) {
             if let Some(ref chan) = self.devtools_sender {
@@ -3904,7 +3904,7 @@ where
                 ));
             }
 
-            new_pipeline.notify_visibility(true);
+            new_pipeline.set_throttled(false);
         }
 
         self.update_activity(old_pipeline_id);
@@ -4267,7 +4267,7 @@ where
         result
     }
 
-    fn handle_visibility_change_complete(&mut self, pipeline_id: PipelineId, visibility: bool) {
+    fn handle_set_throttled_complete(&mut self, pipeline_id: PipelineId, throttled: bool) {
         let browsing_context_id = match self.pipelines.get(&pipeline_id) {
             Some(pipeline) => pipeline.browsing_context_id,
             None => {
@@ -4285,14 +4285,14 @@ where
         };
 
         if let Some(parent_pipeline_id) = parent_pipeline_id {
-            let visibility_msg = ConstellationControlMsg::NotifyVisibilityChange(
+            let msg = ConstellationControlMsg::SetThrottledInContainingIframe(
                 parent_pipeline_id,
                 browsing_context_id,
-                visibility,
+                throttled,
             );
             let result = match self.pipelines.get(&parent_pipeline_id) {
                 None => return warn!("{}: Parent pipeline closed", parent_pipeline_id),
-                Some(parent_pipeline) => parent_pipeline.event_loop.send(visibility_msg),
+                Some(parent_pipeline) => parent_pipeline.event_loop.send(msg),
             };
 
             if let Err(e) = result {
@@ -4454,21 +4454,17 @@ where
         }
     }
 
-    fn notify_webview_visibility(
-        &mut self,
-        top_level_browsing_context_id: TopLevelBrowsingContextId,
-        visible: bool,
-    ) {
-        let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
+    fn set_webview_throttled(&mut self, webview_id: WebViewId, throttled: bool) {
+        let browsing_context_id = BrowsingContextId::from(webview_id);
         let pipeline_id = match self.browsing_contexts.get(&browsing_context_id) {
             Some(browsing_context) => browsing_context.pipeline_id,
             None => {
-                return warn!("{browsing_context_id}: Tried to notify visibility after closure");
+                return warn!("{browsing_context_id}: Tried to SetWebViewThrottled after closure");
             },
         };
         match self.pipelines.get(&pipeline_id) {
-            None => warn!("{pipeline_id}: Tried to notify visibility after closure"),
-            Some(pipeline) => pipeline.notify_visibility(visible),
+            None => warn!("{pipeline_id}: Tried to SetWebViewThrottled after closure"),
+            Some(pipeline) => pipeline.set_throttled(throttled),
         }
     }
 
@@ -4664,13 +4660,13 @@ where
                     change.window_size,
                     new_context_info.is_private,
                     new_context_info.inherited_secure_context,
-                    new_context_info.is_visible,
+                    new_context_info.throttled,
                 );
                 self.update_activity(change.new_pipeline_id);
             },
             Some(old_pipeline_id) => {
                 if let Some(pipeline) = self.pipelines.get(&old_pipeline_id) {
-                    pipeline.notify_visibility(false);
+                    pipeline.set_throttled(true);
                 }
 
                 // https://html.spec.whatwg.org/multipage/#unload-a-document

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -165,7 +165,7 @@ mod from_script {
                 Self::ReplaceHistoryState(_, _) => target!("ReplaceHistoryState"),
                 Self::JointSessionHistoryLength(_) => target!("JointSessionHistoryLength"),
                 Self::RemoveIFrame(_, _) => target!("RemoveIFrame"),
-                Self::VisibilityChangeComplete(_) => target!("VisibilityChangeComplete"),
+                Self::SetThrottledComplete(_) => target!("SetThrottledComplete"),
                 Self::ScriptLoadedURLInIFrame(_) => target!("ScriptLoadedURLInIFrame"),
                 Self::ScriptNewIFrame(_) => target!("ScriptNewIFrame"),
                 Self::ScriptNewAuxiliary(_) => target!("ScriptNewAuxiliary"),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1966,7 +1966,7 @@ impl Document {
 
         // If we are running 'fake' animation frames, we unconditionally
         // set up a one-shot timer for script to execute the rAF callbacks.
-        if self.is_faking_animation_frames() && self.window().visible() {
+        if self.is_faking_animation_frames() && !self.window().throttled() {
             warn!("Scheduling fake animation frame. Animation frames tick too fast.");
             let callback = FakeRequestAnimationFrameCallback {
                 document: Trusted::new(self),

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -87,7 +87,7 @@ pub struct HTMLIFrameElement {
     sandbox: MutNullableDom<DOMTokenList>,
     sandbox_allowance: Cell<Option<SandboxAllowance>>,
     load_blocker: DomRefCell<Option<LoadBlocker>>,
-    visibility: Cell<bool>,
+    throttled: Cell<bool>,
 }
 
 impl HTMLIFrameElement {
@@ -438,7 +438,7 @@ impl HTMLIFrameElement {
             sandbox: Default::default(),
             sandbox_allowance: Cell::new(None),
             load_blocker: DomRefCell::new(None),
-            visibility: Cell::new(true),
+            throttled: Cell::new(false),
         }
     }
 
@@ -473,9 +473,9 @@ impl HTMLIFrameElement {
         self.top_level_browsing_context_id.get()
     }
 
-    pub fn change_visibility_status(&self, visibility: bool) {
-        if self.visibility.get() != visibility {
-            self.visibility.set(visibility);
+    pub fn set_throttled(&self, throttled: bool) {
+        if self.throttled.get() != throttled {
+            self.throttled.set(throttled);
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -206,8 +206,8 @@ struct InProgressLoad {
     /// The activity level of the document (inactive, active or fully active).
     #[no_trace]
     activity: DocumentActivity,
-    /// Window is visible.
-    is_visible: bool,
+    /// Window is throttled, running timers at a heavily limited rate.
+    throttled: bool,
     /// The requested URL of the load.
     #[no_trace]
     url: ServoUrl,
@@ -250,7 +250,7 @@ impl InProgressLoad {
             opener,
             window_size,
             activity: DocumentActivity::FullyActive,
-            is_visible: true,
+            throttled: false,
             url,
             origin,
             navigation_start: navigation_start as u64,
@@ -1832,8 +1832,8 @@ impl ScriptThread {
                 SetScrollState(id, ..) => Some(id),
                 GetTitle(id) => Some(id),
                 SetDocumentActivity(id, ..) => Some(id),
-                ChangeFrameVisibilityStatus(id, ..) => Some(id),
-                NotifyVisibilityChange(id, ..) => Some(id),
+                SetThrottled(id, ..) => Some(id),
+                SetThrottledInContainingIframe(id, ..) => Some(id),
                 NavigateIframe(id, ..) => Some(id),
                 PostMessage { target: id, .. } => Some(id),
                 UpdatePipelineId(_, _, _, id, _) => Some(id),
@@ -1991,17 +1991,17 @@ impl ScriptThread {
             ConstellationControlMsg::SetDocumentActivity(pipeline_id, activity) => {
                 self.handle_set_document_activity_msg(pipeline_id, activity)
             },
-            ConstellationControlMsg::ChangeFrameVisibilityStatus(pipeline_id, visible) => {
-                self.handle_visibility_change_msg(pipeline_id, visible)
+            ConstellationControlMsg::SetThrottled(pipeline_id, throttled) => {
+                self.handle_set_throttled_msg(pipeline_id, throttled)
             },
-            ConstellationControlMsg::NotifyVisibilityChange(
+            ConstellationControlMsg::SetThrottledInContainingIframe(
                 parent_pipeline_id,
                 browsing_context_id,
-                visible,
-            ) => self.handle_visibility_change_complete_msg(
+                throttled,
+            ) => self.handle_set_throttled_in_containing_iframe_msg(
                 parent_pipeline_id,
                 browsing_context_id,
-                visible,
+                throttled,
             ),
             ConstellationControlMsg::PostMessage {
                 target: target_pipeline_id,
@@ -2556,45 +2556,44 @@ impl ScriptThread {
     }
 
     /// Updates iframe element after a change in visibility
-    fn handle_visibility_change_complete_msg(
+    fn handle_set_throttled_in_containing_iframe_msg(
         &self,
         parent_pipeline_id: PipelineId,
         browsing_context_id: BrowsingContextId,
-        visible: bool,
+        throttled: bool,
     ) {
         let iframe = self
             .documents
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
         if let Some(iframe) = iframe {
-            iframe.change_visibility_status(visible);
+            iframe.set_throttled(throttled);
         }
     }
 
-    /// Handle visibility change message
-    fn handle_visibility_change_msg(&self, id: PipelineId, visible: bool) {
+    fn handle_set_throttled_msg(&self, id: PipelineId, throttled: bool) {
         // Separate message sent since parent script thread could be different (Iframe of different
         // domain)
         self.script_sender
-            .send((id, ScriptMsg::VisibilityChangeComplete(visible)))
+            .send((id, ScriptMsg::SetThrottledComplete(throttled)))
             .unwrap();
 
         let window = self.documents.borrow().find_window(id);
         match window {
             Some(window) => {
-                window.alter_resource_utilization(visible);
+                window.set_throttled(throttled);
                 return;
             },
             None => {
                 let mut loads = self.incomplete_loads.borrow_mut();
                 if let Some(ref mut load) = loads.iter_mut().find(|load| load.pipeline_id == id) {
-                    load.is_visible = visible;
+                    load.throttled = throttled;
                     return;
                 }
             },
         }
 
-        warn!("change visibility message sent to nonexistent pipeline");
+        warn!("SetThrottled sent to nonexistent pipeline");
     }
 
     /// Handles activity change message
@@ -3435,8 +3434,8 @@ impl ScriptThread {
             window.suspend();
         }
 
-        if !incomplete.is_visible {
-            window.alter_resource_utilization(false);
+        if incomplete.throttled {
+            window.set_throttled(true);
         }
 
         document.get_current_parser().unwrap()

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -81,8 +81,8 @@ pub enum CompositorMsg {
     CreatePng(Option<Rect<f32, CSSPixel>>, IpcSender<Option<Image>>),
     /// A reply to the compositor asking if the output image is stable.
     IsReadyToSaveImageReply(bool),
-    /// Pipeline visibility changed
-    PipelineVisibilityChanged(PipelineId, bool),
+    /// Set whether to use less resources by stopping animations.
+    SetThrottled(PipelineId, bool),
     /// WebRender has produced a new frame. This message informs the compositor that
     /// the frame is ready, so that it may trigger a recomposite.
     NewWebRenderFrameReady(bool /* composite_needed */),
@@ -157,7 +157,7 @@ impl Debug for CompositorMsg {
             CompositorMsg::TouchEventProcessed(..) => write!(f, "TouchEventProcessed"),
             CompositorMsg::CreatePng(..) => write!(f, "CreatePng"),
             CompositorMsg::IsReadyToSaveImageReply(..) => write!(f, "IsReadyToSaveImageReply"),
-            CompositorMsg::PipelineVisibilityChanged(..) => write!(f, "PipelineVisibilityChanged"),
+            CompositorMsg::SetThrottled(..) => write!(f, "SetThrottled"),
             CompositorMsg::PipelineExited(..) => write!(f, "PipelineExited"),
             CompositorMsg::NewWebRenderFrameReady(..) => write!(f, "NewWebRenderFrameReady"),
             CompositorMsg::PendingPaintMetric(..) => write!(f, "PendingPaintMetric"),

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -312,11 +312,10 @@ pub enum ConstellationControlMsg {
     GetTitle(PipelineId),
     /// Notifies script thread of a change to one of its document's activity
     SetDocumentActivity(PipelineId, DocumentActivity),
-    /// Notifies script thread whether frame is visible
-    ChangeFrameVisibilityStatus(PipelineId, bool),
-    /// Notifies script thread that frame visibility change is complete
-    /// PipelineId is for the parent, BrowsingContextId is for the nested browsing context
-    NotifyVisibilityChange(PipelineId, BrowsingContextId, bool),
+    /// Set whether to use less resources by running timers at a heavily limited rate.
+    SetThrottled(PipelineId, bool),
+    /// Notify the containing iframe (in PipelineId) that the nested browsing context (BrowsingContextId) is throttled.
+    SetThrottledInContainingIframe(PipelineId, BrowsingContextId, bool),
     /// Notifies script thread that a url should be loaded in this iframe.
     /// PipelineId is for the parent, BrowsingContextId is for the nested browsing context
     NavigateIframe(
@@ -416,8 +415,8 @@ impl fmt::Debug for ConstellationControlMsg {
             SetScrollState(..) => "SetScrollState",
             GetTitle(..) => "GetTitle",
             SetDocumentActivity(..) => "SetDocumentActivity",
-            ChangeFrameVisibilityStatus(..) => "ChangeFrameVisibilityStatus",
-            NotifyVisibilityChange(..) => "NotifyVisibilityChange",
+            SetThrottled(..) => "SetThrottled",
+            SetThrottledInContainingIframe(..) => "SetThrottledInContainingIframe",
             NavigateIframe(..) => "NavigateIframe",
             PostMessage { .. } => "PostMessage",
             UpdatePipelineId(..) => "UpdatePipelineId",

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -215,8 +215,8 @@ pub enum ScriptMsg {
     /// Notification that this iframe should be removed.
     /// Returns a list of pipelines which were closed.
     RemoveIFrame(BrowsingContextId, IpcSender<Vec<PipelineId>>),
-    /// Notifies constellation that an iframe's visibility has been changed.
-    VisibilityChangeComplete(bool),
+    /// Successful response to [crate::ConstellationControlMsg::SetThrottled].
+    SetThrottledComplete(bool),
     /// A load has been requested in an IFrame.
     ScriptLoadedURLInIFrame(IFrameLoadInfoWithData),
     /// A load of the initial `about:blank` has been completed in an IFrame.
@@ -304,7 +304,7 @@ impl fmt::Debug for ScriptMsg {
             ReplaceHistoryState(..) => "ReplaceHistoryState",
             JointSessionHistoryLength(..) => "JointSessionHistoryLength",
             RemoveIFrame(..) => "RemoveIFrame",
-            VisibilityChangeComplete(..) => "VisibilityChangeComplete",
+            SetThrottledComplete(..) => "SetThrottledComplete",
             ScriptLoadedURLInIFrame(..) => "ScriptLoadedURLInIFrame",
             ScriptNewIFrame(..) => "ScriptNewIFrame",
             ScriptNewAuxiliary(..) => "ScriptNewAuxiliary",


### PR DESCRIPTION
Servo has a pervasive but confusing concept of webviews or pipelines being “visible”, which actually controls whether script runs timers at a heavily limited rate and the compositor pauses animations.

Continuing from #31815, let’s replace this with a more concrete concept of a webview or pipeline being “throttled” (with the meanings of true and false inverted).

constellation → script

- SetThrottled (was ChangeFrameVisibilityStatus) has been inverted and its concrete effects documented
- SetThrottledInContainingIframe (was NotifyVisibilityChange) has been inverted and its purpose documented

constellation ← script

- SetThrottledComplete (was VisibilityChangeComplete) has been inverted

constellation → compositor

- SetThrottled (was PipelineVisibilityChanged) has been inverted and its concrete effects documented

Other changes in constellation

- Constellation.new_pipeline() now takes an inverted “throttled” argument
- Constellation.new_browsing_context() now takes an inverted “throttled” argument
- BrowsingContext.throttled (was .is_visible) has been inverted and its concrete effects documented
- InitialPipelineState.prev_throttled (was .prev_visibility) has been inverted and its concrete effects documented
- NewBrowsingContextInfo.throttled (was .is_visible) has been inverted and its concrete effects documented

Other changes in script

- InProgressLoad.throttled (was .is_visible) has been inverted and its concrete effects documented
- Window.set_throttled() (was .alter_resource_utilization()) has been inverted
- Window.throttled (was .visible) has been inverted
- HTMLIFrameElement.throttled (was .visibility) has been inverted

Other changes in compositor

- PipelineDetails.throttled (was .visible) has been inverted and its concrete effects documented

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes