### PR TITLE
clippy: Fix `toplevel_ref_arg` warning in `components/script`

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -731,10 +731,9 @@ impl EventTarget {
         listener: Option<Rc<EventListener>>,
         options: EventListenerOptions,
     ) {
-        let listener = &(match listener {
-            Some(l) => l,
-            None => return,
-        });
+        let Some(ref listener) = listener else {
+            return;
+        };
         let mut handlers = self.handlers.borrow_mut();
         let entry = handlers.get_mut(&Atom::from(ty));
         if let Some(entry) = entry {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -731,10 +731,10 @@ impl EventTarget {
         listener: Option<Rc<EventListener>>,
         options: EventListenerOptions,
     ) {
-        let ref listener = match listener {
+        let listener = &(match listener {
             Some(l) => l,
             None => return,
-        };
+        });
         let mut handlers = self.handlers.borrow_mut();
         let entry = handlers.get_mut(&Atom::from(ty));
         if let Some(entry) = entry {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix the `toplevel_ref_arg` warning by taking a reference with `&` rather than denoting the entire `let` binding as a `ref`.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
