### PR TITLE
clippy: Allow `too_many_arguments` for existing functions

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(clippy::too_many_arguments)]
-
 use std::collections::{HashMap, HashSet};
 
 use euclid::Size2D;
@@ -81,6 +79,7 @@ pub struct BrowsingContext {
 impl BrowsingContext {
     /// Create a new browsing context.
     /// Note this just creates the browsing context, it doesn't add it to the constellation's set of browsing contexts.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bc_group_id: BrowsingContextGroupId,
         id: BrowsingContextId,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -84,8 +84,6 @@
 //!
 //! See <https://github.com/servo/servo/issues/14704>
 
-#![allow(clippy::too_many_arguments)]
-
 use std::borrow::{Cow, ToOwned};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -615,6 +613,7 @@ where
     SWF: ServiceWorkerManagerFactory,
 {
     /// Create a new constellation thread.
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         state: InitialConstellationState,
         layout_factory: Arc<dyn LayoutFactory>,
@@ -941,6 +940,7 @@ where
     }
 
     /// Helper function for creating a pipeline
+    #[allow(clippy::too_many_arguments)]
     fn new_pipeline(
         &mut self,
         pipeline_id: PipelineId,
@@ -1126,6 +1126,7 @@ where
     }
 
     /// Create a new browsing context and update the internal bookkeeping.
+    #[allow(clippy::too_many_arguments)]
     fn new_browsing_context(
         &mut self,
         browsing_context_id: BrowsingContextId,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(clippy::too_many_arguments)]
-
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -349,6 +347,7 @@ impl Pipeline {
     }
 
     /// Creates a new `Pipeline`, after the script has been spawned.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: PipelineId,
         browsing_context_id: BrowsingContextId,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -10,7 +10,6 @@
 #![crate_name = "devtools"]
 #![crate_type = "rlib"]
 #![allow(non_snake_case)]
-#![allow(clippy::too_many_arguments)]
 #![deny(unsafe_code)]
 
 use std::borrow::ToOwned;
@@ -420,6 +419,7 @@ fn run_server(
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn handle_network_event(
         actors: Arc<Mutex<ActorRegistry>>,
         mut connections: Vec<TcpStream>,

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(clippy::too_many_arguments)]
-
 use app_units::Au;
 use euclid::default::{Point2D, Rect, SideOffsets2D, Size2D};
 use style::computed_values::background_attachment::single_value::T as BackgroundAttachment;
@@ -145,6 +143,7 @@ pub fn clip(
 /// no intrinsic size.
 ///
 /// Return `None` if the background size is zero, otherwise a [`BackgroundPlacement`].
+#[allow(clippy::too_many_arguments)]
 pub fn placement(
     bg: &Background,
     viewport_size: Size2D<Au>,
@@ -304,6 +303,7 @@ fn tile_image(position: &mut Au, size: &mut Au, absolute_anchor_origin: Au, imag
 /// For either the x or the y axis adjust various values to account for tiling.
 ///
 /// This is done separately for both axes because the repeat keywords may differ.
+#[allow(clippy::too_many_arguments)]
 fn tile_image_axis(
     repeat: BackgroundRepeatKeyword,
     position: &mut Au,

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -8,8 +8,6 @@
 //! list building, as the actual painting does not happen here—only deciding *what* we're going to
 //! paint.
 
-#![allow(clippy::too_many_arguments)]
-
 use std::default::Default;
 use std::sync::Arc;
 use std::{f32, mem};
@@ -1079,6 +1077,7 @@ impl Fragment {
 
     /// Adds the display items necessary to paint the borders of this fragment to a display list if
     /// necessary.
+    #[allow(clippy::too_many_arguments)]
     fn build_display_list_for_borders_if_applicable(
         &self,
         state: &mut DisplayListBuildState,

--- a/components/layout/display_list/items.rs
+++ b/components/layout/display_list/items.rs
@@ -12,8 +12,6 @@
 //! They are therefore not exactly analogous to constructs like Skia pictures, which consist of
 //! low-level drawing primitives.
 
-#![allow(clippy::too_many_arguments)]
-
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::{f32, fmt};
@@ -206,6 +204,7 @@ pub struct StackingContext {
 impl StackingContext {
     /// Creates a new stacking context.
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: StackingContextId,
         context_type: StackingContextType,

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -4,8 +4,6 @@
 
 //! CSS table formatting contexts.
 
-#![allow(clippy::too_many_arguments)]
-
 use std::cmp::max;
 use std::fmt;
 use std::iter::{Enumerate, Peekable};
@@ -982,6 +980,7 @@ pub fn propagate_column_inline_sizes_to_child(
 }
 
 /// Lay out table cells inline according to the computer column sizes.
+#[allow(clippy::too_many_arguments)]
 fn set_inline_position_of_child_flow(
     child_flow: &mut dyn Flow,
     child_index: usize,

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Text layout.
-#![allow(clippy::too_many_arguments)]
 
 use std::borrow::ToOwned;
 use std::collections::LinkedList;
@@ -705,6 +704,7 @@ impl RunMapping {
 
     /// Flushes this run mapping to the list. `run_info` describes the text run that we're
     /// currently working on. `text` refers to the text of this fragment.
+    #[allow(clippy::too_many_arguments)]
     fn flush(
         mut self,
         mappings: &mut Vec<RunMapping>,

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -122,9 +122,9 @@ impl FileManager {
         self.store.invalidate_token(token, file_id);
     }
 
-    // Read a file for the Fetch implementation.
-    // It gets the required headers synchronously and reads the actual content
-    // in a separate thread.
+    /// Read a file for the Fetch implementation.
+    /// It gets the required headers synchronously and reads the actual content
+    /// in a separate thread.
     #[allow(clippy::too_many_arguments)]
     pub fn fetch_file(
         &self,

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -333,6 +333,7 @@ impl CanvasState {
     ///
     /// drawImage coordinates explained
     ///
+    /// ```
     ///  Source Image      Destination Canvas
     /// +-------------+     +-------------+
     /// |             |     |             |
@@ -345,7 +346,7 @@ impl CanvasState {
     /// |     sw      |     |     dw      |
     /// |             |     |             |
     /// +-------------+     +-------------+
-    ///
+    /// ```
     ///
     /// The rectangle (sx, sy, sw, sh) from the source image
     /// is copied on the rectangle (dx, dy, dh, dw) of the destination canvas

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -330,27 +330,27 @@ impl CanvasState {
         pixels
     }
 
-    //
-    // drawImage coordinates explained
-    //
-    //  Source Image      Destination Canvas
-    // +-------------+     +-------------+
-    // |             |     |             |
-    // |(sx,sy)      |     |(dx,dy)      |
-    // |   +----+    |     |   +----+    |
-    // |   |    |    |     |   |    |    |
-    // |   |    |sh  |---->|   |    |dh  |
-    // |   |    |    |     |   |    |    |
-    // |   +----+    |     |   +----+    |
-    // |     sw      |     |     dw      |
-    // |             |     |             |
-    // +-------------+     +-------------+
-    //
-    //
-    // The rectangle (sx, sy, sw, sh) from the source image
-    // is copied on the rectangle (dx, dy, dh, dw) of the destination canvas
-    //
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
+    ///
+    /// drawImage coordinates explained
+    ///
+    ///  Source Image      Destination Canvas
+    /// +-------------+     +-------------+
+    /// |             |     |             |
+    /// |(sx,sy)      |     |(dx,dy)      |
+    /// |   +----+    |     |   +----+    |
+    /// |   |    |    |     |   |    |    |
+    /// |   |    |sh  |---->|   |    |dh  |
+    /// |   |    |    |     |   |    |    |
+    /// |   +----+    |     |   +----+    |
+    /// |     sw      |     |     dw      |
+    /// |             |     |             |
+    /// +-------------+     +-------------+
+    ///
+    ///
+    /// The rectangle (sx, sy, sw, sh) from the source image
+    /// is copied on the rectangle (dx, dy, dh, dw) of the destination canvas
+    ///
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage>
     #[allow(clippy::too_many_arguments)]
     fn draw_image_internal(
         &self,
@@ -594,10 +594,10 @@ impl CanvasState {
         }
     }
 
-    // It is used by DrawImage to calculate the size of the source and destination rectangles based
-    // on the drawImage call arguments
-    // source rectangle = area of the original image to be copied
-    // destination rectangle = area of the destination canvas where the source image is going to be drawn
+    /// It is used by DrawImage to calculate the size of the source and destination rectangles based
+    /// on the drawImage call arguments
+    /// source rectangle = area of the original image to be copied
+    /// destination rectangle = area of the destination canvas where the source image is going to be drawn
     #[allow(clippy::too_many_arguments)]
     fn adjust_source_dest_rects(
         &self,
@@ -844,7 +844,7 @@ impl CanvasState {
         )
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient>
     #[allow(clippy::too_many_arguments)]
     pub fn create_radial_gradient(
         &self,
@@ -1283,9 +1283,8 @@ impl CanvasState {
         )
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
-    #[allow(unsafe_code)]
-    #[allow(clippy::too_many_arguments)]
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn put_image_data_(
         &self,
         canvas_size: Size2D<u64>,
@@ -1381,7 +1380,7 @@ impl CanvasState {
         )
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage>
     #[allow(clippy::too_many_arguments)]
     pub fn draw_image__(
         &self,
@@ -1653,7 +1652,7 @@ impl CanvasState {
         Ok(())
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse>
     #[allow(clippy::too_many_arguments)]
     pub fn ellipse(
         &self,

--- a/components/script/dom/audioparam.rs
+++ b/components/script/dom/audioparam.rs
@@ -64,8 +64,7 @@ impl AudioParam {
         }
     }
 
-    #[allow(crown::unrooted_must_root)]
-    #[allow(clippy::too_many_arguments)]
+    #[allow(crown::unrooted_must_root, clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         context: &BaseAudioContext,

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -50,6 +50,7 @@ impl BluetoothAdvertisingEvent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/bluetoothcharacteristicproperties.rs
+++ b/components/script/dom/bluetoothcharacteristicproperties.rs
@@ -26,6 +26,7 @@ pub struct BluetoothCharacteristicProperties {
 
 #[allow(non_snake_case)]
 impl BluetoothCharacteristicProperties {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_inherited(
         broadcast: bool,
         read: bool,
@@ -51,6 +52,7 @@ impl BluetoothCharacteristicProperties {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         broadcast: bool,

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -50,6 +50,7 @@ impl CloseEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -48,6 +48,7 @@ impl CompositionEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -237,6 +237,7 @@ impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
 }
 
 impl DedicatedWorkerGlobalScope {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         init: WorkerGlobalScopeInit,
         worker_name: DOMString,
@@ -274,7 +275,7 @@ impl DedicatedWorkerGlobalScope {
         }
     }
 
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn new(
         init: WorkerGlobalScopeInit,
         worker_name: DOMString,
@@ -311,8 +312,8 @@ impl DedicatedWorkerGlobalScope {
         unsafe { DedicatedWorkerGlobalScopeBinding::Wrap(SafeJSContext::from_ptr(cx), scope) }
     }
 
-    #[allow(unsafe_code)]
-    // https://html.spec.whatwg.org/multipage/#run-a-worker
+    /// <https://html.spec.whatwg.org/multipage/#run-a-worker>
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn run_worker_scope(
         mut init: WorkerGlobalScopeInit,
         worker_url: ServoUrl,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3060,6 +3060,7 @@ pub enum HasBrowsingContext {
 }
 
 impl Document {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_inherited(
         window: &Window,
         has_browsing_context: HasBrowsingContext,
@@ -3315,6 +3316,7 @@ impl Document {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         has_browsing_context: HasBrowsingContext,
@@ -3348,6 +3350,7 @@ impl Document {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -51,6 +51,7 @@ impl ErrorEvent {
         reflect_dom_object_with_proto(Box::new(ErrorEvent::new_inherited()), global, proto)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         type_: Atom,
@@ -67,6 +68,7 @@ impl ErrorEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -64,6 +64,7 @@ impl ExtendableMessageEvent {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         type_: Atom,
@@ -87,6 +88,7 @@ impl ExtendableMessageEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -66,6 +66,7 @@ impl FocusEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -52,6 +52,7 @@ pub struct Gamepad {
 }
 
 impl Gamepad {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         gamepad_id: u32,
         id: String,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -742,6 +742,7 @@ impl FileListener {
 }
 
 impl GlobalScope {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_inherited(
         pipeline_id: PipelineId,
         devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -63,6 +63,7 @@ impl GPUAdapter {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         channel: WebGPU,

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -98,6 +98,7 @@ impl GPUBuffer {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         channel: WebGPU,

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -114,6 +114,7 @@ pub struct GPUDevice {
 }
 
 impl GPUDevice {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         channel: WebGPU,
         adapter: &GPUAdapter,
@@ -144,6 +145,7 @@ impl GPUDevice {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         channel: WebGPU,

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -46,6 +46,7 @@ pub struct GPUTexture {
 }
 
 impl GPUTexture {
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         texture: WebGPUTexture,
         device: &GPUDevice,
@@ -74,6 +75,7 @@ impl GPUTexture {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         texture: WebGPUTexture,

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -22,6 +22,7 @@ pub struct InputEvent {
 }
 
 impl InputEvent {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -64,6 +64,7 @@ impl KeyboardEvent {
         reflect_dom_object_with_proto(Box::new(KeyboardEvent::new_inherited()), window, proto)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         type_: DOMString,
@@ -99,6 +100,7 @@ impl KeyboardEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -131,6 +131,7 @@ impl MessageEvent {
         ev
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         type_: Atom,
@@ -156,6 +157,7 @@ impl MessageEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -85,6 +85,7 @@ impl MouseEvent {
         reflect_dom_object_with_proto(Box::new(MouseEvent::new_inherited()), window, proto)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         window: &Window,
         type_: DOMString,
@@ -128,6 +129,7 @@ impl MouseEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mutationrecord.rs
+++ b/components/script/dom/mutationrecord.rs
@@ -96,6 +96,7 @@ impl MutationRecord {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_inherited(
         record_type: &str,
         target: &Node,

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -253,8 +253,7 @@ impl ServiceWorkerGlobalScope {
         }
     }
 
-    #[allow(unsafe_code)]
-    #[allow(clippy::too_many_arguments)]
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn new(
         init: WorkerGlobalScopeInit,
         worker_url: ServoUrl,
@@ -285,9 +284,8 @@ impl ServiceWorkerGlobalScope {
         unsafe { ServiceWorkerGlobalScopeBinding::Wrap(SafeJSContext::from_ptr(cx), scope) }
     }
 
-    #[allow(unsafe_code)]
-    // https://w3c.github.io/ServiceWorker/#run-service-worker-algorithm
-    #[allow(clippy::too_many_arguments)]
+    /// <https://w3c.github.io/ServiceWorker/#run-service-worker-algorithm>
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub fn run_serviceworker_scope(
         scope_things: ScopeThings,
         own_sender: Sender<ServiceWorkerScriptMsg>,

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -453,8 +453,7 @@ impl WebGL2RenderingContext {
         })
     }
 
-    #[allow(unsafe_code)]
-    #[allow(clippy::too_many_arguments)]
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     fn read_pixels_into(
         &self,
         x: i32,

--- a/components/script/dom/webgl_validations/tex_image_2d.rs
+++ b/components/script/dom/webgl_validations/tex_image_2d.rs
@@ -254,7 +254,7 @@ pub struct TexImage2DValidator<'a> {
 }
 
 impl<'a> TexImage2DValidator<'a> {
-    // TODO: Move data validation logic here.
+    /// TODO: Move data validation logic here.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         context: &'a WebGLRenderingContext,

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -434,7 +434,7 @@ impl Handler {
         Ok(())
     }
 
-    // https://w3c.github.io/webdriver/#dfn-perform-a-pointer-move
+    /// <https://w3c.github.io/webdriver/#dfn-perform-a-pointer-move>
     #[allow(clippy::too_many_arguments)]
     fn perform_pointer_move(
         &mut self,


### PR DESCRIPTION
Followup to #31962, adds allows for `clippy::too_many_arguments` for existing functions. Most of the new allows are for constructor functions (`new*`), there has been discussions [here](https://github.com/rust-lang/rust-clippy/issues/1576) on whether to make an exception for them, since it makes sense for them to have as many arguments as the struct they are creating. However, adding an explicit allow is still recommended for now.

It also changes the few global allows that were made in some files for function specific ones. This is done to get warnings if new functions with too many arguments are added in the future. Finally, it also changes the surrounding comments to proper rustdoc where necessary.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500
- [x] These changes do not require tests because they do not modify behaviour