### PR TITLE
clippy: Fix all errors in `components/script`

### DIFF
--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -114,8 +114,8 @@ impl AudioBuffer {
         proto: Option<HandleObject>,
         options: &AudioBufferOptions,
     ) -> Fallible<DomRoot<AudioBuffer>> {
-        if options.length <= 0 ||
-            options.numberOfChannels <= 0 ||
+        if options.length == 0 ||
+            options.numberOfChannels == 0 ||
             options.numberOfChannels > MAX_CHANNEL_COUNT ||
             *options.sampleRate < MIN_SAMPLE_RATE ||
             *options.sampleRate > MAX_SAMPLE_RATE

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -404,9 +404,9 @@ impl BaseAudioContextMethods for BaseAudioContext {
         length: u32,
         sample_rate: Finite<f32>,
     ) -> Fallible<DomRoot<AudioBuffer>> {
-        if number_of_channels <= 0 ||
+        if number_of_channels == 0 ||
             number_of_channels > MAX_CHANNEL_COUNT ||
-            length <= 0 ||
+            length == 0 ||
             *sample_rate <= 0.
         {
             return Err(Error::NotSupported);

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -41,7 +41,7 @@ impl<T> DomRefCell<T> {
 
     /// Borrow the contents for the purpose of script deallocation.
     ///
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::mut_from_ref)]
     pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
         assert_in_script();
         &mut *self.value.as_ptr()
@@ -49,7 +49,7 @@ impl<T> DomRefCell<T> {
 
     /// Mutably borrow a cell for layout. Ideally this would use
     /// `RefCell::try_borrow_mut_unguarded` but that doesn't exist yet.
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::mut_from_ref)]
     pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
         assert_in_layout();
         &mut *self.value.as_ptr()

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1049,9 +1049,9 @@ impl HTMLFormElement {
                     validatable
                         .validity_state()
                         .perform_validation_and_update(ValidationFlags::all());
-                    if !validatable.is_instance_validatable() {
-                        None
-                    } else if validatable.validity_state().invalid_flags().is_empty() {
+                    if !validatable.is_instance_validatable() ||
+                        validatable.validity_state().invalid_flags().is_empty()
+                    {
                         None
                     } else {
                         Some(DomRoot::from_ref(el))

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -79,8 +79,8 @@ impl OfflineAudioContext {
         sample_rate: f32,
     ) -> Fallible<DomRoot<OfflineAudioContext>> {
         if channel_count > MAX_CHANNEL_COUNT ||
-            channel_count <= 0 ||
-            length <= 0 ||
+            channel_count == 0 ||
+            length == 0 ||
             sample_rate < MIN_SAMPLE_RATE ||
             sample_rate > MAX_SAMPLE_RATE
         {

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -519,6 +519,7 @@ impl WorkerGlobalScope {
     /// Process a single event as if it were the next event
     /// in the queue for this worker event-loop.
     /// Returns a boolean indicating whether further events should be processed.
+    #[allow(unsafe_code)]
     pub fn process_event(&self, msg: CommonScriptMsg) -> bool {
         if self.is_closing() {
             return false;
@@ -528,7 +529,7 @@ impl WorkerGlobalScope {
             CommonScriptMsg::CollectReports(reports_chan) => {
                 let cx = self.get_cx();
                 let path_seg = format!("url({})", self.get_url());
-                let reports = get_reports(*cx, path_seg);
+                let reports = unsafe { get_reports(*cx, path_seg) };
                 reports_chan.send(reports);
             },
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2548,7 +2548,7 @@ impl ScriptThread {
         let path_seg = format!("url({})", urls);
 
         let mut reports = vec![];
-        reports.extend(get_reports(*self.get_cx(), path_seg));
+        reports.extend(unsafe { get_reports(*self.get_cx(), path_seg) });
         reports_chan.send(reports);
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Resolved all clippy errors:

1. Resolved Clippy error (clippy::if_same_then_else) by refactoring if statement to eliminate redundant blocks. Replaced duplicate code blocks in if and else if branches with consolidated logic.
  - https://rust-lang.github.io/rust-clippy/master/index.html#/if_same_then_else

2. Resolved Clippy error (clippy::absurd_extreme_comparisons) occurring in multiple instances across several files. Replaced comparisons involving <= 0 with == 0.
  - https://rust-lang.github.io/rust-clippy/master/index.html#/absurd_extreme_comparisons

3. Resolved Clippy error immutable borrow from immutable input
  - https://rust-lang.github.io/rust-clippy/master/index.html#/mut_from_ref
  
4. Resolved Clippy error dereference raw pointer arguments but are not marked unsafe
  - https://rust-lang.github.io/rust-clippy/master/index.html#/not_unsafe_ptr_arg_deref 
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500 

<!-- Either: -->
- [x] These changes do not require tests because they do not affect functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
