### PR TITLE
clippy: Fix `search_is_some` warnings in `components/script`

### DIFF
--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -131,7 +131,7 @@ impl MediaStreamMethods for MediaStream {
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-addtrack>
     fn AddTrack(&self, track: &MediaStreamTrack) {
-        let existing = self.tracks.borrow().iter().find(|x| *x == &track).is_some();
+        let existing = self.tracks.borrow().iter().any(|x| x == &track);
 
         if existing {
             return;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1909,11 +1909,7 @@ impl Window {
 
             let mut images = self.pending_layout_images.borrow_mut();
             let nodes = images.entry(id).or_default();
-            if nodes
-                .iter()
-                .find(|n| &***n as *const _ == &*node as *const _)
-                .is_none()
-            {
+            if !nodes.iter().any(|n| &**n as *const _ == &*node as *const _) {
                 let (responder, responder_listener) =
                     ProfiledIpc::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let image_cache_chan = self.image_cache_chan.clone();

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -779,13 +779,12 @@ impl XRSessionMethods for XRSession {
                     (!self.is_immersive() || ty != XRReferenceSpaceType::Local)
                 {
                     let s = ty.as_str();
-                    if self
+                    if !self
                         .session
                         .borrow()
                         .granted_features()
                         .iter()
-                        .find(|f| **f == s)
-                        .is_none()
+                        .any(|f| *f == s)
                     {
                         p.reject_error(Error::NotSupported);
                         return p;
@@ -833,13 +832,12 @@ impl XRSessionMethods for XRSession {
     fn RequestHitTestSource(&self, options: &XRHitTestOptionsInit) -> Rc<Promise> {
         let p = Promise::new(&self.global());
 
-        if self
+        if !self
             .session
             .borrow()
             .granted_features()
             .iter()
-            .find(|f| &**f == "hit-test")
-            .is_none()
+            .any(|f| &*f == "hit-test")
         {
             p.reject_error(Error::NotSupported);
             return p;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Resolve the `search_is_some` warnings by doing the following:
- Replace `_.find(...).is_some()` calls with `_.any(...)`.
- Replace `_.find(...).is_none()` calls with `!_any(...)`.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
