### PR TITLE
layout: Add a `FontMetricsProvider` for resolving font-relative units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3448,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5061,7 +5061,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "bitflags 2.5.0",
  "cssparser",
@@ -5349,7 +5349,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "nodrop",
  "serde",
@@ -5359,7 +5359,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5557,7 +5557,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "static_assertions",
 ]
@@ -5683,7 +5683,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 
 [[package]]
 name = "strict-num"
@@ -5720,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "lazy_static",
 ]
@@ -5787,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "darling",
  "derive_common",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "app_units",
  "bitflags 2.5.0",
@@ -6172,7 +6172,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6185,7 +6185,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2023-10-16#c22dd97c7a826c04a8fb18f99fde5921ec2eea82"
+source = "git+https://github.com/servo/stylo?branch=2023-10-16#273f49fc586a02ff7601725924d2e30f95cfd9d3"
 dependencies = [
  "darling",
  "derive_common",

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -93,12 +93,20 @@ impl<S: FontSource> FontContext<S> {
     /// Font groups are cached, so subsequent calls with the same `style` will return a reference
     /// to an existing `FontGroup`.
     pub fn font_group(&mut self, style: Arc<FontStyleStruct>) -> Rc<RefCell<FontGroup>> {
+        let font_size = style.font_size.computed_size().into();
+        self.font_group_with_size(style, font_size)
+    }
+
+    /// Like [`Self::font_group`], but overriding the size found in the [`FontStyleStruct`] with the given size
+    /// in pixels.
+    pub fn font_group_with_size(
+        &mut self,
+        style: Arc<FontStyleStruct>,
+        size: Au,
+    ) -> Rc<RefCell<FontGroup>> {
         self.expire_font_caches_if_necessary();
 
-        let cache_key = FontGroupCacheKey {
-            size: Au::from_f32_px(style.font_size.computed_size().px()),
-            style,
-        };
+        let cache_key = FontGroupCacheKey { size, style };
 
         if let Some(font_group) = self.font_group_cache.get(&cache_key) {
             return font_group.clone();

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -1597,11 +1597,10 @@ impl InlineFormattingContext {
 
         // It's unfortunate that it isn't possible to get this during IFC text processing, but in
         // that situation the style of the containing block is unknown.
-        let default_font_metrics =
-            crate::context::with_thread_local_font_context(layout_context, |font_context| {
-                get_font_for_first_font_for_style(style, font_context)
-                    .map(|font| font.borrow().metrics.clone())
-            });
+        let default_font_metrics = layout_context.with_font_context(|font_context| {
+            get_font_for_first_font_for_style(style, font_context)
+                .map(|font| font.borrow().metrics.clone())
+        });
 
         let mut ifc = InlineFormattingContextState {
             positioning_context,
@@ -1725,7 +1724,7 @@ impl InlineFormattingContext {
         // For the purposes of `text-transform: capitalize` the start of the IFC is a word boundary.
         let mut on_word_boundary = true;
 
-        crate::context::with_thread_local_font_context(layout_context, |font_context| {
+        layout_context.with_font_context(|font_context| {
             let mut linebreaker = None;
             self.foreach(|iter_item| match iter_item {
                 InlineFormattingContextIterItem::Item(InlineLevelBox::TextRun(

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -92,6 +92,7 @@ use style::media_queries::{Device, MediaList, MediaType};
 use style::properties::style_structs::Font;
 use style::properties::PropertyId;
 use style::selector_parser::{PseudoElement, SnapshotMap};
+use style::servo::media_queries::FontMetricsProvider;
 use style::servo::restyle_damage::ServoRestyleDamage;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard, StylesheetGuards};
 use style::stylesheets::{
@@ -261,6 +262,10 @@ impl Layout for LayoutThread {
 
     fn handle_font_cache_msg(&mut self) {
         self.handle_request(Request::FromFontCache);
+    }
+
+    fn device<'a>(&'a self) -> &'a Device {
+        self.stylist.device()
     }
 
     fn waiting_for_web_fonts_to_load(&self) -> bool {
@@ -506,6 +511,7 @@ impl LayoutThread {
             QuirksMode::NoQuirks,
             window_size.initial_viewport,
             window_size.device_pixel_ratio,
+            Box::new(LayoutFontMetricsProvider),
         );
 
         // Ask the router to proxy IPC messages from the font cache thread to layout.
@@ -1481,6 +1487,7 @@ impl LayoutThread {
             self.stylist.quirks_mode(),
             window_size_data.initial_viewport,
             window_size_data.device_pixel_ratio,
+            Box::new(LayoutFontMetricsProvider),
         );
 
         // Preserve any previously computed root font size.
@@ -1686,5 +1693,21 @@ impl RegisteredPainters for RegisteredPaintersImpl {
         self.0
             .get(name)
             .map(|painter| painter as &dyn RegisteredPainter)
+    }
+}
+
+#[derive(Debug)]
+struct LayoutFontMetricsProvider;
+
+impl FontMetricsProvider for LayoutFontMetricsProvider {
+    fn query_font_metrics(
+        &self,
+        _vertical: bool,
+        _font: &Font,
+        _base_size: style::values::computed::CSSPixelLength,
+        _in_media_query: bool,
+        _retrieve_math_scales: bool,
+    ) -> style::font_metrics::FontMetrics {
+        Default::default()
     }
 }

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -43,7 +43,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use metrics::{PaintTimeMetrics, ProfilerMetadataFactory};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image_cache::{ImageCache, UsePlaceholder};
-use parking_lot::RwLock;
+use parking_lot::{ReentrantMutex, RwLock};
 use profile_traits::mem::{Report, ReportKind, ReportsChan};
 use profile_traits::path;
 use profile_traits::time::{
@@ -70,14 +70,15 @@ use style::context::{
     QuirksMode, RegisteredSpeculativePainter, RegisteredSpeculativePainters, SharedStyleContext,
 };
 use style::dom::{OpaqueNode, TElement, TNode};
-use style::driver;
 use style::error_reporting::RustLogReporter;
+use style::font_metrics::FontMetrics;
 use style::global_style_data::{GLOBAL_STYLE_DATA, STYLE_THREAD_POOL};
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::{Device, MediaList, MediaType};
 use style::properties::style_structs::Font;
 use style::properties::PropertyId;
 use style::selector_parser::{PseudoElement, SnapshotMap};
+use style::servo::media_queries::FontMetricsProvider;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard, StylesheetGuards};
 use style::stylesheets::{
     DocumentStyleSheet, Origin, Stylesheet, StylesheetInDocument, UrlExtraData,
@@ -86,6 +87,8 @@ use style::stylesheets::{
 use style::stylist::Stylist;
 use style::traversal::DomTraversal;
 use style::traversal_flags::TraversalFlags;
+use style::values::computed::CSSPixelLength;
+use style::{driver, Zero};
 use style_traits::{CSSPixel, DevicePixel, SpeculativePainter};
 use url::Url;
 use webrender_api::units::LayoutPixel;
@@ -120,8 +123,9 @@ pub struct LayoutThread {
     /// Reference to the script thread image cache.
     image_cache: Arc<dyn ImageCache>,
 
-    /// Public interface to the font cache thread.
-    font_cache_thread: FontCacheThread,
+    /// Public interface to the font cache thread. This needs to be behind a [`ReentrantMutex`],
+    /// because some font cache operations can trigger others.
+    font_cache_thread: Arc<ReentrantMutex<FontCacheThread>>,
 
     /// Is this the first reflow in this LayoutThread?
     first_reflow: Cell<bool>,
@@ -235,6 +239,10 @@ impl Layout for LayoutThread {
 
     fn handle_font_cache_msg(&mut self) {
         self.handle_request(Request::FromFontCache);
+    }
+
+    fn device<'a>(&'a self) -> &'a Device {
+        self.stylist.device()
     }
 
     fn waiting_for_web_fonts_to_load(&self) -> bool {
@@ -449,11 +457,13 @@ impl LayoutThread {
 
         // The device pixel ratio is incorrect (it does not have the hidpi value),
         // but it will be set correctly when the initial reflow takes place.
+        let font_cache_thread = Arc::new(ReentrantMutex::new(font_cache_thread));
         let device = Device::new(
             MediaType::screen(),
             QuirksMode::NoQuirks,
             window_size.initial_viewport,
             window_size.device_pixel_ratio,
+            Box::new(LayoutFontMetricsProvider(font_cache_thread.clone())),
         );
 
         // Ask the router to proxy IPC messages from the font cache thread to layout.
@@ -547,7 +557,7 @@ impl LayoutThread {
                 traversal_flags,
             ),
             image_cache: self.image_cache.clone(),
-            font_cache_thread: Mutex::new(self.font_cache_thread.clone()),
+            font_cache_thread: self.font_cache_thread.clone(),
             webrender_image_cache: self.webrender_image_cache.clone(),
             pending_images: Mutex::new(vec![]),
             use_rayon,
@@ -630,8 +640,10 @@ impl LayoutThread {
         // Find all font-face rules and notify the font cache of them.
         // GWTODO: Need to handle unloading web fonts.
         if stylesheet.is_effective_for_device(self.stylist.device(), &guard) {
-            let newly_loading_font_count =
-                self.font_cache_thread.add_all_web_fonts_from_stylesheet(
+            let newly_loading_font_count = self
+                .font_cache_thread
+                .lock()
+                .add_all_web_fonts_from_stylesheet(
                     &*stylesheet,
                     &guard,
                     self.stylist.device(),
@@ -1102,6 +1114,7 @@ impl LayoutThread {
             self.stylist.quirks_mode(),
             window_size_data.initial_viewport,
             window_size_data.device_pixel_ratio,
+            Box::new(LayoutFontMetricsProvider(self.font_cache_thread.clone())),
         );
 
         // Preserve any previously computed root font size.
@@ -1256,5 +1269,46 @@ impl RegisteredSpeculativePainters for RegisteredPaintersImpl {
         self.0
             .get(&name)
             .map(|painter| painter as &dyn RegisteredSpeculativePainter)
+    }
+}
+
+#[derive(Debug)]
+struct LayoutFontMetricsProvider(Arc<ReentrantMutex<FontCacheThread>>);
+
+impl FontMetricsProvider for LayoutFontMetricsProvider {
+    fn query_font_metrics(
+        &self,
+        _vertical: bool,
+        font: &Font,
+        base_size: CSSPixelLength,
+        _in_media_query: bool,
+        _retrieve_math_scales: bool,
+    ) -> FontMetrics {
+        layout::context::with_thread_local_font_context(&self.0, move |font_context| {
+            let Some(servo_metrics) = font_context
+                .font_group_with_size(ServoArc::new(font.clone()), base_size.into())
+                .borrow_mut()
+                .first(font_context)
+                .map(|font| font.borrow().metrics.clone())
+            else {
+                return Default::default();
+            };
+
+            // Only use the x-height of this font if it is non-zero. Some fonts return
+            // inaccurate metrics, which shouldn't be used.
+            let x_height = Some(servo_metrics.x_height)
+                .filter(|x_height| !x_height.is_zero())
+                .map(CSSPixelLength::from);
+
+            FontMetrics {
+                x_height,
+                zero_advance_measure: None,
+                cap_height: None,
+                ic_width: None,
+                ascent: servo_metrics.ascent.into(),
+                script_percent_scale_down: None,
+                script_script_percent_scale_down: None,
+            }
+        })
     }
 }

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -72,8 +72,9 @@ impl MediaQueryList {
     }
 
     pub fn evaluate(&self) -> bool {
-        self.media_query_list
-            .evaluate(&self.document.device(), self.document.quirks_mode())
+        let quirks_mode = self.document.quirks_mode();
+        self.document
+            .with_device(move |device| self.media_query_list.evaluate(device, quirks_mode))
     }
 }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -40,6 +40,7 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 use style::animation::DocumentAnimationSet;
 use style::data::ElementData;
 use style::dom::OpaqueNode;
+use style::media_queries::Device;
 use style::properties::style_structs::Font;
 use style::properties::PropertyId;
 use style::selector_parser::PseudoElement;
@@ -178,6 +179,10 @@ pub trait Layout {
 
     /// Handle a a single mesasge from the FontCacheThread.
     fn handle_font_cache_msg(&mut self);
+
+    /// Get a reference to this Layout's Stylo `Device` used to handle media queries and
+    /// resolve font metrics.
+    fn device<'a>(&'a self) -> &'a Device;
 
     /// Whether or not this layout is waiting for fonts from loaded stylesheets to finish loading.
     fn waiting_for_web_fonts_to_load(&self) -> bool;

--- a/tests/unit/style/custom_properties.rs
+++ b/tests/unit/style/custom_properties.rs
@@ -9,12 +9,32 @@ use style::context::QuirksMode;
 use style::custom_properties::{
     ComputedCustomProperties, CustomPropertiesBuilder, Name, SpecifiedValue,
 };
+use style::font_metrics::FontMetrics;
 use style::media_queries::{Device, MediaType};
+use style::properties::style_structs::Font;
 use style::properties::{CustomDeclaration, CustomDeclarationValue};
 use style::rule_tree::CascadeLevel;
+use style::servo::media_queries::FontMetricsProvider;
 use style::stylesheets::layer_rule::LayerOrder;
 use style::stylist::Stylist;
+use style::values::computed::Length;
 use test::{self, Bencher};
+
+#[derive(Debug)]
+struct DummyMetricsProvider;
+
+impl FontMetricsProvider for DummyMetricsProvider {
+    fn query_font_metrics(
+        &self,
+        _vertical: bool,
+        _font: &Font,
+        _base_size: Length,
+        _in_media_query: bool,
+        _retrieve_math_scales: bool,
+    ) -> FontMetrics {
+        Default::default()
+    }
+}
 
 fn cascade(
     name_and_value: &[(&str, &str)],
@@ -36,6 +56,7 @@ fn cascade(
         QuirksMode::NoQuirks,
         Size2D::new(800., 600.),
         Scale::new(1.0),
+        Box::new(DummyMetricsProvider),
     );
     let stylist = Stylist::new(device, QuirksMode::NoQuirks);
     let mut builder = CustomPropertiesBuilder::new(inherited, &stylist, false);

--- a/tests/unit/style/stylist.rs
+++ b/tests/unit/style/stylist.rs
@@ -8,17 +8,37 @@ use selectors::parser::{AncestorHashes, Selector};
 use servo_arc::Arc;
 use servo_atoms::Atom;
 use style::context::QuirksMode;
+use style::font_metrics::FontMetrics;
 use style::media_queries::{Device, MediaType};
+use style::properties::style_structs::Font;
 use style::properties::{longhands, Importance, PropertyDeclaration, PropertyDeclarationBlock};
 use style::selector_map::SelectorMap;
 use style::selector_parser::{SelectorImpl, SelectorParser};
+use style::servo::media_queries::FontMetricsProvider;
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::StyleRule;
 use style::stylist::{
     needs_revalidation_for_testing, ContainerConditionId, LayerId, Rule, Stylist,
 };
 use style::thread_state::{self, ThreadState};
+use style::values::computed::Length;
 use url::Url;
+
+#[derive(Debug)]
+struct DummyMetricsProvider;
+
+impl FontMetricsProvider for DummyMetricsProvider {
+    fn query_font_metrics(
+        &self,
+        _vertical: bool,
+        _font: &Font,
+        _base_size: Length,
+        _in_media_query: bool,
+        _retrieve_math_scales: bool,
+    ) -> FontMetrics {
+        Default::default()
+    }
+}
 
 /// Helper method to get some Rules from selector strings.
 /// Each sublist of the result contains the Rules for one StyleRule.
@@ -223,6 +243,7 @@ fn mock_stylist() -> Stylist {
         QuirksMode::NoQuirks,
         Size2D::new(0f32, 0f32),
         Scale::new(1.0),
+        Box::new(DummyMetricsProvider),
     );
     Stylist::new(device, QuirksMode::NoQuirks)
 }

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-position-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-position-001.xht.ini
@@ -1,2 +1,0 @@
-[background-position-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-position-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-position-002.xht.ini
@@ -1,2 +1,0 @@
-[background-position-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-width-080.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-width-083.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-width-084.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-left-width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-left-width-080.xht.ini
@@ -1,2 +1,0 @@
-[border-left-width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-left-width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-left-width-083.xht.ini
@@ -1,2 +1,0 @@
-[border-left-width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-left-width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-left-width-084.xht.ini
@@ -1,2 +1,0 @@
-[border-left-width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-right-width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-right-width-080.xht.ini
@@ -1,2 +1,0 @@
-[border-right-width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-right-width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-right-width-083.xht.ini
@@ -1,2 +1,0 @@
-[border-right-width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-right-width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-right-width-084.xht.ini
@@ -1,2 +1,0 @@
-[border-right-width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-width-080.xht.ini
@@ -1,2 +1,0 @@
-[border-top-width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-width-083.xht.ini
@@ -1,2 +1,0 @@
-[border-top-width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-width-084.xht.ini
@@ -1,2 +1,0 @@
-[border-top-width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c526-font-sz-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c526-font-sz-002.xht.ini
@@ -1,2 +1,0 @@
-[c526-font-sz-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c541-word-sp-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c541-word-sp-000.xht.ini
@@ -1,2 +1,0 @@
-[c541-word-sp-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c542-letter-sp-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c542-letter-sp-000.xht.ini
@@ -1,2 +1,0 @@
-[c542-letter-sp-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c547-indent-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c547-indent-000.xht.ini
@@ -1,2 +1,0 @@
-[c547-indent-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c548-ln-ht-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c548-ln-ht-002.xht.ini
@@ -1,2 +1,0 @@
-[c548-ln-ht-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c61-ex-len-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c61-ex-len-000.xht.ini
@@ -1,2 +1,0 @@
-[c61-ex-len-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c61-rel-len-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c61-rel-len-000.xht.ini
@@ -1,2 +1,0 @@
-[c61-rel-len-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-size-124.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-size-124.xht.ini
@@ -1,2 +1,0 @@
-[font-size-124.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/line-height-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/line-height-080.xht.ini
@@ -1,2 +1,0 @@
-[line-height-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/line-height-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/line-height-083.xht.ini
@@ -1,2 +1,0 @@
-[line-height-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/line-height-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/line-height-084.xht.ini
@@ -1,2 +1,0 @@
-[line-height-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/vertical-align-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/vertical-align-091.xht.ini
@@ -1,2 +1,0 @@
-[vertical-align-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/vertical-align-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/vertical-align-092.xht.ini
@@ -1,2 +1,0 @@
-[vertical-align-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-bottom-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-bottom-091.xht.ini
@@ -1,2 +1,0 @@
-[margin-bottom-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-bottom-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-bottom-092.xht.ini
@@ -1,2 +1,0 @@
-[margin-bottom-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-left-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-left-091.xht.ini
@@ -1,2 +1,0 @@
-[margin-left-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-left-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-left-092.xht.ini
@@ -1,2 +1,0 @@
-[margin-left-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-right-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-right-091.xht.ini
@@ -1,2 +1,0 @@
-[margin-right-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-right-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-right-092.xht.ini
@@ -1,2 +1,0 @@
-[margin-right-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-top-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-top-091.xht.ini
@@ -1,2 +1,0 @@
-[margin-top-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-top-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-top-092.xht.ini
@@ -1,2 +1,0 @@
-[margin-top-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-080.xht.ini
@@ -1,2 +1,0 @@
-[padding-bottom-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-083.xht.ini
@@ -1,2 +1,0 @@
-[padding-bottom-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-084.xht.ini
@@ -1,2 +1,0 @@
-[padding-bottom-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-080.xht.ini
@@ -1,2 +1,0 @@
-[padding-left-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-083.xht.ini
@@ -1,2 +1,0 @@
-[padding-left-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-084.xht.ini
@@ -1,2 +1,0 @@
-[padding-left-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-080.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-083.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-084.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-080.xht.ini
@@ -1,2 +1,0 @@
-[padding-top-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-083.xht.ini
@@ -1,2 +1,0 @@
-[padding-top-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-084.xht.ini
@@ -1,2 +1,0 @@
-[padding-top-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/height-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/height-080.xht.ini
@@ -1,2 +1,0 @@
-[height-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/height-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/height-083.xht.ini
@@ -1,2 +1,0 @@
-[height-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/height-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/height-084.xht.ini
@@ -1,2 +1,0 @@
-[height-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-height-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-height-080.xht.ini
@@ -1,2 +1,0 @@
-[max-height-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-height-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-height-083.xht.ini
@@ -1,2 +1,0 @@
-[max-height-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-height-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-height-084.xht.ini
@@ -1,2 +1,0 @@
-[max-height-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-width-080.xht.ini
@@ -1,2 +1,0 @@
-[max-width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-width-083.xht.ini
@@ -1,2 +1,0 @@
-[max-width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-width-084.xht.ini
@@ -1,2 +1,0 @@
-[max-width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-height-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-height-080.xht.ini
@@ -1,2 +1,0 @@
-[min-height-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-height-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-height-083.xht.ini
@@ -1,2 +1,0 @@
-[min-height-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-height-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-height-084.xht.ini
@@ -1,2 +1,0 @@
-[min-height-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-width-080.xht.ini
@@ -1,2 +1,0 @@
-[min-width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-width-083.xht.ini
@@ -1,2 +1,0 @@
-[min-width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-width-084.xht.ini
@@ -1,2 +1,0 @@
-[min-width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-080.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-080.xht.ini
@@ -1,2 +1,0 @@
-[width-080.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-083.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-083.xht.ini
@@ -1,2 +1,0 @@
-[width-083.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-084.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-084.xht.ini
@@ -1,2 +1,0 @@
-[width-084.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/bottom-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/bottom-091.xht.ini
@@ -1,2 +1,0 @@
-[bottom-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/bottom-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/bottom-092.xht.ini
@@ -1,2 +1,0 @@
-[bottom-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/left-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/left-091.xht.ini
@@ -1,2 +1,0 @@
-[left-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/left-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/left-092.xht.ini
@@ -1,2 +1,0 @@
-[left-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/right-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/right-091.xht.ini
@@ -1,2 +1,0 @@
-[right-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/right-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/right-092.xht.ini
@@ -1,2 +1,0 @@
-[right-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/top-091.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/top-091.xht.ini
@@ -1,2 +1,0 @@
-[top-091.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/top-092.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/top-092.xht.ini
@@ -1,2 +1,0 @@
-[top-092.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/values/numbers-units-018.xht.ini
+++ b/tests/wpt/meta/css/CSS2/values/numbers-units-018.xht.ini
@@ -1,2 +1,0 @@
-[numbers-units-018.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/values/numbers-units-019.xht.ini
+++ b/tests/wpt/meta/css/CSS2/values/numbers-units-019.xht.ini
@@ -1,2 +1,0 @@
-[numbers-units-019.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/values/units-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/values/units-001.xht.ini
@@ -1,2 +1,0 @@
-[units-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/values/units-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/values/units-002.xht.ini
@@ -1,2 +1,0 @@
-[units-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/values/units-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/values/units-003.xht.ini
@@ -1,2 +1,0 @@
-[units-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/values/units-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/values/units-004.xht.ini
@@ -1,2 +1,0 @@
-[units-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-001.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-001.html.ini
@@ -1,0 +1,2 @@
+[first-available-font-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-values/cap-invalidation.html.ini
+++ b/tests/wpt/meta/css/css-values/cap-invalidation.html.ini
@@ -1,3 +1,0 @@
-[cap-invalidation.html]
-  [CSS Values and Units Test: cap invalidation]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-values/cap-unit-001.html.ini
+++ b/tests/wpt/meta/css/css-values/cap-unit-001.html.ini
@@ -1,2 +1,0 @@
-[cap-unit-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/ex-unit-001.html.ini
+++ b/tests/wpt/meta/css/css-values/ex-unit-001.html.ini
@@ -1,0 +1,2 @@
+[ex-unit-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-values/ex-unit-002.html.ini
+++ b/tests/wpt/meta/css/css-values/ex-unit-002.html.ini
@@ -1,2 +1,0 @@
-[ex-unit-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/ex-unit-003.html.ini
+++ b/tests/wpt/meta/css/css-values/ex-unit-003.html.ini
@@ -1,2 +1,0 @@
-[ex-unit-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/ex-unit-004.html.ini
+++ b/tests/wpt/meta/css/css-values/ex-unit-004.html.ini
@@ -1,0 +1,2 @@
+[ex-unit-004.html]
+  expected: FAIL


### PR DESCRIPTION
The only font relative unit that Servo knows how to resolve currently is
`rem` (relative to the root font size). This is because Stylo cannot do
any font queries. This adds a mechanism to allow this, exposing the
ability to properly render `ex` units in Servo.

This change only allows resolving some font size relative units thoug,
as Servo doesn't collect all the FontMetrics it needs to resolve them
all. This capability will be added in followup changes.

Some new tests fail:
 - ex-unit-001.html: This test fails because Servo does not yet have
   support for setting the weight using @font-face rules on web fonts.
 - ex-unit-004.html: This test fails because Servo does not yet have
   support for setting the Unicode range of a web font using @font-face
   rules.
 - first-available-font-001.html: This test fails because the above
   two feature are missing.

Fixes #31938. Fixes #14079.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31938 and fix #14079.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
