### PR TITLE
tidy: Make sure to run WPT lints when `--all` is passed to tidy

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -799,7 +799,7 @@ def run_wpt_lints(only_changed_files: bool):
         yield (WPT_CONFIG_INI_PATH, 0, f"{WPT_CONFIG_INI_PATH} is required but was not found")
         return
 
-    if not list(FileList("./tests/wpt", only_changed_files=True, progress=False)):
+    if not list(FileList("./tests/wpt", only_changed_files=only_changed_files, progress=False)):
         print("\r ➤  Skipping WPT lint checks, because no relevant files changed.")
         return
 


### PR DESCRIPTION
This also fixes the checked in WPT manifest.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix tests on the CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
