### PR TITLE
clippy: Fix `collapsible_else_if` warnings in `components/script`

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -579,16 +579,14 @@ impl EventTarget {
             Some(CommonEventHandler::ErrorEventHandler(unsafe {
                 OnErrorEventHandlerNonNull::new(cx, funobj)
             }))
+        } else if ty == &atom!("beforeunload") {
+            Some(CommonEventHandler::BeforeUnloadEventHandler(unsafe {
+                OnBeforeUnloadEventHandlerNonNull::new(cx, funobj)
+            }))
         } else {
-            if ty == &atom!("beforeunload") {
-                Some(CommonEventHandler::BeforeUnloadEventHandler(unsafe {
-                    OnBeforeUnloadEventHandlerNonNull::new(cx, funobj)
-                }))
-            } else {
-                Some(CommonEventHandler::EventHandler(unsafe {
-                    EventHandlerNonNull::new(cx, funobj)
-                }))
-            }
+            Some(CommonEventHandler::EventHandler(unsafe {
+                EventHandlerNonNull::new(cx, funobj)
+            }))
         }
     }
 

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -210,10 +210,8 @@ impl GPUDevice {
                 }
             }
             self.try_remove_scope(s_id);
-        } else {
-            if let Err((err, _)) = result {
-                self.fire_uncaptured_error(err);
-            }
+        } else if let Err((err, _)) = result {
+            self.fire_uncaptured_error(err);
         }
     }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -578,17 +578,16 @@ impl HTMLFormElementMethods for HTMLFormElement {
                 } else {
                     a.source.cmp(&b.source)
                 }
+            } else if a
+                .element
+                .upcast::<Node>()
+                .CompareDocumentPosition(b.element.upcast::<Node>()) &
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+            {
+                std::cmp::Ordering::Less
             } else {
-                if a.element
-                    .upcast::<Node>()
-                    .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                    NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                    NodeConstants::DOCUMENT_POSITION_FOLLOWING
-                {
-                    std::cmp::Ordering::Less
-                } else {
-                    std::cmp::Ordering::Greater
-                }
+                std::cmp::Ordering::Greater
             }
         });
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2868,11 +2868,9 @@ fn filter_from_accept(s: &DOMString) -> Vec<FilterPattern> {
     for p in split_commas(s) {
         if let Some('.') = p.chars().nth(0) {
             filter.push(FilterPattern(p[1..].to_string()));
-        } else {
-            if let Some(exts) = mime_guess::get_mime_extensions_str(p) {
-                for ext in exts {
-                    filter.push(FilterPattern(ext.to_string()));
-                }
+        } else if let Some(exts) = mime_guess::get_mime_extensions_str(p) {
+            for ext in exts {
+                filter.push(FilterPattern(ext.to_string()));
             }
         }
     }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -167,11 +167,9 @@ impl HTMLSelectElement {
 
         if let Some(last_selected) = last_selected {
             last_selected.set_selectedness(true);
-        } else {
-            if self.display_size() == 1 {
-                if let Some(first_enabled) = first_enabled {
-                    first_enabled.set_selectedness(true);
-                }
+        } else if self.display_size() == 1 {
+            if let Some(first_enabled) = first_enabled {
+                first_enabled.set_selectedness(true);
             }
         }
     }

--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -92,12 +92,10 @@ impl StylePropertyMapReadOnlyMethods for StylePropertyMapReadOnly {
                 } else {
                     Ordering::Greater
                 }
+            } else if let Ok(_) = custom_properties::parse_name(key2) {
+                Ordering::Less
             } else {
-                if let Ok(_) = custom_properties::parse_name(key2) {
-                    Ordering::Less
-                } else {
-                    key1.cmp(key2)
-                }
+                key1.cmp(key2)
             }
         });
         result

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -82,12 +82,10 @@ impl<'dom, LayoutDataType: LayoutDataTrait> fmt::Debug for ServoLayoutNode<'dom,
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(el) = self.as_element() {
             el.fmt(f)
+        } else if self.is_text_node() {
+            write!(f, "<text node> ({:#x})", self.opaque().0)
         } else {
-            if self.is_text_node() {
-                write!(f, "<text node> ({:#x})", self.opaque().0)
-            } else {
-                write!(f, "<non-text node> ({:#x})", self.opaque().0)
-            }
+            write!(f, "<non-text node> ({:#x})", self.opaque().0)
         }
     }
 }

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -627,15 +627,13 @@ impl<T: ClipboardProvider> TextInput<T> {
             if self.selection_origin.is_none() {
                 self.selection_origin = Some(self.edit_point);
             }
-        } else {
-            if self.has_selection() {
-                self.edit_point = match adjust {
-                    Direction::Backward => self.selection_start(),
-                    Direction::Forward => self.selection_end(),
-                };
-                self.clear_selection();
-                return true;
-            }
+        } else if self.has_selection() {
+            self.edit_point = match adjust {
+                Direction::Backward => self.selection_start(),
+                Direction::Forward => self.selection_end(),
+            };
+            self.clear_selection();
+            return true;
         }
         false
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Collapse the `else { if ... }` expressions to fix the `collapsible_else_if` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
