### PR TITLE
Run platform bootstrap first in bootstrap

### DIFF
--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -55,9 +55,9 @@ class Base:
             return False
 
     def bootstrap(self, force: bool):
-        installed_something = self.install_taplo(force)
+        installed_something = self._platform_bootstrap(force)
+        installed_something |= self.install_taplo(force)
         installed_something |= self.install_crown(force)
-        installed_something |= self._platform_bootstrap(force)
         if not installed_something:
             print("Dependencies were already installed!")
 

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -146,9 +146,11 @@ class Linux(Base):
             'void',
             'fedora linux asahi remix'
         ]:
-            raise NotImplementedError(f"mach bootstrap does not support {self.distro}."
-                                      " You may be able to install dependencies manually."
-                                      " See https://github.com/servo/servo/wiki/Building.")
+            print(f"mach bootstrap does not support {self.distro}."
+                  " You may be able to install dependencies manually."
+                  " See https://github.com/servo/servo/wiki/Building.")
+            input("Press Enter to continue...")
+            return False
 
         installed_something = self.install_non_gstreamer_dependencies(force)
         return installed_something


### PR DESCRIPTION
So the user do not need to install llvm via choco manually. This should solve `error: linker lld-link.exe not found` error on windows.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust the bootstrap scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
