### PR TITLE
clippy: Remove unneeded return statements

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -338,7 +338,7 @@ impl Callback for TransmitBodyPromiseRejectionHandler {
     fn callback(&self, _cx: JSContext, _v: HandleValue, _realm: InRealm) {
         // Step 5.4, the "rejection" steps.
         let _ = self.control_sender.send(BodyChunkRequest::Error);
-        return self.stream.stop_reading();
+        self.stream.stop_reading();
     }
 }
 

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -602,7 +602,7 @@ fn get_proto_id_for_new_target(new_target: HandleObject) -> Option<PrototypeList
             let dom_class = &(*domjsclass).dom_class;
             return Some(dom_class.interface_chain[dom_class.depth as usize]);
         }
-        return None;
+        None
     }
 }
 
@@ -698,6 +698,6 @@ pub fn get_desired_proto(
         }
 
         maybe_wrap_object(*cx, desired_proto);
-        return Ok(());
+        Ok(())
     }
 }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -448,7 +448,7 @@ impl DOMString {
                 return Some(val);
             }
         }
-        return None;
+        None
     }
 
     /// <https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number>

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -107,7 +107,7 @@ unsafe fn write_blob(
         "Writing structured data for a blob failed in {:?}.",
         owner.get_url()
     );
-    return false;
+    false
 }
 
 unsafe extern "C" fn read_callback(
@@ -134,7 +134,7 @@ unsafe extern "C" fn read_callback(
             &mut *(closure as *mut StructuredDataHolder),
         );
     }
-    return ptr::null_mut();
+    ptr::null_mut()
 }
 
 unsafe extern "C" fn write_callback(

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -330,7 +330,7 @@ where
             sender,
         ))
         .unwrap();
-    return p;
+    p
 }
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothlescanfilterinit-canonicalizing

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2878,7 +2878,7 @@ impl ElementMethods for Element {
         match self.as_maybe_activatable() {
             Some(a) => {
                 a.exit_formal_activation_state();
-                return Ok(());
+                Ok(())
             },
             None => Err(Error::NotSupported),
         }

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -286,11 +286,7 @@ impl Gamepad {
 /// <https://www.w3.org/TR/gamepad/#dfn-gamepad-user-gesture>
 pub fn contains_user_gesture(update_type: GamepadUpdateType) -> bool {
     match update_type {
-        GamepadUpdateType::Axis(_, value) => {
-            return value.abs() > AXIS_TILT_THRESHOLD;
-        },
-        GamepadUpdateType::Button(_, value) => {
-            return value > BUTTON_PRESS_THRESHOLD;
-        },
-    };
+        GamepadUpdateType::Axis(_, value) => value.abs() > AXIS_TILT_THRESHOLD,
+        GamepadUpdateType::Button(_, value) => value > BUTTON_PRESS_THRESHOLD,
+    }
 }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1143,7 +1143,7 @@ impl GlobalScope {
                 );
             }
         } else {
-            return warn!("post_messageport_msg called on a global not managing any ports.");
+            warn!("post_messageport_msg called on a global not managing any ports.");
         }
     }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -800,7 +800,7 @@ where
                 }
             },
         }
-        return false;
+        false
     }
 
     fn receive_messages(&mut self) {

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -336,7 +336,7 @@ impl Minibrowser {
     ) -> bool {
         let need_update = browser.load_status() != self.load_status;
         self.load_status = browser.load_status();
-        return need_update;
+        need_update
     }
 
     /// Updates all fields taken from the given [WebViewManager], such as the location field.
@@ -349,6 +349,6 @@ impl Minibrowser {
         //       because logical OR would short-circuit if any of the functions return true.
         //       We want to ensure that all functions are called. The "bitwise OR" operator
         //       does not short-circuit.
-        return self.update_location_in_toolbar(browser) | self.update_spinner_in_toolbar(browser);
+        self.update_location_in_toolbar(browser) | self.update_spinner_in_toolbar(browser)
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed unneeded return statements across project, that were causing needless_return warnings
- https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
<!-- Either: -->
- [x] These changes do not require tests because they do not affect functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
