### PR TITLE
clippy: Fix `clone_on_copy` warnings in `components/script`

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -397,7 +397,7 @@ impl Animations {
                 pipeline_id,
                 event_type,
                 node: key.node,
-                pseudo_element: key.pseudo_element.clone(),
+                pseudo_element: key.pseudo_element,
                 property_or_animation_name: transition
                     .property_animation
                     .property_id()
@@ -450,7 +450,7 @@ impl Animations {
                 pipeline_id,
                 event_type,
                 node: key.node,
-                pseudo_element: key.pseudo_element.clone(),
+                pseudo_element: key.pseudo_element,
                 property_or_animation_name: animation.name.to_string(),
                 elapsed_time,
             });

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -287,7 +287,7 @@ struct TransmitBodyPromiseHandler {
 impl Callback for TransmitBodyPromiseHandler {
     /// Step 5 of <https://fetch.spec.whatwg.org/#concept-request-transmit-body>
     fn callback(&self, cx: JSContext, v: HandleValue, _realm: InRealm) {
-        let is_done = match get_read_promise_done(cx.clone(), &v) {
+        let is_done = match get_read_promise_done(cx, &v) {
             Ok(is_done) => is_done,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
@@ -304,7 +304,7 @@ impl Callback for TransmitBodyPromiseHandler {
             return self.stream.stop_reading();
         }
 
-        let chunk = match get_read_promise_bytes(cx.clone(), &v) {
+        let chunk = match get_read_promise_bytes(cx, &v) {
             Ok(chunk) => chunk,
             Err(_) => {
                 // Step 5.5, the "otherwise" steps.
@@ -656,7 +656,7 @@ impl Callback for ConsumeBodyPromiseHandler {
             .as_ref()
             .expect("ConsumeBodyPromiseHandler has no stream in callback.");
 
-        let is_done = match get_read_promise_done(cx.clone(), &v) {
+        let is_done = match get_read_promise_done(cx, &v) {
             Ok(is_done) => is_done,
             Err(err) => {
                 stream.stop_reading();
@@ -667,9 +667,9 @@ impl Callback for ConsumeBodyPromiseHandler {
 
         if is_done {
             // When read is fulfilled with an object whose done property is true.
-            self.resolve_result_promise(cx.clone());
+            self.resolve_result_promise(cx);
         } else {
-            let chunk = match get_read_promise_bytes(cx.clone(), &v) {
+            let chunk = match get_read_promise_bytes(cx, &v) {
                 Ok(chunk) => chunk,
                 Err(err) => {
                     stream.stop_reading();

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -509,9 +509,7 @@ impl<T> Clone for Dom<T> {
     #[allow(crown::unrooted_must_root)]
     fn clone(&self) -> Self {
         assert_in_script();
-        Dom {
-            ptr: self.ptr.clone(),
-        }
+        Dom { ptr: self.ptr }
     }
 }
 

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -65,7 +65,7 @@ unsafe fn read_blob(
         &mut index as *mut u32
     ));
     let storage_key = StorageKey { index, name_space };
-    if <Blob as Serializable>::deserialize(owner, sc_holder, storage_key.clone()).is_ok() {
+    if <Blob as Serializable>::deserialize(owner, sc_holder, storage_key).is_ok() {
         let blobs = match sc_holder {
             StructuredDataHolder::Read { blobs, .. } => blobs,
             _ => panic!("Unexpected variant of StructuredDataHolder"),

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -116,7 +116,7 @@ impl Serializable for Blob {
             _ => panic!("Unexpected variant of StructuredDataHolder"),
         };
 
-        let blob_id = self.blob_id.clone();
+        let blob_id = self.blob_id;
 
         // 1. Get a clone of the blob impl.
         let blob_impl = self.global().serialize_blob(&blob_id);
@@ -126,7 +126,7 @@ impl Serializable for Blob {
 
         // 2. Store the object at a given key.
         let blobs = blob_impls.get_or_insert_with(|| HashMap::new());
-        blobs.insert(new_blob_id.clone(), blob_impl);
+        blobs.insert(new_blob_id, blob_impl);
 
         let PipelineNamespaceId(name_space) = new_blob_id.namespace_id;
         let BlobIndex(index) = new_blob_id.index;
@@ -152,10 +152,9 @@ impl Serializable for Blob {
     ) -> Result<(), ()> {
         // 1. Re-build the key for the storage location
         // of the serialized object.
-        let namespace_id = PipelineNamespaceId(storage_key.name_space.clone());
-        let index = BlobIndex(
-            NonZeroU32::new(storage_key.index.clone()).expect("Deserialized blob index is zero"),
-        );
+        let namespace_id = PipelineNamespaceId(storage_key.name_space);
+        let index =
+            BlobIndex(NonZeroU32::new(storage_key.index).expect("Deserialized blob index is zero"));
 
         let id = BlobId {
             namespace_id,
@@ -245,7 +244,7 @@ impl BlobMethods for Blob {
         let type_string =
             normalize_type_string(&content_type.unwrap_or(DOMString::from("")).to_string());
         let rel_pos = RelativePos::from_opts(start, end);
-        let blob_impl = BlobImpl::new_sliced(rel_pos, self.blob_id.clone(), type_string);
+        let blob_impl = BlobImpl::new_sliced(rel_pos, self.blob_id, type_string);
         Blob::new(&self.global(), blob_impl)
     }
 

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -85,9 +85,9 @@ impl BluetoothAdvertisingEvent {
     ) -> Fallible<DomRoot<BluetoothAdvertisingEvent>> {
         let global = window.upcast::<GlobalScope>();
         let name = init.name.clone();
-        let appearance = init.appearance.clone();
-        let txPower = init.txPower.clone();
-        let rssi = init.rssi.clone();
+        let appearance = init.appearance;
+        let txPower = init.txPower;
+        let rssi = init.rssi;
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
         Ok(BluetoothAdvertisingEvent::new(

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -257,7 +257,7 @@ impl CSSStyleDeclaration {
                     return DOMString::new();
                 }
                 let addr = node.to_trusted_node_address();
-                window_from_node(node).resolved_style_query(addr, self.pseudo.clone(), property)
+                window_from_node(node).resolved_style_query(addr, self.pseudo, property)
             },
         }
     }

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -89,7 +89,7 @@ impl DOMMatrix {
     }
 
     pub fn from_readonly(global: &GlobalScope, ro: &DOMMatrixReadOnly) -> DomRoot<Self> {
-        Self::new(global, ro.is2D(), ro.matrix().clone())
+        Self::new(global, ro.is2D(), *ro.matrix())
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrix-fromfloat32array


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove the `clone()` calls on `Copy` types to fix the `clone_on_copy` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
