### PR TITLE
Clippy: Fix the error of variants having the same prefix.

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -104,9 +104,9 @@ pub enum DedicatedWorkerScriptMsg {
 }
 
 pub enum MixedMessage {
-    FromWorker(DedicatedWorkerScriptMsg),
-    FromDevtools(DevtoolScriptControlMsg),
-    FromControl(DedicatedWorkerControlMsg),
+    Worker(DedicatedWorkerScriptMsg),
+    Devtools(DevtoolScriptControlMsg),
+    Control(DedicatedWorkerControlMsg),
 }
 
 impl QueuedTaskConversion for DedicatedWorkerScriptMsg {
@@ -220,15 +220,15 @@ impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
     }
 
     fn from_control_msg(&self, msg: DedicatedWorkerControlMsg) -> MixedMessage {
-        MixedMessage::FromControl(msg)
+        MixedMessage::Control(msg)
     }
 
     fn from_worker_msg(&self, msg: DedicatedWorkerScriptMsg) -> MixedMessage {
-        MixedMessage::FromWorker(msg)
+        MixedMessage::Worker(msg)
     }
 
     fn from_devtools_msg(&self, msg: DevtoolScriptControlMsg) -> MixedMessage {
-        MixedMessage::FromDevtools(msg)
+        MixedMessage::Devtools(msg)
     }
 
     fn control_receiver(&self) -> &Receiver<DedicatedWorkerControlMsg> {
@@ -538,7 +538,7 @@ impl DedicatedWorkerGlobalScope {
     fn handle_mixed_message(&self, msg: MixedMessage) -> bool {
         // FIXME(#26324): `self.worker` is None in devtools messages.
         match msg {
-            MixedMessage::FromDevtools(msg) => match msg {
+            MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
                     devtools::handle_evaluate_js(self.upcast(), string, sender)
                 },
@@ -547,15 +547,12 @@ impl DedicatedWorkerGlobalScope {
                 },
                 _ => debug!("got an unusable devtools control message inside the worker!"),
             },
-            MixedMessage::FromWorker(DedicatedWorkerScriptMsg::CommonWorker(
-                linked_worker,
-                msg,
-            )) => {
+            MixedMessage::Worker(DedicatedWorkerScriptMsg::CommonWorker(linked_worker, msg)) => {
                 let _ar = AutoWorkerReset::new(self, linked_worker);
                 self.handle_script_event(msg);
             },
-            MixedMessage::FromWorker(DedicatedWorkerScriptMsg::WakeUp) => {},
-            MixedMessage::FromControl(DedicatedWorkerControlMsg::Exit) => {
+            MixedMessage::Worker(DedicatedWorkerScriptMsg::WakeUp) => {},
+            MixedMessage::Control(DedicatedWorkerControlMsg::Exit) => {
                 return false;
             },
         }

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -41,9 +41,9 @@ use crate::task_source::{TaskSource, TaskSourceName};
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 pub enum FileReaderFunction {
-    ReadAsText,
-    ReadAsDataUrl,
-    ReadAsArrayBuffer,
+    Text,
+    DataUrl,
+    ArrayBuffer,
 }
 
 pub type TrustedFileReader = Trusted<FileReader>;
@@ -253,13 +253,13 @@ impl FileReader {
         // Step 8.2
 
         match data.function {
-            FileReaderFunction::ReadAsDataUrl => {
+            FileReaderFunction::DataUrl => {
                 FileReader::perform_readasdataurl(&fr.result, data, &blob_contents)
             },
-            FileReaderFunction::ReadAsText => {
+            FileReaderFunction::Text => {
                 FileReader::perform_readastext(&fr.result, data, &blob_contents)
             },
-            FileReaderFunction::ReadAsArrayBuffer => {
+            FileReaderFunction::ArrayBuffer => {
                 let _ac = enter_realm(&*fr);
                 FileReader::perform_readasarraybuffer(
                     &fr.result,
@@ -349,17 +349,17 @@ impl FileReaderMethods for FileReader {
 
     // https://w3c.github.io/FileAPI/#dfn-readAsArrayBuffer
     fn ReadAsArrayBuffer(&self, blob: &Blob) -> ErrorResult {
-        self.read(FileReaderFunction::ReadAsArrayBuffer, blob, None)
+        self.read(FileReaderFunction::ArrayBuffer, blob, None)
     }
 
     // https://w3c.github.io/FileAPI/#dfn-readAsDataURL
     fn ReadAsDataURL(&self, blob: &Blob) -> ErrorResult {
-        self.read(FileReaderFunction::ReadAsDataUrl, blob, None)
+        self.read(FileReaderFunction::DataUrl, blob, None)
     }
 
     // https://w3c.github.io/FileAPI/#dfn-readAsText
     fn ReadAsText(&self, blob: &Blob, label: Option<DOMString>) -> ErrorResult {
-        self.read(FileReaderFunction::ReadAsText, blob, label)
+        self.read(FileReaderFunction::Text, blob, label)
     }
 
     // https://w3c.github.io/FileAPI/#dfn-abort

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -826,21 +826,19 @@ impl HTMLFormElement {
 
         // Step 22
         match (&*scheme, method) {
-            (_, FormMethod::FormDialog) => {
+            (_, FormMethod::Dialog) => {
                 // TODO: Submit dialog
                 // https://html.spec.whatwg.org/multipage/#submit-dialog
             },
             // https://html.spec.whatwg.org/multipage/#submit-mutate-action
-            ("http", FormMethod::FormGet) |
-            ("https", FormMethod::FormGet) |
-            ("data", FormMethod::FormGet) => {
+            ("http", FormMethod::Get) | ("https", FormMethod::Get) | ("data", FormMethod::Get) => {
                 load_data
                     .headers
                     .typed_insert(ContentType::from(mime::APPLICATION_WWW_FORM_URLENCODED));
                 self.mutate_action_url(&mut form_data, load_data, encoding, target_window);
             },
             // https://html.spec.whatwg.org/multipage/#submit-body
-            ("http", FormMethod::FormPost) | ("https", FormMethod::FormPost) => {
+            ("http", FormMethod::Post) | ("https", FormMethod::Post) => {
                 load_data.method = Method::POST;
                 self.submit_entity_body(
                     &mut form_data,
@@ -853,16 +851,16 @@ impl HTMLFormElement {
             // https://html.spec.whatwg.org/multipage/#submit-get-action
             ("file", _) |
             ("about", _) |
-            ("data", FormMethod::FormPost) |
+            ("data", FormMethod::Post) |
             ("ftp", _) |
             ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
-            ("mailto", FormMethod::FormPost) => {
+            ("mailto", FormMethod::Post) => {
                 // TODO: Mail as body
                 // https://html.spec.whatwg.org/multipage/#submit-mailto-body
             },
-            ("mailto", FormMethod::FormGet) => {
+            ("mailto", FormMethod::Get) => {
                 // TODO: Mail with headers
                 // https://html.spec.whatwg.org/multipage/#submit-mailto-headers
             },
@@ -1361,9 +1359,9 @@ pub enum FormEncType {
 
 #[derive(Clone, Copy, MallocSizeOf)]
 pub enum FormMethod {
-    FormGet,
-    FormPost,
-    FormDialog,
+    Get,
+    Post,
+    Dialog,
 }
 
 /// <https://html.spec.whatwg.org/multipage/#form-associated-element>
@@ -1431,9 +1429,9 @@ impl<'a> FormSubmitter<'a> {
             ),
         };
         match &*attr {
-            "dialog" => FormMethod::FormDialog,
-            "post" => FormMethod::FormPost,
-            _ => FormMethod::FormGet,
+            "dialog" => FormMethod::Dialog,
+            "post" => FormMethod::Post,
+            _ => FormMethod::Get,
         }
     }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -404,8 +404,7 @@ pub enum NetworkState {
 /// <https://html.spec.whatwg.org/multipage/#dom-media-readystate>
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
 #[repr(u8)]
-#[allow(clippy::enum_variant_names)]
-/// Clippy warning silenced here because these names are from the specification.
+#[allow(clippy::enum_variant_names)] // Clippy warning silenced here because these names are from the specification.
 pub enum ReadyState {
     HaveNothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
     HaveMetadata = HTMLMediaElementConstants::HAVE_METADATA as u8,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -404,6 +404,7 @@ pub enum NetworkState {
 /// <https://html.spec.whatwg.org/multipage/#dom-media-readystate>
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
 #[repr(u8)]
+#[allow(clippy::enum_variant_names)]  /// Clippy warning silenced here because these names are from the specification.
 pub enum ReadyState {
     HaveNothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
     HaveMetadata = HTMLMediaElementConstants::HAVE_METADATA as u8,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -404,7 +404,8 @@ pub enum NetworkState {
 /// <https://html.spec.whatwg.org/multipage/#dom-media-readystate>
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
 #[repr(u8)]
-#[allow(clippy::enum_variant_names)]  /// Clippy warning silenced here because these names are from the specification.
+#[allow(clippy::enum_variant_names)]
+/// Clippy warning silenced here because these names are from the specification.
 pub enum ReadyState {
     HaveNothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
     HaveMetadata = HTMLMediaElementConstants::HAVE_METADATA as u8,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -405,11 +405,11 @@ pub enum NetworkState {
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum ReadyState {
-    Nothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
-    Metadata = HTMLMediaElementConstants::HAVE_METADATA as u8,
-    CurrentData = HTMLMediaElementConstants::HAVE_CURRENT_DATA as u8,
-    FutureData = HTMLMediaElementConstants::HAVE_FUTURE_DATA as u8,
-    EnoughData = HTMLMediaElementConstants::HAVE_ENOUGH_DATA as u8,
+    HaveNothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
+    HaveMetadata = HTMLMediaElementConstants::HAVE_METADATA as u8,
+    HaveCurrentData = HTMLMediaElementConstants::HAVE_CURRENT_DATA as u8,
+    HaveFutureData = HTMLMediaElementConstants::HAVE_FUTURE_DATA as u8,
+    HaveEnoughData = HTMLMediaElementConstants::HAVE_ENOUGH_DATA as u8,
 }
 
 impl HTMLMediaElement {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -405,11 +405,11 @@ pub enum NetworkState {
 #[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
 #[repr(u8)]
 pub enum ReadyState {
-    HaveNothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
-    HaveMetadata = HTMLMediaElementConstants::HAVE_METADATA as u8,
-    HaveCurrentData = HTMLMediaElementConstants::HAVE_CURRENT_DATA as u8,
-    HaveFutureData = HTMLMediaElementConstants::HAVE_FUTURE_DATA as u8,
-    HaveEnoughData = HTMLMediaElementConstants::HAVE_ENOUGH_DATA as u8,
+    Nothing = HTMLMediaElementConstants::HAVE_NOTHING as u8,
+    Metadata = HTMLMediaElementConstants::HAVE_METADATA as u8,
+    CurrentData = HTMLMediaElementConstants::HAVE_CURRENT_DATA as u8,
+    FutureData = HTMLMediaElementConstants::HAVE_FUTURE_DATA as u8,
+    EnoughData = HTMLMediaElementConstants::HAVE_ENOUGH_DATA as u8,
 }
 
 impl HTMLMediaElement {
@@ -417,7 +417,7 @@ impl HTMLMediaElement {
         Self {
             htmlelement: HTMLElement::new_inherited(tag_name, prefix, document),
             network_state: Cell::new(NetworkState::Empty),
-            ready_state: Cell::new(ReadyState::HaveNothing),
+            ready_state: Cell::new(ReadyState::Nothing),
             src_object: Default::default(),
             current_src: DomRefCell::new("".to_owned()),
             generation_id: Cell::new(0),
@@ -611,12 +611,12 @@ impl HTMLMediaElement {
 
         // Step 1.
         match (old_ready_state, ready_state) {
-            (ReadyState::HaveNothing, ReadyState::HaveMetadata) => {
+            (ReadyState::Nothing, ReadyState::Metadata) => {
                 task_source.queue_simple_event(self.upcast(), atom!("loadedmetadata"), &window);
                 // No other steps are applicable in this case.
                 return;
             },
-            (ReadyState::HaveMetadata, new) if new >= ReadyState::HaveCurrentData => {
+            (ReadyState::Metadata, new) if new >= ReadyState::CurrentData => {
                 if !self.fired_loadeddata_event.get() {
                     self.fired_loadeddata_event.set(true);
                     let this = Trusted::new(self);
@@ -635,7 +635,7 @@ impl HTMLMediaElement {
                 // or HaveFutureData also apply here, as per the next match
                 // expression.
             },
-            (ReadyState::HaveFutureData, new) if new <= ReadyState::HaveCurrentData => {
+            (ReadyState::FutureData, new) if new <= ReadyState::CurrentData => {
                 // FIXME(nox): Queue a task to fire timeupdate and waiting
                 // events if the conditions call from the spec are met.
 
@@ -646,9 +646,7 @@ impl HTMLMediaElement {
             _ => (),
         }
 
-        if old_ready_state <= ReadyState::HaveCurrentData &&
-            ready_state >= ReadyState::HaveFutureData
-        {
+        if old_ready_state <= ReadyState::CurrentData && ready_state >= ReadyState::FutureData {
             task_source.queue_simple_event(self.upcast(), atom!("canplay"), &window);
 
             if !self.Paused() {
@@ -656,7 +654,7 @@ impl HTMLMediaElement {
             }
         }
 
-        if ready_state == ReadyState::HaveEnoughData {
+        if ready_state == ReadyState::EnoughData {
             // TODO: Check sandboxed automatic features browsing context flag.
             // FIXME(nox): I have no idea what this TODO is about.
 
@@ -1066,7 +1064,7 @@ impl HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#blocked-media-element
     fn is_blocked_media_element(&self) -> bool {
-        self.ready_state.get() <= ReadyState::HaveCurrentData ||
+        self.ready_state.get() <= ReadyState::CurrentData ||
             self.is_paused_for_user_interaction() ||
             self.is_paused_for_in_band_content()
     }
@@ -1126,8 +1124,8 @@ impl HTMLMediaElement {
             self.VideoTracks().clear();
 
             // Step 6.5.
-            if self.ready_state.get() != ReadyState::HaveNothing {
-                self.change_ready_state(ReadyState::HaveNothing);
+            if self.ready_state.get() != ReadyState::Nothing {
+                self.change_ready_state(ReadyState::Nothing);
             }
 
             // Step 6.6.
@@ -1243,7 +1241,7 @@ impl HTMLMediaElement {
         self.show_poster.set(false);
 
         // Step 2.
-        if self.ready_state.get() == ReadyState::HaveNothing {
+        if self.ready_state.get() == ReadyState::Nothing {
             return;
         }
 
@@ -1483,7 +1481,7 @@ impl HTMLMediaElement {
                 // https://html.spec.whatwg.org/multipage/#media-data-processing-steps-list
                 // => "If the media data can be fetched but is found by inspection to be in
                 //    an unsupported format, or can otherwise not be rendered at all"
-                if self.ready_state.get() < ReadyState::HaveMetadata {
+                if self.ready_state.get() < ReadyState::Metadata {
                     self.queue_dedicated_media_source_failure_steps();
                 } else {
                     // https://html.spec.whatwg.org/multipage/#reaches-the-end
@@ -1723,7 +1721,7 @@ impl HTMLMediaElement {
                 }
 
                 // Step 6.
-                self.change_ready_state(ReadyState::HaveMetadata);
+                self.change_ready_state(ReadyState::Metadata);
 
                 // Step 7.
                 let mut jumped = false;
@@ -1842,8 +1840,8 @@ impl HTMLMediaElement {
                 match *state {
                     PlaybackState::Paused => {
                         media_session_playback_state = MediaSessionPlaybackState::Paused;
-                        if self.ready_state.get() == ReadyState::HaveMetadata {
-                            self.change_ready_state(ReadyState::HaveEnoughData);
+                        if self.ready_state.get() == ReadyState::Metadata {
+                            self.change_ready_state(ReadyState::EnoughData);
                         }
                     },
                     PlaybackState::Playing => {
@@ -1878,7 +1876,7 @@ impl HTMLMediaElement {
 
     fn render_controls(&self) {
         let element = self.htmlelement.upcast::<Element>();
-        if self.ready_state.get() < ReadyState::HaveMetadata || element.is_shadow_host() {
+        if self.ready_state.get() < ReadyState::Metadata || element.is_shadow_host() {
             // Bail out if we have no metadata yet or
             // if we are already showing the controls.
             return;
@@ -2188,16 +2186,14 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
 
             // Step 6.4.
             match state {
-                ReadyState::HaveNothing |
-                ReadyState::HaveMetadata |
-                ReadyState::HaveCurrentData => {
+                ReadyState::Nothing | ReadyState::Metadata | ReadyState::CurrentData => {
                     task_source.queue_simple_event(self.upcast(), atom!("waiting"), &window);
                 },
-                ReadyState::HaveFutureData | ReadyState::HaveEnoughData => {
+                ReadyState::FutureData | ReadyState::EnoughData => {
                     self.notify_about_playing();
                 },
             }
-        } else if state == ReadyState::HaveFutureData || state == ReadyState::HaveEnoughData {
+        } else if state == ReadyState::FutureData || state == ReadyState::EnoughData {
             // Step 7.
             self.take_pending_play_promises(Ok(()));
             let this = Trusted::new(self);
@@ -2307,7 +2303,7 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-media-currenttime
     fn SetCurrentTime(&self, time: Finite<f64>) {
-        if self.ready_state.get() == ReadyState::HaveNothing {
+        if self.ready_state.get() == ReadyState::Nothing {
             self.default_playback_start_position.set(*time);
         } else {
             self.playback_position.set(*time);
@@ -2322,7 +2318,7 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#ended-playback
     fn Ended(&self) -> bool {
-        if self.ready_state.get() < ReadyState::HaveMetadata {
+        if self.ready_state.get() < ReadyState::Metadata {
             return false;
         }
 
@@ -2809,12 +2805,12 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         }
 
         if status.is_ok() && self.latest_fetched_content != 0 {
-            if elem.ready_state.get() == ReadyState::HaveNothing {
+            if elem.ready_state.get() == ReadyState::Nothing {
                 // Make sure that we don't skip the HaveMetadata and HaveCurrentData
                 // states for short streams.
-                elem.change_ready_state(ReadyState::HaveMetadata);
+                elem.change_ready_state(ReadyState::Metadata);
             }
-            elem.change_ready_state(ReadyState::HaveEnoughData);
+            elem.change_ready_state(ReadyState::EnoughData);
 
             elem.upcast::<EventTarget>().fire_event(atom!("progress"));
 
@@ -2825,7 +2821,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             elem.delay_load_event(false);
         }
         // => "If the connection is interrupted after some media data has been received..."
-        else if elem.ready_state.get() != ReadyState::HaveNothing {
+        else if elem.ready_state.get() != ReadyState::Nothing {
             // Step 1
             if let Some(ref mut current_fetch_context) = *elem.current_fetch_context.borrow_mut() {
                 current_fetch_context.cancel(CancelReason::Error);

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -245,7 +245,7 @@ impl HTMLVideoElement {
 impl HTMLVideoElementMethods for HTMLVideoElement {
     // https://html.spec.whatwg.org/multipage/#dom-video-videowidth
     fn VideoWidth(&self) -> u32 {
-        if self.htmlmediaelement.get_ready_state() == ReadyState::HaveNothing {
+        if self.htmlmediaelement.get_ready_state() == ReadyState::Nothing {
             return 0;
         }
         self.video_width.get()
@@ -253,7 +253,7 @@ impl HTMLVideoElementMethods for HTMLVideoElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-video-videoheight
     fn VideoHeight(&self) -> u32 {
-        if self.htmlmediaelement.get_ready_state() == ReadyState::HaveNothing {
+        if self.htmlmediaelement.get_ready_state() == ReadyState::Nothing {
             return 0;
         }
         self.video_height.get()

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -245,7 +245,7 @@ impl HTMLVideoElement {
 impl HTMLVideoElementMethods for HTMLVideoElement {
     // https://html.spec.whatwg.org/multipage/#dom-video-videowidth
     fn VideoWidth(&self) -> u32 {
-        if self.htmlmediaelement.get_ready_state() == ReadyState::Nothing {
+        if self.htmlmediaelement.get_ready_state() == ReadyState::HaveNothing {
             return 0;
         }
         self.video_width.get()
@@ -253,7 +253,7 @@ impl HTMLVideoElementMethods for HTMLVideoElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-video-videoheight
     fn VideoHeight(&self) -> u32 {
-        if self.htmlmediaelement.get_ready_state() == ReadyState::Nothing {
+        if self.htmlmediaelement.get_ready_state() == ReadyState::HaveNothing {
             return 0;
         }
         self.video_height.get()

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -123,9 +123,9 @@ pub enum ServiceWorkerControlMsg {
 }
 
 pub enum MixedMessage {
-    FromServiceWorker(ServiceWorkerScriptMsg),
-    FromDevtools(DevtoolScriptControlMsg),
-    FromControl(ServiceWorkerControlMsg),
+    ServiceWorker(ServiceWorkerScriptMsg),
+    Devtools(DevtoolScriptControlMsg),
+    Control(ServiceWorkerControlMsg),
 }
 
 #[derive(Clone, JSTraceable)]
@@ -202,15 +202,15 @@ impl WorkerEventLoopMethods for ServiceWorkerGlobalScope {
     }
 
     fn from_control_msg(&self, msg: ServiceWorkerControlMsg) -> MixedMessage {
-        MixedMessage::FromControl(msg)
+        MixedMessage::Control(msg)
     }
 
     fn from_worker_msg(&self, msg: ServiceWorkerScriptMsg) -> MixedMessage {
-        MixedMessage::FromServiceWorker(msg)
+        MixedMessage::ServiceWorker(msg)
     }
 
     fn from_devtools_msg(&self, msg: DevtoolScriptControlMsg) -> MixedMessage {
-        MixedMessage::FromDevtools(msg)
+        MixedMessage::Devtools(msg)
     }
 
     fn control_receiver(&self) -> &Receiver<ServiceWorkerControlMsg> {
@@ -413,7 +413,7 @@ impl ServiceWorkerGlobalScope {
 
     fn handle_mixed_message(&self, msg: MixedMessage) -> bool {
         match msg {
-            MixedMessage::FromDevtools(msg) => match msg {
+            MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
                     devtools::handle_evaluate_js(self.upcast(), string, sender)
                 },
@@ -422,10 +422,10 @@ impl ServiceWorkerGlobalScope {
                 },
                 _ => debug!("got an unusable devtools control message inside the worker!"),
             },
-            MixedMessage::FromServiceWorker(msg) => {
+            MixedMessage::ServiceWorker(msg) => {
                 self.handle_script_event(msg);
             },
-            MixedMessage::FromControl(ServiceWorkerControlMsg::Exit) => {
+            MixedMessage::Control(ServiceWorkerControlMsg::Exit) => {
                 return false;
             },
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Renamed the variants having similar prefixes by using full paths to variants rather.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500.
- [X] These changes do not require tests because they only fix clippy warnings and no functionality changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
