### PR TITLE
layout: Allow transforming inline replaced elements

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -474,7 +474,7 @@ impl StackingContext {
         if effects.filter.0.is_empty() &&
             effects.opacity == 1.0 &&
             effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
-            !style.has_transform_or_perspective()
+            !style.has_transform_or_perspective(FragmentFlags::empty())
         {
             return false;
         }
@@ -896,7 +896,7 @@ struct ReferenceFrameData {
 
 impl BoxFragment {
     fn get_stacking_context_type(&self) -> Option<StackingContextType> {
-        if self.style.establishes_stacking_context() {
+        if self.style.establishes_stacking_context(self.base.flags) {
             return Some(StackingContextType::RealStackingContext);
         }
 
@@ -986,7 +986,7 @@ impl BoxFragment {
         // properties will be replaced before recursing into children.
         assert!(self
             .style
-            .establishes_containing_block_for_all_descendants());
+            .establishes_containing_block_for_all_descendants(self.base.flags));
         let adjusted_containing_block = ContainingBlock::new(
             containing_block
                 .rect
@@ -1168,7 +1168,7 @@ impl BoxFragment {
         // absolute and fixed descendants.
         let new_containing_block_info = if self
             .style
-            .establishes_containing_block_for_all_descendants()
+            .establishes_containing_block_for_all_descendants(self.base.flags)
         {
             containing_block_info.new_for_absolute_and_fixed_descendants(
                 &for_non_absolute_descendants,
@@ -1176,7 +1176,7 @@ impl BoxFragment {
             )
         } else if self
             .style
-            .establishes_containing_block_for_absolute_descendants()
+            .establishes_containing_block_for_absolute_descendants(self.base.flags)
         {
             containing_block_info.new_for_absolute_descendants(
                 &for_non_absolute_descendants,
@@ -1389,7 +1389,7 @@ impl BoxFragment {
         &self,
         containing_block_rect: &PhysicalRect<Length>,
     ) -> Option<ReferenceFrameData> {
-        if !self.style.has_transform_or_perspective() {
+        if !self.style.has_transform_or_perspective(self.base.flags) {
             return None;
         }
 

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -16,7 +16,7 @@ use crate::dom::NodeExt;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
-use crate::fragment_tree::{BaseFragmentInfo, Fragment};
+use crate::fragment_tree::{BaseFragmentInfo, Fragment, FragmentFlags};
 use crate::positioned::PositioningContext;
 use crate::replaced::ReplacedContent;
 use crate::sizing::{self, ContentSizes};
@@ -131,11 +131,15 @@ impl IndependentFormattingContext {
                     contents,
                 })
             },
-            Err(contents) => Self::Replaced(ReplacedFormattingContext {
-                base_fragment_info: node_and_style_info.into(),
-                style: Arc::clone(&node_and_style_info.style),
-                contents,
-            }),
+            Err(contents) => {
+                let mut base_fragment_info: BaseFragmentInfo = node_and_style_info.into();
+                base_fragment_info.flags.insert(FragmentFlags::IS_REPLACED);
+                Self::Replaced(ReplacedFormattingContext {
+                    base_fragment_info,
+                    style: Arc::clone(&node_and_style_info.style),
+                    contents,
+                })
+            },
         }
     }
 

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -88,6 +88,9 @@ bitflags! {
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 0b00000001;
         /// Whether or not the node that created this Fragment is a `<br>` element.
         const IS_BR_ELEMENT = 0b00000010;
+        /// Whether or not this Fragment was created to contain a replaced element or is
+        /// a replaced element.
+        const IS_REPLACED = 0b00000100;
     }
 }
 

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -192,12 +192,12 @@ impl Fragment {
                     .translate(containing_block.origin.to_vector());
                 let new_manager = if fragment
                     .style
-                    .establishes_containing_block_for_all_descendants()
+                    .establishes_containing_block_for_all_descendants(fragment.base.flags)
                 {
                     manager.new_for_absolute_and_fixed_descendants(&content_rect, &padding_rect)
                 } else if fragment
                     .style
-                    .establishes_containing_block_for_absolute_descendants()
+                    .establishes_containing_block_for_absolute_descendants(fragment.base.flags)
                 {
                     manager.new_for_absolute_descendants(&content_rect, &padding_rect)
                 } else {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -18,7 +18,8 @@ use crate::dom::NodeExt;
 use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{
-    AbsoluteBoxOffsets, BoxFragment, CollapsedBlockMargins, Fragment, HoistedSharedFragment,
+    AbsoluteBoxOffsets, BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags,
+    HoistedSharedFragment,
 };
 use crate::geom::{
     AuOrAuto, LengthOrAuto, LengthPercentageOrAuto, LogicalRect, LogicalSides, LogicalVec2,
@@ -144,9 +145,13 @@ impl PositioningContext {
     }
 
     pub(crate) fn new_for_style(style: &ComputedValues) -> Option<Self> {
-        if style.establishes_containing_block_for_all_descendants() {
+        // NB: We never make PositioningContexts for replaced elements, which is why we always
+        // pass false here.
+        if style.establishes_containing_block_for_all_descendants(FragmentFlags::empty()) {
             Some(Self::new_for_containing_block_for_all_descendants())
-        } else if style.establishes_containing_block_for_absolute_descendants() {
+        } else if style
+            .establishes_containing_block_for_absolute_descendants(FragmentFlags::empty())
+        {
             Some(Self {
                 for_nearest_positioned_ancestor: Some(Vec::new()),
                 for_nearest_containing_block_for_all_descendants: Vec::new(),

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -22,7 +22,7 @@ use super::{Table, TableSlot, TableSlotCell, TableTrack, TableTrackGroup};
 use crate::context::LayoutContext;
 use crate::formatting_contexts::{Baselines, IndependentLayout};
 use crate::fragment_tree::{
-    BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, ExtraBackground, Fragment,
+    BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, ExtraBackground, Fragment, FragmentFlags,
     PositioningFragment,
 };
 use crate::geom::{AuOrAuto, LengthPercentageOrAuto, LogicalRect, LogicalSides, LogicalVec2};
@@ -979,11 +979,15 @@ impl<'a> TableLayout<'a> {
                         row.group_index.map_or(false, |group_index| {
                             self.table.row_groups[group_index]
                                 .style
-                                .establishes_containing_block_for_absolute_descendants()
+                                .establishes_containing_block_for_absolute_descendants(
+                                    FragmentFlags::empty(),
+                                )
                         });
                     row_group_collects_for_nearest_positioned_ancestor ||
                         row.style
-                            .establishes_containing_block_for_absolute_descendants()
+                            .establishes_containing_block_for_absolute_descendants(
+                                FragmentFlags::empty(),
+                            )
                 });
 
             let mut cells_laid_out_row = Vec::new();

--- a/tests/wpt/meta/css/css-transforms/transform3d-image-scale-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-image-scale-001.html.ini
@@ -1,2 +1,0 @@
-[transform3d-image-scale-001.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-transforms/support/transform-iframe-002-contents.html
+++ b/tests/wpt/tests/css/css-transforms/support/transform-iframe-002-contents.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Iframe (contents)</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <style>
+        body {
+            background: green;
+        }
+    </style>
+  </head>
+  <body>
+  </body>
+</html>

--- a/tests/wpt/tests/css/css-transforms/transform-iframe-002.html
+++ b/tests/wpt/tests/css/css-transforms/transform-iframe-002.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Iframe</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+    <meta name="assert" content="This test ensures that an iframe element can be transformed.">
+    <link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+    <style>
+      iframe {
+        height: 50px;
+        width: 50px;
+        transform: translate(25px, 25px) scale(2, 2);
+        border: none;
+      }
+    </style>
+    <p>Test passes if there is a filled green square.</p>
+    <iframe src="support/transform-iframe-002-contents.html"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
This requires passing through information about whether or not the
element in question is replaced when checking to see if it's
transformable and transitively all functions that make decisions about
containing blocks. A new FragmentFlag is added to help track this -- it
will be set on both the replaced items BoxFragment container as well as
the Fragment for the replaced item itself.

Fixes #31806.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31806.
- [x] There are tests for these changes
