### PR TITLE
clippy: Fix `option_map_unit_fn` warnings in `components/script`

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -126,9 +126,9 @@ impl Animations {
     pub(crate) fn cancel_animations_for_node(&self, node: &Node) {
         let mut animations = self.sets.sets.write();
         let mut cancel_animations_for = |key| {
-            animations.get_mut(&key).map(|set| {
+            if let Some(set) = animations.get_mut(&key) {
                 set.cancel_all_animations();
-            });
+            }
         };
 
         let opaque_node = node.to_opaque();

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -92,7 +92,9 @@ unsafe impl<T: CustomTraceable> CustomTraceable for DomRefCell<T> {
 
 unsafe impl<T: JSTraceable> CustomTraceable for OnceCell<T> {
     unsafe fn trace(&self, tracer: *mut JSTracer) {
-        self.get().map(|value| value.trace(tracer));
+        if let Some(value) = self.get() {
+            value.trace(tracer)
+        }
     }
 }
 

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -159,6 +159,8 @@ impl SpecificCSSRule for CSSKeyframesRule {
     }
 
     fn deparent_children(&self) {
-        self.rulelist.get().map(|list| list.deparent_all());
+        if let Some(list) = self.rulelist.get() {
+            list.deparent_all()
+        }
     }
 }

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -144,14 +144,18 @@ impl CSSRuleList {
             RulesSource::Rules(ref css_rules) => {
                 css_rules.write_with(&mut guard).remove_rule(index)?;
                 let mut dom_rules = self.dom_rules.borrow_mut();
-                dom_rules[index].get().map(|r| r.detach());
+                if let Some(r) = dom_rules[index].get() {
+                    r.detach()
+                }
                 dom_rules.remove(index);
                 Ok(())
             },
             RulesSource::Keyframes(ref kf) => {
                 // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-deleterule
                 let mut dom_rules = self.dom_rules.borrow_mut();
-                dom_rules[index].get().map(|r| r.detach());
+                if let Some(r) = dom_rules[index].get() {
+                    r.detach()
+                }
                 dom_rules.remove(index);
                 kf.write_with(&mut guard).keyframes.remove(index);
                 Ok(())
@@ -162,7 +166,9 @@ impl CSSRuleList {
     // Remove parent stylesheets from all children
     pub fn deparent_all(&self) {
         for rule in self.dom_rules.borrow().iter() {
-            rule.get().map(|r| DomRoot::upcast(r).deparent());
+            if let Some(r) = rule.get() {
+                DomRoot::upcast(r).deparent()
+            }
         }
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2832,18 +2832,20 @@ impl Activatable for HTMLInputElement {
                 // https://html.spec.whatwg.org/multipage/#submit-button-state-(type=submit):activation-behavior
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 // Check if document owner is fully active
-                self.form_owner().map(|o| {
+                if let Some(o) = self.form_owner() {
                     o.submit(
                         SubmittedFrom::NotFromForm,
                         FormSubmitter::InputElement(self),
                     )
-                });
+                }
             },
             InputType::Reset => {
                 // https://html.spec.whatwg.org/multipage/#reset-button-state-(type=reset):activation-behavior
                 // FIXME (Manishearth): support document owners (needs ability to get parent browsing context)
                 // Check if document owner is fully active
-                self.form_owner().map(|o| o.reset(ResetFrom::NotFromForm));
+                if let Some(o) = self.form_owner() {
+                    o.reset(ResetFrom::NotFromForm)
+                }
             },
             InputType::Checkbox | InputType::Radio => {
                 // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):activation-behavior

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1432,23 +1432,21 @@ impl HTMLMediaElement {
 
                             match msg {
                                 GLPlayerMsgForward::Lock(sender) => {
-                                    video_renderer
+                                    if let Some(holder) = video_renderer
                                         .lock()
                                         .unwrap()
                                         .current_frame_holder
-                                        .as_mut()
-                                        .map(|holder| {
+                                        .as_mut() {
                                             holder.lock();
                                             sender.send(holder.get()).unwrap();
-                                        });
+                                        };
                                 },
                                 GLPlayerMsgForward::Unlock() => {
-                                    video_renderer
+                                    if let Some(holder) = video_renderer
                                         .lock()
                                         .unwrap()
                                         .current_frame_holder
-                                        .as_mut()
-                                        .map(|holder| holder.unlock());
+                                        .as_mut() { holder.unlock() }
                                 },
                                 _ => (),
                             }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -485,7 +485,9 @@ impl Tokenizer {
             },
             ParseOperation::MarkScriptAlreadyStarted { node } => {
                 let script = self.get_node(&node).downcast::<HTMLScriptElement>();
-                script.map(|script| script.set_already_started(true));
+                if let Some(script) = script {
+                    script.set_already_started(true)
+                }
             },
             ParseOperation::ReparentChildren { parent, new_parent } => {
                 let parent = self.get_node(&parent);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1259,7 +1259,9 @@ impl TreeSink for Sink {
 
     fn mark_script_already_started(&mut self, node: &Dom<Node>) {
         let script = node.downcast::<HTMLScriptElement>();
-        script.map(|script| script.set_already_started(true));
+        if let Some(script) = script {
+            script.set_already_started(true)
+        }
     }
 
     fn complete_script(&mut self, node: &Dom<Node>) -> NextParserState {

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -267,10 +267,9 @@ impl WorkerMethods for Worker {
         self.terminated.set(true);
 
         // Step 3
-        self.context_for_interrupt
-            .borrow()
-            .as_ref()
-            .map(|cx| cx.request_interrupt());
+        if let Some(cx) = self.context_for_interrupt.borrow().as_ref() {
+            cx.request_interrupt()
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-worker-onmessage

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -70,9 +70,9 @@ struct DroppableField {
 impl Drop for DroppableField {
     fn drop(&mut self) {
         let worklet_id = self.worklet_id;
-        self.thread_pool.get_mut().map(|thread_pool| {
+        if let Some(thread_pool) = self.thread_pool.get_mut() {
             thread_pool.exit_worklet(worklet_id);
-        });
+        }
     }
 }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1127,13 +1127,13 @@ impl XMLHttpRequest {
                 // Part of step 13, send() (processing response)
                 // XXXManishearth handle errors, if any (substep 1)
                 // Substep 2
-                status.map(|(code, reason)| {
+                if let Some((code, reason)) = status {
                     self.status.set(code);
                     *self.status_text.borrow_mut() = ByteString::new(reason);
-                });
-                headers
-                    .as_ref()
-                    .map(|h| *self.response_headers.borrow_mut() = h.clone());
+                }
+                if let Some(h) = headers.as_ref() {
+                    *self.response_headers.borrow_mut() = h.clone();
+                }
                 {
                     let len = headers.and_then(|h| h.typed_get::<ContentLength>());
                     let mut response = self.response.borrow_mut();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Change `option.map(...)` calls to `if let Some(...)` statements to fix the `option_map_unit_fn` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#option_map_unit_fn

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
