### PR TITLE
fonts: Add support for WOFF2 and properly load web fonts from @imports

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -559,9 +559,8 @@ impl FontCacheThread {
             // Either increment the count of loading web fonts, or wait for a synchronous load.
             if let Some(ref receiver) = receiver {
                 receiver.recv().unwrap();
-            } else {
-                number_loading += 1;
             }
+            number_loading += 1;
         });
 
         number_loading
@@ -689,14 +688,18 @@ fn is_supported_web_font_source(source: &&Source) -> bool {
         FontFaceSourceFormat::Keyword(
             FontFaceSourceFormatKeyword::Truetype |
                 FontFaceSourceFormatKeyword::Opentype |
-                FontFaceSourceFormatKeyword::Woff
+                FontFaceSourceFormatKeyword::Woff |
+                FontFaceSourceFormatKeyword::Woff2
         )
     ) {
         return true;
     }
 
     if let FontFaceSourceFormat::String(string) = format_hint {
-        return string == "truetype" || string == "opentype" || string == "woff";
+        return string == "truetype" ||
+            string == "opentype" ||
+            string == "woff" ||
+            string == "woff2";
     }
 
     false

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -319,6 +319,37 @@ impl Layout for LayoutThread {
     fn current_epoch(&self) -> Epoch {
         self.epoch.get()
     }
+
+    fn load_web_fonts_from_stylesheet(&self, stylesheet: ServoArc<Stylesheet>) {
+        let guard = stylesheet.shared_lock.read();
+        self.load_all_web_fonts_from_stylesheet_with_guard(&stylesheet, &guard);
+    }
+
+    fn add_stylesheet(
+        &mut self,
+        stylesheet: ServoArc<Stylesheet>,
+        before_stylesheet: Option<ServoArc<Stylesheet>>,
+    ) {
+        let guard = stylesheet.shared_lock.read();
+        self.load_all_web_fonts_from_stylesheet_with_guard(&stylesheet, &guard);
+
+        match before_stylesheet {
+            Some(insertion_point) => self.stylist.insert_stylesheet_before(
+                DocumentStyleSheet(stylesheet.clone()),
+                DocumentStyleSheet(insertion_point),
+                &guard,
+            ),
+            None => self
+                .stylist
+                .append_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard),
+        }
+    }
+
+    fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>) {
+        let guard = stylesheet.shared_lock.read();
+        self.stylist
+            .remove_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard);
+    }
 }
 enum Request {
     FromPipeline(LayoutControlMsg),
@@ -472,10 +503,7 @@ impl LayoutThread {
             Request::FromFontCache => {
                 let _rw_data = rw_data.lock();
                 self.outstanding_web_fonts.fetch_sub(1, Ordering::SeqCst);
-                font_context::invalidate_font_caches();
-                self.script_chan
-                    .send(ConstellationControlMsg::WebFontLoaded(self.id))
-                    .unwrap();
+                self.handle_web_font_loaded();
             },
         };
     }
@@ -487,26 +515,6 @@ impl LayoutThread {
         possibly_locked_rw_data: &mut RwData<'a, 'b>,
     ) {
         match request {
-            Msg::AddStylesheet(stylesheet, before_stylesheet) => {
-                let guard = stylesheet.shared_lock.read();
-                self.handle_add_stylesheet(&stylesheet, &guard);
-
-                match before_stylesheet {
-                    Some(insertion_point) => self.stylist.insert_stylesheet_before(
-                        DocumentStyleSheet(stylesheet.clone()),
-                        DocumentStyleSheet(insertion_point),
-                        &guard,
-                    ),
-                    None => self
-                        .stylist
-                        .append_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard),
-                }
-            },
-            Msg::RemoveStylesheet(stylesheet) => {
-                let guard = stylesheet.shared_lock.read();
-                self.stylist
-                    .remove_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard);
-            },
             Msg::SetQuirksMode(mode) => self.handle_set_quirks_mode(mode),
             Msg::GetRPC(response_chan) => {
                 response_chan
@@ -606,7 +614,11 @@ impl LayoutThread {
         self.root_flow.borrow_mut().take();
     }
 
-    fn handle_add_stylesheet(&self, stylesheet: &Stylesheet, guard: &SharedRwLockReadGuard) {
+    fn load_all_web_fonts_from_stylesheet_with_guard(
+        &self,
+        stylesheet: &Stylesheet,
+        guard: &SharedRwLockReadGuard,
+    ) {
         // Find all font-face rules and notify the font cache of them.
         // GWTODO: Need to handle unloading web fonts.
         if stylesheet.is_effective_for_device(self.stylist.device(), &guard) {
@@ -618,9 +630,21 @@ impl LayoutThread {
                     &self.font_cache_sender,
                     self.debug.load_webfonts_synchronously,
                 );
-            self.outstanding_web_fonts
-                .fetch_add(newly_loading_font_count, Ordering::SeqCst);
+
+            if !self.debug.load_webfonts_synchronously {
+                self.outstanding_web_fonts
+                    .fetch_add(newly_loading_font_count, Ordering::SeqCst);
+            } else if newly_loading_font_count > 0 {
+                self.handle_web_font_loaded();
+            }
         }
+    }
+
+    fn handle_web_font_loaded(&self) {
+        font_context::invalidate_font_caches();
+        self.script_chan
+            .send(ConstellationControlMsg::WebFontLoaded(self.id))
+            .unwrap();
     }
 
     /// Sets quirks mode for the document, causing the quirks mode stylesheet to be used.
@@ -964,7 +988,10 @@ impl LayoutThread {
             for stylesheet in &ua_stylesheets.user_or_user_agent_stylesheets {
                 self.stylist
                     .append_stylesheet(stylesheet.clone(), &ua_or_user_guard);
-                self.handle_add_stylesheet(&stylesheet.0, &ua_or_user_guard);
+                self.load_all_web_fonts_from_stylesheet_with_guard(
+                    &stylesheet.0,
+                    &ua_or_user_guard,
+                );
             }
 
             if self.stylist.quirks_mode() != QuirksMode::NoQuirks {
@@ -972,7 +999,7 @@ impl LayoutThread {
                     ua_stylesheets.quirks_mode_stylesheet.clone(),
                     &ua_or_user_guard,
                 );
-                self.handle_add_stylesheet(
+                self.load_all_web_fonts_from_stylesheet_with_guard(
                     &ua_stylesheets.quirks_mode_stylesheet.0,
                     &ua_or_user_guard,
                 );

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -298,6 +298,38 @@ impl Layout for LayoutThread {
     fn current_epoch(&self) -> Epoch {
         self.epoch.get()
     }
+
+    fn load_web_fonts_from_stylesheet(&self, stylesheet: ServoArc<Stylesheet>) {
+        let guard = stylesheet.shared_lock.read();
+        self.load_all_web_fonts_from_stylesheet_with_guard(&stylesheet, &guard);
+    }
+
+    fn add_stylesheet(
+        &mut self,
+        stylesheet: ServoArc<Stylesheet>,
+        before_stylesheet: Option<ServoArc<Stylesheet>>,
+    ) {
+        let guard = stylesheet.shared_lock.read();
+        self.load_all_web_fonts_from_stylesheet_with_guard(&stylesheet, &guard);
+
+        match before_stylesheet {
+            Some(insertion_point) => self.stylist.insert_stylesheet_before(
+                DocumentStyleSheet(stylesheet.clone()),
+                DocumentStyleSheet(insertion_point),
+                &guard,
+            ),
+            None => self
+                .stylist
+                .append_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard),
+        }
+    }
+
+    fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>) {
+        // TODO(mrobinson): This should also unload web fonts from the FontCacheThread.
+        let guard = stylesheet.shared_lock.read();
+        self.stylist
+            .remove_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard);
+    }
 }
 
 enum Request {
@@ -451,10 +483,7 @@ impl LayoutThread {
             Request::FromFontCache => {
                 let _rw_data = rw_data.lock();
                 self.outstanding_web_fonts.fetch_sub(1, Ordering::SeqCst);
-                font_context::invalidate_font_caches();
-                self.script_chan
-                    .send(ConstellationControlMsg::WebFontLoaded(self.id))
-                    .unwrap();
+                self.handle_web_font_loaded();
             },
         };
     }
@@ -466,26 +495,6 @@ impl LayoutThread {
         possibly_locked_rw_data: &mut RwData<'a, 'b>,
     ) {
         match request {
-            Msg::AddStylesheet(stylesheet, before_stylesheet) => {
-                let guard = stylesheet.shared_lock.read();
-                self.handle_add_stylesheet(&stylesheet, &guard);
-
-                match before_stylesheet {
-                    Some(insertion_point) => self.stylist.insert_stylesheet_before(
-                        DocumentStyleSheet(stylesheet.clone()),
-                        DocumentStyleSheet(insertion_point),
-                        &guard,
-                    ),
-                    None => self
-                        .stylist
-                        .append_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard),
-                }
-            },
-            Msg::RemoveStylesheet(stylesheet) => {
-                let guard = stylesheet.shared_lock.read();
-                self.stylist
-                    .remove_stylesheet(DocumentStyleSheet(stylesheet.clone()), &guard);
-            },
             Msg::SetQuirksMode(mode) => self.handle_set_quirks_mode(mode),
             Msg::GetRPC(response_chan) => {
                 response_chan
@@ -542,7 +551,11 @@ impl LayoutThread {
         reports_chan.send(reports);
     }
 
-    fn handle_add_stylesheet(&self, stylesheet: &Stylesheet, guard: &SharedRwLockReadGuard) {
+    fn load_all_web_fonts_from_stylesheet_with_guard(
+        &self,
+        stylesheet: &Stylesheet,
+        guard: &SharedRwLockReadGuard,
+    ) {
         // Find all font-face rules and notify the font cache of them.
         // GWTODO: Need to handle unloading web fonts.
         if stylesheet.is_effective_for_device(self.stylist.device(), &guard) {
@@ -554,9 +567,21 @@ impl LayoutThread {
                     &self.font_cache_sender,
                     self.debug.load_webfonts_synchronously,
                 );
-            self.outstanding_web_fonts
-                .fetch_add(newly_loading_font_count, Ordering::SeqCst);
+
+            if !self.debug.load_webfonts_synchronously {
+                self.outstanding_web_fonts
+                    .fetch_add(newly_loading_font_count, Ordering::SeqCst);
+            } else if newly_loading_font_count > 0 {
+                self.handle_web_font_loaded();
+            }
         }
+    }
+
+    fn handle_web_font_loaded(&self) {
+        font_context::invalidate_font_caches();
+        self.script_chan
+            .send(ConstellationControlMsg::WebFontLoaded(self.id))
+            .unwrap();
     }
 
     /// Sets quirks mode for the document, causing the quirks mode stylesheet to be used.
@@ -656,7 +681,10 @@ impl LayoutThread {
             for stylesheet in &ua_stylesheets.user_or_user_agent_stylesheets {
                 self.stylist
                     .append_stylesheet(stylesheet.clone(), &ua_or_user_guard);
-                self.handle_add_stylesheet(&stylesheet.0, &ua_or_user_guard);
+                self.load_all_web_fonts_from_stylesheet_with_guard(
+                    &stylesheet.0,
+                    &ua_or_user_guard,
+                );
             }
 
             if self.stylist.quirks_mode() != QuirksMode::NoQuirks {
@@ -664,7 +692,7 @@ impl LayoutThread {
                     ua_stylesheets.quirks_mode_stylesheet.clone(),
                     &ua_or_user_guard,
                 );
-                self.handle_add_stylesheet(
+                self.load_all_web_fonts_from_stylesheet_with_guard(
                     &ua_stylesheets.quirks_mode_stylesheet.0,
                     &ua_or_user_guard,
                 );

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3853,10 +3853,10 @@ impl Document {
         let cloned_stylesheet = sheet.clone();
         let insertion_point2 = insertion_point.clone();
         let _ = self.window.with_layout(move |layout| {
-            layout.process(Msg::AddStylesheet(
+            layout.add_stylesheet(
                 cloned_stylesheet,
                 insertion_point2.as_ref().map(|s| s.sheet.clone()),
-            ));
+            );
         });
 
         DocumentOrShadowRoot::add_stylesheet(
@@ -3868,13 +3868,20 @@ impl Document {
         );
     }
 
+    /// Given a stylesheet, load all web fonts from it in Layout.
+    pub fn load_web_fonts_from_stylesheet(&self, stylesheet: Arc<Stylesheet>) {
+        let _ = self.window.with_layout(move |layout| {
+            layout.load_web_fonts_from_stylesheet(stylesheet);
+        });
+    }
+
     /// Remove a stylesheet owned by `owner` from the list of document sheets.
     #[allow(crown::unrooted_must_root)] // Owner needs to be rooted already necessarily.
     pub fn remove_stylesheet(&self, owner: &Element, stylesheet: &Arc<Stylesheet>) {
         let cloned_stylesheet = stylesheet.clone();
         let _ = self
             .window
-            .with_layout(|layout| layout.process(Msg::RemoveStylesheet(cloned_stylesheet)));
+            .with_layout(|layout| layout.remove_stylesheet(cloned_stylesheet));
 
         DocumentOrShadowRoot::remove_stylesheet(
             owner,

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -186,6 +186,10 @@ impl FetchResponseListener for StylesheetContext {
                         Some(&loader),
                         win.css_error_reporter(),
                     );
+
+                    // Layout knows about this stylesheet, because Stylo added it to the Stylist,
+                    // but Layout doesn't know about any new web fonts that it contains.
+                    document.load_web_fonts_from_stylesheet(stylesheet.clone());
                 },
             }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -32,8 +32,10 @@ use script_traits::{
     ConstellationControlMsg, InitialScriptState, LayoutControlMsg, LayoutMsg, LoadData,
     UntrustedNodeAddress, WebrenderIpcSender, WindowSizeData,
 };
+use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::data::ElementData;
+use style::stylesheets::Stylesheet;
 use webrender_api::ImageKey;
 
 #[derive(MallocSizeOf)]
@@ -203,6 +205,22 @@ pub trait Layout {
 
     /// The currently laid out Epoch that this Layout has finished.
     fn current_epoch(&self) -> Epoch;
+
+    /// Load all fonts from the given stylesheet, returning the number of fonts that
+    /// need to be loaded.
+    fn load_web_fonts_from_stylesheet(&self, stylesheet: ServoArc<Stylesheet>);
+
+    /// Add a stylesheet to this Layout. This will add it to the Layout's `Stylist` as well as
+    /// loading all web fonts defined in the stylesheet. The second stylesheet is the insertion
+    /// point (if it exists, the sheet needs to be inserted before it).
+    fn add_stylesheet(
+        &mut self,
+        stylesheet: ServoArc<Stylesheet>,
+        before_stylsheet: Option<ServoArc<Stylesheet>>,
+    );
+
+    /// Removes a stylesheet from the Layout.
+    fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>);
 }
 
 /// This trait is part of `script_layout_interface` because it depends on both `script_traits`

--- a/components/shared/script_layout/message.rs
+++ b/components/shared/script_layout/message.rs
@@ -9,7 +9,6 @@ use malloc_size_of_derive::MallocSizeOf;
 use msg::constellation_msg::BrowsingContextId;
 use profile_traits::mem::ReportsChan;
 use script_traits::{Painter, ScrollState, WindowSizeData};
-use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
 use servo_url::ImmutableOrigin;
 use style::animation::DocumentAnimationSet;
@@ -18,21 +17,12 @@ use style::dom::OpaqueNode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::PropertyId;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
-use style::stylesheets::Stylesheet;
 
 use crate::rpc::LayoutRPC;
 use crate::{PendingImage, TrustedNodeAddress};
 
 /// Asynchronous messages that script can send to layout.
 pub enum Msg {
-    /// Adds the given stylesheet to the document. The second stylesheet is the
-    /// insertion point (if it exists, the sheet needs to be inserted before
-    /// it).
-    AddStylesheet(ServoArc<Stylesheet>, Option<ServoArc<Stylesheet>>),
-
-    /// Removes a stylesheet from the document.
-    RemoveStylesheet(ServoArc<Stylesheet>),
-
     /// Change the quirks mode.
     SetQuirksMode(QuirksMode),
 

--- a/tests/wpt/meta-legacy-layout/css/CSS2/tables/border-collapse-dynamic-table-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/CSS2/tables/border-collapse-dynamic-table-002.xht.ini
@@ -1,3 +1,0 @@
-[border-collapse-dynamic-table-002.xht]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-001.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-002.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-003.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-004.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-004.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-005.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-005.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-006.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-006.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-007.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-007.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-008.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-extraneous-data-008.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-overlap-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-overlap-001.xht.ini
@@ -1,2 +1,0 @@
-[blocks-overlap-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-overlap-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-overlap-002.xht.ini
@@ -1,2 +1,0 @@
-[blocks-overlap-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-overlap-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/blocks-overlap-003.xht.ini
@@ -1,2 +1,0 @@
-[blocks-overlap-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/datatypes-invalid-base128-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/datatypes-invalid-base128-001.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-invalid-base128-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/datatypes-invalid-base128-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/datatypes-invalid-base128-002.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-invalid-base128-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/datatypes-invalid-base128-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/datatypes-invalid-base128-003.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-invalid-base128-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/directory-knowntags-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/directory-knowntags-001.xht.ini
@@ -1,0 +1,2 @@
+[directory-knowntags-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/directory-mismatched-tables-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/directory-mismatched-tables-001.xht.ini
@@ -1,2 +1,0 @@
-[directory-mismatched-tables-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/header-length-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/header-length-001.xht.ini
@@ -1,2 +1,0 @@
-[header-length-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/header-length-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/header-length-002.xht.ini
@@ -1,2 +1,0 @@
-[header-length-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/header-numTables-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/header-numTables-001.xht.ini
@@ -1,2 +1,0 @@
-[header-numTables-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/header-signature-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/header-signature-001.xht.ini
@@ -1,2 +1,0 @@
-[header-signature-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/header-totalsfntsize-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/header-totalsfntsize-001.xht.ini
@@ -1,0 +1,2 @@
+[header-totalsfntsize-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-bad-origlength-loca-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-bad-origlength-loca-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-bad-origlength-loca-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-bad-origlength-loca-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-bad-origlength-loca-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-bad-origlength-loca-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-brotli-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-brotli-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-brotli-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-004.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-decompressed-length-004.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-extraneous-data-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-extraneous-data-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-extraneous-data-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-bbox-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-bbox-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-bbox-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-glyf-bbox-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-bbox-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-bbox-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-glyf-bbox-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-origlength-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-origlength-001.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-origlength-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-origlength-002.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-003.xht]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-non-zero-loca-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-non-zero-loca-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-non-zero-loca-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-bad-flag-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-bad-flag-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-bad-flag-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-bad-flag-002.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-bad-flag-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-bad-flag-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-hmtx-003.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-hmtx-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-hmtx-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-hmtx-004.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/WOFF2/tabledata-transform-hmtx-004.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-hmtx-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-flexbox/nested-orthogonal-flexbox-relayout.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-flexbox/nested-orthogonal-flexbox-relayout.html.ini
@@ -1,2 +1,0 @@
-[nested-orthogonal-flexbox-relayout.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text/shaping/shaping-025.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/shaping/shaping-025.html.ini
@@ -1,0 +1,2 @@
+[shaping-025.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text/text-encoding/shaping-no-join-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/text-encoding/shaping-no-join-002.html.ini
@@ -1,2 +1,0 @@
-[shaping-no-join-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-001.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-002.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-003.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-004.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-004.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-005.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-005.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-006.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-006.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-007.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-007.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-008.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-extraneous-data-008.xht.ini
@@ -1,2 +1,0 @@
-[blocks-extraneous-data-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-overlap-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-overlap-001.xht.ini
@@ -1,2 +1,0 @@
-[blocks-overlap-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-overlap-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-overlap-002.xht.ini
@@ -1,2 +1,0 @@
-[blocks-overlap-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/blocks-overlap-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/blocks-overlap-003.xht.ini
@@ -1,2 +1,0 @@
-[blocks-overlap-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/datatypes-alt-255uint16-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/datatypes-alt-255uint16-001.xht.ini
@@ -1,0 +1,2 @@
+[datatypes-alt-255uint16-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/datatypes-invalid-base128-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/datatypes-invalid-base128-001.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-invalid-base128-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/datatypes-invalid-base128-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/datatypes-invalid-base128-002.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-invalid-base128-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/datatypes-invalid-base128-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/datatypes-invalid-base128-003.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-invalid-base128-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/directory-knowntags-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/directory-knowntags-001.xht.ini
@@ -1,0 +1,2 @@
+[directory-knowntags-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/directory-mismatched-tables-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/directory-mismatched-tables-001.xht.ini
@@ -1,2 +1,0 @@
-[directory-mismatched-tables-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/header-length-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-length-001.xht.ini
@@ -1,2 +1,0 @@
-[header-length-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/header-length-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-length-002.xht.ini
@@ -1,2 +1,0 @@
-[header-length-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/header-numTables-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-numTables-001.xht.ini
@@ -1,2 +1,0 @@
-[header-numTables-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/header-signature-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-signature-001.xht.ini
@@ -1,2 +1,0 @@
-[header-signature-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/header-totalsfntsize-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-totalsfntsize-001.xht.ini
@@ -1,0 +1,2 @@
+[header-totalsfntsize-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-bad-origlength-loca-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-bad-origlength-loca-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-bad-origlength-loca-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-bad-origlength-loca-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-bad-origlength-loca-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-bad-origlength-loca-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-brotli-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-brotli-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-brotli-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-004.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-decompressed-length-004.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-decompressed-length-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-extraneous-data-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-extraneous-data-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-extraneous-data-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-bbox-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-glyf-bbox-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-glyf-bbox-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-001.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-002.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-003.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-non-zero-loca-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-non-zero-loca-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-non-zero-loca-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-bad-flag-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-bad-flag-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-bad-flag-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-bad-flag-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-bad-flag-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-bad-flag-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-001.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-transform-hmtx-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-002.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-transform-hmtx-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-hmtx-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-004.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-004.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-hmtx-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-005.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-005.xht.ini
@@ -1,0 +1,2 @@
+[valid-005.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-006.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-006.xht.ini
@@ -1,0 +1,2 @@
+[valid-006.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-007.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-007.xht.ini
@@ -1,0 +1,2 @@
+[valid-007.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-008.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-008.xht.ini
@@ -1,0 +1,2 @@
+[valid-008.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-012.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-012.html.ini
@@ -1,0 +1,2 @@
+[shaping-012.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-013.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-013.html.ini
@@ -1,0 +1,2 @@
+[shaping-013.html]
+  expected: FAIL


### PR DESCRIPTION
This change also makes two fixes that are necessary to get WOFF2 font
tests working:

1. It adds support for loading web fonts from stylesheets included via
   @import rules.
2. It ensure that when web fonts are loaded synchronusly they invalidate
   the font cache. This led to incorrect font rendering when running
   tests before.

Fixes #31598. Fixes #16257.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31598 and fix #16257.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
