### PR TITLE
Don't update row baseline if cell is empty

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -54,6 +54,12 @@ impl CellLayout {
     fn outer_block_size(&self) -> Au {
         self.layout.content_block_size + (self.border.block_sum() + self.padding.block_sum()).into()
     }
+
+    /// Whether the cell has no in-flow or out-of-flow contents, other than collapsed whitespace.
+    /// Note this logic differs from 'empty-cells', which counts abspos contents as empty.
+    fn is_empty(&self) -> bool {
+        self.layout.fragments.is_empty()
+    }
 }
 
 /// Information stored during the layout of rows.
@@ -1560,7 +1566,7 @@ impl<'a> TableLayout<'a> {
 
         let row_block_offset = row_rect.start_corner.block;
         let row_baseline = self.row_baselines[row_index];
-        if cell.effective_vertical_align() == VerticalAlignKeyword::Baseline {
+        if cell.effective_vertical_align() == VerticalAlignKeyword::Baseline && !layout.is_empty() {
             let baseline = row_block_offset + row_baseline;
             if row_index == 0 {
                 baselines.first = Some(baseline);

--- a/tests/wpt/meta-legacy-layout/css/CSS2/tables/table-vertical-align-baseline-008.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/CSS2/tables/table-vertical-align-baseline-008.xht.ini
@@ -1,0 +1,2 @@
+[table-vertical-align-baseline-008.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-width-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-width-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[max-width-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-height-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-height-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[min-height-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-width-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-width-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[min-width-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/tables/table-vertical-align-baseline-008.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-vertical-align-baseline-008.xht
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Test: Test for baseline alignment of table cells</title>
+  <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com" />
+  <link rel="help" href="https://github.com/servo/servo/issues/31722" />
+  <link rel="help" href="https://drafts.csswg.org/css2/#height-layout" />
+  <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
+  <meta name="assert" content="Since the cell is empty, the baseline of the row
+      is synthesized from the bottom content edge of the cell." />
+  <style><![CDATA[
+  .wrapper { float: left; font-size: 0; background: red }
+  .wrapper > * { width: 50px; height: 100px; background: green }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div class="wrapper">
+    <div style="display: inline-block"></div>
+    <table style="display: inline-table; border-spacing: 0">
+      <td style="vertical-align: baseline; padding: 0"></td>
+    </table>
+  </div>
+ </body>
+</html>


### PR DESCRIPTION
Gecko, Blink and WebKit agree that the if a row only has empty cells, its baseline should be at the bottom, not at the top.

There isn't interoperability when the cells are just empty-ish, so this patch takes the simplest approach, aligning with Blink: any out-of-flow or in-flow content other than collapsed whitespace counts as not empty.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31722
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
