### PR TITLE
Clippy: add ' #Safety' section for unsafe functions

### DIFF
--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -192,10 +192,11 @@ where
 ///
 /// # Safety
 ///
-/// This function is `unsafe` because it modifies the layout tree and context without any synchronization.
-///  The caller must ensure that:
-/// - There are no concurrent modifications to the layout tree.
-/// - The `LayoutContext` and `node` references are valid for the duration of the call.
+/// Marked `unsafe` because it directly modifies the layout tree and context without internal synchronization. Safe usage requires:
+/// - No concurrent access or modifications to the layout tree.
+/// - Valid `LayoutContext` and `node` references for the function's duration.
+///
+/// Non-compliance may lead to undefined behavior including data races and memory safety violations.
 pub unsafe fn construct_flows_at_ancestors<'dom>(
     context: &LayoutContext,
     mut node: impl LayoutNode<'dom>,

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -192,7 +192,8 @@ where
 ///
 /// # Safety
 ///
-/// Marked `unsafe` because it directly modifies the layout tree and context without internal synchronization. Safe usage requires:
+/// Marked `unsafe` because it directly modifies the layout tree and context without internal synchronization.
+///  Safe usage requires:
 /// - No concurrent access or modifications to the layout tree.
 /// - Valid `LayoutContext` and `node` references for the function's duration.
 ///

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -188,6 +188,14 @@ where
 
 #[allow(unsafe_code)]
 #[inline]
+/// Constructs layout flows up to the ancestors of a given node.
+///
+/// # Safety
+///
+/// This function is `unsafe` because it modifies the layout tree and context without any synchronization.
+///  The caller must ensure that:
+/// - There are no concurrent modifications to the layout tree.
+/// - The `LayoutContext` and `node` references are valid for the duration of the call.
 pub unsafe fn construct_flows_at_ancestors<'dom>(
     context: &LayoutContext,
     mut node: impl LayoutNode<'dom>,

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -30,6 +30,8 @@ pub struct DomRefCell<T> {
 impl<T> DomRefCell<T> {
     /// Return a reference to the contents.
     ///
+    /// # Safety
+    ///
     /// For use in layout only.
     #[allow(unsafe_code)]
     pub unsafe fn borrow_for_layout(&self) -> &T {
@@ -41,6 +43,13 @@ impl<T> DomRefCell<T> {
 
     /// Borrow the contents for the purpose of script deallocation.
     ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it returns a mutable reference to the inner data
+    /// without any form of synchronization or protection. It is the caller's responsibility
+    /// to ensure that the borrow is valid and does not result in data races or memory safety
+    /// violations. Additionally, this function is intended for script deallocation, and incorrect
+    /// usage may lead to memory leaks or other memory-related issues.
     #[allow(unsafe_code, clippy::mut_from_ref)]
     pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
         assert_in_script();
@@ -49,6 +58,13 @@ impl<T> DomRefCell<T> {
 
     /// Mutably borrow a cell for layout. Ideally this would use
     /// `RefCell::try_borrow_mut_unguarded` but that doesn't exist yet.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it returns a mutable reference to the inner data
+    /// without any form of synchronization or protection. It is the caller's responsibility
+    /// to ensure that the borrow is valid and exclusive, and that it does not result in data races
+    /// or memory safety violations.
     #[allow(unsafe_code, clippy::mut_from_ref)]
     pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
         assert_in_layout();

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -41,35 +41,33 @@ impl<T> DomRefCell<T> {
             .expect("cell is mutably borrowed")
     }
 
-    /// Borrow the contents for the purpose of script deallocation.
-    ///
-    /// # Safety
-    ///
-    /// This function is marked as `unsafe` because it returns a mutable reference to the inner data
-    /// without any form of synchronization or protection. It is the caller's responsibility
-    /// to ensure that the borrow is valid and does not result in data races or memory safety
-    /// violations. Additionally, this function is intended for script deallocation, and incorrect
-    /// usage may lead to memory leaks or other memory-related issues.
-    #[allow(unsafe_code, clippy::mut_from_ref)]
-    pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
-        assert_in_script();
-        &mut *self.value.as_ptr()
-    }
+    /// Gets a mutable reference for script deallocation.
+///
+/// # Safety
+///
+/// Unsafe as it exposes internal data without synchronization, risking data races and memory safety issues. 
+/// The caller must ensure no concurrent access and adhere to borrowing rules. Intended solely for script 
+/// deallocation; improper use may cause memory leaks or corruption. `assert_in_script` checks the operation 
+/// context but does not ensure safety.
+#[allow(unsafe_code, clippy::mut_from_ref)]
+pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
+    assert_in_script();
+    &mut *self.value.as_ptr()
+}
 
-    /// Mutably borrow a cell for layout. Ideally this would use
-    /// `RefCell::try_borrow_mut_unguarded` but that doesn't exist yet.
-    ///
-    /// # Safety
-    ///
-    /// This function is marked as `unsafe` because it returns a mutable reference to the inner data
-    /// without any form of synchronization or protection. It is the caller's responsibility
-    /// to ensure that the borrow is valid and exclusive, and that it does not result in data races
-    /// or memory safety violations.
-    #[allow(unsafe_code, clippy::mut_from_ref)]
-    pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
-        assert_in_layout();
-        &mut *self.value.as_ptr()
-    }
+    /// Mutably borrows a cell for layout adjustments.
+///
+/// # Safety
+///
+/// Declared `unsafe` as it yields a mutable reference to internal data without locking or checks, 
+/// risking data races and memory safety violations. Callers must ensure exclusive access and comply 
+/// with Rust's borrowing principles. Primarily for layout use; incorrect application may lead to 
+/// severe errors. `assert_in_layout` confirms context but not safety.
+#[allow(unsafe_code, clippy::mut_from_ref)]
+pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
+    assert_in_layout();
+    &mut *self.value.as_ptr()
+}
 }
 
 // Functionality duplicated with `std::cell::RefCell`

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -42,32 +42,32 @@ impl<T> DomRefCell<T> {
     }
 
     /// Gets a mutable reference for script deallocation.
-///
-/// # Safety
-///
-/// Unsafe as it exposes internal data without synchronization, risking data races and memory safety issues. 
-/// The caller must ensure no concurrent access and adhere to borrowing rules. Intended solely for script 
-/// deallocation; improper use may cause memory leaks or corruption. `assert_in_script` checks the operation 
-/// context but does not ensure safety.
-#[allow(unsafe_code, clippy::mut_from_ref)]
-pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
-    assert_in_script();
-    &mut *self.value.as_ptr()
-}
+    ///
+    /// # Safety
+    ///
+    /// Unsafe as it exposes internal data without synchronization, risking data races and memory safety issues.
+    /// The caller must ensure no concurrent access and adhere to borrowing rules. Intended solely for script
+    /// deallocation; improper use may cause memory leaks or corruption. `assert_in_script` checks the operation
+    /// context but does not ensure safety.
+    #[allow(unsafe_code, clippy::mut_from_ref)]
+    pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
+        assert_in_script();
+        &mut *self.value.as_ptr()
+    }
 
     /// Mutably borrows a cell for layout adjustments.
-///
-/// # Safety
-///
-/// Declared `unsafe` as it yields a mutable reference to internal data without locking or checks, 
-/// risking data races and memory safety violations. Callers must ensure exclusive access and comply 
-/// with Rust's borrowing principles. Primarily for layout use; incorrect application may lead to 
-/// severe errors. `assert_in_layout` confirms context but not safety.
-#[allow(unsafe_code, clippy::mut_from_ref)]
-pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
-    assert_in_layout();
-    &mut *self.value.as_ptr()
-}
+    ///
+    /// # Safety
+    ///
+    /// Declared `unsafe` as it yields a mutable reference to internal data without locking or checks,
+    /// risking data races and memory safety violations. Callers must ensure exclusive access and comply
+    /// with Rust's borrowing principles. Primarily for layout use; incorrect application may lead to
+    /// severe errors. `assert_in_layout` confirms context but not safety.
+    #[allow(unsafe_code, clippy::mut_from_ref)]
+    pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
+        assert_in_layout();
+        &mut *self.value.as_ptr()
+    }
 }
 
 // Functionality duplicated with `std::cell::RefCell`

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -332,12 +332,14 @@ impl<T> MallocSizeOf for Dom<T> {
 
 impl<T> Dom<T> {
     /// Returns `LayoutDom<T>` containing the same pointer.
-    ///
-    ///  # Safety
-    ///
-    /// This function is marked as `unsafe` because it returns a `LayoutDom<T>` instance without
-    /// any form of synchronization or protection. It is the caller's responsibility to ensure
-    /// that the conversion is safe and that the resulting layout is correctly managed.
+///
+/// # Safety
+///
+/// Marked as `unsafe` because it returns a `LayoutDom<T>` instance encapsulating a raw pointer without
+/// adding synchronization or validation mechanisms. The caller is responsible for ensuring the safety of this
+/// operation, including the validity and exclusive access of the pointer during the `LayoutDom<T>`'s lifetime.
+/// The caller must also prevent any data races or memory safety violations that could arise from concurrent access.
+/// Use `assert_in_layout` to verify the appropriateness of the context, but note it does not ensure overall safety.
     pub unsafe fn to_layout(&self) -> LayoutDom<T> {
         assert_in_layout();
         LayoutDom {

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -332,14 +332,14 @@ impl<T> MallocSizeOf for Dom<T> {
 
 impl<T> Dom<T> {
     /// Returns `LayoutDom<T>` containing the same pointer.
-///
-/// # Safety
-///
-/// Marked as `unsafe` because it returns a `LayoutDom<T>` instance encapsulating a raw pointer without
-/// adding synchronization or validation mechanisms. The caller is responsible for ensuring the safety of this
-/// operation, including the validity and exclusive access of the pointer during the `LayoutDom<T>`'s lifetime.
-/// The caller must also prevent any data races or memory safety violations that could arise from concurrent access.
-/// Use `assert_in_layout` to verify the appropriateness of the context, but note it does not ensure overall safety.
+    ///
+    /// # Safety
+    ///
+    /// Marked as `unsafe` because it returns a `LayoutDom<T>` instance encapsulating a raw pointer without
+    /// adding synchronization or validation mechanisms. The caller is responsible for ensuring the safety of this
+    /// operation, including the validity and exclusive access of the pointer during the `LayoutDom<T>`'s lifetime.
+    /// The caller must also prevent any data races or memory safety violations that could arise from concurrent access.
+    /// Use `assert_in_layout` to verify the appropriateness of the context, but note it does not ensure overall safety.
     pub unsafe fn to_layout(&self) -> LayoutDom<T> {
         assert_in_layout();
         LayoutDom {

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -332,6 +332,12 @@ impl<T> MallocSizeOf for Dom<T> {
 
 impl<T> Dom<T> {
     /// Returns `LayoutDom<T>` containing the same pointer.
+    ///
+    ///  # Safety
+    ///
+    /// This function is marked as `unsafe` because it returns a `LayoutDom<T>` instance without
+    /// any form of synchronization or protection. It is the caller's responsibility to ensure
+    /// that the conversion is safe and that the resulting layout is correctly managed.
     pub unsafe fn to_layout(&self) -> LayoutDom<T> {
         assert_in_layout();
         LayoutDom {

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -115,28 +115,25 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutElement<'dom, LayoutDataT
             .map(|data| &data.style_data)
     }
 
-    /// Unsets the snapshot flags.
-    ///
-    /// # Safety
-    ///
-    /// This function is marked as `unsafe` because it operates on internal data structures
-    /// without any form of synchronization or protection. It is the caller's responsibility
-    /// to ensure that calling this function does not lead to data races or memory safety
-    /// violations.
+    /// Clears snapshot-related flags of a node.
+///
+/// # Safety
+///
+/// Marked `unsafe` as it alters node flags without lock or check, risking data races and state corruption.
+/// Caller must ensure exclusive access to prevent concurrent modifications. Careful management is required
+/// to maintain node integrity and execution safety.
     pub unsafe fn unset_snapshot_flags(&self) {
         self.as_node()
             .node
             .set_flag(NodeFlags::HAS_SNAPSHOT | NodeFlags::HANDLED_SNAPSHOT, false);
     }
-
-    /// Sets the snapshot flag.
-    ///
-    /// # Safety
-    ///
-    /// This function is marked as `unsafe` because it operates on internal data structures
-    /// without any form of synchronization or protection. It is the caller's responsibility
-    /// to ensure that calling this function does not lead to data races or memory safety
-    /// violations.
+ /// Sets the `HAS_SNAPSHOT` flag for a node.
+///
+/// # Safety
+///
+/// Unsafe due to direct modification of node flags without synchronization, posing a risk of data races
+/// and memory safety issues. The caller must ensure exclusive access and that the operation is safe
+/// in the current context to prevent compromising the node's integrity.
     pub unsafe fn set_has_snapshot(&self) {
         self.as_node().node.set_flag(NodeFlags::HAS_SNAPSHOT, true);
     }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -115,12 +115,28 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutElement<'dom, LayoutDataT
             .map(|data| &data.style_data)
     }
 
+    /// Unsets the snapshot flags.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it operates on internal data structures
+    /// without any form of synchronization or protection. It is the caller's responsibility
+    /// to ensure that calling this function does not lead to data races or memory safety
+    /// violations.
     pub unsafe fn unset_snapshot_flags(&self) {
         self.as_node()
             .node
             .set_flag(NodeFlags::HAS_SNAPSHOT | NodeFlags::HANDLED_SNAPSHOT, false);
     }
 
+    /// Sets the snapshot flag.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it operates on internal data structures
+    /// without any form of synchronization or protection. It is the caller's responsibility
+    /// to ensure that calling this function does not lead to data races or memory safety
+    /// violations.
     pub unsafe fn set_has_snapshot(&self) {
         self.as_node().node.set_flag(NodeFlags::HAS_SNAPSHOT, true);
     }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -116,24 +116,24 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutElement<'dom, LayoutDataT
     }
 
     /// Clears snapshot-related flags of a node.
-///
-/// # Safety
-///
-/// Marked `unsafe` as it alters node flags without lock or check, risking data races and state corruption.
-/// Caller must ensure exclusive access to prevent concurrent modifications. Careful management is required
-/// to maintain node integrity and execution safety.
+    ///
+    /// # Safety
+    ///
+    /// Marked `unsafe` as it alters node flags without lock or check, risking data races and state corruption.
+    /// Caller must ensure exclusive access to prevent concurrent modifications. Careful management is required
+    /// to maintain node integrity and execution safety.
     pub unsafe fn unset_snapshot_flags(&self) {
         self.as_node()
             .node
             .set_flag(NodeFlags::HAS_SNAPSHOT | NodeFlags::HANDLED_SNAPSHOT, false);
     }
- /// Sets the `HAS_SNAPSHOT` flag for a node.
-///
-/// # Safety
-///
-/// Unsafe due to direct modification of node flags without synchronization, posing a risk of data races
-/// and memory safety issues. The caller must ensure exclusive access and that the operation is safe
-/// in the current context to prevent compromising the node's integrity.
+    /// Sets the `HAS_SNAPSHOT` flag for a node.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe due to direct modification of node flags without synchronization, posing a risk of data races
+    /// and memory safety issues. The caller must ensure exclusive access and that the operation is safe
+    /// in the current context to prevent compromising the node's integrity.
     pub unsafe fn set_has_snapshot(&self) {
         self.as_node().node.set_flag(NodeFlags::HAS_SNAPSHOT, true);
     }

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -98,15 +98,14 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutNode<'dom, LayoutDataType
         }
     }
 
-    /// Creates a new `Node` instance from the given trusted node address.
-    ///
-    /// # Safety
-    ///
-    /// This function is marked as `unsafe` because it constructs a `Node` instance
-    /// directly from a trusted node address without performing any validation or
-    /// checks. It is the caller's responsibility to ensure that the provided address
-    /// is valid and points to a valid node object. Incorrect usage may lead to memory
-    /// safety violations or undefined behavior.
+    /// Instantiates a `Node` using a trusted node address.
+///
+/// # Safety
+///
+/// Declared `unsafe` as it relies on a raw address to construct a `Node`, bypassing validation. 
+/// The caller must verify the address's validity, ensuring it corresponds to a legitimate node. 
+/// Misuse can result in memory safety breaches or undefined behavior. It's critical to confirm 
+/// the integrity and authenticity of the address prior to use.
     pub unsafe fn new(address: &TrustedNodeAddress) -> Self {
         ServoLayoutNode::from_layout_js(LayoutDom::from_trusted_node_address(*address))
     }

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -98,6 +98,15 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutNode<'dom, LayoutDataType
         }
     }
 
+    /// Creates a new `Node` instance from the given trusted node address.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it constructs a `Node` instance
+    /// directly from a trusted node address without performing any validation or
+    /// checks. It is the caller's responsibility to ensure that the provided address
+    /// is valid and points to a valid node object. Incorrect usage may lead to memory
+    /// safety violations or undefined behavior.
     pub unsafe fn new(address: &TrustedNodeAddress) -> Self {
         ServoLayoutNode::from_layout_js(LayoutDom::from_trusted_node_address(*address))
     }

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -99,13 +99,13 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutNode<'dom, LayoutDataType
     }
 
     /// Instantiates a `Node` using a trusted node address.
-///
-/// # Safety
-///
-/// Declared `unsafe` as it relies on a raw address to construct a `Node`, bypassing validation. 
-/// The caller must verify the address's validity, ensuring it corresponds to a legitimate node. 
-/// Misuse can result in memory safety breaches or undefined behavior. It's critical to confirm 
-/// the integrity and authenticity of the address prior to use.
+    ///
+    /// # Safety
+    ///
+    /// Declared `unsafe` as it relies on a raw address to construct a `Node`, bypassing validation.
+    /// The caller must verify the address's validity, ensuring it corresponds to a legitimate node.
+    /// Misuse can result in memory safety breaches or undefined behavior. It's critical to confirm
+    /// the integrity and authenticity of the address prior to use.
     pub unsafe fn new(address: &TrustedNodeAddress) -> Self {
         ServoLayoutNode::from_layout_js(LayoutDom::from_trusted_node_address(*address))
     }

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -71,6 +71,16 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoShadowRoot<'dom, LayoutDataType
         }
     }
 
+    /// Flushes the stylesheets within the shadow root.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it operates on internal data structures
+    /// without any form of synchronization or protection. It is the caller's responsibility
+    /// to ensure that calling this function does not lead to data races or memory safety
+    /// violations. Additionally, the caller must ensure that the provided `stylist` and
+    /// `guard` parameters are correctly initialized and represent valid state for flushing
+    /// stylesheets.
     pub unsafe fn flush_stylesheets(
         &self,
         stylist: &mut Stylist,

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -72,12 +72,12 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoShadowRoot<'dom, LayoutDataType
     }
 
     /// Flushes stylesheets in the shadow root.
-///
-/// # Safety
-///
-/// Unsafe as it modifies internal structures without locks, risking data races and memory issues. 
-/// Callers must ensure the `stylist` and `guard` are properly initialized and valid, preventing 
-/// unsafe states. The operation demands careful management of context and concurrency to maintain safety.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe as it modifies internal structures without locks, risking data races and memory issues.
+    /// Callers must ensure the `stylist` and `guard` are properly initialized and valid, preventing
+    /// unsafe states. The operation demands careful management of context and concurrency to maintain safety.
     pub unsafe fn flush_stylesheets(
         &self,
         stylist: &mut Stylist,

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -71,16 +71,13 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoShadowRoot<'dom, LayoutDataType
         }
     }
 
-    /// Flushes the stylesheets within the shadow root.
-    ///
-    /// # Safety
-    ///
-    /// This function is marked as `unsafe` because it operates on internal data structures
-    /// without any form of synchronization or protection. It is the caller's responsibility
-    /// to ensure that calling this function does not lead to data races or memory safety
-    /// violations. Additionally, the caller must ensure that the provided `stylist` and
-    /// `guard` parameters are correctly initialized and represent valid state for flushing
-    /// stylesheets.
+    /// Flushes stylesheets in the shadow root.
+///
+/// # Safety
+///
+/// Unsafe as it modifies internal structures without locks, risking data races and memory issues. 
+/// Callers must ensure the `stylist` and `guard` are properly initialized and valid, preventing 
+/// unsafe states. The operation demands careful management of context and concurrency to maintain safety.
     pub unsafe fn flush_stylesheets(
         &self,
         stylist: &mut Stylist,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -433,15 +433,14 @@ lazy_static! {
     static ref JS_ENGINE: Mutex<Option<JSEngineHandle>> = Mutex::new(None);
 }
 
-/// Creates a new child runtime.
+/// Constructs a new child runtime from a parent runtime.
 ///
 /// # Safety
 ///
-/// This function is marked as `unsafe` because it constructs a new runtime instance
-/// without performing any validation or checks. It is the caller's responsibility
-/// to ensure that the parent runtime provided is valid and that all parameters are
-/// correctly initialized. Incorrect usage may lead to memory safety violations or
-/// undefined behavior.
+/// Marked `unsafe` as it instantiates a new runtime without checks, entrusting parameter 
+/// validation to the caller. Ensuring the parent runtime's validity and the correct initialization 
+/// of all parameters is essential to avoid memory safety issues or undefined behavior. Misuse 
+/// could compromise the integrity of the runtime environment
 #[allow(unsafe_code)]
 pub unsafe fn new_child_runtime(
     parent: ParentRuntime,
@@ -699,15 +698,15 @@ unsafe extern "C" fn get_size(obj: *mut JSObject) -> usize {
     }
 }
 
-/// Retrieves reports from the specified context and path segment.
+/// Fetches reports based on context and path segment.
 ///
 /// # Safety
 ///
-/// This function is marked as `unsafe` because it operates on a raw JavaScript context pointer (`cx`)
-/// without performing any validation or checks. It is the caller's responsibility to ensure that
-/// the context pointer is valid and points to a correctly initialized JavaScript context. Additionally,
-/// the `path_seg` parameter should be a valid string representing the path segment. Incorrect usage may
-/// lead to memory safety violations or undefined behavior.
+/// Marked as `unsafe` due to use of a raw JavaScript context pointer (`cx`) without validation. 
+/// Ensuring the `cx` points to a valid and properly initialized JavaScript context is critical. 
+/// The `path_seg` parameter must be a valid path segment string. Failure to validate these can 
+/// result in memory safety violations or undefined behavior. Careful handling is required to 
+/// avoid compromising the execution environment.
 #[allow(unsafe_code)]
 pub unsafe fn get_reports(cx: *mut RawJSContext, path_seg: String) -> Vec<Report> {
     let mut reports = vec![];
@@ -909,15 +908,15 @@ unsafe impl Send for ContextForRequestInterrupt {}
 pub struct JSContext(*mut RawJSContext);
 
 #[allow(unsafe_code)]
-/// Constructs a new `ScriptRuntime` instance from a raw JavaScript context pointer.
+/// Creates a `ScriptRuntime` from a raw JavaScript context pointer.
 ///
 /// # Safety
 ///
-/// This function is marked as `unsafe` because it constructs a `ScriptRuntime` instance
-/// from a raw JavaScript context pointer without performing any validation or checks.
-/// It is the caller's responsibility to ensure that the `raw_js_context` pointer is
-/// valid and points to a correctly initialized JavaScript context. Incorrect usage may
-/// lead to memory safety violations or undefined behavior.
+/// Declared `unsafe` as it initializes a `ScriptRuntime` with a raw JavaScript context pointer 
+/// (`raw_js_context`) without any validation. The caller must verify the pointer's validity and 
+/// that it refers to a properly initialized JavaScript context. Misuse could result in memory 
+/// safety breaches or undefined behavior. Ensuring the integrity and appropriateness of the 
+/// `raw_js_context` is essential.
 impl JSContext {
     pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
         JSContext(raw_js_context)

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -437,9 +437,9 @@ lazy_static! {
 ///
 /// # Safety
 ///
-/// Marked `unsafe` as it instantiates a new runtime without checks, entrusting parameter 
-/// validation to the caller. Ensuring the parent runtime's validity and the correct initialization 
-/// of all parameters is essential to avoid memory safety issues or undefined behavior. Misuse 
+/// Marked `unsafe` as it instantiates a new runtime without checks, entrusting parameter
+/// validation to the caller. Ensuring the parent runtime's validity and the correct initialization
+/// of all parameters is essential to avoid memory safety issues or undefined behavior. Misuse
 /// could compromise the integrity of the runtime environment
 #[allow(unsafe_code)]
 pub unsafe fn new_child_runtime(
@@ -702,10 +702,10 @@ unsafe extern "C" fn get_size(obj: *mut JSObject) -> usize {
 ///
 /// # Safety
 ///
-/// Marked as `unsafe` due to use of a raw JavaScript context pointer (`cx`) without validation. 
-/// Ensuring the `cx` points to a valid and properly initialized JavaScript context is critical. 
-/// The `path_seg` parameter must be a valid path segment string. Failure to validate these can 
-/// result in memory safety violations or undefined behavior. Careful handling is required to 
+/// Marked as `unsafe` due to use of a raw JavaScript context pointer (`cx`) without validation.
+/// Ensuring the `cx` points to a valid and properly initialized JavaScript context is critical.
+/// The `path_seg` parameter must be a valid path segment string. Failure to validate these can
+/// result in memory safety violations or undefined behavior. Careful handling is required to
 /// avoid compromising the execution environment.
 #[allow(unsafe_code)]
 pub unsafe fn get_reports(cx: *mut RawJSContext, path_seg: String) -> Vec<Report> {
@@ -912,10 +912,10 @@ pub struct JSContext(*mut RawJSContext);
 ///
 /// # Safety
 ///
-/// Declared `unsafe` as it initializes a `ScriptRuntime` with a raw JavaScript context pointer 
-/// (`raw_js_context`) without any validation. The caller must verify the pointer's validity and 
-/// that it refers to a properly initialized JavaScript context. Misuse could result in memory 
-/// safety breaches or undefined behavior. Ensuring the integrity and appropriateness of the 
+/// Declared `unsafe` as it initializes a `ScriptRuntime` with a raw JavaScript context pointer
+/// (`raw_js_context`) without any validation. The caller must verify the pointer's validity and
+/// that it refers to a properly initialized JavaScript context. Misuse could result in memory
+/// safety breaches or undefined behavior. Ensuring the integrity and appropriateness of the
 /// `raw_js_context` is essential.
 impl JSContext {
     pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -433,6 +433,15 @@ lazy_static! {
     static ref JS_ENGINE: Mutex<Option<JSEngineHandle>> = Mutex::new(None);
 }
 
+/// Creates a new child runtime.
+///
+/// # Safety
+///
+/// This function is marked as `unsafe` because it constructs a new runtime instance
+/// without performing any validation or checks. It is the caller's responsibility
+/// to ensure that the parent runtime provided is valid and that all parameters are
+/// correctly initialized. Incorrect usage may lead to memory safety violations or
+/// undefined behavior.
 #[allow(unsafe_code)]
 pub unsafe fn new_child_runtime(
     parent: ParentRuntime,
@@ -690,6 +699,15 @@ unsafe extern "C" fn get_size(obj: *mut JSObject) -> usize {
     }
 }
 
+/// Retrieves reports from the specified context and path segment.
+///
+/// # Safety
+///
+/// This function is marked as `unsafe` because it operates on a raw JavaScript context pointer (`cx`)
+/// without performing any validation or checks. It is the caller's responsibility to ensure that
+/// the context pointer is valid and points to a correctly initialized JavaScript context. Additionally,
+/// the `path_seg` parameter should be a valid string representing the path segment. Incorrect usage may
+/// lead to memory safety violations or undefined behavior.
 #[allow(unsafe_code)]
 pub unsafe fn get_reports(cx: *mut RawJSContext, path_seg: String) -> Vec<Report> {
     let mut reports = vec![];
@@ -891,6 +909,15 @@ unsafe impl Send for ContextForRequestInterrupt {}
 pub struct JSContext(*mut RawJSContext);
 
 #[allow(unsafe_code)]
+/// Constructs a new `ScriptRuntime` instance from a raw JavaScript context pointer.
+///
+/// # Safety
+///
+/// This function is marked as `unsafe` because it constructs a `ScriptRuntime` instance
+/// from a raw JavaScript context pointer without performing any validation or checks.
+/// It is the caller's responsibility to ensure that the `raw_js_context` pointer is
+/// valid and points to a correctly initialized JavaScript context. Incorrect usage may
+/// lead to memory safety violations or undefined behavior.
 impl JSContext {
     pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
         JSContext(raw_js_context)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -170,6 +170,14 @@ pub type ImageCacheMsg = (PipelineId, PendingImageResponse);
 
 thread_local!(static SCRIPT_THREAD_ROOT: Cell<Option<*const ScriptThread>> = Cell::new(None));
 
+/// Traces the thread using the given `JSTracer`.
+///
+/// # Safety
+///
+/// This function is marked as `unsafe` because it operates on a raw JavaScript tracer pointer (`tr`)
+/// without performing any validation or checks. It is the caller's responsibility to ensure that
+/// the tracer pointer is valid and points to a correctly initialized tracer object. Incorrect usage
+/// may lead to memory safety violations or undefined behavior.
 pub unsafe fn trace_thread(tr: *mut JSTracer) {
     SCRIPT_THREAD_ROOT.with(|root| {
         if let Some(script_thread) = root.get() {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -174,9 +174,9 @@ thread_local!(static SCRIPT_THREAD_ROOT: Cell<Option<*const ScriptThread>> = Cel
 ///
 /// # Safety
 ///
-/// Marked as `unsafe` due to using a raw `JSTracer` pointer (`tr`) without validation. 
-/// The caller must ensure the pointer's validity and that it references an initialized tracer. 
-/// Failure to validate `tr` could result in memory safety issues or undefined behavior. It's 
+/// Marked as `unsafe` due to using a raw `JSTracer` pointer (`tr`) without validation.
+/// The caller must ensure the pointer's validity and that it references an initialized tracer.
+/// Failure to validate `tr` could result in memory safety issues or undefined behavior. It's
 /// crucial to confirm the tracer's appropriateness before invocation.
 pub unsafe fn trace_thread(tr: *mut JSTracer) {
     SCRIPT_THREAD_ROOT.with(|root| {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -170,14 +170,14 @@ pub type ImageCacheMsg = (PipelineId, PendingImageResponse);
 
 thread_local!(static SCRIPT_THREAD_ROOT: Cell<Option<*const ScriptThread>> = Cell::new(None));
 
-/// Traces the thread using the given `JSTracer`.
+/// Traces the current thread with a specified `JSTracer`.
 ///
 /// # Safety
 ///
-/// This function is marked as `unsafe` because it operates on a raw JavaScript tracer pointer (`tr`)
-/// without performing any validation or checks. It is the caller's responsibility to ensure that
-/// the tracer pointer is valid and points to a correctly initialized tracer object. Incorrect usage
-/// may lead to memory safety violations or undefined behavior.
+/// Marked as `unsafe` due to using a raw `JSTracer` pointer (`tr`) without validation. 
+/// The caller must ensure the pointer's validity and that it references an initialized tracer. 
+/// Failure to validate `tr` could result in memory safety issues or undefined behavior. It's 
+/// crucial to confirm the tracer's appropriateness before invocation.
 pub unsafe fn trace_thread(tr: *mut JSTracer) {
     SCRIPT_THREAD_ROOT.with(|root| {
         if let Some(script_thread) = root.get() {

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -89,8 +89,37 @@ pub trait LayoutNode<'dom>:
     /// Returns the type ID of this node.
     fn type_id(&self) -> LayoutNodeType;
 
+    /// Initializes the data associated with the wrapper.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it may involve operations that are inherently
+    /// unsafe or rely on external conditions for correctness. It is the caller's responsibility
+    /// to ensure that the initialization process is performed correctly and safely. Incorrect
+    /// usage may lead to memory safety violations or undefined behavior.
     unsafe fn initialize_data(&self);
+
+    /// Initializes the style and opaque layout data associated with the wrapper.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it may involve operations that are inherently
+    /// unsafe or rely on external conditions for correctness. It is the caller's responsibility
+    /// to ensure that the initialization process is performed correctly and safely. The provided
+    /// `data` parameter must be a valid boxed instance of `StyleAndOpaqueLayoutData`. Incorrect
+    /// usage may lead to memory safety violations or undefined behavior.
     unsafe fn init_style_and_opaque_layout_data(&self, data: Box<StyleAndOpaqueLayoutData>);
+
+    /// Takes ownership of the style and opaque layout data associated with the wrapper.
+    ///
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it may involve operations that are inherently
+    /// unsafe or rely on external conditions for correctness. It is the caller's responsibility
+    /// to ensure that calling this function does not lead to data races or memory safety
+    /// violations. Additionally, the caller must ensure that the returned boxed instance of
+    /// `StyleAndOpaqueLayoutData` is correctly used and managed. Incorrect usage may lead to
+    /// memory safety violations or undefined behavior.
     unsafe fn take_style_and_opaque_layout_data(&self) -> Box<StyleAndOpaqueLayoutData>;
 
     fn rev_children(self) -> LayoutIterator<ReverseChildrenIterator<Self>> {
@@ -253,12 +282,14 @@ pub trait ThreadSafeLayoutNode<'dom>:
         self.type_id().is_some()
     }
 
-    /// Returns access to the underlying LayoutNode. This is breaks the abstraction
-    /// barrier of ThreadSafeLayout wrapper layer, and can lead to races if not used
-    /// carefully.
+    /// Unsafely retrieves the concrete node.
     ///
-    /// We need this because the implementation of some methods need to access the layout
-    /// data flags, and we have this annoying trait separation between script and layout :-(
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it may involve operations that are inherently
+    /// unsafe or rely on external conditions for correctness. It is the caller's responsibility
+    /// to ensure that the retrieved concrete node is used in a safe and correct manner. Incorrect
+    /// usage may lead to memory safety violations or undefined behavior.
     unsafe fn unsafe_get(self) -> Self::ConcreteNode;
 
     fn node_text_content(self) -> Cow<'dom, str>;
@@ -332,12 +363,14 @@ pub trait ThreadSafeLayoutElement<'dom>:
     /// Returns `None` if this is a pseudo-element; otherwise, returns `Some`.
     fn type_id(&self) -> Option<LayoutNodeType>;
 
-    /// Returns access to the underlying TElement. This is breaks the abstraction
-    /// barrier of ThreadSafeLayout wrapper layer, and can lead to races if not used
-    /// carefully.
+    /// Unsafely retrieves the concrete element.
     ///
-    /// We need this so that the functions defined on this trait can call
-    /// lazily_compute_pseudo_element_style, which operates on TElement.
+    /// # Safety
+    ///
+    /// This function is marked as `unsafe` because it may involve operations that are inherently
+    /// unsafe or rely on external conditions for correctness. It is the caller's responsibility
+    /// to ensure that the retrieved concrete element is used in a safe and correct manner. Incorrect
+    /// usage may lead to memory safety violations or undefined behavior.
     unsafe fn unsafe_get(self) -> Self::ConcreteElement;
 
     /// Get the local name of this element. See


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of https://github.com/servo/servo/issues/31500


- [x] These changes do not require tests because only docs were changed

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
