### PR TITLE
clippy: Fix `option_map_or_none` warnings in `components/script`

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3955,7 +3955,7 @@ pub(crate) fn referrer_policy_for_element(element: &Element) -> Option<ReferrerP
 }
 
 pub(crate) fn cors_setting_for_element(element: &Element) -> Option<CorsSettings> {
-    reflect_cross_origin_attribute(element).map_or(None, |attr| match &*attr {
+    reflect_cross_origin_attribute(element).and_then(|attr| match &*attr {
         "anonymous" => Some(CorsSettings::Anonymous),
         "use-credentials" => Some(CorsSettings::UseCredentials),
         _ => unreachable!(),

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -310,7 +310,7 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     fn NamedItem(&self, name: DOMString) -> Option<DomRoot<HTMLOptionElement>> {
         self.Options()
             .NamedGetter(name)
-            .map_or(None, DomRoot::downcast::<HTMLOptionElement>)
+            .and_then(DomRoot::downcast::<HTMLOptionElement>)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-select-remove


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Change `_.map_or(None, _)` calls to `_.and_then(_)` to fix the `option_map_or_none` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#option_map_or_none

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
