### PR TITLE
Ignore spaces before atomic inline for the min-content size

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2380,6 +2380,9 @@ impl<'a> ContentSizesComputation<'a> {
                     self.containing_block_writing_mode,
                 );
 
+                // For the min-content size we should wrap lines wherever is possible,
+                // so wrappable spaces shouldn't increase the length of the line,
+                // they will just be removed or hang at the end of the line.
                 self.current_line.min_content += outer.min_content;
                 self.current_line.max_content += self.pending_whitespace + outer.max_content;
                 self.pending_whitespace = Au::zero();

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2380,7 +2380,7 @@ impl<'a> ContentSizesComputation<'a> {
                     self.containing_block_writing_mode,
                 );
 
-                self.current_line.min_content += self.pending_whitespace + outer.min_content;
+                self.current_line.min_content += outer.min_content;
                 self.current_line.max_content += self.pending_whitespace + outer.max_content;
                 self.pending_whitespace = Au::zero();
                 self.had_content_yet = true;

--- a/tests/wpt/meta/css/css-tables/absolute-tables-013.html.ini
+++ b/tests/wpt/meta/css/css-tables/absolute-tables-013.html.ini
@@ -1,2 +1,0 @@
-[absolute-tables-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/absolute-tables-014.html.ini
+++ b/tests/wpt/meta/css/css-tables/absolute-tables-014.html.ini
@@ -1,2 +1,0 @@
-[absolute-tables-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/absolute-tables-015.html.ini
+++ b/tests/wpt/meta/css/css-tables/absolute-tables-015.html.ini
@@ -1,2 +1,0 @@
-[absolute-tables-015.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
For the min-content size we should wrap lines wherever is possible,
so wrappable spaces shouldn't increase the length of the line,
they will just be removed or hang at the end of the line.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
