### PR TITLE
Update HtmlInputElement webidl and implement setter for the files property

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1186,6 +1186,13 @@ impl HTMLInputElementMethods for HTMLInputElement {
         self.filelist.get().as_ref().cloned()
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-input-files>
+    fn SetFiles(&self, files: Option<&FileList>) {
+        if self.input_type() == InputType::File && files.is_some() {
+            self.filelist.set(files);
+        }
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-input-defaultchecked
     make_bool_getter!(DefaultChecked, "checked");
 

--- a/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/components/script/dom/webidls/HTMLInputElement.webidl
@@ -23,7 +23,7 @@ interface HTMLInputElement : HTMLElement {
   [CEReactions]
            attribute boolean disabled;
   readonly attribute HTMLFormElement? form;
-  readonly attribute FileList? files;
+  attribute FileList? files;
   [CEReactions]
            attribute DOMString formAction;
   [CEReactions]

--- a/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
@@ -3381,9 +3381,6 @@
   [HTMLSlotElement interface: operation assignedElements(AssignedNodesOptions)]
     expected: FAIL
 
-  [HTMLInputElement interface: attribute files]
-    expected: FAIL
-
   [Stringification of document.all]
     expected: FAIL
 

--- a/tests/wpt/meta-legacy-layout/html/semantics/forms/the-input-element/files.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/forms/the-input-element/files.html.ini
@@ -1,7 +1,4 @@
 [files.html]
   type: testharness
-  [setting <input type=file>.files]
-    expected: FAIL
-
   [setting <input type=file>.files from DataTransfer]
     expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -3219,9 +3219,6 @@
   [HTMLInputElement interface: createInput("image") must inherit property "width" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: attribute files]
-    expected: FAIL
-
   [Stringification of document.all]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/files.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/files.html.ini
@@ -1,7 +1,4 @@
 [files.html]
   type: testharness
-  [setting <input type=file>.files]
-    expected: FAIL
-
   [setting <input type=file>.files from DataTransfer]
     expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removes `readonly` from the `files` attribute for HtmlInputElement. It was previously `readonly` however the [webidl](https://html.spec.whatwg.org/multipage/input.html#htmlinputelement) was updated to make it mutable, with the spec defining the [setter behaviour](https://html.spec.whatwg.org/multipage/input.html#dom-input-files).

There is an associated [issue](https://github.com/whatwg/html/issues/3269) - it remains open, but I think only because of uncertainty around dispatching change events - it looks like the outcome was that events should not be fired when setting `.files` directly - I've left it out based on [this chromium issue](https://issues.chromium.org/issues/41359566) as well as firefox dispatching events [only when a flag is set](https://searchfox.org/mozilla-central/source/dom/html/HTMLInputElement.cpp#2520). 

This change does not affect more tests because they depend on copying files via a `DataTransfer` object, which has not been implemented in servo - so I didn't find any unexpected passes (I have a branch with `DataTransfer` implemented and expected the wpt to pass, but it failed due to this missing setter)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
