### PR TITLE
Obey `white-space: pre-wrap` when intrinsically sizing an IFC

### DIFF
--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-003.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-003.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-004.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-004.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-013.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-013.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-014.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-014.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-014.html]
-  expected: FAIL


### PR DESCRIPTION
It was being treated like `pre`, but it allows wrapping lines.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
