### PR TITLE
clippy: Fix `unnecessary_lazy_evaluations` warnings in `components`

### DIFF
--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -237,7 +237,7 @@ impl FontHandleMethods for FontHandle {
             None => {
                 let bytes = template.bytes();
                 let font_file =
-                    FontFile::new_from_data(bytes).ok_or_else(|| "Could not create FontFile")?;
+                    FontFile::new_from_data(bytes).ok_or("Could not create FontFile")?;
                 let face = font_file
                     .create_face(0, dwrote::DWRITE_FONT_SIMULATIONS_NONE)
                     .map_err(|_| "Could not create FontFace")?;

--- a/components/script/dom/mediafragmentparser.rs
+++ b/components/script/dom/mediafragmentparser.rs
@@ -300,11 +300,7 @@ fn parse_hms(s: &str) -> Result<f64, ()> {
 
     let result = match vec.len() {
         1 => {
-            let secs = vec
-                .pop_front()
-                .ok_or_else(|| ())?
-                .parse::<f64>()
-                .map_err(|_| ())?;
+            let secs = vec.pop_front().ok_or(())?.parse::<f64>().map_err(|_| ())?;
 
             if secs == 0. {
                 return Err(());
@@ -318,7 +314,7 @@ fn parse_hms(s: &str) -> Result<f64, ()> {
             parse_npt_seconds(vec.pop_front().ok_or(())?)?,
         ),
         3 => hms_to_seconds(
-            vec.pop_front().ok_or_else(|| ())?.parse().map_err(|_| ())?,
+            vec.pop_front().ok_or(())?.parse().map_err(|_| ())?,
             parse_npt_minute(vec.pop_front().ok_or(())?)?,
             parse_npt_seconds(vec.pop_front().ok_or(())?)?,
         ),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Change `ok_or_else(...)` to `ok_or(...)` to fix the `unnecessary_lazy_evaluations` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
