### PR TITLE
clippy: Fix `len_zero` warnings in `components/script`

### DIFF
--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -222,7 +222,7 @@ impl DOMString {
     /// Removes leading and trailing ASCII whitespaces according to
     /// <https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace>.
     pub fn strip_leading_and_trailing_ascii_whitespace(&mut self) {
-        if self.0.len() == 0 {
+        if self.0.is_empty() {
             return;
         }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1881,7 +1881,7 @@ impl HTMLInputElement {
         } else {
             let opt_test_path = match opt_test_paths {
                 Some(paths) => {
-                    if paths.len() == 0 {
+                    if paths.is_empty() {
                         return;
                     } else {
                         Some(paths[0].to_string()) // neglect other paths

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -213,7 +213,7 @@ impl Performance {
             let buffer = self.buffer.borrow();
             let mut new_entries =
                 buffer.get_entries_by_name_and_type(None, Some(entry_type.clone()));
-            if new_entries.len() > 0 {
+            if !new_entries.is_empty() {
                 let mut obs_entries = observer.entries();
                 obs_entries.append(&mut new_entries);
                 observer.set_entries(obs_entries);
@@ -408,7 +408,7 @@ impl PerformanceMethods for Performance {
     // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#performance-timing-attribute
     fn Timing(&self) -> DomRoot<PerformanceNavigationTiming> {
         let entries = self.GetEntriesByType(DOMString::from("navigation"));
-        if entries.len() > 0 {
+        if !entries.is_empty() {
             return DomRoot::from_ref(
                 entries[0]
                     .downcast::<PerformanceNavigationTiming>()

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -4136,7 +4136,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             Float32ArrayOrUnrestrictedFloatSequence::Float32Array(v) => v.to_vec(),
             Float32ArrayOrUnrestrictedFloatSequence::UnrestrictedFloatSequence(v) => v,
         };
-        if values.len() < 1 {
+        if values.is_empty() {
             // https://github.com/KhronosGroup/WebGL/issues/2700
             return self.webgl_error(InvalidValue);
         }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -721,7 +721,7 @@ impl ModuleTree {
 
         match specifier_urls {
             // Step 3.
-            Ok(valid_specifier_urls) if valid_specifier_urls.len() == 0 => {
+            Ok(valid_specifier_urls) if valid_specifier_urls.is_empty() => {
                 debug!("Module {} doesn't have any dependencies.", self.url.clone());
                 self.advance_finished_and_link(&global);
             },
@@ -746,7 +746,7 @@ impl ModuleTree {
                 }
 
                 // Step 3.
-                if urls.len() == 0 {
+                if urls.is_empty() {
                     debug!(
                         "After checking with visited urls, module {} doesn't have dependencies to load.",
                         self.url.clone()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Change `len()` syntax to `is_empty()` to fix the `len_zero` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
