### PR TITLE
fix: Remove unused imports in `components/script`

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -4,7 +4,6 @@
 
 use std::cell::Cell;
 use std::collections::VecDeque;
-use std::ops::Deref;
 use std::rc::Rc;
 use std::{mem, ptr};
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -21,7 +21,6 @@ use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::{hash_map, HashMap, HashSet};
 use std::default::Default;
-use std::ops::Deref;
 use std::option::Option;
 use std::rc::Rc;
 use std::result::Result;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed compile warnings related to unused imports in components/script

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are related to fix #31927

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
