### PR TITLE
clippy: Fix `match_like_matches` warnings

### DIFF
--- a/components/script/dom/bindings/xmlname.rs
+++ b/components/script/dom/bindings/xmlname.rs
@@ -110,15 +110,13 @@ pub fn xml_name_type(name: &str) -> XMLName {
 
     fn is_valid_continuation(c: char) -> bool {
         is_valid_start(c) ||
-            match c {
+            matches!(c,
                 '-' |
                 '.' |
                 '0'..='9' |
                 '\u{B7}' |
                 '\u{300}'..='\u{36F}' |
-                '\u{203F}'..='\u{2040}' => true,
-                _ => false,
-            }
+                '\u{203F}'..='\u{2040}')
     }
 
     let mut iter = name.chars();

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -64,14 +64,14 @@ impl CryptoMethods for Crypto {
 }
 
 fn is_integer_buffer(array_type: Type) -> bool {
-    match array_type {
+    matches!(
+        array_type,
         Type::Uint8 |
-        Type::Uint8Clamped |
-        Type::Int8 |
-        Type::Uint16 |
-        Type::Int16 |
-        Type::Uint32 |
-        Type::Int32 => true,
-        _ => false,
-    }
+            Type::Uint8Clamped |
+            Type::Int8 |
+            Type::Uint16 |
+            Type::Int16 |
+            Type::Uint32 |
+            Type::Int32
+    )
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -345,7 +345,7 @@ impl Element {
         self.is.borrow().clone()
     }
 
-    /// <https://dom.spec.whatwg.org/#concept-element-defined>
+    /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
     pub fn set_custom_element_state(&self, state: CustomElementState) {
         // no need to inflate rare data for uncustomized
         if state != CustomElementState::Uncustomized || self.rare_data().is_some() {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -345,16 +345,17 @@ impl Element {
         self.is.borrow().clone()
     }
 
+    /// <https://dom.spec.whatwg.org/#concept-element-defined>
     pub fn set_custom_element_state(&self, state: CustomElementState) {
         // no need to inflate rare data for uncustomized
         if state != CustomElementState::Uncustomized || self.rare_data().is_some() {
             self.ensure_rare_data().custom_element_state = state;
         }
-        // https://dom.spec.whatwg.org/#concept-element-defined
-        let in_defined_state = match state {
-            CustomElementState::Uncustomized | CustomElementState::Custom => true,
-            _ => false,
-        };
+
+        let in_defined_state = matches!(
+            state,
+            CustomElementState::Uncustomized | CustomElementState::Custom
+        );
         self.set_state(ElementState::DEFINED, in_defined_state)
     }
 
@@ -1393,21 +1394,18 @@ impl Element {
         }
 
         // <a>, <input>, <select>, and <textrea> are inherently focusable.
-        match node.type_id() {
+        matches!(
+            node.type_id(),
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLAnchorElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLInputElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLSelectElement,
-            )) |
-            NodeTypeId::Element(ElementTypeId::HTMLElement(
+            )) | NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLTextAreaElement,
-            )) => true,
-            _ => false,
-        }
+            ))
+        )
     }
 
     pub fn is_actually_disabled(&self) -> bool {
@@ -1493,7 +1491,7 @@ impl Element {
             .map(|js| DomRoot::from_ref(&**js))
     }
 
-    // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
+    /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
     pub fn get_attribute_by_name(&self, name: DOMString) -> Option<DomRoot<Attr>> {
         let name = &self.parsed_name(name);
         let maybe_attribute = self
@@ -1506,10 +1504,7 @@ impl Element {
             if *name == local_name!("id") || *name == local_name!("name") {
                 match maybe_attr {
                     None => true,
-                    Some(ref attr) => match *attr.value() {
-                        AttrValue::Atom(_) => true,
-                        _ => false,
-                    },
+                    Some(ref attr) => matches!(*attr.value(), AttrValue::Atom(_)),
                 }
             } else {
                 true
@@ -2932,10 +2927,7 @@ impl VirtualMethods for Element {
                         //
                         // Juggle a bit to keep the borrow checker happy
                         // while avoiding the extra clone.
-                        let is_declaration = match *attr.value() {
-                            AttrValue::Declaration(..) => true,
-                            _ => false,
-                        };
+                        let is_declaration = matches!(*attr.value(), AttrValue::Declaration(..));
 
                         let block = if is_declaration {
                             let mut value = AttrValue::String(String::new());

--- a/components/script/dom/webgl_validations/types.rs
+++ b/components/script/dom/webgl_validations/types.rs
@@ -24,10 +24,7 @@ gl_enums! {
 
 impl TexImageTarget {
     pub fn is_cubic(&self) -> bool {
-        match *self {
-            TexImageTarget::Texture2D => false,
-            _ => true,
-        }
+        !matches!(*self, TexImageTarget::Texture2D)
     }
 
     pub fn dimensions(self) -> u8 {

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -149,10 +149,7 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ServoLayoutElement<'dom, LayoutDataT
     fn is_root(&self) -> bool {
         match self.as_node().parent_node() {
             None => false,
-            Some(node) => match node.script_type_id() {
-                NodeTypeId::Document(_) => true,
-                _ => false,
-            },
+            Some(node) => matches!(node.script_type_id(), NodeTypeId::Document(_)),
         }
     }
 }
@@ -587,15 +584,11 @@ impl<'dom, LayoutDataType: LayoutDataTrait> ::selectors::Element
 
             NonTSPseudoClass::Lang(ref lang) => self.match_element_lang(None, lang),
 
-            NonTSPseudoClass::ServoNonZeroBorder => {
-                match self
-                    .element
-                    .get_attr_for_layout(&ns!(), &local_name!("border"))
-                {
-                    None | Some(&AttrValue::UInt(_, 0)) => false,
-                    _ => true,
-                }
-            },
+            NonTSPseudoClass::ServoNonZeroBorder => !matches!(
+                self.element
+                    .get_attr_for_layout(&ns!(), &local_name!("border")),
+                None | Some(&AttrValue::UInt(_, 0))
+            ),
             NonTSPseudoClass::ReadOnly => !self
                 .element
                 .get_state_for_layout()


### PR DESCRIPTION
Fixes the remaining [`match_like_matches`](https://rust-lang.github.io/rust-clippy/master/index.html#/match_like_matches_macro) clippy warnings in `components/script`. Also updates comments near the changes to be proper rustdoc.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500
- [x] These changes do not require tests because they do not modify behaviour