### PR TITLE
clippy: Mark functions taking many arguments as exceptions to clippy lints

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1544,6 +1544,7 @@ impl<'a> TableLayout<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn do_final_cell_layout(
         &mut self,
         row_index: usize,

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -351,6 +351,7 @@ impl CanvasState {
     // is copied on the rectangle (dx, dy, dh, dw) of the destination canvas
     //
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
+    #[allow(clippy::too_many_arguments)]
     fn draw_image_internal(
         &self,
         htmlcanvas: Option<&HTMLCanvasElement>,
@@ -425,6 +426,7 @@ impl CanvasState {
         result
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_offscreen_canvas(
         &self,
         canvas: &OffscreenCanvas,
@@ -479,6 +481,7 @@ impl CanvasState {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_html_canvas_element(
         &self,
         canvas: &HTMLCanvasElement,             // source canvas
@@ -539,6 +542,7 @@ impl CanvasState {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn fetch_and_draw_image_data(
         &self,
         canvas: Option<&HTMLCanvasElement>,
@@ -594,6 +598,7 @@ impl CanvasState {
     // on the drawImage call arguments
     // source rectangle = area of the original image to be copied
     // destination rectangle = area of the destination canvas where the source image is going to be drawn
+    #[allow(clippy::too_many_arguments)]
     fn adjust_source_dest_rects(
         &self,
         image_size: Size2D<f64>,
@@ -840,6 +845,7 @@ impl CanvasState {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient
+    #[allow(clippy::too_many_arguments)]
     pub fn create_radial_gradient(
         &self,
         global: &GlobalScope,
@@ -1279,6 +1285,7 @@ impl CanvasState {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     #[allow(unsafe_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn put_image_data_(
         &self,
         canvas_size: Size2D<u64>,
@@ -1375,6 +1382,7 @@ impl CanvasState {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
+    #[allow(clippy::too_many_arguments)]
     pub fn draw_image__(
         &self,
         canvas: Option<&HTMLCanvasElement>,
@@ -1646,6 +1654,7 @@ impl CanvasState {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse
+    #[allow(clippy::too_many_arguments)]
     pub fn ellipse(
         &self,
         x: f64,

--- a/components/script/dom/audioparam.rs
+++ b/components/script/dom/audioparam.rs
@@ -40,6 +40,7 @@ pub struct AudioParam {
 }
 
 impl AudioParam {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_inherited(
         context: &BaseAudioContext,
         node: NodeId,
@@ -64,6 +65,7 @@ impl AudioParam {
     }
 
     #[allow(crown::unrooted_must_root)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         context: &BaseAudioContext,

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -229,6 +229,7 @@ pub fn create_callback_interface_object(
 }
 
 /// Create the interface prototype object of a non-callback interface.
+#[allow(clippy::too_many_arguments)]
 pub fn create_interface_prototype_object(
     cx: SafeJSContext,
     global: HandleObject,
@@ -273,6 +274,7 @@ pub fn create_interface_prototype_object(
 }
 
 /// Create and define the interface object of a non-callback interface.
+#[allow(clippy::too_many_arguments)]
 pub fn create_noncallback_interface_object(
     cx: SafeJSContext,
     global: HandleObject,
@@ -353,6 +355,7 @@ pub fn create_named_constructors(
 }
 
 /// Create a new object with a unique type.
+#[allow(clippy::too_many_arguments)]
 pub fn create_object(
     cx: SafeJSContext,
     global: HandleObject,

--- a/components/script/dom/bindings/namespace.rs
+++ b/components/script/dom/bindings/namespace.rs
@@ -35,6 +35,7 @@ impl NamespaceObjectClass {
 }
 
 /// Create a new namespace object.
+#[allow(clippy::too_many_arguments)]
 pub fn create_namespace_object(
     cx: JSContext,
     global: HandleObject,

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -56,6 +56,7 @@ impl ProgressEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -219,6 +219,7 @@ impl WorkerEventLoopMethods for ServiceWorkerGlobalScope {
 }
 
 impl ServiceWorkerGlobalScope {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         init: WorkerGlobalScopeInit,
         worker_url: ServoUrl,
@@ -253,6 +254,7 @@ impl ServiceWorkerGlobalScope {
     }
 
     #[allow(unsafe_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         init: WorkerGlobalScopeInit,
         worker_url: ServoUrl,
@@ -285,6 +287,7 @@ impl ServiceWorkerGlobalScope {
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/ServiceWorker/#run-service-worker-algorithm
+    #[allow(clippy::too_many_arguments)]
     pub fn run_serviceworker_scope(
         scope_things: ScopeThings,
         own_sender: Sender<ServiceWorkerScriptMsg>,

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -64,6 +64,7 @@ impl StorageEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &Window,
         type_: Atom,
@@ -89,6 +90,7 @@ impl StorageEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/textmetrics.rs
+++ b/components/script/dom/textmetrics.rs
@@ -30,6 +30,7 @@ pub struct TextMetrics {
 
 #[allow(non_snake_case)]
 impl TextMetrics {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         width: f64,
         actualBoundingBoxLeft: f64,
@@ -61,6 +62,7 @@ impl TextMetrics {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         width: f64,

--- a/components/script/dom/touch.rs
+++ b/components/script/dom/touch.rs
@@ -25,6 +25,7 @@ pub struct Touch {
 }
 
 impl Touch {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         identifier: i32,
         target: &EventTarget,
@@ -48,6 +49,7 @@ impl Touch {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         identifier: i32,

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -63,6 +63,7 @@ impl TouchEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         type_: DOMString,

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -456,6 +456,7 @@ impl WebGL2RenderingContext {
     }
 
     #[allow(unsafe_code)]
+    #[allow(clippy::too_many_arguments)]
     fn read_pixels_into(
         &self,
         x: i32,
@@ -848,6 +849,7 @@ impl WebGL2RenderingContext {
             .send_command(WebGLCommand::VertexAttribU(index, x, y, z, w));
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn tex_storage(
         &self,
         dimensions: u8,

--- a/components/script/dom/webgl_validations/tex_image_2d.rs
+++ b/components/script/dom/webgl_validations/tex_image_2d.rs
@@ -255,6 +255,7 @@ pub struct TexImage2DValidator<'a> {
 
 impl<'a> TexImage2DValidator<'a> {
     // TODO: Move data validation logic here.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &'a WebGLRenderingContext,
         target: u32,
@@ -386,6 +387,7 @@ pub struct CommonCompressedTexImage2DValidator<'a> {
 }
 
 impl<'a> CommonCompressedTexImage2DValidator<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &'a WebGLRenderingContext,
         target: u32,
@@ -509,6 +511,7 @@ pub struct CompressedTexImage2DValidator<'a> {
 }
 
 impl<'a> CompressedTexImage2DValidator<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &'a WebGLRenderingContext,
         target: u32,
@@ -585,6 +588,7 @@ pub struct CompressedTexSubImage2DValidator<'a> {
 }
 
 impl<'a> CompressedTexSubImage2DValidator<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &'a WebGLRenderingContext,
         target: u32,
@@ -697,6 +701,7 @@ pub struct TexStorageValidatorResult {
 }
 
 impl<'a> TexStorageValidator<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &'a WebGLRenderingContext,
         dimensions: u8,

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -747,6 +747,7 @@ impl WebGLRenderingContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn tex_image_2d(
         &self,
         texture: &WebGLTexture,
@@ -834,6 +835,7 @@ impl WebGLRenderingContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn tex_sub_image_2d(
         &self,
         texture: DomRoot<WebGLTexture>,
@@ -1575,6 +1577,7 @@ impl WebGLRenderingContext {
         constants::COLOR_ATTACHMENT0 <= attachment && attachment <= last_slot
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn compressed_tex_image_2d(
         &self,
         target: u32,
@@ -1642,6 +1645,7 @@ impl WebGLRenderingContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn compressed_tex_sub_image_2d(
         &self,
         target: u32,

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -152,6 +152,7 @@ impl WebGLTexture {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn initialize(
         &self,
         target: TexImageTarget,

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -44,6 +44,7 @@ impl WheelEvent {
         reflect_dom_object_with_proto(Box::new(WheelEvent::new_inherited()), window, proto)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         type_: DOMString,
@@ -62,6 +63,7 @@ impl WheelEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -129,6 +129,7 @@ pub struct WorkerGlobalScope {
 }
 
 impl WorkerGlobalScope {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_inherited(
         init: WorkerGlobalScopeInit,
         worker_name: DOMString,

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -301,6 +301,7 @@ impl WorkletThreadPool {
     /// If all of the threads load successfully, the promise is resolved.
     /// If any of the threads fails to load, the promise is rejected.
     /// <https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script>
+    #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
         pipeline_id: PipelineId,
@@ -625,6 +626,7 @@ impl WorkletThread {
 
     /// Fetch and invoke a worklet script.
     /// <https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script>
+    #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
         global_scope: &WorkletGlobalScope,

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -28,6 +28,7 @@ pub struct XMLDocument {
 }
 
 impl XMLDocument {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         window: &Window,
         has_browsing_context: HasBrowsingContext,
@@ -59,6 +60,7 @@ impl XMLDocument {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         has_browsing_context: HasBrowsingContext,

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -61,6 +61,7 @@ impl XRInputSourcesChangeEvent {
     }
 
     #[allow(unsafe_code)]
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1545,6 +1545,7 @@ struct DynamicModule {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#fetch-a-single-module-script>
+#[allow(clippy::too_many_arguments)]
 fn fetch_single_module_script(
     owner: ModuleOwner,
     url: ServoUrl,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -225,6 +225,7 @@ struct InProgressLoad {
 
 impl InProgressLoad {
     /// Create a new InProgressLoad object.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         id: PipelineId,
         browsing_context_id: BrowsingContextId,
@@ -3645,6 +3646,7 @@ impl ScriptThread {
         ScriptThread::set_user_interacting(false);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_mouse_event(
         &self,
         pipeline_id: PipelineId,

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -65,6 +65,7 @@ pub struct TaskManager {
 }
 
 impl TaskManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         dom_manipulation_task_source: DOMManipulationTaskSource,
         file_reading_task_source: FileReadingTaskSource,


### PR DESCRIPTION
Mark these functions as allowed for clippy lints. The idea is that they can be
fixed iteratively, but fixing them all now is too much work.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because they don't touch functionality.

