### PR TITLE
chore: Clean up use of `gfx` and `constellation` types

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -2270,7 +2270,7 @@ impl Fragment {
     fn unique_id(&self) -> u64 {
         let fragment_type = self.fragment_type();
         let id = self.node.id();
-        combine_id_with_fragment_type(id, fragment_type) as u64
+        combine_id_with_fragment_type(id, fragment_type)
     }
 
     fn fragment_type(&self) -> FragmentType {
@@ -2737,8 +2737,7 @@ impl BlockFlow {
         let content_size = self.base.overflow.scroll.origin + self.base.overflow.scroll.size;
         let content_size = Size2D::new(content_size.x, content_size.y);
 
-        let external_id =
-            ExternalScrollId(self.fragment.unique_id(), state.pipeline_id.to_webrender());
+        let external_id = ExternalScrollId(self.fragment.unique_id(), state.pipeline_id.into());
         let new_clip_scroll_index = state.add_clip_scroll_node(ClipScrollNode {
             parent_index: self.clipping_and_scrolling().scrolling,
             clip,

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -133,7 +133,7 @@ impl DisplayList {
         viewport_size: LayoutSize,
         epoch: Epoch,
     ) -> (DisplayListBuilder, CompositorDisplayListInfo, IsContentful) {
-        let webrender_pipeline = pipeline_id.to_webrender();
+        let webrender_pipeline = pipeline_id.into();
         let mut builder = DisplayListBuilder::new(webrender_pipeline);
         builder.begin();
 
@@ -314,7 +314,7 @@ impl DisplayItem {
                         spatial_id: common.spatial_id,
                         clip_chain_id: common.clip_chain_id,
                     },
-                    item.iframe.to_webrender(),
+                    item.iframe.into(),
                     true,
                 );
                 IsContentful(false)

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -9,7 +9,6 @@ use std::ops::Deref;
 
 use app_units::Au;
 use euclid::default::{Box2D, Point2D, Rect, Size2D, Vector2D};
-use msg::constellation_msg::PipelineId;
 use script_layout_interface::wrapper_traits::{
     LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
@@ -31,7 +30,6 @@ use style::selector_parser::PseudoElement;
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use style_traits::{ParsingMode, ToCss};
-use webrender_api::ExternalScrollId;
 
 use crate::construct::ConstructionResult;
 use crate::display_list::items::OpaqueNode;
@@ -569,14 +567,6 @@ pub fn process_client_rect_query(
     let mut iterator = FragmentClientRectQueryIterator::new(requested_node);
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
     iterator.client_rect
-}
-
-pub fn process_node_scroll_id_request<'dom>(
-    id: PipelineId,
-    requested_node: impl LayoutNode<'dom>,
-) -> ExternalScrollId {
-    let layout_node = requested_node.to_threadsafe();
-    layout_node.generate_scroll_id(id)
 }
 
 /// <https://drafts.csswg.org/cssom-view/#scrolling-area>

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -291,7 +291,7 @@ impl Fragment {
                             spatial_id: common.spatial_id,
                             clip_chain_id: common.clip_chain_id,
                         },
-                        iframe.pipeline_id.to_webrender(),
+                        iframe.pipeline_id.into(),
                         true,
                     );
                 },

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -126,6 +126,6 @@ impl Tag {
             Some(PseudoElement::After) => FragmentType::AfterPseudoContent,
             _ => FragmentType::FragmentBody,
         };
-        combine_id_with_fragment_type(self.node.id(), fragment_type) as u64
+        combine_id_with_fragment_type(self.node.id(), fragment_type)
     }
 }

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -9,7 +9,6 @@ use app_units::Au;
 use euclid::default::{Point2D, Rect};
 use euclid::{SideOffsets2D, Size2D, Vector2D};
 use log::warn;
-use msg::constellation_msg::PipelineId;
 use script_layout_interface::wrapper_traits::{
     LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
@@ -31,7 +30,6 @@ use style::stylist::RuleInclusion;
 use style::traversal::resolve_style;
 use style::values::generics::font::LineHeight;
 use style_traits::{ParsingMode, ToCss};
-use webrender_api::ExternalScrollId;
 
 use crate::fragment_tree::{Fragment, FragmentFlags, FragmentTree, Tag};
 
@@ -69,14 +67,6 @@ pub fn process_node_geometry_request(
     } else {
         Rect::zero()
     }
-}
-
-pub fn process_node_scroll_id_request<'dom>(
-    id: PipelineId,
-    requested_node: impl LayoutNode<'dom>,
-) -> ExternalScrollId {
-    let layout_node = requested_node.to_threadsafe();
-    layout_node.generate_scroll_id(id)
 }
 
 /// <https://drafts.csswg.org/cssom-view/#scrolling-area>

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -39,7 +39,7 @@ use layout::flow_ref::FlowRef;
 use layout::incremental::{RelayoutMode, SpecialRestyleDamage};
 use layout::query::{
     process_client_rect_query, process_content_box_request, process_content_boxes_request,
-    process_element_inner_text_query, process_node_scroll_id_request, process_offset_parent_query,
+    process_element_inner_text_query, process_offset_parent_query,
     process_resolved_font_style_request, process_resolved_style_request,
     process_scrolling_area_request,
 };
@@ -365,9 +365,9 @@ impl Layout for LayoutThread {
         flags.insert(HitTestFlags::POINT_RELATIVE_TO_PIPELINE_VIEWPORT);
 
         let client_point = units::DevicePoint::from_untyped(point);
-        let results =
-            self.webrender_api
-                .hit_test(Some(self.id.to_webrender()), client_point, flags);
+        let results = self
+            .webrender_api
+            .hit_test(Some(self.id.into()), client_point, flags);
 
         results.iter().map(|result| result.node).collect()
     }
@@ -451,14 +451,6 @@ impl Layout for LayoutThread {
         )
     }
 
-    fn query_scroll_id(
-        &self,
-        node: script_layout_interface::TrustedNodeAddress,
-    ) -> webrender_api::ExternalScrollId {
-        let node = unsafe { ServoLayoutNode::new(&node) };
-        process_node_scroll_id_request(self.id, node)
-    }
-
     fn query_scrolling_area(&self, node: Option<OpaqueNode>) -> UntypedRect<i32> {
         let Some(mut root_flow) = self.root_flow_for_query() else {
             return UntypedRect::zero();
@@ -504,7 +496,7 @@ impl LayoutThread {
         window_size: WindowSizeData,
     ) -> LayoutThread {
         // Let webrender know about this pipeline by sending an empty display list.
-        webrender_api.send_initial_transaction(id.to_webrender());
+        webrender_api.send_initial_transaction(id.into());
 
         let device = Device::new(
             MediaType::screen(),
@@ -1238,7 +1230,7 @@ impl LayoutThread {
 
         let point = Point2D::new(-state.scroll_offset.x, -state.scroll_offset.y);
         self.webrender_api.send_scroll_node(
-            self.id.to_webrender(),
+            self.id.into(),
             units::LayoutPoint::from_untyped(point),
             state.scroll_id,
         );

--- a/components/shared/msg/constellation_msg.rs
+++ b/components/shared/msg/constellation_msg.rs
@@ -223,14 +223,14 @@ impl PipelineId {
         })
     }
 
-    pub fn to_webrender(&self) -> WebRenderPipelineId {
-        let PipelineNamespaceId(namespace_id) = self.namespace_id;
-        let PipelineIndex(index) = self.index;
-        WebRenderPipelineId(namespace_id, index.get())
+    pub fn root_scroll_id(&self) -> webrender_api::ExternalScrollId {
+        ExternalScrollId(0, self.into())
     }
+}
 
+impl From<WebRenderPipelineId> for PipelineId {
     #[allow(unsafe_code)]
-    pub fn from_webrender(pipeline: WebRenderPipelineId) -> PipelineId {
+    fn from(pipeline: WebRenderPipelineId) -> Self {
         let WebRenderPipelineId(namespace_id, index) = pipeline;
         unsafe {
             PipelineId {
@@ -239,9 +239,19 @@ impl PipelineId {
             }
         }
     }
+}
 
-    pub fn root_scroll_id(&self) -> webrender_api::ExternalScrollId {
-        ExternalScrollId(0, self.to_webrender())
+impl From<PipelineId> for WebRenderPipelineId {
+    fn from(value: PipelineId) -> Self {
+        let PipelineNamespaceId(namespace_id) = value.namespace_id;
+        let PipelineIndex(index) = value.index;
+        WebRenderPipelineId(namespace_id, index.get())
+    }
+}
+
+impl From<&PipelineId> for WebRenderPipelineId {
+    fn from(value: &PipelineId) -> Self {
+        (*value).into()
     }
 }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -46,7 +46,7 @@ use style::properties::PropertyId;
 use style::selector_parser::PseudoElement;
 use style::stylesheets::Stylesheet;
 use style_traits::CSSPixel;
-use webrender_api::{ExternalScrollId, ImageKey};
+use webrender_api::ImageKey;
 
 pub type GenericLayoutData = dyn Any + Send + Sync;
 
@@ -235,7 +235,6 @@ pub trait Layout {
         animations: DocumentAnimationSet,
         animation_timeline_value: f64,
     ) -> Option<ServoArc<Font>>;
-    fn query_scroll_id(&self, node: TrustedNodeAddress) -> ExternalScrollId;
     fn query_scrolling_area(&self, node: Option<OpaqueNode>) -> Rect<i32>;
     fn query_text_indext(&self, node: OpaqueNode, point: Point2D<f32>) -> Option<usize>;
 }

--- a/components/shared/script_layout/message.rs
+++ b/components/shared/script_layout/message.rs
@@ -55,7 +55,6 @@ pub enum QueryMsg {
     OffsetParentQuery,
     TextIndexQuery,
     NodesFromPointQuery,
-    NodeScrollIdQuery,
     ResolvedStyleQuery,
     StyleQuery,
     ElementInnerTextQuery,
@@ -90,7 +89,6 @@ impl ReflowGoal {
                 QueryMsg::ClientRectQuery |
                 QueryMsg::ContentBox |
                 QueryMsg::ContentBoxes |
-                QueryMsg::NodeScrollIdQuery |
                 QueryMsg::OffsetParentQuery |
                 QueryMsg::ResolvedFontStyleQuery |
                 QueryMsg::ScrollingAreaQuery |
@@ -112,7 +110,6 @@ impl ReflowGoal {
                 QueryMsg::ContentBoxes |
                 QueryMsg::ClientRectQuery |
                 QueryMsg::ScrollingAreaQuery |
-                QueryMsg::NodeScrollIdQuery |
                 QueryMsg::ResolvedStyleQuery |
                 QueryMsg::ResolvedFontStyleQuery |
                 QueryMsg::OffsetParentQuery |

--- a/components/shared/script_layout/wrapper_traits.rs
+++ b/components/shared/script_layout/wrapper_traits.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::sync::Arc as StdArc;
 
 use atomic_refcell::AtomicRef;
-use gfx_traits::{combine_id_with_fragment_type, ByteIndex, FragmentType};
+use gfx_traits::{ByteIndex, FragmentType};
 use html5ever::{local_name, namespace_url, ns, LocalName, Namespace};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image::base::{Image, ImageMetadata};
@@ -23,7 +23,6 @@ use style::dom::{LayoutIterator, NodeInfo, OpaqueNode, TElement, TNode};
 use style::properties::ComputedValues;
 use style::selector_parser::{PseudoElement, PseudoElementCascadeType, SelectorImpl};
 use style::stylist::RuleInclusion;
-use webrender_api::ExternalScrollId;
 
 use crate::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutNodeType, SVGSVGData, StyleData,
@@ -314,11 +313,6 @@ pub trait ThreadSafeLayoutNode<'dom>: Clone + Copy + Debug + NodeInfo + PartialE
 
     fn fragment_type(&self) -> FragmentType {
         self.get_pseudo_element_type().fragment_type()
-    }
-
-    fn generate_scroll_id(&self, pipeline_id: PipelineId) -> ExternalScrollId {
-        let id = combine_id_with_fragment_type(self.opaque().id(), self.fragment_type());
-        ExternalScrollId(id as u64, pipeline_id.to_webrender())
     }
 }
 


### PR DESCRIPTION
This change contains three semi-related cleanups:

1. the `to_webrender()` and `from_webrender()` functions on Pipeline are
   turned into more-idiomatic `From` and `Into` implementations.
2. `combine_id_with_fragment_type` now returns a `u64` as that is what is
   expected for all callers and not a `usize`.
3. The `query_scroll_id` query is removed entirely. The
   `ExternalScrollId` that this queries is easily generated directly
   from the node's opaque id. Querying into layout isn't necessary at
   all.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
