### PR TITLE
clippy: Fix warnings about dereferencing immutable references in `components/script`

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -746,10 +746,10 @@ impl CanvasState {
                 StringOrCanvasGradientOrCanvasPattern::String(DOMString::from(result))
             },
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
-                StringOrCanvasGradientOrCanvasPattern::CanvasGradient(DomRoot::from_ref(&*gradient))
+                StringOrCanvasGradientOrCanvasPattern::CanvasGradient(DomRoot::from_ref(gradient))
             },
             CanvasFillOrStrokeStyle::Pattern(ref pattern) => {
-                StringOrCanvasGradientOrCanvasPattern::CanvasPattern(DomRoot::from_ref(&*pattern))
+                StringOrCanvasGradientOrCanvasPattern::CanvasPattern(DomRoot::from_ref(pattern))
             },
         }
     }
@@ -789,10 +789,10 @@ impl CanvasState {
                 StringOrCanvasGradientOrCanvasPattern::String(DOMString::from(result))
             },
             CanvasFillOrStrokeStyle::Gradient(ref gradient) => {
-                StringOrCanvasGradientOrCanvasPattern::CanvasGradient(DomRoot::from_ref(&*gradient))
+                StringOrCanvasGradientOrCanvasPattern::CanvasGradient(DomRoot::from_ref(gradient))
             },
             CanvasFillOrStrokeStyle::Pattern(ref pattern) => {
-                StringOrCanvasGradientOrCanvasPattern::CanvasPattern(DomRoot::from_ref(&*pattern))
+                StringOrCanvasGradientOrCanvasPattern::CanvasPattern(DomRoot::from_ref(pattern))
             },
         }
     }
@@ -1038,7 +1038,7 @@ impl CanvasState {
             None => return, // offscreen canvas doesn't have a placeholder canvas
         };
         let node = canvas.upcast::<Node>();
-        let window = window_from_node(&*canvas);
+        let window = window_from_node(canvas);
         let resolved_font_style = match window.resolved_font_style_query(node, value.to_string()) {
             Some(value) => value,
             None => return, // syntax error

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -349,7 +349,7 @@ pub fn read(
     rval: MutableHandleValue,
 ) -> Result<Vec<DomRoot<MessagePort>>, ()> {
     let cx = GlobalScope::get_cx();
-    let _ac = enter_realm(&*global);
+    let _ac = enter_realm(global);
     let mut sc_holder = StructuredDataHolder::Read {
         blobs: None,
         message_ports: None,

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -353,7 +353,7 @@ where
 {
     #[inline]
     unsafe fn trace(&self, trc: *mut JSTracer) {
-        for (k, v) in &*self {
+        for (k, v) in self {
             k.trace(trc);
             v.trace(trc);
         }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -180,7 +180,7 @@ impl Serializable for Blob {
             *blob_impls = None;
         }
 
-        let deserialized_blob = Blob::new(&*owner, blob_impl);
+        let deserialized_blob = Blob::new(owner, blob_impl);
 
         let blobs = blobs.get_or_insert_with(|| HashMap::new());
         blobs.insert(storage_key, deserialized_blob);

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -786,7 +786,7 @@ impl CustomElementReaction {
                     .iter()
                     .map(|arg| unsafe { HandleValue::from_raw(arg.handle()) })
                     .collect();
-                let _ = callback.Call_(&*element, arguments, ExceptionHandling::Report);
+                let _ = callback.Call_(element, arguments, ExceptionHandling::Report);
             },
         }
     }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -461,7 +461,7 @@ impl DedicatedWorkerGlobalScope {
 
                 {
                     let _ar = AutoWorkerReset::new(&global, worker.clone());
-                    let _ac = enter_realm(&*scope);
+                    let _ac = enter_realm(scope);
                     scope.execute_script(DOMString::from(source));
                 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1079,7 +1079,7 @@ impl Document {
             return;
         }
         self.request_focus(
-            self.GetBody().as_ref().map(|e| &*e.upcast()),
+            self.GetBody().as_ref().map(|e| e.upcast()),
             FocusType::Element,
         )
     }
@@ -1837,7 +1837,7 @@ impl Document {
 
     pub fn ime_dismissed(&self) {
         self.request_focus(
-            self.GetBody().as_ref().map(|e| &*e.upcast()),
+            self.GetBody().as_ref().map(|e| e.upcast()),
             FocusType::Element,
         )
     }
@@ -5264,7 +5264,7 @@ impl DocumentMethods for Document {
     // media element matching the given id.
     fn ServoGetMediaControls(&self, id: DOMString) -> Fallible<DomRoot<ShadowRoot>> {
         match self.media_controls.borrow().get(&*id) {
-            Some(m) => Ok(DomRoot::from_ref(&*m)),
+            Some(m) => Ok(DomRoot::from_ref(m)),
             None => Err(Error::InvalidAccess),
         }
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -240,7 +240,7 @@ impl FromStr for AdjacentPosition {
     type Err = Error;
 
     fn from_str(position: &str) -> Result<Self, Self::Err> {
-        match_ignore_ascii_case! { &*position,
+        match_ignore_ascii_case! { position,
             "beforebegin" => Ok(AdjacentPosition::BeforeBegin),
             "afterbegin"  => Ok(AdjacentPosition::AfterBegin),
             "beforeend"   => Ok(AdjacentPosition::BeforeEnd),
@@ -3346,7 +3346,7 @@ impl<'a> SelectorsElement for DomRoot<Element> {
         self.id_attribute
             .borrow()
             .as_ref()
-            .map_or(false, |atom| case_sensitivity.eq_atom(&*id, atom))
+            .map_or(false, |atom| case_sensitivity.eq_atom(id, atom))
     }
 
     fn is_part(&self, _name: &AtomIdent) -> bool {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -277,7 +277,7 @@ impl Event {
 
         // Step 5.13
         for object in event_path.iter().rev() {
-            if &**object == &*target {
+            if &**object == target {
                 self.phase.set(EventPhase::AtTarget);
             } else {
                 self.phase.set(EventPhase::Capturing);
@@ -298,7 +298,7 @@ impl Event {
 
         // Step 5.14
         for object in event_path.iter() {
-            let at_target = &**object == &*target;
+            let at_target = &**object == target;
             if at_target || self.bubbles.get() {
                 self.phase.set(if at_target {
                     EventPhase::AtTarget

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -512,7 +512,7 @@ impl EventTarget {
 
         // Step 3.8 TODO: settings objects not implemented
         let window = document.window();
-        let _ac = enter_realm(&*window);
+        let _ac = enter_realm(window);
 
         // Step 3.9
 
@@ -560,7 +560,7 @@ impl EventTarget {
         if handler.get().is_null() {
             // Step 3.7
             unsafe {
-                let ar = enter_realm(&*self);
+                let ar = enter_realm(self);
                 // FIXME(#13152): dispatch error event.
                 report_pending_exception(*cx, false, InRealm::Entered(&ar));
             }

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -124,7 +124,7 @@ impl FormDataMethods for FormData {
                 FormDatumValue::String(ref s) => {
                     FileOrUSVString::USVString(USVString(s.to_string()))
                 },
-                FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(&*b)),
+                FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(b)),
             })
     }
 
@@ -142,7 +142,7 @@ impl FormDataMethods for FormData {
                     FormDatumValue::String(ref s) => {
                         FileOrUSVString::USVString(USVString(s.to_string()))
                     },
-                    FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(&*b)),
+                    FormDatumValue::File(ref b) => FileOrUSVString::File(DomRoot::from_ref(b)),
                 })
             })
             .collect()

--- a/components/script/dom/gamepadlist.rs
+++ b/components/script/dom/gamepadlist.rs
@@ -38,7 +38,7 @@ impl GamepadList {
                 .iter()
                 .any(|g| g.gamepad_id() == gamepad.gamepad_id())
             {
-                self.list.borrow_mut().push(Dom::from_ref(&*gamepad));
+                self.list.borrow_mut().push(Dom::from_ref(gamepad));
                 // Ensure that the gamepad has the correct index
                 gamepad.update_index(self.list.borrow().len() as i32 - 1);
             }

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -443,7 +443,7 @@ fn index_of_last_non_whitespace(value: &ByteString) -> Option<usize> {
 
 // http://tools.ietf.org/html/rfc7230#section-3.2
 fn is_field_name(name: &ByteString) -> bool {
-    is_token(&*name)
+    is_token(name)
 }
 
 // https://fetch.spec.whatg.org/#concept-header-value

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -768,7 +768,7 @@ impl HTMLInputElement {
         first_with_id
             .as_ref()
             .and_then(|el| el.downcast::<HTMLDataListElement>())
-            .map(|el| DomRoot::from_ref(&*el))
+            .map(|el| DomRoot::from_ref(el))
     }
 
     // https://html.spec.whatwg.org/multipage/#suffering-from-being-missing

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -967,7 +967,7 @@ impl HTMLMediaElement {
                 if let Some(ref src_object) = *self.src_object.borrow() {
                     match src_object {
                         SrcObject::Blob(blob) => {
-                            let blob_url = URL::CreateObjectURL(&self.global(), &*blob);
+                            let blob_url = URL::CreateObjectURL(&self.global(), blob);
                             *self.blob_url.borrow_mut() =
                                 Some(ServoUrl::parse(&blob_url).expect("infallible"));
                             self.fetch_request(None, None);
@@ -1891,7 +1891,7 @@ impl HTMLMediaElement {
             .SetTextContent(Some(DOMString::from(media_controls_script)));
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(&*script.upcast::<Node>())
+            .AppendChild(script.upcast::<Node>())
         {
             warn!("Could not render media controls {:?}", e);
             return;
@@ -1911,7 +1911,7 @@ impl HTMLMediaElement {
 
         if let Err(e) = shadow_root
             .upcast::<Node>()
-            .AppendChild(&*style.upcast::<Node>())
+            .AppendChild(style.upcast::<Node>())
         {
             warn!("Could not render media controls {:?}", e);
         }
@@ -2075,9 +2075,9 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
     fn GetSrcObject(&self) -> Option<MediaStreamOrBlob> {
         match *self.src_object.borrow() {
             Some(ref src_object) => Some(match src_object {
-                SrcObject::Blob(blob) => MediaStreamOrBlob::Blob(DomRoot::from_ref(&*blob)),
+                SrcObject::Blob(blob) => MediaStreamOrBlob::Blob(DomRoot::from_ref(blob)),
                 SrcObject::MediaStream(stream) => {
-                    MediaStreamOrBlob::MediaStream(DomRoot::from_ref(&*stream))
+                    MediaStreamOrBlob::MediaStream(DomRoot::from_ref(stream))
                 },
             }),
             None => None,
@@ -2468,7 +2468,7 @@ pub trait LayoutHTMLMediaElementHelpers {
 impl LayoutHTMLMediaElementHelpers for LayoutDom<'_, HTMLMediaElement> {
     #[allow(unsafe_code)]
     fn data(self) -> HTMLMediaData {
-        let media = unsafe { &*self.unsafe_get() };
+        let media = unsafe { self.unsafe_get() };
         HTMLMediaData {
             current_frame: media.video_renderer.lock().unwrap().current_frame,
         }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -316,7 +316,7 @@ fn finish_fetching_a_classic_script(
     // Step 11, Asynchronously complete this algorithm with script,
     // which refers to step 26.6 "When the chosen algorithm asynchronously completes",
     // of https://html.spec.whatwg.org/multipage/#prepare-a-script
-    let document = document_from_node(&*elem);
+    let document = document_from_node(elem);
 
     match script_kind {
         ExternalScriptKind::Asap => document.asap_script_loaded(elem, load),

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -41,13 +41,13 @@ impl From<&WindowProxyOrMessagePortOrServiceWorker> for SrcObject {
     fn from(src_object: &WindowProxyOrMessagePortOrServiceWorker) -> SrcObject {
         match src_object {
             WindowProxyOrMessagePortOrServiceWorker::WindowProxy(blob) => {
-                SrcObject::WindowProxy(Dom::from_ref(&*blob))
+                SrcObject::WindowProxy(Dom::from_ref(blob))
             },
             WindowProxyOrMessagePortOrServiceWorker::MessagePort(stream) => {
-                SrcObject::MessagePort(Dom::from_ref(&*stream))
+                SrcObject::MessagePort(Dom::from_ref(stream))
             },
             WindowProxyOrMessagePortOrServiceWorker::ServiceWorker(stream) => {
-                SrcObject::ServiceWorker(Dom::from_ref(&*stream))
+                SrcObject::ServiceWorker(Dom::from_ref(stream))
             },
         }
     }
@@ -258,13 +258,13 @@ impl MessageEventMethods for MessageEvent {
     fn GetSource(&self) -> Option<WindowProxyOrMessagePortOrServiceWorker> {
         match &*self.source.borrow() {
             Some(SrcObject::WindowProxy(i)) => Some(
-                WindowProxyOrMessagePortOrServiceWorker::WindowProxy(DomRoot::from_ref(&*i)),
+                WindowProxyOrMessagePortOrServiceWorker::WindowProxy(DomRoot::from_ref(i)),
             ),
             Some(SrcObject::MessagePort(i)) => Some(
-                WindowProxyOrMessagePortOrServiceWorker::MessagePort(DomRoot::from_ref(&*i)),
+                WindowProxyOrMessagePortOrServiceWorker::MessagePort(DomRoot::from_ref(i)),
             ),
             Some(SrcObject::ServiceWorker(i)) => Some(
-                WindowProxyOrMessagePortOrServiceWorker::ServiceWorker(DomRoot::from_ref(&*i)),
+                WindowProxyOrMessagePortOrServiceWorker::ServiceWorker(DomRoot::from_ref(i)),
             ),
             None => None,
         }

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -251,7 +251,7 @@ impl Transferable for MessagePort {
         };
 
         let transferred_port =
-            MessagePort::new_transferred(&*owner, id, port_impl.entangled_port_id());
+            MessagePort::new_transferred(owner, id, port_impl.entangled_port_id());
         owner.track_message_port(&transferred_port, Some(port_impl));
 
         return_object.set(transferred_port.reflector().rootable().get());

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -785,7 +785,7 @@ impl Node {
     }
 
     pub fn to_trusted_node_address(&self) -> TrustedNodeAddress {
-        TrustedNodeAddress(&*self as *const Node as *const libc::c_void)
+        TrustedNodeAddress(self as *const Node as *const libc::c_void)
     }
 
     /// Returns the rendered bounding content box if the element is rendered,
@@ -1242,7 +1242,7 @@ impl Node {
 
     /// <https://dom.spec.whatwg.org/#retarget>
     pub fn retarget(&self, b: &Node) -> DomRoot<Node> {
-        let mut a = DomRoot::from_ref(&*self);
+        let mut a = DomRoot::from_ref(self);
         loop {
             // Step 1.
             let a_root = a.GetRootNode(&GetRootNodeOptions::empty());
@@ -2970,7 +2970,7 @@ impl NodeMethods for Node {
             attr2 = Some(a);
             attr2owner = a.GetOwnerElement();
             node2 = match attr2owner {
-                Some(ref e) => Some(&*e.upcast()),
+                Some(ref e) => Some(e.upcast()),
                 None => None,
             }
         }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -88,7 +88,7 @@ impl Drop for Promise {
 
 impl Promise {
     pub fn new(global: &GlobalScope) -> Rc<Promise> {
-        let realm = enter_realm(&*global);
+        let realm = enter_realm(global);
         let comp = InRealm::Entered(&realm);
         Promise::new_in_current_realm(comp)
     }
@@ -175,7 +175,7 @@ impl Promise {
         T: ToJSValConvertible,
     {
         let cx = GlobalScope::get_cx();
-        let _ac = enter_realm(&*self);
+        let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
         unsafe {
             val.to_jsval(*cx, v.handle_mut());
@@ -198,7 +198,7 @@ impl Promise {
         T: ToJSValConvertible,
     {
         let cx = GlobalScope::get_cx();
-        let _ac = enter_realm(&*self);
+        let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
         unsafe {
             val.to_jsval(*cx, v.handle_mut());
@@ -209,7 +209,7 @@ impl Promise {
     #[allow(unsafe_code)]
     pub fn reject_error(&self, error: Error) {
         let cx = GlobalScope::get_cx();
-        let _ac = enter_realm(&*self);
+        let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
         unsafe {
             error.to_jsval(*cx, &self.global(), v.handle_mut());

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -362,8 +362,7 @@ impl ServiceWorkerGlobalScope {
                     .origin(origin);
 
                 let (_url, source) =
-                    match load_whole_resource(request, &resource_threads_sender, &*global.upcast())
-                    {
+                    match load_whole_resource(request, &resource_threads_sender, global.upcast()) {
                         Err(_) => {
                             println!("error loading script {}", serialized_worker_url);
                             scope.clear_js_runtime(context_for_interrupt);
@@ -381,7 +380,7 @@ impl ServiceWorkerGlobalScope {
 
                 {
                     // TODO: use AutoWorkerReset as in dedicated worker?
-                    let _ac = enter_realm(&*scope);
+                    let _ac = enter_realm(scope);
                     scope.execute_script(DOMString::from(source));
                 }
 
@@ -445,7 +444,7 @@ impl ServiceWorkerGlobalScope {
             CommonWorker(WorkerScriptMsg::DOMMessage { data, .. }) => {
                 let scope = self.upcast::<WorkerGlobalScope>();
                 let target = self.upcast();
-                let _ac = enter_realm(&*scope);
+                let _ac = enter_realm(scope);
                 rooted!(in(*scope.get_cx()) let mut message = UndefinedValue());
                 if let Ok(ports) = structuredclone::read(scope.upcast(), data, message.handle_mut())
                 {

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -4478,7 +4478,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, WebGL2RenderingContext> {
     #[allow(unsafe_code)]
     unsafe fn canvas_data_source(self) -> HTMLCanvasDataSource {
-        let this = &*self.unsafe_get();
+        let this = self.unsafe_get();
         (*this.base.to_layout().unsafe_get()).layout_handle()
     }
 }

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -147,7 +147,7 @@ impl WebGLFramebuffer {
         context: &WebGLRenderingContext,
         size: Size2D<i32, Viewport>,
     ) -> Option<DomRoot<Self>> {
-        let framebuffer = Self::maybe_new(&*context)?;
+        let framebuffer = Self::maybe_new(context)?;
         framebuffer.size.set(Some((size.width, size.height)));
         framebuffer.status.set(constants::FRAMEBUFFER_COMPLETE);
         framebuffer.xr_session.set(Some(session));

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -830,7 +830,7 @@ impl WebGLRenderingContext {
         }
 
         if let Some(fb) = self.bound_draw_framebuffer.get() {
-            fb.invalidate_texture(&*texture);
+            fb.invalidate_texture(texture);
         }
     }
 

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -455,7 +455,7 @@ impl WorkerGlobalScope {
                     // https://github.com/servo/servo/issues/6422
                     println!("evaluate_script failed");
                     unsafe {
-                        let ar = enter_realm(&*self);
+                        let ar = enter_realm(self);
                         report_pending_exception(cx, true, InRealm::Entered(&ar));
                     }
                 }

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -58,7 +58,7 @@ impl XRInputSource {
             global,
         );
 
-        let _ac = enter_realm(&*global);
+        let _ac = enter_realm(global);
         let cx = GlobalScope::get_cx();
         unsafe {
             rooted!(in(*cx) let mut profiles = UndefinedValue());

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -80,7 +80,7 @@ impl XRInputSourcesChangeEvent {
             let event = changeevent.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
         }
-        let _ac = enter_realm(&*global);
+        let _ac = enter_realm(global);
         let cx = GlobalScope::get_cx();
         unsafe {
             rooted!(in(*cx) let mut added_val = UndefinedValue());

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -43,7 +43,7 @@ impl XRViewerPose {
         to_base: BaseTransform,
         viewer_pose: &ViewerPose,
     ) -> DomRoot<XRViewerPose> {
-        let _ac = enter_realm(&*global);
+        let _ac = enter_realm(global);
         rooted_vec!(let mut views);
         match &viewer_pose.views {
             Views::Inline => views.push(XRView::new(

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -409,7 +409,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> style::dom::TElement
             Some(None) => AtomString::default(),
             None => AtomString::from(&*self.element.get_lang_for_layout()),
         };
-        extended_filtering(&element_lang, &*value)
+        extended_filtering(&element_lang, value)
     }
 
     fn is_html_document_body_element(&self) -> bool {
@@ -585,7 +585,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ::selectors::Element
             NonTSPseudoClass::Link | NonTSPseudoClass::AnyLink => self.is_link(),
             NonTSPseudoClass::Visited => false,
 
-            NonTSPseudoClass::Lang(ref lang) => self.match_element_lang(None, &*lang),
+            NonTSPseudoClass::Lang(ref lang) => self.match_element_lang(None, lang),
 
             NonTSPseudoClass::ServoNonZeroBorder => {
                 match self

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -543,7 +543,7 @@ impl ModuleTree {
 
         if let Some(exception) = &*module_error {
             unsafe {
-                let ar = enter_realm(&*global);
+                let ar = enter_realm(global);
                 JS_SetPendingException(
                     *GlobalScope::get_cx(),
                     exception.handle(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3463,7 +3463,7 @@ impl ScriptThread {
 
     /// Reflows non-incrementally, rebuilding the entire layout tree in the process.
     fn rebuild_and_force_reflow(&self, document: &Document, reason: ReflowReason) {
-        let window = window_from_node(&*document);
+        let window = window_from_node(document);
         document.dirty_all_nodes();
         window.reflow(ReflowGoal::Full, reason);
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed the dereferencing from an immutable reference as not needed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500.
- [X] These changes do not require tests because only dereferencing is removed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
