### PR TITLE
clippy: refactor struct literals to use shorthands

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -230,7 +230,7 @@ impl DerefMut for ScriptReflowResult {
 impl ScriptReflowResult {
     fn new(script_reflow: ScriptReflow) -> ScriptReflowResult {
         ScriptReflowResult {
-            script_reflow: script_reflow,
+            script_reflow,
             result: RefCell::new(Some(Default::default())),
         }
     }
@@ -470,7 +470,7 @@ impl LayoutThread {
                 registered_speculative_painters: &self.registered_painters,
                 current_time_for_animations: animation_timeline_value,
                 traversal_flags,
-                snapshot_map: snapshot_map,
+                snapshot_map,
             },
             image_cache: self.image_cache.clone(),
             font_cache_thread: Mutex::new(self.font_cache_thread.clone()),
@@ -784,9 +784,7 @@ impl LayoutThread {
 
                 layout_root.mut_base().clip = data.page_clip_rect;
 
-                let traversal = ComputeStackingRelativePositions {
-                    layout_context: layout_context,
-                };
+                let traversal = ComputeStackingRelativePositions { layout_context };
                 traversal.traverse(layout_root);
 
                 if layout_root
@@ -1676,8 +1674,8 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
 
     Ok(UserAgentStylesheets {
         shared_lock: shared_lock.clone(),
-        user_or_user_agent_stylesheets: user_or_user_agent_stylesheets,
-        quirks_mode_stylesheet: quirks_mode_stylesheet,
+        user_or_user_agent_stylesheets,
+        quirks_mode_stylesheet,
     })
 }
 

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -209,7 +209,7 @@ impl DerefMut for ScriptReflowResult {
 impl ScriptReflowResult {
     fn new(script_reflow: ScriptReflow) -> ScriptReflowResult {
         ScriptReflowResult {
-            script_reflow: script_reflow,
+            script_reflow,
             result: RefCell::new(Some(Default::default())),
         }
     }
@@ -416,7 +416,7 @@ impl LayoutThread {
                 inner_window_dimensions_response: None,
             })),
             webrender_image_cache: Default::default(),
-            paint_time_metrics: paint_time_metrics,
+            paint_time_metrics,
             last_iframe_sizes: Default::default(),
             debug: opts::get().debug.clone(),
         }
@@ -450,7 +450,7 @@ impl LayoutThread {
                 registered_speculative_painters: &self.registered_painters,
                 current_time_for_animations: animation_timeline_value,
                 traversal_flags,
-                snapshot_map: snapshot_map,
+                snapshot_map,
             },
             image_cache: self.image_cache.clone(),
             font_cache_thread: Mutex::new(self.font_cache_thread.clone()),
@@ -1291,8 +1291,8 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
 
     Ok(UserAgentStylesheets {
         shared_lock: shared_lock.clone(),
-        user_or_user_agent_stylesheets: user_or_user_agent_stylesheets,
-        quirks_mode_stylesheet: quirks_mode_stylesheet,
+        user_or_user_agent_stylesheets,
+        quirks_mode_stylesheet,
     })
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -187,9 +187,7 @@ struct RenderNotifier {
 
 impl RenderNotifier {
     pub fn new(compositor_proxy: CompositorProxy) -> RenderNotifier {
-        RenderNotifier {
-            compositor_proxy: compositor_proxy,
-        }
+        RenderNotifier { compositor_proxy }
     }
 }
 
@@ -338,7 +336,7 @@ where
                     use_optimized_shaders: true,
                     resource_override_path: opts.shaders_dir.clone(),
                     enable_aa: !opts.debug.disable_text_antialiasing,
-                    debug_flags: debug_flags,
+                    debug_flags,
                     precache_flags: if opts.debug.precache_shaders {
                         ShaderPrecacheFlags::FULL_COMPILE
                     } else {
@@ -461,8 +459,8 @@ where
                 sender: compositor_proxy,
                 receiver: compositor_receiver,
                 constellation_chan: constellation_chan.clone(),
-                time_profiler_chan: time_profiler_chan,
-                mem_profiler_chan: mem_profiler_chan,
+                time_profiler_chan,
+                mem_profiler_chan,
                 webrender,
                 webrender_document,
                 webrender_api,
@@ -477,9 +475,9 @@ where
         );
 
         let servo = Servo {
-            compositor: compositor,
-            constellation_chan: constellation_chan,
-            embedder_receiver: embedder_receiver,
+            compositor,
+            constellation_chan,
+            embedder_receiver,
             messages_for_embedder: Vec::new(),
             profiler_enabled: false,
             _js_engine_setup: js_engine_setup,
@@ -901,10 +899,10 @@ fn create_embedder_channel(
     let (sender, receiver) = unbounded();
     (
         EmbedderProxy {
-            sender: sender,
-            event_loop_waker: event_loop_waker,
+            sender,
+            event_loop_waker,
         },
-        EmbedderReceiver { receiver: receiver },
+        EmbedderReceiver { receiver },
     )
 }
 
@@ -914,10 +912,10 @@ fn create_compositor_channel(
     let (sender, receiver) = unbounded();
     (
         CompositorProxy {
-            sender: sender,
-            event_loop_waker: event_loop_waker,
+            sender,
+            event_loop_waker,
         },
-        CompositorReceiver { receiver: receiver },
+        CompositorReceiver { receiver },
     )
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed redundant field names warnings 
- https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_field_names

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500 

<!-- Either: -->
- [x] These changes do not require tests because they do not affect functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
