### PR TITLE
clippy: Fix some warnings in `components/script/timers.rs`

### DIFF
--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -418,8 +418,8 @@ enum InternalTimerCallback {
     ),
 }
 
-impl JsTimers {
-    pub fn default() -> JsTimers {
+impl Default for JsTimers {
+    pub fn default() -> Self {
         JsTimers {
             next_timer_handle: Cell::new(JsTimerHandle(1)),
             active_timers: DomRefCell::new(HashMap::new()),

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -131,7 +131,7 @@ impl PartialEq for OneshotTimer {
 impl OneshotTimers {
     pub fn new(scheduler_chan: IpcSender<TimerSchedulerMsg>) -> OneshotTimers {
         OneshotTimers {
-            js_timers: JsTimers::new(),
+            js_timers: JsTimers::default(),
             timer_event_chan: DomRefCell::new(None),
             scheduler_chan,
             next_timer_handle: Cell::new(OneshotTimerHandle(1)),
@@ -418,14 +418,8 @@ enum InternalTimerCallback {
     ),
 }
 
-impl Default for JsTimers {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl JsTimers {
-    pub fn new() -> JsTimers {
+    pub fn default() -> JsTimers {
         JsTimers {
             next_timer_handle: Cell::new(JsTimerHandle(1)),
             active_timers: DomRefCell::new(HashMap::new()),

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -124,7 +124,7 @@ impl PartialOrd for OneshotTimer {
 impl Eq for OneshotTimer {}
 impl PartialEq for OneshotTimer {
     fn eq(&self, other: &OneshotTimer) -> bool {
-        self as *const OneshotTimer == other as *const OneshotTimer
+        std::ptr::eq(self, other)
     }
 }
 
@@ -194,7 +194,7 @@ impl OneshotTimers {
     fn is_next_timer(&self, handle: OneshotTimerHandle) -> bool {
         match self.timers.borrow().last() {
             None => false,
-            Some(ref max_timer) => max_timer.handle == handle,
+            Some(max_timer) => max_timer.handle == handle,
         }
     }
 
@@ -418,6 +418,12 @@ enum InternalTimerCallback {
     ),
 }
 
+impl Default for JsTimers {
+        fn default() -> Self {
+            Self::new()
+       }
+    }
+        |
 impl JsTimers {
     pub fn new() -> JsTimers {
         JsTimers {

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -419,7 +419,7 @@ enum InternalTimerCallback {
 }
 
 impl Default for JsTimers {
-    pub fn default() -> Self {
+    fn default() -> Self {
         JsTimers {
             next_timer_handle: Cell::new(JsTimerHandle(1)),
             active_timers: DomRefCell::new(HashMap::new()),
@@ -427,7 +427,9 @@ impl Default for JsTimers {
             min_duration: Cell::new(None),
         }
     }
+}
 
+impl JsTimers {
     // see https://html.spec.whatwg.org/multipage/#timer-initialisation-steps
     pub fn set_timeout_or_interval(
         &self,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -419,11 +419,11 @@ enum InternalTimerCallback {
 }
 
 impl Default for JsTimers {
-        fn default() -> Self {
-            Self::new()
-       }
+    fn default() -> Self {
+        Self::new()
     }
-        |
+}
+
 impl JsTimers {
     pub fn new() -> JsTimers {
         JsTimers {


### PR DESCRIPTION
Fixed clippy warnings in components/script/timers.rs

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because it doesn't change functionality

