### PR TITLE
wpt: Limit the console output sent to the intermittent tracker

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -31,6 +31,7 @@ CERTS_PATH = os.path.join(WPT_TOOLS_PATH, "certs")
 TRACKER_API = "https://build.servo.org/intermittent-tracker"
 TRACKER_API_ENV_VAR = "INTERMITTENT_TRACKER_API"
 TRACKER_DASHBOARD_SECRET_ENV_VAR = "INTERMITTENT_TRACKER_DASHBOARD_SECRET"
+TRACKER_DASHBOARD_MAXIMUM_OUTPUT_LENGTH = 1024
 
 
 def set_if_none(args: dict, key: str, value):
@@ -235,7 +236,10 @@ class TrackerDashboardFilter():
             'expected': result.expected,
             'actual': result.actual,
             'time': result.time // 1000,
-            'message': result.message,
+            # Truncate the message, to avoid issues with lots of output causing "HTTP
+            # Error 413: Request Entity Too Large."
+            # See https://github.com/servo/servo/issues/31845.
+            'message': result.message[0:TRACKER_DASHBOARD_MAXIMUM_OUTPUT_LENGTH],
             'stack': result.stack,
         }
         if isinstance(result, UnexpectedSubtestResult):


### PR DESCRIPTION
This is a speculative fix for #31845. Instead of sending all of the
output to the dashboard, send just the first 1024 characters. This value
can be adjusted in the future if it is too large or too small.

Fixes #31845.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31845.
- [x] These changes do not require tests because they just fix a CI job.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
