### PR TITLE
clippy: Fix `from_over_into` warnings

### DIFF
--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -543,9 +543,9 @@ pub enum ProtoOrIfaceIndex {
     Constructor(PrototypeList::Constructor),
 }
 
-impl Into<usize> for ProtoOrIfaceIndex {
-    fn into(self) -> usize {
-        match self {
+impl From<ProtoOrIfaceIndex> for usize {
+    fn from(index: ProtoOrIfaceIndex) -> usize {
+        match index {
             ProtoOrIfaceIndex::ID(id) => id as usize,
             ProtoOrIfaceIndex::Constructor(constructor) => constructor as usize,
         }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -51,9 +51,9 @@ impl ByteString {
     }
 }
 
-impl Into<Vec<u8>> for ByteString {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<ByteString> for Vec<u8> {
+    fn from(byte_string: ByteString) -> Vec<u8> {
+        byte_string.0
     }
 }
 
@@ -640,21 +640,21 @@ impl From<DOMString> for String {
     }
 }
 
-impl Into<Vec<u8>> for DOMString {
-    fn into(self) -> Vec<u8> {
-        self.0.into()
+impl From<DOMString> for Vec<u8> {
+    fn from(contents: DOMString) -> Vec<u8> {
+        contents.0.into()
     }
 }
 
-impl<'a> Into<Cow<'a, str>> for DOMString {
-    fn into(self) -> Cow<'a, str> {
-        self.0.into()
+impl<'a> From<DOMString> for Cow<'a, str> {
+    fn from(contents: DOMString) -> Cow<'a, str> {
+        contents.0.into()
     }
 }
 
-impl<'a> Into<CowRcStr<'a>> for DOMString {
-    fn into(self) -> CowRcStr<'a> {
-        self.0.into()
+impl<'a> From<DOMString> for CowRcStr<'a> {
+    fn from(contents: DOMString) -> CowRcStr<'a> {
+        contents.0.into()
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3454,10 +3454,10 @@ impl UniqueId {
     }
 }
 
-impl Into<LayoutNodeType> for NodeTypeId {
+impl From<NodeTypeId> for LayoutNodeType {
     #[inline(always)]
-    fn into(self) -> LayoutNodeType {
-        match self {
+    fn from(node_type: NodeTypeId) -> LayoutNodeType {
+        match node_type {
             NodeTypeId::Element(e) => LayoutNodeType::Element(e.into()),
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => LayoutNodeType::Text,
             x => unreachable!("Layout should not traverse nodes of type {:?}", x),
@@ -3465,10 +3465,10 @@ impl Into<LayoutNodeType> for NodeTypeId {
     }
 }
 
-impl Into<LayoutElementType> for ElementTypeId {
+impl From<ElementTypeId> for LayoutElementType {
     #[inline(always)]
-    fn into(self) -> LayoutElementType {
-        match self {
+    fn from(element_type: ElementTypeId) -> LayoutElementType {
+        match element_type {
             ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement) => {
                 LayoutElementType::HTMLBodyElement
             },

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -99,9 +99,9 @@ impl XRSystem {
     }
 }
 
-impl Into<SessionMode> for XRSessionMode {
-    fn into(self) -> SessionMode {
-        match self {
+impl From<XRSessionMode> for SessionMode {
+    fn from(mode: XRSessionMode) -> SessionMode {
+        match mode {
             XRSessionMode::Immersive_vr => SessionMode::ImmersiveVR,
             XRSessionMode::Immersive_ar => SessionMode::ImmersiveAR,
             XRSessionMode::Inline => SessionMode::Inline,


### PR DESCRIPTION
Fixes the [`from_over_into`](https://rust-lang.github.io/rust-clippy/master/index.html#/from_over_into) clippy warnings in `components/script`. Replaces `Into<A> for B` with `From<B> for A` since that already implies `Into` and the std docs recommend this.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500
- [x] These changes do not require tests because they do not modify behaviour