### PR TITLE
fix: Remove unused imports in `components/script/dom`

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::mem;
-
 use canvas_traits::canvas::{Canvas2dMsg, CanvasId, CanvasMsg};
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -6,7 +6,6 @@ use core::ffi::c_void;
 use std::cell::Cell;
 use std::fs::{create_dir_all, read_to_string, File};
 use std::io::{Read, Seek, Write};
-use std::mem::replace;
 use std::path::PathBuf;
 use std::process::Command;
 use std::ptr;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed compile warnings related to unused imports

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31927 
<!-- Either: -->
- [x] These changes do not require tests because they do not affect functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
