### PR TITLE
layout: Have `current_block_direction_position` in `PlacementState` use `Au`

### DIFF
--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-baseline-horiz-004.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-baseline-horiz-004.xhtml.ini
@@ -1,0 +1,2 @@
+[flexbox-align-self-baseline-horiz-004.xhtml]
+  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #29819.
- [x] These changes do not require tests because it's a type adjustment and doesn't alter the underlying logic 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
