### PR TITLE
clippy: Fix several warnings in `components/script/dom/bindings`

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -418,7 +418,7 @@ where
     /// without causing conflicts , unexpected behavior.
     /// <https://github.com/servo/mozjs/blob/main/mozjs-sys/mozjs/js/public/ArrayBuffer.h#L89>
     unsafe extern "C" fn free_func(_contents: *mut c_void, free_user_data: *mut c_void) {
-        let _ = Arc::from_raw(free_user_data as _);
+        let _ = Arc::from_raw(free_user_data as *const _);
     }
 
     unsafe {

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -165,7 +165,7 @@ pub unsafe fn create_global_object(
     let private_val = PrivateValue(private);
     JS_SetReservedSlot(rval.get(), DOM_OBJECT_SLOT, &private_val);
     let proto_array: Box<ProtoOrIfaceArray> =
-        Box::new([0 as *mut JSObject; PrototypeList::PROTO_OR_IFACE_LENGTH]);
+        Box::new([ptr::null_mut::<JSObject>(); PrototypeList::PROTO_OR_IFACE_LENGTH]);
     let val = PrivateValue(Box::into_raw(proto_array) as *const libc::c_void);
     JS_SetReservedSlot(rval.get(), DOM_PROTOTYPE_SLOT, &val);
 

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -563,13 +563,13 @@ pub unsafe fn cross_origin_set(
 
 unsafe fn get_getter_object(d: &PropertyDescriptor, out: RawMutableHandleObject) {
     if d.hasGetter_() {
-        out.set(std::mem::transmute(d.getter_));
+        out.set(d.getter_);
     }
 }
 
 unsafe fn get_setter_object(d: &PropertyDescriptor, out: RawMutableHandleObject) {
     if d.hasSetter_() {
-        out.set(std::mem::transmute(d.setter_));
+        out.set(d.setter_);
     }
 }
 

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -521,8 +521,12 @@ impl<T> Clone for Dom<T> {
 
 impl<T> Clone for LayoutDom<'_, T> {
     #[inline]
+    #[allow(clippy::non_canonical_clone_impl)]
     fn clone(&self) -> Self {
-        *self
+        assert_in_layout();
+        {
+            *self
+        }
     }
 }
 

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -524,9 +524,7 @@ impl<T> Clone for LayoutDom<'_, T> {
     #[allow(clippy::non_canonical_clone_impl)]
     fn clone(&self) -> Self {
         assert_in_layout();
-        {
-            *self
-        }
+        *self
     }
 }
 

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -275,7 +275,6 @@ impl RootCollection {
     unsafe fn unroot(&self, object: *const dyn JSTraceable) {
         assert_in_script();
         let roots = &mut *self.roots.get();
-        #[allow(clippy::vtable_address_comparisons)]
         match roots.iter().rposition(|r| std::ptr::eq(*r, object)) {
             Some(idx) => {
                 roots.remove(idx);

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -275,6 +275,7 @@ impl RootCollection {
     unsafe fn unroot(&self, object: *const dyn JSTraceable) {
         assert_in_script();
         let roots = &mut *self.roots.get();
+        #[allow(clippy::vtable_address_comparisons)]
         match roots.iter().rposition(|r| std::ptr::eq(*r, object)) {
             Some(idx) => {
                 roots.remove(idx);
@@ -521,8 +522,7 @@ impl<T> Clone for Dom<T> {
 impl<T> Clone for LayoutDom<'_, T> {
     #[inline]
     fn clone(&self) -> Self {
-        assert_in_layout();
-        LayoutDom { value: self.value }
+        *self
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed warnings triggered by following checks:

- https://rust-lang.github.io/rust-clippy/master/index.html#from_raw_with_void_ptr
- https://rust-lang.github.io/rust-clippy/master/index.html#zero_ptr
- https://rust-lang.github.io/rust-clippy/master/index.html#useless_transmute
- https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_clone_impl

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500 

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
