### PR TITLE
compositing: Send entire scene's scroll offsets when sending WebRender display lists

### DIFF
--- a/tests/wpt/tests/css/css-transforms/support/transform-iframe-scroll-position-contents.html
+++ b/tests/wpt/tests/css/css-transforms/support/transform-iframe-scroll-position-contents.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <title>CSS Test (Transforms): iframe scroll position</title>
+        <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+        <style>
+            html { background: red; }
+        </style>
+    </head>
+
+    <body>
+        <!-- Make a large red page with a small green and blue square that is scrolled to immediately. -->
+        <div style="position: absolute; width: 50px; height: 25px; top: 3000px; left: 3000px; background: green;"></div>
+        <div style="position: absolute; width: 50px; height: 25px; top: 3025px; left: 3000px; background: blue;"></div>
+        <div style="width: 10000px; height: 10000px;"></div>
+        <script>
+            window.scrollTo(3000, 3000);
+        </script>
+    </body>
+</html>

--- a/tests/wpt/tests/css/css-transforms/transform-iframe-scroll-position-ref.html
+++ b/tests/wpt/tests/css/css-transforms/transform-iframe-scroll-position-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): iframe scroll position</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <style>
+        #iframe {
+            border: 0;
+            width: 50px;
+            height: 50px;
+            border: solid;
+        }
+
+        #iframe div {
+            width: 25px;
+            height: 50px;
+            float: left;
+        }
+
+        .rotate {
+            transform: rotate(90deg);
+        }
+    </style>
+    <body onload="onLoad();">
+        <div id="iframe">
+            <div style="background: blue;"></div>
+            <div style="background: green;"></div>
+        </div>
+    </body>
+</html>

--- a/tests/wpt/tests/css/css-transforms/transform-iframe-scroll-position.html
+++ b/tests/wpt/tests/css/css-transforms/transform-iframe-scroll-position.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): iframe scroll position</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+    <meta name="assert" content="This test ensures that when an iframe element is transformed, the scroll position of the iframe content is preserved.">
+    <link rel="match" href="transform-iframe-scroll-position-ref.html">
+    <style>
+        iframe {
+            border: 0;
+            width: 50px;
+            height: 50px;
+            border: solid;
+        }
+
+        .rotate {
+            transform: rotate(90deg);
+        }
+    </style>
+    <body onload="onLoad();">
+        <iframe id="iframe" src="support/transform-iframe-scroll-position-contents.html"></iframe>
+        <script>
+            function onLoad() {
+                iframe.classList.toggle("rotate");
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
WebRender does not preserve spatial tree offsets when updating the
spatial tree. Updating the spatial tree of a pipeline can also
update the spatial tree of child pipelines. This change ensures that
WebRender always gets the scroll offsets of the entire scene when
modifying display lists in a way that may rebuild the spatial tree.

Fixes #31807.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31807.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
