### PR TITLE
wpt: Enable tests in `/css/css-inline/baseline-source/`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
@@ -5351,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "nodrop",
  "serde",
@@ -5361,7 +5361,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5559,7 +5559,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "static_assertions",
 ]
@@ -5685,7 +5685,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 
 [[package]]
 name = "strict-num"
@@ -5722,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "lazy_static",
 ]
@@ -5789,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "darling",
  "derive_common",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "app_units",
  "bitflags 1.3.2",
@@ -6174,7 +6174,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
+source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
 dependencies = [
  "darling",
  "derive_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5063,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
@@ -5351,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "nodrop",
  "serde",
@@ -5361,7 +5361,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5559,7 +5559,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "static_assertions",
 ]
@@ -5685,7 +5685,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 
 [[package]]
 name = "strict-num"
@@ -5722,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "lazy_static",
 ]
@@ -5789,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "darling",
  "derive_common",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "app_units",
  "bitflags 1.3.2",
@@ -6174,7 +6174,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-09-01#bcdebc41b2a2222e9fa5ae6d7d1572025c32dc47"
+source = "git+https://github.com/servo/stylo?rev=refs/pull/26/head#11bf0832b412cd359f81e8f7d0e7e2665d11ab0a"
 dependencies = [
  "darling",
  "derive_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ keyboard-types = "0.6"
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
+malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head", features = ["servo"] }
 malloc_size_of_derive = "0.1"
 mime = "0.3.13"
 mime_guess = "2.0.3"
@@ -87,31 +87,31 @@ rustls = { version = "0.21.10", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
 serde = "1.0.197"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
-servo_atoms = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
-size_of_test = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
+servo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
+size_of_test = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 sparkle = "0.1.26"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
-style_traits = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
+style_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head", features = ["servo"] }
 # NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
 surfman = { version = "0.9", features = ["chains", "sm-angle", "sm-angle-default"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
-to_shmem = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+to_shmem = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
 tokio = "1"
 tokio-rustls = "0.24"
 tungstenite = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ keyboard-types = "0.6"
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head", features = ["servo"] }
+malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
 malloc_size_of_derive = "0.1"
 mime = "0.3.13"
 mime_guess = "2.0.3"
@@ -87,31 +87,31 @@ rustls = { version = "0.21.10", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
 serde = "1.0.197"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
-servo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
-size_of_test = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+servo_atoms = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+size_of_test = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 sparkle = "0.1.26"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
-style_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
+style_traits = { git = "https://github.com/servo/stylo", branch = "2023-09-01", features = ["servo"] }
 # NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
 surfman = { version = "0.9", features = ["chains", "sm-angle", "sm-angle-default"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
-to_shmem = { git = "https://github.com/servo/stylo", rev = "refs/pull/26/head" }
+to_shmem = { git = "https://github.com/servo/stylo", branch = "2023-09-01" }
 tokio = "1"
 tokio-rustls = "0.24"
 tungstenite = "0.20"

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -85,7 +85,6 @@ use style::properties::ComputedValues;
 use style::values::computed::Length;
 use style::values::generics::box_::VerticalAlignKeyword;
 use style::values::generics::text::LineHeight;
-use style::values::specified::box_::BaselineSource;
 use style::values::specified::text::{TextAlignKeyword, TextDecorationLine};
 use style::values::specified::{TextAlignLast, TextJustify};
 use style::Zero;
@@ -2144,18 +2143,13 @@ impl IndependentFormattingContext {
     /// Picks either the first or the last baseline, depending on `baseline-source`.
     /// <https://drafts.csswg.org/css-inline/#baseline-source>
     fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
-        match self.style().clone_baseline_source() {
-            BaselineSource::First => baselines.first,
-            BaselineSource::Last => baselines.last,
-            BaselineSource::Auto => {
-                if let Self::NonReplaced(non_replaced) = self {
-                    if let NonReplacedFormattingContextContents::Flow(_) = non_replaced.contents {
-                        return baselines.last;
-                    }
-                }
-                baselines.first
-            },
+        // TODO: Currently this only supports the initial `baseline-source: auto`.
+        if let Self::NonReplaced(non_replaced) = self {
+            if let NonReplacedFormattingContextContents::Flow(_) = non_replaced.contents {
+                return baselines.last;
+            }
         }
+        baselines.first
     }
 
     fn get_block_sizes_and_baseline_offset(

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -85,6 +85,7 @@ use style::properties::ComputedValues;
 use style::values::computed::Length;
 use style::values::generics::box_::VerticalAlignKeyword;
 use style::values::generics::text::LineHeight;
+use style::values::specified::box_::BaselineSource;
 use style::values::specified::text::{TextAlignKeyword, TextDecorationLine};
 use style::values::specified::{TextAlignLast, TextJustify};
 use style::Zero;
@@ -2143,13 +2144,18 @@ impl IndependentFormattingContext {
     /// Picks either the first or the last baseline, depending on `baseline-source`.
     /// <https://drafts.csswg.org/css-inline/#baseline-source>
     fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
-        // TODO: Currently this only supports the initial `baseline-source: auto`.
-        if let Self::NonReplaced(non_replaced) = self {
-            if let NonReplacedFormattingContextContents::Flow(_) = non_replaced.contents {
-                return baselines.last;
-            }
+        match self.style().clone_baseline_source() {
+            BaselineSource::First => baselines.first,
+            BaselineSource::Last => baselines.last,
+            BaselineSource::Auto => {
+                if let Self::NonReplaced(non_replaced) = self {
+                    if let NonReplacedFormattingContextContents::Flow(_) = non_replaced.contents {
+                        return baselines.last;
+                    }
+                }
+                baselines.first
+            },
         }
-        baselines.first
     }
 
     fn get_block_sizes_and_baseline_offset(

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -49,6 +49,8 @@ skip: true
     skip: true
   [css-inline]
     skip: true
+    [baseline-source]
+      skip: false
   [css-layout-api]
     skip: true
   [css-masking]

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-computed.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-computed.html.ini
@@ -1,0 +1,9 @@
+[baseline-source-computed.html]
+  [Property baseline-source value 'auto']
+    expected: FAIL
+
+  [Property baseline-source value 'first']
+    expected: FAIL
+
+  [Property baseline-source value 'last']
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-001.html.ini
@@ -1,0 +1,42 @@
+[baseline-source-first-001.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 14]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-002.html.ini
@@ -1,0 +1,60 @@
+[baseline-source-first-002.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-003.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-003.html.ini
@@ -1,0 +1,60 @@
+[baseline-source-first-003.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html.ini
@@ -1,0 +1,18 @@
+[baseline-source-first-textarea-001.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-textarea-002.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-textarea-002.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-first-textarea-002.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-textarea-003.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-first-textarea-003.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-first-textarea-003.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-001.html.ini
@@ -1,0 +1,33 @@
+[baseline-source-last-001.html]
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 14]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-002.html.ini
@@ -1,0 +1,60 @@
+[baseline-source-last-002.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-003.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-003.html.ini
@@ -1,0 +1,60 @@
+[baseline-source-last-003.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html.ini
@@ -1,0 +1,9 @@
+[baseline-source-last-textarea-001.tentative.html]
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-textarea-002.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-textarea-002.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-last-textarea-002.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-textarea-003.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-last-textarea-003.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-last-textarea-003.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-no-interpolation.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-no-interpolation.html.ini
@@ -1,0 +1,126 @@
+[baseline-source-no-interpolation.html]
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-valid.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-valid.html.ini
@@ -1,0 +1,9 @@
+[baseline-source-valid.html]
+  [e.style['baseline-source'\] = "auto" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-source'\] = "first" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-source'\] = "last" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-vertical-align.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-inline/baseline-source/baseline-source-vertical-align.html.ini
@@ -1,0 +1,3 @@
+[baseline-source-vertical-align.html]
+  [baseline-source-vertical-align]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-computed.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-computed.html.ini
@@ -1,0 +1,9 @@
+[baseline-source-computed.html]
+  [Property baseline-source value 'auto']
+    expected: FAIL
+
+  [Property baseline-source value 'first']
+    expected: FAIL
+
+  [Property baseline-source value 'last']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
@@ -1,0 +1,45 @@
+[baseline-source-first-001.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 14]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-002.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-002.html.ini
@@ -1,0 +1,57 @@
+[baseline-source-first-002.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-003.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-003.html.ini
@@ -1,0 +1,57 @@
+[baseline-source-first-003.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html.ini
@@ -1,0 +1,18 @@
+[baseline-source-first-textarea-001.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-002.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-first-textarea-002.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-003.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-003.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-first-textarea-003.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-001.html.ini
@@ -1,0 +1,39 @@
+[baseline-source-last-001.html]
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 14]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-002.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-002.html.ini
@@ -1,0 +1,57 @@
+[baseline-source-last-002.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-003.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-003.html.ini
@@ -1,0 +1,57 @@
+[baseline-source-last-003.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 15]
+    expected: FAIL
+
+  [.target > * 16]
+    expected: FAIL
+
+  [.target > * 17]
+    expected: FAIL
+
+  [.target > * 18]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 20]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 22]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-textarea-001.tentative.html.ini
@@ -1,0 +1,9 @@
+[baseline-source-last-textarea-001.tentative.html]
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-textarea-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-textarea-002.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-last-textarea-002.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-textarea-003.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-textarea-003.tentative.html.ini
@@ -1,0 +1,36 @@
+[baseline-source-last-textarea-003.tentative.html]
+  [.target > * 1]
+    expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 4]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 6]
+    expected: FAIL
+
+  [.target > * 7]
+    expected: FAIL
+
+  [.target > * 8]
+    expected: FAIL
+
+  [.target > * 9]
+    expected: FAIL
+
+  [.target > * 10]
+    expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL
+
+  [.target > * 12]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-no-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-no-interpolation.html.ini
@@ -1,0 +1,126 @@
+[baseline-source-no-interpolation.html]
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [Web Animations: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0.3) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0.5) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (0.6) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (1) should be [last\]]
+    expected: FAIL
+
+  [CSS Animations: property <baseline-source> from [initial\] to [last\] at (1.5) should be [last\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-valid.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-valid.html.ini
@@ -1,0 +1,9 @@
+[baseline-source-valid.html]
+  [e.style['baseline-source'\] = "auto" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-source'\] = "first" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-source'\] = "last" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-vertical-align.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-vertical-align.html.ini
@@ -1,0 +1,3 @@
+[baseline-source-vertical-align.html]
+  [baseline-source-vertical-align]
+    expected: FAIL


### PR DESCRIPTION
**Description**
-Tests for `baseline-source`

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31875 

addresses the  [issue](https://github.com/servo/servo/issues/31875)
