### PR TITLE
Update servo's testharnessreport

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/testharnessreport-servo.js
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/testharnessreport-servo.js
@@ -1,4 +1,9 @@
-var props = {output:%(output)d, debug: %(debug)s};
+var props = {
+    output:%(output)d,
+    timeout_multiplier: %(timeout_multiplier)s,
+    explicit_timeout: %(explicit_timeout)s,
+    debug: %(debug)s
+};
 var start_loc = document.createElement('a');
 start_loc.href = location.href;
 setup(props);


### PR DESCRIPTION
Update servo's testharnessreport to include new props as in [general testharnessreport](https://github.com/web-platform-tests/wpt/blob/d6c9b797f371f92fb23681150148e9ec81a63510/tools/wptrunner/wptrunner/testharnessreport.js#L73).

This makes `--timeout-multiplier` actually work.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31919 
- [x] These changes are tested manually with try run: https://github.com/sagudev/servo/actions/runs/8466221634 (longer times in WPT tests means we are waiting more time).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
