### PR TITLE
clippy: Fix `mem_replace_with_default` warnings in `components`

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -816,14 +816,10 @@ impl LayoutThread {
                         build_state.root_stacking_context.overflow = origin;
 
                         // We will not use build_state.iframe_sizes again, so it's safe to move it.
-                        let iframe_sizes =
-                            std::mem::replace(&mut build_state.iframe_sizes, FnvHashMap::default());
+                        let iframe_sizes = std::mem::take(&mut build_state.iframe_sizes);
                         self.update_iframe_sizes(iframe_sizes);
 
-                        rw_data.indexable_text = std::mem::replace(
-                            &mut build_state.indexable_text,
-                            IndexableText::default(),
-                        );
+                        rw_data.indexable_text = std::mem::take(&mut build_state.indexable_text);
                         rw_data.display_list = Some(build_state.to_display_list());
                     }
                 }
@@ -1186,8 +1182,7 @@ impl LayoutThread {
         reflow_result: &mut ReflowComplete,
         shared_lock: &SharedRwLock,
     ) {
-        reflow_result.pending_images =
-            std::mem::replace(&mut *context.pending_images.lock().unwrap(), vec![]);
+        reflow_result.pending_images = std::mem::take(&mut *context.pending_images.lock().unwrap());
 
         let mut root_flow = match self.root_flow.borrow().clone() {
             Some(root_flow) => root_flow,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -867,8 +867,7 @@ impl LayoutThread {
         reflow_result: &mut ReflowComplete,
         shared_lock: &SharedRwLock,
     ) {
-        reflow_result.pending_images =
-            std::mem::replace(&mut *context.pending_images.lock().unwrap(), vec![]);
+        reflow_result.pending_images = std::mem::take(&mut *context.pending_images.lock().unwrap());
 
         match *reflow_goal {
             ReflowGoal::LayoutQuery(ref querymsg, _) => match querymsg {

--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -459,7 +459,7 @@ impl Animations {
     pub(crate) fn send_pending_events(&self, window: &Window) {
         // Take all of the events here, in case sending one of these events
         // triggers adding new events by forcing a layout.
-        let events = std::mem::replace(&mut *self.pending_events.borrow_mut(), Vec::new());
+        let events = std::mem::take(&mut *self.pending_events.borrow_mut());
         if events.is_empty() {
             return;
         }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -95,10 +95,7 @@ impl CanvasRenderingContext2D {
     }
 
     pub fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
-        mem::replace(
-            &mut self.canvas_state.get_missing_image_urls().borrow_mut(),
-            vec![],
-        )
+        std::mem::take(&mut self.canvas_state.get_missing_image_urls().borrow_mut())
     }
 
     pub fn get_canvas_id(&self) -> CanvasId {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1191,8 +1191,7 @@ impl HTMLMediaElement {
     /// `fulfill_in_flight_play_promises`, to actually fulfill the promises
     /// which were taken and moved to the in-flight queue.
     fn take_pending_play_promises(&self, result: ErrorResult) {
-        let pending_play_promises =
-            mem::replace(&mut *self.pending_play_promises.borrow_mut(), vec![]);
+        let pending_play_promises = std::mem::take(&mut *self.pending_play_promises.borrow_mut());
         self.in_flight_play_promises_queue
             .borrow_mut()
             .push_back((pending_play_promises.into(), result));

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -106,7 +106,7 @@ unsafe extern "C" fn off_thread_compilation_callback(
     let final_url = context.final_url.clone();
     let script_element = context.script_element.clone();
     let script_kind = context.script_kind;
-    let script = replace(&mut context.script_text, String::new());
+    let script = std::mem::take(&mut context.script_text);
     let fetch_options = context.fetch_options.clone();
 
     // Continue with <https://html.spec.whatwg.org/multipage/#fetch-a-classic-script>

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1401,10 +1401,7 @@ impl NetworkDecoder {
 
     fn decode(&mut self, chunk: Vec<u8>) -> StrTendril {
         self.decoder.process(ByteTendril::from(&*chunk));
-        mem::replace(
-            &mut self.decoder.inner_sink_mut().output,
-            Default::default(),
-        )
+        std::mem::take(&mut self.decoder.inner_sink_mut().output)
     }
 
     fn finish(self) -> StrTendril {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Change `std::mem::replace()` code with `std::mem::take()` to fix the `mem_replace_with_default` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
