### PR TITLE
clippy: Fix `option_as_ref_deref` warnings in `components/script`

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -88,8 +88,7 @@ impl CanvasRenderingContext2D {
     }
 
     pub fn mark_as_dirty(&self) {
-        self.canvas_state
-            .mark_as_dirty(self.canvas.as_ref().map(|c| &**c))
+        self.canvas_state.mark_as_dirty(self.canvas.as_deref())
     }
 
     pub fn take_missing_image_urls(&self) -> Vec<ServoUrl> {
@@ -455,7 +454,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_stroke_style(self.canvas.as_ref().map(|c| &**c), value)
+            .set_stroke_style(self.canvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1019,8 +1019,7 @@ impl ElementQueue {
         self.queue
             .borrow_mut()
             .pop_front()
-            .as_ref()
-            .map(Dom::deref)
+            .as_deref()
             .map(DomRoot::from_ref)
     }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -791,7 +791,7 @@ impl HTMLFormElement {
                 Some(submitter.target())
             } else {
                 let form_owner = submitter.form_owner();
-                let form = form_owner.as_ref().map(|form| &**form).unwrap_or(self);
+                let form = form_owner.as_deref().unwrap_or(self);
                 get_element_target(form.upcast::<Element>())
             };
 

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -134,7 +134,7 @@ impl OffscreenCanvas {
         let context = OffscreenCanvasRenderingContext2D::new(
             &self.global(),
             self,
-            self.placeholder.as_ref().map(|c| &**c),
+            self.placeholder.as_deref(),
         );
         *self.context.borrow_mut() = Some(OffscreenCanvasContext::OffscreenContext2d(
             Dom::from_ref(&*context),

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -141,7 +141,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn SetShadowColor(&self, value: DOMString) {
         self.canvas_state
-            .set_shadow_color(self.htmlcanvas.as_ref().map(|c| &**c), value)
+            .set_shadow_color(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -152,7 +152,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_stroke_style(self.htmlcanvas.as_ref().map(|c| &**c), value)
+            .set_stroke_style(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -163,7 +163,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_fill_style(self.htmlcanvas.as_ref().map(|c| &**c), value)
+            .set_fill_style(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient
@@ -250,13 +250,8 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
     fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
-        self.canvas_state.fill_text(
-            self.htmlcanvas.as_ref().map(|c| &**c),
-            text,
-            x,
-            y,
-            max_width,
-        )
+        self.canvas_state
+            .fill_text(self.htmlcanvas.as_deref(), text, x, y, max_width)
     }
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
@@ -272,7 +267,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
     fn SetFont(&self, value: DOMString) {
         self.canvas_state
-            .set_font(self.htmlcanvas.as_ref().map(|c| &**c), value)
+            .set_font(self.htmlcanvas.as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-textalign
@@ -395,7 +390,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage(&self, image: CanvasImageSource, dx: f64, dy: f64) -> ErrorResult {
         self.canvas_state
-            .draw_image(self.htmlcanvas.as_ref().map(|c| &**c), image, dx, dy)
+            .draw_image(self.htmlcanvas.as_deref(), image, dx, dy)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -407,14 +402,8 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        self.canvas_state.draw_image_(
-            self.htmlcanvas.as_ref().map(|c| &**c),
-            image,
-            dx,
-            dy,
-            dw,
-            dh,
-        )
+        self.canvas_state
+            .draw_image_(self.htmlcanvas.as_deref(), image, dx, dy, dw, dh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
@@ -431,7 +420,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         dh: f64,
     ) -> ErrorResult {
         self.canvas_state.draw_image__(
-            self.htmlcanvas.as_ref().map(|c| &**c),
+            self.htmlcanvas.as_deref(),
             image,
             sx,
             sy,

--- a/components/script/dom/xrrenderstate.rs
+++ b/components/script/dom/xrrenderstate.rs
@@ -74,7 +74,7 @@ impl XRRenderState {
             self.depth_near.get(),
             self.depth_far.get(),
             self.inline_vertical_fov.get(),
-            self.base_layer.get().as_ref().map(|x| &**x),
+            self.base_layer.get().as_deref(),
             self.layers.borrow().iter().map(|x| &**x).collect(),
         )
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3359,8 +3359,7 @@ impl ScriptThread {
 
         let referrer_policy = metadata
             .headers
-            .as_ref()
-            .map(Serde::deref)
+            .as_deref()
             .and_then(|h| h.typed_get::<ReferrerPolicyHeader>())
             .map(ReferrerPolicy::from);
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Change `as_ref().map()` syntax to `as_deref()` to fix the `option_as_ref_deref` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
