### PR TITLE
clippy: Fix `filter_next` warnings in `components/script`

### DIFF
--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -118,8 +118,7 @@ impl FormDataMethods for FormData {
         self.data
             .borrow()
             .iter()
-            .filter(|(datum_name, _)| datum_name.0 == name.0)
-            .next()
+            .find(|(datum_name, _)| datum_name.0 == name.0)
             .map(|(_, datum)| match &datum.value {
                 FormDatumValue::String(ref s) => {
                     FileOrUSVString::USVString(USVString(s.to_string()))

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -170,8 +170,7 @@ impl HTMLLabelElement {
         self.upcast::<Node>()
             .traverse_preorder(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<HTMLElement>)
-            .filter(|elem| elem.is_labelable_element())
-            .next()
+            .find(|elem| elem.is_labelable_element())
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3309,8 +3309,7 @@ impl<'a> ChildrenMutation<'a> {
                 ..
             } => next
                 .inclusively_following_siblings()
-                .filter(|node| node.is::<Element>())
-                .next(),
+                .find(|node| node.is::<Element>()),
             // Add/remove at end of container: Return the last preceding element.
             ChildrenMutation::Append { prev, .. } |
             ChildrenMutation::Replace {
@@ -3319,8 +3318,7 @@ impl<'a> ChildrenMutation<'a> {
                 ..
             } => prev
                 .inclusively_preceding_siblings()
-                .filter(|node| node.is::<Element>())
-                .next(),
+                .find(|node| node.is::<Element>()),
             // Insert or replace in the middle:
             ChildrenMutation::Insert { prev, next, .. } |
             ChildrenMutation::Replace {
@@ -3334,16 +3332,14 @@ impl<'a> ChildrenMutation<'a> {
                 {
                     // Before the first element: Return the first following element.
                     next.inclusively_following_siblings()
-                        .filter(|node| node.is::<Element>())
-                        .next()
+                        .find(|node| node.is::<Element>())
                 } else if next
                     .inclusively_following_siblings()
                     .all(|node| !node.is::<Element>())
                 {
                     // After the last element: Return the last preceding element.
                     prev.inclusively_preceding_siblings()
-                        .filter(|node| node.is::<Element>())
-                        .next()
+                        .find(|node| node.is::<Element>())
                 } else {
                     None
                 }

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -67,8 +67,7 @@ impl XRFrame {
         self.data
             .sub_images
             .iter()
-            .filter(|sub_images| sub_images.layer_id == layer_id)
-            .next()
+            .find(|sub_images| sub_images.layer_id == layer_id)
     }
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace `_.filter(_).next()` calls with `_.find(_)` to fix the `filter_next` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#filter_next

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
