### PR TITLE
clippy: Fix the `unneeded return` statement warnings in `components/script`

### DIFF
--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -153,7 +153,7 @@ unsafe extern "C" fn write_callback(
             &mut *(closure as *mut StructuredDataHolder),
         );
     }
-    return false;
+    false
 }
 
 unsafe extern "C" fn read_transfer_callback(

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -539,7 +539,7 @@ impl BluetoothMethods for Bluetooth {
         let sender = response_async(&p, self);
         self.request_bluetooth_devices(&p, &option.filters, &option.optionalServices, sender);
         //Note: Step 3 - 4. in response function, Step 5. in handle_response function.
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -109,7 +109,7 @@ impl BluetoothDevice {
             service.instance_id.clone(),
         );
         service_map.insert(service.instance_id.clone(), Dom::from_ref(&bt_service));
-        return bt_service;
+        bt_service
     }
 
     pub fn get_or_create_characteristic(
@@ -145,7 +145,7 @@ impl BluetoothDevice {
             characteristic.instance_id.clone(),
             Dom::from_ref(&bt_characteristic),
         );
-        return bt_characteristic;
+        bt_characteristic
     }
 
     pub fn is_represented_device_null(&self) -> bool {
@@ -179,7 +179,7 @@ impl BluetoothDevice {
             descriptor.instance_id.clone(),
             Dom::from_ref(&bt_descriptor),
         );
-        return bt_descriptor;
+        bt_descriptor
     }
 
     fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
@@ -288,7 +288,7 @@ impl BluetoothDeviceMethods for BluetoothDevice {
                 sender,
             ))
             .unwrap();
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-unwatchadvertisements

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -167,7 +167,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         self.get_bluetooth_thread()
             .send(BluetoothRequest::ReadValue(self.get_instance_id(), sender))
             .unwrap();
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
@@ -218,7 +218,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                 sender,
             ))
             .unwrap();
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
@@ -255,7 +255,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                 sender,
             ))
             .unwrap();
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications
@@ -274,7 +274,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
                 sender,
             ))
             .unwrap();
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-characteristiceventhandlers-oncharacteristicvaluechanged

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -122,7 +122,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         self.get_bluetooth_thread()
             .send(BluetoothRequest::ReadValue(self.get_instance_id(), sender))
             .unwrap();
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
@@ -168,7 +168,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
                 sender,
             ))
             .unwrap();
-        return p;
+        p
     }
 }
 

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -90,7 +90,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
             ))
             .unwrap();
         // Step 5: return promise.
-        return p;
+        p
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-disconnect

--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -667,10 +667,10 @@ fn resolve_uuid_name(
                             _ => unreachable!(),
                         };
                         // Step 4.
-                        return Err(Type(format!(
+                        Err(Type(format!(
                             "Invalid {} name : '{}'.\n{} {}",
                             attribute_type, dstring, UUID_ERROR_MESSAGE, error_url_message
-                        )));
+                        )))
                     },
                 }
             }

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -73,7 +73,7 @@ where
 unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) -> DOMString {
     rooted!(in(cx) let mut js_string = std::ptr::null_mut::<jsapi::JSString>());
     js_string.set(JS_ValueToSource(cx, value));
-    return jsstring_to_str(cx, *js_string);
+    jsstring_to_str(cx, *js_string)
 }
 
 #[allow(unsafe_code)]

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -49,7 +49,7 @@ impl CryptoMethods for Crypto {
         let array_type = input.get_array_type();
 
         if !is_integer_buffer(array_type) {
-            return Err(Error::TypeMismatch);
+            Err(Error::TypeMismatch)
         } else {
             let data = unsafe { input.as_mut_slice() };
             if data.len() > 65536 {

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -93,7 +93,7 @@ impl CSSStyleRuleMethods for CSSStyleRule {
     fn SelectorText(&self) -> DOMString {
         let guard = self.cssrule.shared_lock().read();
         let stylerule = self.stylerule.read_with(&guard);
-        return DOMString::from_string(stylerule.selectors.to_css_string());
+        DOMString::from_string(stylerule.selectors.to_css_string())
     }
 
     // https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3605,7 +3605,7 @@ impl Document {
 
     //TODO - default still at no-referrer
     pub fn get_referrer_policy(&self) -> Option<ReferrerPolicy> {
-        return self.referrer_policy.get();
+        self.referrer_policy.get()
     }
 
     pub fn set_target_element(&self, node: Option<&Element>) {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2407,7 +2407,7 @@ impl ElementMethods for Element {
 
         // Step 9
         let point = node.scroll_offset();
-        return point.y.abs() as f64;
+        point.y.abs() as f64
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
@@ -2503,7 +2503,7 @@ impl ElementMethods for Element {
 
         // Step 9
         let point = node.scroll_offset();
-        return point.x.abs() as f64;
+        point.x.abs() as f64
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
@@ -2595,9 +2595,9 @@ impl ElementMethods for Element {
             self.local_name().clone(),
         );
         if document_from_node(self).is_html_document() {
-            return self.serialize(ChildrenOnly(Some(qname)));
+            self.serialize(ChildrenOnly(Some(qname)))
         } else {
-            return self.xmlSerialize(XmlChildrenOnly(Some(qname)));
+            self.xmlSerialize(XmlChildrenOnly(Some(qname)))
         }
     }
 
@@ -2634,9 +2634,9 @@ impl ElementMethods for Element {
     // https://dvcs.w3.org/hg/innerhtml/raw-file/tip/index.html#widl-Element-outerHTML
     fn GetOuterHTML(&self) -> Fallible<DOMString> {
         if document_from_node(self).is_html_document() {
-            return self.serialize(IncludeNode);
+            self.serialize(IncludeNode)
         } else {
-            return self.xmlSerialize(XmlIncludeNode);
+            self.xmlSerialize(XmlIncludeNode)
         }
     }
 
@@ -2867,9 +2867,9 @@ impl ElementMethods for Element {
         match self.as_maybe_activatable() {
             Some(a) => {
                 a.enter_formal_activation_state();
-                return Ok(());
+                Ok(())
             },
-            None => return Err(Error::NotSupported),
+            None => Err(Error::NotSupported),
         }
     }
 
@@ -2879,7 +2879,7 @@ impl ElementMethods for Element {
                 a.exit_formal_activation_state();
                 return Ok(());
             },
-            None => return Err(Error::NotSupported),
+            None => Err(Error::NotSupported),
         }
     }
 
@@ -3960,7 +3960,7 @@ pub fn reflect_referrer_policy_attribute(element: &Element) -> DOMString {
             return val;
         }
     }
-    return DOMString::new();
+    DOMString::new()
 }
 
 pub(crate) fn referrer_policy_for_element(element: &Element) -> Option<ReferrerPolicy> {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -360,7 +360,7 @@ impl Event {
             }
         }
 
-        return self.status();
+        self.status()
     }
 
     pub fn status(&self) -> EventStatus {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1090,7 +1090,7 @@ impl GlobalScope {
                 }
             }
         } else {
-            return warn!("start_message_port called on a global not managing any ports.");
+            warn!("start_message_port called on a global not managing any ports.")
         }
     }
 
@@ -1111,7 +1111,7 @@ impl GlobalScope {
                 },
             };
         } else {
-            return warn!("close_message_port called on a global not managing any ports.");
+            warn!("close_message_port called on a global not managing any ports.")
         }
     }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -871,7 +871,7 @@ impl HTMLFormElement {
                 // TODO: Mail with headers
                 // https://html.spec.whatwg.org/multipage/#submit-mailto-headers
             },
-            _ => return,
+            _ => (),
         }
     }
 


### PR DESCRIPTION
Removed the unneeded return statement to reduce the number of warnings.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500.
- [X] These changes do not require tests because they only fix clippy warnings, no functionality changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
