### PR TITLE
Fix: removed  mutable compile warnings in script

### DIFF
--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -55,7 +55,7 @@ enum StructuredCloneTags {
 unsafe fn read_blob(
     owner: &GlobalScope,
     r: *mut JSStructuredCloneReader,
-    mut sc_holder: &mut StructuredDataHolder,
+    sc_holder: &mut StructuredDataHolder,
 ) -> *mut JSObject {
     let mut name_space: u32 = 0;
     let mut index: u32 = 0;
@@ -166,7 +166,7 @@ unsafe extern "C" fn read_transfer_callback(
     return_object: RawMutableHandleObject,
 ) -> bool {
     if tag == StructuredCloneTags::MessagePort as u32 {
-        let mut sc_holder = &mut *(closure as *mut StructuredDataHolder);
+        let sc_holder = &mut *(closure as *mut StructuredDataHolder);
         let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
         let owner = GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof));
         if let Ok(_) = <MessagePort as Transferable>::transfer_receive(
@@ -194,7 +194,7 @@ unsafe extern "C" fn write_transfer_callback(
     if let Ok(port) = root_from_object::<MessagePort>(*obj, cx) {
         *tag = StructuredCloneTags::MessagePort as u32;
         *ownership = TransferableOwnership::SCTAG_TMO_CUSTOM;
-        let mut sc_holder = &mut *(closure as *mut StructuredDataHolder);
+        let sc_holder = &mut *(closure as *mut StructuredDataHolder);
         if let Ok(data) = port.transfer(sc_holder) {
             *extra_data = data;
             return true;

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -51,7 +51,7 @@ impl CryptoMethods for Crypto {
         if !is_integer_buffer(array_type) {
             return Err(Error::TypeMismatch);
         } else {
-            let mut data = unsafe { input.as_mut_slice() };
+            let data = unsafe { input.as_mut_slice() };
             if data.len() > 65536 {
                 return Err(Error::QuotaExceeded);
             }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -72,7 +72,7 @@ impl CSSStyleOwner {
                 let result = if attr.is_some() {
                     let lock = attr.as_ref().unwrap();
                     let mut guard = shared_lock.write();
-                    let mut pdb = lock.write_with(&mut guard);
+                    let pdb = lock.write_with(&mut guard);
                     let result = f(pdb, &mut changed);
                     result
                 } else {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
**Removed mut keyword from variables which caused compiler warnings**

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31820

<!-- Either: -->

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
