### PR TITLE
clippy: Use `matches!` and dereferencing in match statements in `components/script`

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -169,10 +169,7 @@ impl QueuedTaskConversion for DedicatedWorkerScriptMsg {
     }
 
     fn is_wake_up(&self) -> bool {
-        match self {
-            DedicatedWorkerScriptMsg::WakeUp => true,
-            _ => false,
-        }
+        matches!(self, DedicatedWorkerScriptMsg::WakeUp)
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -206,12 +206,12 @@ pub enum FireMouseEventType {
 
 impl FireMouseEventType {
     pub fn as_str(&self) -> &str {
-        match self {
-            &FireMouseEventType::Move => "mousemove",
-            &FireMouseEventType::Over => "mouseover",
-            &FireMouseEventType::Out => "mouseout",
-            &FireMouseEventType::Enter => "mouseenter",
-            &FireMouseEventType::Leave => "mouseleave",
+        match *self {
+            FireMouseEventType::Move => "mousemove",
+            FireMouseEventType::Over => "mouseover",
+            FireMouseEventType::Out => "mouseout",
+            FireMouseEventType::Enter => "mouseenter",
+            FireMouseEventType::Leave => "mouseleave",
         }
     }
 }
@@ -2924,10 +2924,7 @@ impl Document {
 }
 
 fn is_character_value_key(key: &Key) -> bool {
-    match key {
-        Key::Character(_) | Key::Enter => true,
-        _ => false,
-    }
+    matches!(key, Key::Character(_) | Key::Enter)
 }
 
 #[derive(MallocSizeOf, PartialEq)]
@@ -3055,10 +3052,7 @@ fn get_registrable_domain_suffix_of_or_is_equal_to(
 
 /// <https://url.spec.whatwg.org/#network-scheme>
 fn url_has_network_scheme(url: &ServoUrl) -> bool {
-    match url.scheme() {
-        "ftp" | "http" | "https" => true,
-        _ => false,
-    }
+    matches!(url.scheme(), "ftp" | "http" | "https")
 }
 
 #[derive(Clone, Copy, Eq, JSTraceable, MallocSizeOf, PartialEq)]
@@ -3982,8 +3976,7 @@ impl Document {
 impl Element {
     fn click_event_filter_by_disabled_state(&self) -> bool {
         let node = self.upcast::<Node>();
-        match node.type_id() {
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+        matches!(node.type_id(), NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLButtonElement,
             )) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(
@@ -3997,9 +3990,7 @@ impl Element {
             )) |
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLTextAreaElement,
-            )) if self.disabled_state() => true,
-            _ => false,
-        }
+            )) if self.disabled_state())
     }
 }
 
@@ -4599,14 +4590,15 @@ impl DocumentMethods for Document {
         self.get_html_element().and_then(|root| {
             let node = root.upcast::<Node>();
             node.children()
-                .find(|child| match child.type_id() {
-                    NodeTypeId::Element(ElementTypeId::HTMLElement(
-                        HTMLElementTypeId::HTMLBodyElement,
-                    )) |
-                    NodeTypeId::Element(ElementTypeId::HTMLElement(
-                        HTMLElementTypeId::HTMLFrameSetElement,
-                    )) => true,
-                    _ => false,
+                .find(|child| {
+                    matches!(
+                        child.type_id(),
+                        NodeTypeId::Element(ElementTypeId::HTMLElement(
+                            HTMLElementTypeId::HTMLBodyElement,
+                        )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                            HTMLElementTypeId::HTMLFrameSetElement,
+                        ))
+                    )
                 })
                 .map(|node| DomRoot::downcast(node).unwrap())
         })

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -136,11 +136,11 @@ impl EventListenerType {
         owner: &EventTarget,
         ty: &Atom,
     ) -> Option<CompiledEventListener> {
-        match self {
-            &mut EventListenerType::Inline(ref mut inline) => inline
+        match *self {
+            EventListenerType::Inline(ref mut inline) => inline
                 .get_compiled_handler(owner, ty)
                 .map(CompiledEventListener::Handler),
-            &mut EventListenerType::Additive(ref listener) => {
+            EventListenerType::Additive(ref listener) => {
                 Some(CompiledEventListener::Listener(listener.clone()))
             },
         }
@@ -415,10 +415,9 @@ impl EventTarget {
             Vacant(entry) => entry.insert(EventListeners(vec![])),
         };
 
-        let idx = entries.iter().position(|ref entry| match entry.listener {
-            EventListenerType::Inline(_) => true,
-            _ => false,
-        });
+        let idx = entries
+            .iter()
+            .position(|ref entry| matches!(entry.listener, EventListenerType::Inline(_)));
 
         match idx {
             Some(idx) => match listener {

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -301,10 +301,11 @@ impl GPUBufferMethods for GPUBuffer {
         } else {
             return Err(Error::Operation);
         };
-        let mut valid = match self.state.get() {
-            GPUBufferState::Mapped | GPUBufferState::MappedAtCreation => true,
-            _ => false,
-        };
+        let mut valid = matches!(
+            self.state.get(),
+            GPUBufferState::Mapped | GPUBufferState::MappedAtCreation
+        );
+
         valid &= offset % RANGE_OFFSET_ALIGN_MASK == 0 &&
             range_size % RANGE_SIZE_ALIGN_MASK == 0 &&
             offset >= m_info.mapping_range.start &&

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -74,10 +74,9 @@ impl GPUQueueMethods for GPUQueue {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit>
     fn Submit(&self, command_buffers: Vec<DomRoot<GPUCommandBuffer>>) {
         let valid = command_buffers.iter().all(|cb| {
-            cb.buffers().iter().all(|b| match b.state() {
-                GPUBufferState::Unmapped => true,
-                _ => false,
-            })
+            cb.buffers()
+                .iter()
+                .all(|b| matches!(b.state(), GPUBufferState::Unmapped))
         });
         let scope_id = self.device.borrow().as_ref().unwrap().use_current_scope();
         if !valid {

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -344,10 +344,7 @@ impl Iterable for Headers {
 
 // https://fetch.spec.whatwg.org/#forbidden-response-header-name
 fn is_forbidden_response_header(name: &str) -> bool {
-    match name {
-        "set-cookie" | "set-cookie2" => true,
-        _ => false,
-    }
+    matches!(name, "set-cookie" | "set-cookie2")
 }
 
 // https://fetch.spec.whatwg.org/#forbidden-header-name
@@ -487,18 +484,12 @@ fn is_legal_header_value(value: &ByteString) -> bool {
 
 // https://tools.ietf.org/html/rfc5234#appendix-B.1
 pub fn is_vchar(x: u8) -> bool {
-    match x {
-        0x21..=0x7E => true,
-        _ => false,
-    }
+    matches!(x, 0x21..=0x7E)
 }
 
 // http://tools.ietf.org/html/rfc7230#section-3.2.6
 pub fn is_obs_text(x: u8) -> bool {
-    match x {
-        0x80..=0xFF => true,
-        _ => false,
-    }
+    matches!(x, 0x80..=0xFF)
 }
 
 // https://fetch.spec.whatwg.org/#concept-header-extract-mime-type

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -186,20 +186,19 @@ impl VirtualMethods for HTMLFieldSetElement {
                 let fields = children.flat_map(|child| {
                     child
                         .traverse_preorder(ShadowIncluding::No)
-                        .filter(|descendant| match descendant.type_id() {
-                            NodeTypeId::Element(ElementTypeId::HTMLElement(
-                                HTMLElementTypeId::HTMLButtonElement,
-                            )) |
-                            NodeTypeId::Element(ElementTypeId::HTMLElement(
-                                HTMLElementTypeId::HTMLInputElement,
-                            )) |
-                            NodeTypeId::Element(ElementTypeId::HTMLElement(
-                                HTMLElementTypeId::HTMLSelectElement,
-                            )) |
-                            NodeTypeId::Element(ElementTypeId::HTMLElement(
-                                HTMLElementTypeId::HTMLTextAreaElement,
-                            )) => true,
-                            _ => false,
+                        .filter(|descendant| {
+                            matches!(
+                                descendant.type_id(),
+                                NodeTypeId::Element(ElementTypeId::HTMLElement(
+                                    HTMLElementTypeId::HTMLButtonElement,
+                                )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                                    HTMLElementTypeId::HTMLInputElement,
+                                )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                                    HTMLElementTypeId::HTMLSelectElement,
+                                )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
+                                    HTMLElementTypeId::HTMLTextAreaElement,
+                                ))
+                            )
                         })
                 });
                 if disabled_state {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1065,10 +1065,7 @@ impl HTMLImageElement {
 
         let elem = self.upcast::<Element>();
         let document = document_from_node(elem);
-        let has_pending_request = match self.image_request.get() {
-            ImageRequestPhase::Pending => true,
-            _ => false,
-        };
+        let has_pending_request = matches!(self.image_request.get(), ImageRequestPhase::Pending);
 
         // Step 2
         if !document.is_active() || !Self::uses_srcset_or_picture(elem) || has_pending_request {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2270,8 +2270,8 @@ impl VirtualMethods for HTMLInputElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("disabled") => {
+        match *attr.local_name() {
+            local_name!("disabled") => {
                 let disabled_state = match mutation {
                     AttributeMutation::Set(None) => true,
                     AttributeMutation::Set(Some(_)) => {
@@ -2292,7 +2292,7 @@ impl VirtualMethods for HTMLInputElement {
 
                 el.update_sequentially_focusable_status();
             },
-            &local_name!("checked") if !self.checked_changed.get() => {
+            local_name!("checked") if !self.checked_changed.get() => {
                 let checked_state = match mutation {
                     AttributeMutation::Set(None) => true,
                     AttributeMutation::Set(Some(_)) => {
@@ -2303,11 +2303,11 @@ impl VirtualMethods for HTMLInputElement {
                 };
                 self.update_checked_state(checked_state, false);
             },
-            &local_name!("size") => {
+            local_name!("size") => {
                 let size = mutation.new_value(attr).map(|value| value.as_uint());
                 self.size.set(size.unwrap_or(DEFAULT_INPUT_SIZE));
             },
-            &local_name!("type") => {
+            local_name!("type") => {
                 let el = self.upcast::<Element>();
                 match mutation {
                     AttributeMutation::Set(_) => {
@@ -2396,7 +2396,7 @@ impl VirtualMethods for HTMLInputElement {
 
                 self.update_placeholder_shown_state();
             },
-            &local_name!("value") if !self.value_dirty.get() => {
+            local_name!("value") if !self.value_dirty.get() => {
                 let value = mutation.new_value(attr).map(|value| (**value).to_owned());
                 let mut value = value.map_or(DOMString::new(), DOMString::from);
 
@@ -2404,12 +2404,12 @@ impl VirtualMethods for HTMLInputElement {
                 self.textinput.borrow_mut().set_content(value);
                 self.update_placeholder_shown_state();
             },
-            &local_name!("name") if self.input_type() == InputType::Radio => {
+            local_name!("name") if self.input_type() == InputType::Radio => {
                 self.radio_group_updated(
                     mutation.new_value(attr).as_ref().map(|name| name.as_atom()),
                 );
             },
-            &local_name!("maxlength") => match *attr.value() {
+            local_name!("maxlength") => match *attr.value() {
                 AttrValue::Int(_, value) => {
                     let mut textinput = self.textinput.borrow_mut();
 
@@ -2421,7 +2421,7 @@ impl VirtualMethods for HTMLInputElement {
                 },
                 _ => panic!("Expected an AttrValue::Int"),
             },
-            &local_name!("minlength") => match *attr.value() {
+            local_name!("minlength") => match *attr.value() {
                 AttrValue::Int(_, value) => {
                     let mut textinput = self.textinput.borrow_mut();
 
@@ -2433,7 +2433,7 @@ impl VirtualMethods for HTMLInputElement {
                 },
                 _ => panic!("Expected an AttrValue::Int"),
             },
-            &local_name!("placeholder") => {
+            local_name!("placeholder") => {
                 {
                     let mut placeholder = self.placeholder.borrow_mut();
                     placeholder.clear();
@@ -2444,7 +2444,7 @@ impl VirtualMethods for HTMLInputElement {
                 }
                 self.update_placeholder_shown_state();
             },
-            &local_name!("readonly") => {
+            local_name!("readonly") => {
                 if self.input_type().is_textual() {
                     let el = self.upcast::<Element>();
                     match mutation {
@@ -2457,7 +2457,7 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
             },
-            &local_name!("form") => {
+            local_name!("form") => {
                 self.form_attribute_mutated(mutation);
             },
             _ => {},
@@ -2468,14 +2468,14 @@ impl VirtualMethods for HTMLInputElement {
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
-        match name {
-            &local_name!("accept") => AttrValue::from_comma_separated_tokenlist(value.into()),
-            &local_name!("size") => AttrValue::from_limited_u32(value.into(), DEFAULT_INPUT_SIZE),
-            &local_name!("type") => AttrValue::from_atomic(value.into()),
-            &local_name!("maxlength") => {
+        match *name {
+            local_name!("accept") => AttrValue::from_comma_separated_tokenlist(value.into()),
+            local_name!("size") => AttrValue::from_limited_u32(value.into(), DEFAULT_INPUT_SIZE),
+            local_name!("type") => AttrValue::from_atomic(value.into()),
+            local_name!("maxlength") => {
                 AttrValue::from_limited_i32(value.into(), DEFAULT_MAX_LENGTH)
             },
-            &local_name!("minlength") => {
+            local_name!("minlength") => {
                 AttrValue::from_limited_i32(value.into(), DEFAULT_MIN_LENGTH)
             },
             _ => self

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -156,8 +156,8 @@ impl VirtualMethods for HTMLLabelElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("form") => {
+        match *attr.local_name() {
+            local_name!("form") => {
                 self.form_attribute_mutated(mutation);
             },
             _ => {},

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -204,8 +204,8 @@ impl VirtualMethods for HTMLLinkElement {
         }
 
         let rel = get_attr(self.upcast(), &local_name!("rel"));
-        match attr.local_name() {
-            &local_name!("href") => {
+        match *attr.local_name() {
+            local_name!("href") => {
                 if string_is_stylesheet(&rel) {
                     self.handle_stylesheet_url(&attr.value());
                 } else if is_favicon(&rel) {
@@ -213,7 +213,7 @@ impl VirtualMethods for HTMLLinkElement {
                     self.handle_favicon_url(rel.as_ref().unwrap(), &attr.value(), &sizes);
                 }
             },
-            &local_name!("sizes") => {
+            local_name!("sizes") => {
                 if is_favicon(&rel) {
                     if let Some(ref href) = get_attr(self.upcast(), &local_name!("href")) {
                         self.handle_favicon_url(

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2425,17 +2425,17 @@ impl VirtualMethods for HTMLMediaElement {
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
 
-        match attr.local_name() {
-            &local_name!("muted") => {
+        match *attr.local_name() {
+            local_name!("muted") => {
                 self.SetMuted(mutation.new_value(attr).is_some());
             },
-            &local_name!("src") => {
+            local_name!("src") => {
                 if mutation.new_value(attr).is_none() {
                     return;
                 }
                 self.media_element_load_algorithm();
             },
-            &local_name!("controls") => {
+            local_name!("controls") => {
                 if mutation.new_value(attr).is_some() {
                     self.render_controls();
                 } else {

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -155,13 +155,13 @@ impl VirtualMethods for HTMLObjectElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("data") => {
+        match *attr.local_name() {
+            local_name!("data") => {
                 if let AttributeMutation::Set(_) = mutation {
                     self.process_data_url();
                 }
             },
-            &local_name!("form") => {
+            local_name!("form") => {
                 self.form_attribute_mutated(mutation);
             },
             _ => {},

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -298,8 +298,8 @@ impl VirtualMethods for HTMLOptionElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("disabled") => {
+        match *attr.local_name() {
+            local_name!("disabled") => {
                 let el = self.upcast::<Element>();
                 match mutation {
                     AttributeMutation::Set(_) => {
@@ -314,7 +314,7 @@ impl VirtualMethods for HTMLOptionElement {
                 }
                 self.update_select_validity();
             },
-            &local_name!("selected") => {
+            local_name!("selected") => {
                 match mutation {
                     AttributeMutation::Set(_) => {
                         // https://html.spec.whatwg.org/multipage/#concept-option-selectedness

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -419,12 +419,12 @@ impl VirtualMethods for HTMLSelectElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("required") => {
+        match *attr.local_name() {
+            local_name!("required") => {
                 self.validity_state()
                     .perform_validation_and_update(ValidationFlags::VALUE_MISSING);
             },
-            &local_name!("disabled") => {
+            local_name!("disabled") => {
                 let el = self.upcast::<Element>();
                 match mutation {
                     AttributeMutation::Set(_) => {
@@ -441,7 +441,7 @@ impl VirtualMethods for HTMLSelectElement {
                 self.validity_state()
                     .perform_validation_and_update(ValidationFlags::VALUE_MISSING);
             },
-            &local_name!("form") => {
+            local_name!("form") => {
                 self.form_attribute_mutated(mutation);
             },
             _ => {},

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -144,9 +144,9 @@ impl HTMLTableElement {
 
         let section =
             HTMLTableSectionElement::new(atom.clone(), None, &document_from_node(self), None);
-        match atom {
-            &local_name!("thead") => self.SetTHead(Some(&section)),
-            &local_name!("tfoot") => self.SetTFoot(Some(&section)),
+        match *atom {
+            local_name!("thead") => self.SetTHead(Some(&section)),
+            local_name!("tfoot") => self.SetTFoot(Some(&section)),
             _ => unreachable!("unexpected section type"),
         }
         .expect("unexpected section type");

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -118,18 +118,18 @@ impl Permissions {
                 // (Query, Request) Step 5.
                 let result = BluetoothPermissionResult::new(&self.global(), &status);
 
-                match &op {
+                match op {
                     // (Request) Step 6 - 8.
-                    &Operation::Request => {
+                    Operation::Request => {
                         Bluetooth::permission_request(cx, &p, &bluetooth_desc, &result)
                     },
 
                     // (Query) Step 6 - 7.
-                    &Operation::Query => {
+                    Operation::Query => {
                         Bluetooth::permission_query(cx, &p, &bluetooth_desc, &result)
                     },
 
-                    &Operation::Revoke => {
+                    Operation::Revoke => {
                         // (Revoke) Step 3.
                         let globalscope = self.global();
                         globalscope
@@ -143,8 +143,8 @@ impl Permissions {
                 }
             },
             _ => {
-                match &op {
-                    &Operation::Request => {
+                match op {
+                    Operation::Request => {
                         // (Request) Step 6.
                         Permissions::permission_request(cx, &p, &root_desc, &status);
 
@@ -153,7 +153,7 @@ impl Permissions {
                         // (Request) Step 8.
                         p.resolve_native(&status);
                     },
-                    &Operation::Query => {
+                    Operation::Query => {
                         // (Query) Step 6.
                         Permissions::permission_query(cx, &p, &root_desc, &status);
 
@@ -161,7 +161,7 @@ impl Permissions {
                         p.resolve_native(&status);
                     },
 
-                    &Operation::Revoke => {
+                    Operation::Revoke => {
                         // (Revoke) Step 3.
                         let globalscope = self.global();
                         globalscope

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -229,10 +229,7 @@ impl Promise {
     #[allow(unsafe_code)]
     pub fn is_fulfilled(&self) -> bool {
         let state = unsafe { GetPromiseState(self.promise_obj()) };
-        match state {
-            PromiseState::Rejected | PromiseState::Fulfilled => true,
-            _ => false,
-        }
+        matches!(state, PromiseState::Rejected | PromiseState::Fulfilled)
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -127,13 +127,13 @@ impl Range {
 
     /// <https://dom.spec.whatwg.org/#contained>
     fn contains(&self, node: &Node) -> bool {
-        match (
-            bp_position(node, 0, &self.start_container(), self.start_offset()),
-            bp_position(node, node.len(), &self.end_container(), self.end_offset()),
-        ) {
-            (Some(Ordering::Greater), Some(Ordering::Less)) => true,
-            _ => false,
-        }
+        matches!(
+            (
+                bp_position(node, 0, &self.start_container(), self.start_offset()),
+                bp_position(node, node.len(), &self.end_container(), self.end_offset()),
+            ),
+            (Some(Ordering::Greater), Some(Ordering::Less))
+        )
     }
 
     /// <https://dom.spec.whatwg.org/#partially-contained>

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -493,12 +493,10 @@ fn is_method(m: &ByteString) -> bool {
 
 // https://fetch.spec.whatwg.org/#forbidden-method
 fn is_forbidden_method(m: &ByteString) -> bool {
-    match m.to_lower().as_str() {
-        Some("connect") => true,
-        Some("trace") => true,
-        Some("track") => true,
-        _ => false,
-    }
+    matches!(
+        m.to_lower().as_str(),
+        Some("connect") | Some("trace") | Some("track")
+    )
 }
 
 // https://fetch.spec.whatwg.org/#cors-safelisted-method

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -112,10 +112,7 @@ impl QueuedTaskConversion for ServiceWorkerScriptMsg {
     }
 
     fn is_wake_up(&self) -> bool {
-        match self {
-            ServiceWorkerScriptMsg::WakeUp => true,
-            _ => false,
-        }
+        matches!(self, ServiceWorkerScriptMsg::WakeUp)
     }
 }
 

--- a/components/script/dom/svgsvgelement.rs
+++ b/components/script/dom/svgsvgelement.rs
@@ -81,9 +81,9 @@ impl VirtualMethods for SVGSVGElement {
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
-        match name {
-            &local_name!("width") => AttrValue::from_u32(value.into(), DEFAULT_WIDTH),
-            &local_name!("height") => AttrValue::from_u32(value.into(), DEFAULT_HEIGHT),
+        match *name {
+            local_name!("width") => AttrValue::from_u32(value.into(), DEFAULT_WIDTH),
+            local_name!("height") => AttrValue::from_u32(value.into(), DEFAULT_HEIGHT),
             _ => self
                 .super_type()
                 .unwrap()

--- a/components/script/dom/vertexarrayobject.rs
+++ b/components/script/dom/vertexarrayobject.rs
@@ -116,10 +116,7 @@ impl VertexArrayObject {
             return Err(WebGLError::InvalidValue);
         }
 
-        let is_webgl2 = match self.context.webgl_version() {
-            WebGLVersion::WebGL2 => true,
-            _ => false,
-        };
+        let is_webgl2 = matches!(self.context.webgl_version(), WebGLVersion::WebGL2);
 
         let bytes_per_component: i32 = match type_ {
             constants::BYTE | constants::UNSIGNED_BYTE => 1,

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -851,13 +851,10 @@ impl WebGLFramebuffer {
             attachment: &DomRefCell<Option<WebGLFramebufferAttachment>>,
             target: &WebGLTextureId,
         ) -> bool {
-            match *attachment.borrow() {
-                Some(WebGLFramebufferAttachment::Texture {
-                    texture: ref att_texture,
-                    ..
-                }) if att_texture.id() == *target => true,
-                _ => false,
-            }
+            matches!(*attachment.borrow(), Some(WebGLFramebufferAttachment::Texture {
+                                     texture: ref att_texture,
+                                     ..
+                                }) if att_texture.id() == *target)
         }
 
         for (attachment, name) in &attachments {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -627,17 +627,16 @@ impl WebGLRenderingContext {
     }
 
     fn validate_stencil_actions(&self, action: u32) -> bool {
-        match action {
-            0 |
-            constants::KEEP |
-            constants::REPLACE |
-            constants::INCR |
-            constants::DECR |
-            constants::INVERT |
-            constants::INCR_WRAP |
-            constants::DECR_WRAP => true,
-            _ => false,
-        }
+        matches!(
+            action,
+            0 | constants::KEEP |
+                constants::REPLACE |
+                constants::INCR |
+                constants::DECR |
+                constants::INVERT |
+                constants::INCR_WRAP |
+                constants::DECR_WRAP
+        )
     }
 
     pub fn get_image_pixels(&self, source: TexImageSource) -> Fallible<Option<TexPixels>> {
@@ -3146,23 +3145,20 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             .attachment(attachment)
         {
             Some(attachment_root) => match attachment_root {
-                WebGLFramebufferAttachmentRoot::Renderbuffer(_) => match pname {
+                WebGLFramebufferAttachmentRoot::Renderbuffer(_) => matches!(
+                    pname,
                     constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME => true,
-                    _ => false,
-                },
-                WebGLFramebufferAttachmentRoot::Texture(_) => match pname {
+                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+                ),
+                WebGLFramebufferAttachmentRoot::Texture(_) => matches!(
+                    pname,
                     constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
-                    constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
-                    constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE => true,
-                    _ => false,
-                },
+                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
+                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
+                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+                ),
             },
-            _ => match pname {
-                constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE => true,
-                _ => false,
-            },
+            _ => matches!(pname, constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE),
         };
 
         if !target_matches || !attachment_matches || !pname_matches || !bound_attachment_matches {
@@ -3212,18 +3208,18 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         // https://github.com/immersive-web/webxr/issues/862
         let target_matches = target == constants::RENDERBUFFER;
 
-        let pname_matches = match pname {
+        let pname_matches = matches!(
+            pname,
             constants::RENDERBUFFER_WIDTH |
-            constants::RENDERBUFFER_HEIGHT |
-            constants::RENDERBUFFER_INTERNAL_FORMAT |
-            constants::RENDERBUFFER_RED_SIZE |
-            constants::RENDERBUFFER_GREEN_SIZE |
-            constants::RENDERBUFFER_BLUE_SIZE |
-            constants::RENDERBUFFER_ALPHA_SIZE |
-            constants::RENDERBUFFER_DEPTH_SIZE |
-            constants::RENDERBUFFER_STENCIL_SIZE => true,
-            _ => false,
-        };
+                constants::RENDERBUFFER_HEIGHT |
+                constants::RENDERBUFFER_INTERNAL_FORMAT |
+                constants::RENDERBUFFER_RED_SIZE |
+                constants::RENDERBUFFER_GREEN_SIZE |
+                constants::RENDERBUFFER_BLUE_SIZE |
+                constants::RENDERBUFFER_ALPHA_SIZE |
+                constants::RENDERBUFFER_DEPTH_SIZE |
+                constants::RENDERBUFFER_STENCIL_SIZE
+        );
 
         if !target_matches || !pname_matches {
             self.webgl_error(InvalidEnum);

--- a/components/script/dom/webglsampler.rs
+++ b/components/script/dom/webglsampler.rs
@@ -66,10 +66,10 @@ fn validate_params(pname: u32, value: WebGLSamplerValue) -> bool {
             };
             allowed_values.contains(&value)
         },
-        WebGLSamplerValue::Float(_) => match pname {
-            constants::TEXTURE_MIN_LOD | constants::TEXTURE_MAX_LOD => true,
-            _ => false,
-        },
+        WebGLSamplerValue::Float(_) => matches!(
+            pname,
+            constants::TEXTURE_MIN_LOD | constants::TEXTURE_MAX_LOD
+        ),
     }
 }
 

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -347,12 +347,14 @@ impl WebGLTexture {
 
     pub fn is_using_linear_filtering(&self) -> bool {
         let filters = [self.min_filter.get(), self.mag_filter.get()];
-        filters.iter().any(|filter| match *filter {
-            constants::LINEAR |
-            constants::NEAREST_MIPMAP_LINEAR |
-            constants::LINEAR_MIPMAP_NEAREST |
-            constants::LINEAR_MIPMAP_LINEAR => true,
-            _ => false,
+        filters.iter().any(|filter| {
+            matches!(
+                *filter,
+                constants::LINEAR |
+                    constants::NEAREST_MIPMAP_LINEAR |
+                    constants::LINEAR_MIPMAP_NEAREST |
+                    constants::LINEAR_MIPMAP_LINEAR
+            )
         })
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2706,20 +2706,20 @@ fn debug_reflow_events(id: PipelineId, reflow_goal: &ReflowGoal, reason: &Reflow
         ReflowGoal::Full => "\tFull",
         ReflowGoal::TickAnimations => "\tTickAnimations",
         ReflowGoal::UpdateScrollNode(_) => "\tUpdateScrollNode",
-        ReflowGoal::LayoutQuery(ref query_msg, _) => match query_msg {
-            &QueryMsg::ContentBoxQuery(_n) => "\tContentBoxQuery",
-            &QueryMsg::ContentBoxesQuery(_n) => "\tContentBoxesQuery",
-            &QueryMsg::NodesFromPointQuery(..) => "\tNodesFromPointQuery",
-            &QueryMsg::ClientRectQuery(_n) => "\tClientRectQuery",
-            &QueryMsg::ScrollingAreaQuery(_n) => "\tNodeScrollGeometryQuery",
-            &QueryMsg::NodeScrollIdQuery(_n) => "\tNodeScrollIdQuery",
-            &QueryMsg::ResolvedStyleQuery(_, _, _) => "\tResolvedStyleQuery",
-            &QueryMsg::ResolvedFontStyleQuery(..) => "\nResolvedFontStyleQuery",
-            &QueryMsg::OffsetParentQuery(_n) => "\tOffsetParentQuery",
-            &QueryMsg::StyleQuery => "\tStyleQuery",
-            &QueryMsg::TextIndexQuery(..) => "\tTextIndexQuery",
-            &QueryMsg::ElementInnerTextQuery(_) => "\tElementInnerTextQuery",
-            &QueryMsg::InnerWindowDimensionsQuery(_) => "\tInnerWindowDimensionsQuery",
+        ReflowGoal::LayoutQuery(ref query_msg, _) => match *query_msg {
+            QueryMsg::ContentBoxQuery(_n) => "\tContentBoxQuery",
+            QueryMsg::ContentBoxesQuery(_n) => "\tContentBoxesQuery",
+            QueryMsg::NodesFromPointQuery(..) => "\tNodesFromPointQuery",
+            QueryMsg::ClientRectQuery(_n) => "\tClientRectQuery",
+            QueryMsg::ScrollingAreaQuery(_n) => "\tNodeScrollGeometryQuery",
+            QueryMsg::NodeScrollIdQuery(_n) => "\tNodeScrollIdQuery",
+            QueryMsg::ResolvedStyleQuery(_, _, _) => "\tResolvedStyleQuery",
+            QueryMsg::ResolvedFontStyleQuery(..) => "\nResolvedFontStyleQuery",
+            QueryMsg::OffsetParentQuery(_n) => "\tOffsetParentQuery",
+            QueryMsg::StyleQuery => "\tStyleQuery",
+            QueryMsg::TextIndexQuery(..) => "\tTextIndexQuery",
+            QueryMsg::ElementInnerTextQuery(_) => "\tElementInnerTextQuery",
+            QueryMsg::InnerWindowDimensionsQuery(_) => "\tInnerWindowDimensionsQuery",
         },
     };
 
@@ -2836,13 +2836,13 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
         NodeTypeId::Element(ElementTypeId::HTMLElement(type_)) => type_,
         _ => return false,
     };
-    match type_ {
+    matches!(
+        type_,
         HTMLElementTypeId::HTMLEmbedElement |
-        HTMLElementTypeId::HTMLFormElement |
-        HTMLElementTypeId::HTMLImageElement |
-        HTMLElementTypeId::HTMLObjectElement => true,
-        _ => false,
-    }
+            HTMLElementTypeId::HTMLFormElement |
+            HTMLElementTypeId::HTMLImageElement |
+            HTMLElementTypeId::HTMLObjectElement
+    )
 }
 
 fn is_named_element_with_id_attribute(elem: &Element) -> bool {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -345,10 +345,7 @@ impl QueuedTaskConversion for MainThreadScriptMsg {
     }
 
     fn is_wake_up(&self) -> bool {
-        match self {
-            MainThreadScriptMsg::WakeUp => true,
-            _ => false,
-        }
+        matches!(self, MainThreadScriptMsg::WakeUp)
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed the clippy warnings, by converting match to matches! and also de-referencing wherever needed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they also fix clippy warnings and no functionality changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
