### PR TITLE
Fix table with rows but no column

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1432,11 +1432,7 @@ impl<'a> TableLayout<'a> {
             };
         }
 
-        let fallback_size = LogicalVec2 {
-            block: self.final_table_height,
-            inline: self.assignable_width,
-        };
-        let table_and_track_dimensions = TableAndTrackDimensions::new(&self, &fallback_size);
+        let table_and_track_dimensions = TableAndTrackDimensions::new(&self);
         self.make_fragments_for_columns_and_column_groups(
             &table_and_track_dimensions,
             &mut table_fragments,
@@ -1795,12 +1791,16 @@ struct TableAndTrackDimensions {
 }
 
 impl TableAndTrackDimensions {
-    fn new(table_layout: &TableLayout, fallback_size: &LogicalVec2<Au>) -> Self {
+    fn new(table_layout: &TableLayout) -> Self {
         let border_spacing = table_layout.table.border_spacing();
+
+        // The sizes used for a dimension when that dimension has no table tracks.
+        let fallback_inline_size = table_layout.assignable_width;
+        let fallback_block_size = table_layout.final_table_height;
 
         let mut column_dimensions = Vec::new();
         let mut column_offset = if table_layout.table.size.width == 0 {
-            fallback_size.inline
+            fallback_inline_size
         } else {
             border_spacing.inline
         };
@@ -1812,7 +1812,7 @@ impl TableAndTrackDimensions {
 
         let mut row_dimensions = Vec::new();
         let mut row_offset = if table_layout.table.size.height == 0 {
-            fallback_size.block
+            fallback_block_size
         } else {
             border_spacing.block
         };
@@ -1829,8 +1829,8 @@ impl TableAndTrackDimensions {
         let table_size = &LogicalVec2 {
             inline: column_dimensions
                 .last()
-                .map_or(fallback_size.inline, |v| v.1),
-            block: row_dimensions.last().map_or(fallback_size.block, |v| v.1),
+                .map_or(fallback_inline_size, |v| v.1),
+            block: row_dimensions.last().map_or(fallback_block_size, |v| v.1),
         } - &table_start_corner;
         let table_cells_rect = LogicalRect {
             start_corner: table_start_corner,

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1423,7 +1423,7 @@ impl<'a> TableLayout<'a> {
         let mut baselines = Baselines::default();
         let mut table_fragments = Vec::new();
 
-        if self.table.size.width == 0 || self.table.size.height == 0 {
+        if self.table.size.width == 0 && self.table.size.height == 0 {
             return IndependentLayout {
                 fragments: table_fragments,
                 content_block_size: self.final_table_height,
@@ -1432,7 +1432,11 @@ impl<'a> TableLayout<'a> {
             };
         }
 
-        let table_and_track_dimensions = TableAndTrackDimensions::new(&self);
+        let fallback_size = LogicalVec2 {
+            block: self.final_table_height,
+            inline: self.assignable_width,
+        };
+        let table_and_track_dimensions = TableAndTrackDimensions::new(&self, &fallback_size);
         self.make_fragments_for_columns_and_column_groups(
             &table_and_track_dimensions,
             &mut table_fragments,
@@ -1791,11 +1795,15 @@ struct TableAndTrackDimensions {
 }
 
 impl TableAndTrackDimensions {
-    fn new(table_layout: &TableLayout) -> Self {
+    fn new(table_layout: &TableLayout, fallback_size: &LogicalVec2<Au>) -> Self {
         let border_spacing = table_layout.table.border_spacing();
 
         let mut column_dimensions = Vec::new();
-        let mut column_offset = border_spacing.inline;
+        let mut column_offset = if table_layout.table.size.width == 0 {
+            fallback_size.inline
+        } else {
+            border_spacing.inline
+        };
         for column_index in 0..table_layout.table.size.width {
             let column_size = table_layout.distributed_column_widths[column_index];
             column_dimensions.push((column_offset, column_offset + column_size));
@@ -1803,7 +1811,11 @@ impl TableAndTrackDimensions {
         }
 
         let mut row_dimensions = Vec::new();
-        let mut row_offset = border_spacing.block;
+        let mut row_offset = if table_layout.table.size.height == 0 {
+            fallback_size.block
+        } else {
+            border_spacing.block
+        };
         for row_index in 0..table_layout.table.size.height {
             let row_size = table_layout.row_sizes[row_index];
             row_dimensions.push((row_offset, row_offset + row_size));
@@ -1811,12 +1823,14 @@ impl TableAndTrackDimensions {
         }
 
         let table_start_corner = LogicalVec2 {
-            inline: column_dimensions[0].0,
-            block: row_dimensions[0].0,
+            inline: column_dimensions.first().map_or_else(Au::zero, |v| v.0),
+            block: row_dimensions.first().map_or_else(Au::zero, |v| v.0),
         };
         let table_size = &LogicalVec2 {
-            inline: column_dimensions[column_dimensions.len() - 1].1,
-            block: row_dimensions[row_dimensions.len() - 1].1,
+            inline: column_dimensions
+                .last()
+                .map_or(fallback_size.inline, |v| v.1),
+            block: row_dimensions.last().map_or(fallback_size.block, |v| v.1),
         } - &table_start_corner;
         let table_cells_rect = LogicalRect {
             start_corner: table_start_corner,

--- a/tests/wpt/meta-legacy-layout/css/css-tables/tentative/table-rows-with-zero-columns.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-tables/tentative/table-rows-with-zero-columns.html.ini
@@ -1,0 +1,36 @@
+[table-rows-with-zero-columns.html]
+  [tr 1]
+    expected: FAIL
+
+  [tr 2]
+    expected: FAIL
+
+  [tr 3]
+    expected: FAIL
+
+  [tr 4]
+    expected: FAIL
+
+  [tr 5]
+    expected: FAIL
+
+  [tr 6]
+    expected: FAIL
+
+  [tr 7]
+    expected: FAIL
+
+  [tr 8]
+    expected: FAIL
+
+  [tr 9]
+    expected: FAIL
+
+  [tr 10]
+    expected: FAIL
+
+  [tr 11]
+    expected: FAIL
+
+  [tr 12]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/baseline-table.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/baseline-table.html.ini
@@ -7,6 +7,3 @@
 
   [.container 13]
     expected: FAIL
-
-  [.container 3]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-height-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-height-redistribution.html.ini
@@ -2,37 +2,7 @@
   [table 5]
     expected: FAIL
 
-  [table 6]
-    expected: FAIL
-
-  [table 7]
-    expected: FAIL
-
-  [table 8]
-    expected: FAIL
-
-  [table 9]
-    expected: FAIL
-
-  [table 10]
-    expected: FAIL
-
   [table 11]
-    expected: FAIL
-
-  [table 12]
-    expected: FAIL
-
-  [table 13]
-    expected: FAIL
-
-  [table 14]
-    expected: FAIL
-
-  [table 15]
-    expected: FAIL
-
-  [table 16]
     expected: FAIL
 
   [table 17]
@@ -51,9 +21,6 @@
     expected: FAIL
 
   [table 22]
-    expected: FAIL
-
-  [table 23]
     expected: FAIL
 
   [table 25]

--- a/tests/wpt/tests/css/css-tables/tentative/table-rows-with-zero-columns.html
+++ b/tests/wpt/tests/css/css-tables/tentative/table-rows-with-zero-columns.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: size of table rows when the table has no columns</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10132">
+<meta name="assert" content="If a table has rows but no columns, the rows are as wide as the inner width of the table.">
+
+<style>
+#tests table {
+  box-sizing: border-box;
+  width: 60px;
+  height: 60px;
+}
+</style>
+
+<div id="log"></div>
+
+<main id="tests">
+  <table cellspacing="0">
+    <tr data-expected-width="60" data-expected-height="60"></tr>
+  </table>
+
+  <table cellspacing="0">
+    <tr data-expected-width="60" data-expected-height="30"></tr>
+    <tr data-expected-width="60" data-expected-height="30"></tr>
+  </table>
+
+  <table cellspacing="10">
+    <tr data-expected-width="60" data-expected-height="40"></tr>
+  </table>
+
+  <table cellspacing="10">
+    <tr data-expected-width="60" data-expected-height="15"></tr>
+    <tr data-expected-width="60" data-expected-height="15"></tr>
+  </table>
+
+  <table cellspacing="0" border="5">
+    <tr data-expected-width="50" data-expected-height="50"></tr>
+  </table>
+
+  <table cellspacing="0" border="5">
+    <tr data-expected-width="50" data-expected-height="25"></tr>
+    <tr data-expected-width="50" data-expected-height="25"></tr>
+  </table>
+
+  <table cellspacing="10" border="5">
+    <tr data-expected-width="50" data-expected-height="30"></tr>
+  </table>
+
+  <table cellspacing="10" border="5">
+    <tr data-expected-width="50" data-expected-height="10"></tr>
+    <tr data-expected-width="50" data-expected-height="10"></tr>
+  </table>
+</main>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout("tr");
+</script>


### PR DESCRIPTION
We weren't generating any fragment for the rows, which meant that JS APIs like clientWidth would be 0, and also outlines weren't painted.

This aligns Servo with Blink and WebKit. Gecko is broken, it distributes twice the table height among the rows.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
