### PR TITLE
clippy: Fix `manual_map` warnings in `components/script`

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -109,10 +109,9 @@ pub fn run_worker_event_loop<T, WorkerMsg, Event>(
         + DomObject,
 {
     let scope = worker_scope.upcast::<WorkerGlobalScope>();
-    let devtools_port = match scope.from_devtools_sender() {
-        Some(_) => Some(scope.from_devtools_receiver()),
-        None => None,
-    };
+    let devtools_port = scope
+        .from_devtools_sender()
+        .map(|_| scope.from_devtools_receiver());
     let task_queue = worker_scope.task_queue();
     let event = select! {
         recv(worker_scope.control_receiver()) -> msg => worker_scope.from_control_msg(msg.unwrap()),

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3204,11 +3204,9 @@ impl<'a> SelectorsElement for DomRoot<Element> {
     }
 
     fn containing_shadow_host(&self) -> Option<Self> {
-        if let Some(shadow_root) = self.upcast::<Node>().containing_shadow_root() {
-            Some(shadow_root.Host())
-        } else {
-            None
-        }
+        self.upcast::<Node>()
+            .containing_shadow_root()
+            .map(|shadow_root| shadow_root.Host())
     }
 
     fn is_pseudo_element(&self) -> bool {

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -84,16 +84,14 @@ pub fn view<Eye>(view: &FakeXRViewInit) -> Fallible<MockViewInit<Eye>> {
     };
     let viewport = Rect::new(origin, size);
 
-    let fov = if let Some(ref fov) = view.fieldOfView {
-        Some((
+    let fov = view.fieldOfView.as_ref().map(|fov| {
+        (
             fov.leftDegrees.to_radians(),
             fov.rightDegrees.to_radians(),
             fov.upDegrees.to_radians(),
             fov.downDegrees.to_radians(),
-        ))
-    } else {
-        None
-    };
+        )
+    });
 
     Ok(MockViewInit {
         projection,

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1184,10 +1184,7 @@ impl HTMLInputElementMethods for HTMLInputElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-input-files
     fn GetFiles(&self) -> Option<DomRoot<FileList>> {
-        match self.filelist.get() {
-            Some(ref fl) => Some(fl.clone()),
-            None => None,
-        }
+        self.filelist.get().as_ref().map(|fl| fl.clone())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-input-defaultchecked

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -130,11 +130,8 @@ fn convert_culong(js: &ConstrainULong) -> Option<Constrain<u32>> {
                     max: range.parent.max,
                     ideal: range.ideal,
                 }))
-            } else if let Some(exact) = range.exact {
-                Some(Constrain::Value(exact))
             } else {
-                // the unspecified case is treated as all three being none
-                None
+                range.exact.map(Constrain::Value)
             }
         },
     }
@@ -150,11 +147,8 @@ fn convert_cdouble(js: &ConstrainDouble) -> Option<Constrain<f64>> {
                     max: range.parent.max.map(|x| *x),
                     ideal: range.ideal.map(|x| *x),
                 }))
-            } else if let Some(exact) = range.exact {
-                Some(Constrain::Value(*exact))
             } else {
-                // the unspecified case is treated as all three being none
-                None
+                range.exact.map(|exact| Constrain::Value(*exact))
             }
         },
     }

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -122,13 +122,9 @@ impl XRInputSourceMethods for XRInputSource {
 
     // https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md
     fn GetHand(&self) -> Option<DomRoot<XRHand>> {
-        if let Some(ref hand) = self.info.hand_support {
-            Some(
-                self.hand
-                    .or_init(|| XRHand::new(&self.global(), self, hand.clone())),
-            )
-        } else {
-            None
-        }
+        self.info.hand_support.as_ref().map(|hand| {
+            self.hand
+                .or_init(|| XRHand::new(&self.global(), self, hand.clone()))
+        })
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3352,10 +3352,10 @@ impl ScriptThread {
             _ => IsHTMLDocument::HTMLDocument,
         };
 
-        let referrer = match metadata.referrer {
-            Some(ref referrer) => Some(referrer.clone().into_string()),
-            None => None,
-        };
+        let referrer = metadata
+            .referrer
+            .as_ref()
+            .map(|referrer| referrer.clone().into_string());
 
         let referrer_policy = metadata
             .headers


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace `match` code with their `map` method alternatives to fix the `manual_map` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#manual_map

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
