### PR TITLE
clippy: Fix `let_and_return` warnings in `components/script`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -751,10 +751,7 @@ fn consume_body_with_promise<T: BodyMixin + DomObject>(
     // Step 2.
     let stream = match object.body() {
         Some(stream) => stream,
-        None => {
-            let stream = ReadableStream::new_from_bytes(&global, Vec::with_capacity(0));
-            stream
-        },
+        None => ReadableStream::new_from_bytes(&global, Vec::with_capacity(0)),
     };
 
     // Step 3.

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -122,7 +122,7 @@ impl BaseAudioContext {
 
         let client_context_id =
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
-        let context = BaseAudioContext {
+        BaseAudioContext {
             eventtarget: EventTarget::new_inherited(),
             audio_context_impl: ServoMedia::get()
                 .unwrap()
@@ -135,9 +135,7 @@ impl BaseAudioContext {
             sample_rate,
             state: Cell::new(AudioContextState::Suspended),
             channel_count: channel_count.into(),
-        };
-
-        context
+        }
     }
 
     /// Tells whether this is an OfflineAudioContext or not.

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -309,11 +309,10 @@ impl BlobMethods for Blob {
 /// see <https://github.com/w3c/FileAPI/issues/43>
 pub fn normalize_type_string(s: &str) -> String {
     if is_ascii_printable(s) {
-        let s_lower = s.to_ascii_lowercase();
+        s.to_ascii_lowercase()
         // match s_lower.parse() as Result<Mime, ()> {
         // Ok(_) => s_lower,
         // Err(_) => "".to_string()
-        s_lower
     } else {
         "".to_string()
     }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -73,8 +73,7 @@ impl CSSStyleOwner {
                     let lock = attr.as_ref().unwrap();
                     let mut guard = shared_lock.write();
                     let pdb = lock.write_with(&mut guard);
-                    let result = f(pdb, &mut changed);
-                    result
+                    f(pdb, &mut changed)
                 } else {
                     let mut pdb = PropertyDeclarationBlock::new();
                     let result = f(&mut pdb, &mut changed);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2771,7 +2771,7 @@ impl GlobalScope {
             return p;
         }
 
-        let promise = match image {
+        match image {
             ImageBitmapSource::HTMLCanvasElement(ref canvas) => {
                 // https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument
                 if !canvas.is_valid() {
@@ -2815,8 +2815,7 @@ impl GlobalScope {
                 p.reject_error(Error::NotSupported);
                 return p;
             },
-        };
-        promise
+        }
     }
 
     pub fn fire_timer(&self, handle: TimerEventId) {

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -50,14 +50,13 @@ pub struct MediaSession {
 impl MediaSession {
     #[allow(crown::unrooted_must_root)]
     fn new_inherited() -> MediaSession {
-        let media_session = MediaSession {
+        MediaSession {
             reflector_: Reflector::new(),
             metadata: DomRefCell::new(None),
             playback_state: DomRefCell::new(MediaSessionPlaybackState::None),
             action_handlers: DomRefCell::new(HashMapTracedValues::new()),
             media_instance: Default::default(),
-        };
-        media_session
+        }
     }
 
     pub fn new(window: &Window) -> DomRoot<MediaSession> {

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -72,7 +72,7 @@ impl RTCDataChannel {
                 .expect("Expected data channel id"),
         );
 
-        let channel = RTCDataChannel {
+        RTCDataChannel {
             eventtarget: EventTarget::new_inherited(),
             servo_media_id,
             peer_connection: Dom::from_ref(peer_connection),
@@ -85,9 +85,7 @@ impl RTCDataChannel {
             id: options.id,
             ready_state: Cell::new(RTCDataChannelState::Connecting),
             binary_type: DomRefCell::new(DOMString::from("blob")),
-        };
-
-        channel
+        }
     }
 
     pub fn new(

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -427,10 +427,9 @@ impl WebGL2RenderingContext {
             let last_row_bytes = bytes_per_pixel
                 .checked_mul(width as usize)
                 .ok_or(InvalidOperation)?;
-            let result = full_row_bytes
+            full_row_bytes
                 .checked_add(last_row_bytes)
-                .ok_or(InvalidOperation)?;
-            result
+                .ok_or(InvalidOperation)?
         };
         let skipped_bytes = {
             let skipped_row_bytes = self
@@ -443,10 +442,9 @@ impl WebGL2RenderingContext {
                 .get()
                 .checked_mul(bytes_per_pixel)
                 .ok_or(InvalidOperation)?;
-            let result = skipped_row_bytes
+            skipped_row_bytes
                 .checked_add(skipped_pixel_bytes)
-                .ok_or(InvalidOperation)?;
-            result
+                .ok_or(InvalidOperation)?
         };
         Ok(ReadPixelsSizes {
             row_stride,
@@ -4117,12 +4115,11 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             self.base.validate_ownership(program),
             return constants::INVALID_INDEX
         );
-        let index = handle_potential_webgl_error!(
+        handle_potential_webgl_error!(
             self.base,
             program.get_uniform_block_index(block_name),
             return constants::INVALID_INDEX
-        );
-        index
+        )
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.16>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove `let-`bindings that are subsequently returned to fix the `let_and_return` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
