### PR TITLE
clippy: Fix `needless_lifetimes` warnings in `components`

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -509,10 +509,10 @@ impl LayoutThread {
     }
 
     /// Receives and dispatches messages from other threads.
-    fn handle_request_helper<'a, 'b>(
+    fn handle_request_helper(
         &mut self,
         request: Msg,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         match request {
             Msg::SetQuirksMode(mode) => self.handle_set_quirks_mode(mode),
@@ -561,10 +561,10 @@ impl LayoutThread {
         }
     }
 
-    fn collect_reports<'a, 'b>(
+    fn collect_reports(
         &self,
         reports_chan: ReportsChan,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         let mut reports = vec![];
         // Servo uses vanilla jemalloc, which doesn't have a
@@ -873,10 +873,10 @@ impl LayoutThread {
     }
 
     /// The high-level routine that performs layout.
-    fn handle_reflow<'a, 'b>(
+    fn handle_reflow(
         &mut self,
         data: &mut ScriptReflowResult,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         let document = unsafe { ServoLayoutNode::new(&data.document) };
         let document = document.as_document().unwrap();
@@ -1289,10 +1289,10 @@ impl LayoutThread {
         );
     }
 
-    fn set_scroll_states<'a, 'b>(
+    fn set_scroll_states(
         &mut self,
         new_scroll_states: Vec<ScrollState>,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         let mut rw_data = possibly_locked_rw_data.lock();
         let mut script_scroll_states = vec![];

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -489,10 +489,10 @@ impl LayoutThread {
     }
 
     /// Receives and dispatches messages from other threads.
-    fn handle_request_helper<'a, 'b>(
+    fn handle_request_helper(
         &mut self,
         request: Msg,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         match request {
             Msg::SetQuirksMode(mode) => self.handle_set_quirks_mode(mode),
@@ -522,10 +522,10 @@ impl LayoutThread {
         }
     }
 
-    fn collect_reports<'a, 'b>(
+    fn collect_reports(
         &self,
         reports_chan: ReportsChan,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         let mut reports = vec![];
         // Servo uses vanilla jemalloc, which doesn't have a
@@ -590,10 +590,10 @@ impl LayoutThread {
     }
 
     /// The high-level routine that performs layout.
-    fn handle_reflow<'a, 'b>(
+    fn handle_reflow(
         &mut self,
         data: &mut ScriptReflowResult,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         let document = unsafe { ServoLayoutNode::<DOMLayoutData>::new(&data.document) };
         let document = document.as_document().unwrap();
@@ -976,10 +976,10 @@ impl LayoutThread {
         );
     }
 
-    fn set_scroll_states<'a, 'b>(
+    fn set_scroll_states(
         &mut self,
         new_scroll_states: Vec<ScrollState>,
-        possibly_locked_rw_data: &mut RwData<'a, 'b>,
+        possibly_locked_rw_data: &mut RwData<'_, '_>,
     ) {
         let mut rw_data = possibly_locked_rw_data.lock();
         let mut script_scroll_states = vec![];

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -88,7 +88,7 @@ unsafe impl<T> StableTraceObject for Dom<T>
 where
     T: DomObject,
 {
-    fn stable_trace_object<'a>(&'a self) -> *const dyn JSTraceable {
+    fn stable_trace_object(&self) -> *const dyn JSTraceable {
         // The JSTraceable impl for Reflector doesn't actually do anything,
         // so we need this shenanigan to actually trace the reflector of the
         // T pointer in Dom<T>.
@@ -107,7 +107,7 @@ unsafe impl<T> StableTraceObject for MaybeUnreflectedDom<T>
 where
     T: DomObject,
 {
-    fn stable_trace_object<'a>(&'a self) -> *const dyn JSTraceable {
+    fn stable_trace_object(&self) -> *const dyn JSTraceable {
         // The JSTraceable impl for Reflector doesn't actually do anything,
         // so we need this shenanigan to actually trace the reflector of the
         // T pointer in Dom<T>.

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2645,7 +2645,7 @@ impl FormControl for HTMLInputElement {
         self.form_owner.set(form);
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         self.upcast::<Element>()
     }
 }

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -190,7 +190,7 @@ impl FormControl for HTMLLabelElement {
         // form owner. Therefore it doesn't hold form owner itself.
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         self.upcast::<Element>()
     }
 }

--- a/components/script/dom/htmllegendelement.rs
+++ b/components/script/dom/htmllegendelement.rs
@@ -103,7 +103,7 @@ impl FormControl for HTMLLegendElement {
         self.form_owner.set(form);
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         self.upcast::<Element>()
     }
 }

--- a/components/script/dom/htmlobjectelement.rs
+++ b/components/script/dom/htmlobjectelement.rs
@@ -175,7 +175,7 @@ impl FormControl for HTMLObjectElement {
         self.form_owner.set(form);
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         self.upcast::<Element>()
     }
 }

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -152,7 +152,7 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
 }
 
 impl VirtualMethods for HTMLOutputElement {
-    fn super_type<'b>(&'b self) -> Option<&'b dyn VirtualMethods> {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
@@ -176,7 +176,7 @@ impl FormControl for HTMLOutputElement {
         self.form_owner.set(form);
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         self.upcast::<Element>()
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -490,7 +490,7 @@ impl FormControl for HTMLSelectElement {
         self.form_owner.set(form);
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         self.upcast::<Element>()
     }
 }

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -138,7 +138,7 @@ impl NodeList {
         }
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = DomRoot<Node>> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = DomRoot<Node>> + '_ {
         let len = self.Length();
         // There is room for optimization here in non-simple cases,
         // as calling Item repeatedly on a live list can involve redundant work.

--- a/components/script/dom/webgl_extensions/wrapper.rs
+++ b/components/script/dom/webgl_extensions/wrapper.rs
@@ -87,7 +87,7 @@ where
         T::name()
     }
 
-    fn as_any<'a>(&'a self) -> &'a dyn Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1575,7 +1575,7 @@ impl WebGLRenderingContext {
         constants::COLOR_ATTACHMENT0 <= attachment && attachment <= last_slot
     }
 
-    pub fn compressed_tex_image_2d<'a>(
+    pub fn compressed_tex_image_2d(
         &self,
         target: u32,
         level: i32,
@@ -1583,7 +1583,7 @@ impl WebGLRenderingContext {
         width: i32,
         height: i32,
         border: i32,
-        data: &'a [u8],
+        data: &[u8],
     ) {
         let validator = CompressedTexImage2DValidator::new(
             self,
@@ -1642,7 +1642,7 @@ impl WebGLRenderingContext {
         }
     }
 
-    pub fn compressed_tex_sub_image_2d<'a>(
+    pub fn compressed_tex_sub_image_2d(
         &self,
         target: u32,
         level: i32,
@@ -1651,7 +1651,7 @@ impl WebGLRenderingContext {
         width: i32,
         height: i32,
         format: u32,
-        data: &'a [u8],
+        data: &[u8],
     ) {
         let validator = CompressedTexSubImage2DValidator::new(
             self,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -478,7 +478,7 @@ impl Documents {
             .and_then(|doc| doc.find_iframe(browsing_context_id))
     }
 
-    pub fn iter<'a>(&'a self) -> DocumentsIter<'a> {
+    pub fn iter(&self) -> DocumentsIter<'_> {
         DocumentsIter {
             iter: self.map.iter(),
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove lifetime annotations to fix the `needless_lifetimes` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
