### PR TITLE
script: Split style and layout data in DOM nodes

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -43,7 +43,7 @@ use style::LocalName;
 
 use crate::block::BlockFlow;
 use crate::context::{with_thread_local_font_context, LayoutContext};
-use crate::data::{LayoutData, LayoutDataFlags};
+use crate::data::{InnerLayoutData, LayoutDataFlags};
 use crate::display_list::items::OpaqueNode;
 use crate::flex::FlexFlow;
 use crate::floats::FloatKind;
@@ -71,14 +71,15 @@ use crate::table_rowgroup::TableRowGroupFlow;
 use crate::table_wrapper::TableWrapperFlow;
 use crate::text::TextRunScanner;
 use crate::traversal::PostorderNodeMutTraversal;
-use crate::wrapper::{LayoutNodeLayoutData, TextContent, ThreadSafeLayoutNodeHelpers};
+use crate::wrapper::{TextContent, ThreadSafeLayoutNodeHelpers};
 use crate::{parallel, ServoArc};
 
 /// The results of flow construction for a DOM node.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum ConstructionResult {
     /// This node contributes nothing at all (`display: none`). Alternately, this is what newly
     /// created nodes have their `ConstructionResult` set to.
+    #[default]
     None,
 
     /// This node contributed a flow at the proper position in the tree.
@@ -1992,7 +1993,7 @@ trait NodeUtils {
     /// Returns true if this node doesn't render its kids and false otherwise.
     fn is_replaced_content(&self) -> bool;
 
-    fn construction_result_mut(self, layout_data: &mut LayoutData) -> &mut ConstructionResult;
+    fn construction_result_mut(self, layout_data: &mut InnerLayoutData) -> &mut ConstructionResult;
 
     /// Sets the construction result of a flow.
     fn set_flow_construction_result(self, result: ConstructionResult);
@@ -2029,7 +2030,7 @@ where
         }
     }
 
-    fn construction_result_mut(self, data: &mut LayoutData) -> &mut ConstructionResult {
+    fn construction_result_mut(self, data: &mut InnerLayoutData) -> &mut ConstructionResult {
         match self.get_pseudo_element_type() {
             PseudoElementType::Before => &mut data.before_flow_construction_result,
             PseudoElementType::After => &mut data.after_flow_construction_result,

--- a/components/layout/data.rs
+++ b/components/layout/data.rs
@@ -5,20 +5,12 @@
 use atomic_refcell::AtomicRefCell;
 use bitflags::bitflags;
 use script_layout_interface::wrapper_traits::LayoutDataTrait;
-use script_layout_interface::StyleData;
 
 use crate::construct::ConstructionResult;
 
-pub struct StyleAndLayoutData<'dom> {
-    /// The style data associated with a node.
-    pub style_data: &'dom StyleData,
-    /// The layout data associated with a node.
-    pub layout_data: &'dom AtomicRefCell<LayoutData>,
-}
-
 /// Data that layout associates with a node.
-#[derive(Clone)]
-pub struct LayoutData {
+#[derive(Clone, Default)]
+pub struct InnerLayoutData {
     /// The current results of flow construction for this node. This is either a
     /// flow or a `ConstructionItem`. See comments in `construct.rs` for more
     /// details.
@@ -29,31 +21,14 @@ pub struct LayoutData {
     pub after_flow_construction_result: ConstructionResult,
 
     pub details_summary_flow_construction_result: ConstructionResult,
-
     pub details_content_flow_construction_result: ConstructionResult,
 
     /// Various flags.
     pub flags: LayoutDataFlags,
 }
 
-impl LayoutDataTrait for LayoutData {}
-
-impl Default for LayoutData {
-    /// Creates new layout data.
-    fn default() -> LayoutData {
-        Self {
-            flow_construction_result: ConstructionResult::None,
-            before_flow_construction_result: ConstructionResult::None,
-            after_flow_construction_result: ConstructionResult::None,
-            details_summary_flow_construction_result: ConstructionResult::None,
-            details_content_flow_construction_result: ConstructionResult::None,
-            flags: LayoutDataFlags::empty(),
-        }
-    }
-}
-
 bitflags! {
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Default)]
     pub struct LayoutDataFlags: u8 {
         /// Whether a flow has been newly constructed.
         const HAS_NEWLY_CONSTRUCTED_FLOW = 0x01;
@@ -61,3 +36,12 @@ bitflags! {
         const HAS_BEEN_TRAVERSED = 0x02;
     }
 }
+
+/// A wrapper for [`InnerLayoutData`]. This is necessary to give the entire data
+/// structure interior mutability, as we will need to mutate the layout data of
+/// non-mutable DOM nodes.
+#[derive(Clone, Default)]
+pub struct LayoutData(pub AtomicRefCell<InnerLayoutData>);
+
+// The implementation of this trait allows the data to be stored in the DOM.
+impl LayoutDataTrait for LayoutData {}

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -40,7 +40,7 @@ use crate::flow::{Flow, GetBaseFlow};
 use crate::fragment::{Fragment, FragmentBorderBoxIterator, FragmentFlags, SpecificFragmentInfo};
 use crate::inline::InlineFragmentNodeFlags;
 use crate::sequential;
-use crate::wrapper::LayoutNodeLayoutData;
+use crate::wrapper::ThreadSafeLayoutNodeHelpers;
 
 // https://drafts.csswg.org/cssom-view/#overflow-directions
 fn overflow_direction(writing_mode: &WritingMode) -> OverflowDirection {
@@ -851,7 +851,7 @@ fn process_resolved_style_request_internal<'dom>(
     where
         N: LayoutNode<'dom>,
     {
-        let maybe_data = layout_el.borrow_layout_data();
+        let maybe_data = layout_el.as_node().borrow_layout_data();
         let position = maybe_data.map_or(Point2D::zero(), |data| {
             match data.flow_construction_result {
                 ConstructionResult::Flow(ref flow_ref, _) => flow_ref
@@ -1021,8 +1021,8 @@ fn inner_text_collection_steps<'dom>(
             _ => child,
         };
 
-        let element_data = match node.get_style_and_opaque_layout_data() {
-            Some(data) => &data.style_data.element_data,
+        let element_data = match node.style_data() {
+            Some(data) => &data.element_data,
             None => continue,
         };
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -18,7 +18,8 @@ use crate::construct::FlowConstructor;
 use crate::context::LayoutContext;
 use crate::display_list::DisplayListBuildState;
 use crate::flow::{Flow, FlowFlags, GetBaseFlow, ImmutableFlowUtils};
-use crate::wrapper::{GetStyleAndLayoutData, LayoutNodeLayoutData, ThreadSafeLayoutNodeHelpers};
+use crate::wrapper::ThreadSafeLayoutNodeHelpers;
+use crate::LayoutData;
 
 pub struct RecalcStyleAndConstructFlows<'a> {
     context: LayoutContext<'a>,
@@ -58,7 +59,7 @@ where
     {
         // FIXME(pcwalton): Stop allocating here. Ideally this should just be
         // done by the HTML parser.
-        unsafe { node.initialize_data() };
+        unsafe { node.initialize_style_and_layout_data::<LayoutData>() };
 
         if !node.is_text_node() {
             let el = node.as_element().unwrap();
@@ -76,7 +77,7 @@ where
         // flow construction:
         // (1) They child doesn't yet have layout data (preorder traversal initializes it).
         // (2) The parent element has restyle damage (so the text flow also needs fixup).
-        node.get_style_and_layout_data().is_none() || !parent_data.damage.is_empty()
+        node.layout_data().is_none() || !parent_data.damage.is_empty()
     }
 
     fn shared_context(&self) -> &SharedStyleContext {

--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -5,11 +5,11 @@
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
-use atomic_refcell::{AtomicRefCell, AtomicRefMut};
+use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image::base::Image as NetImage;
 use script_layout_interface::wrapper_traits::{LayoutDataTrait, LayoutNode, ThreadSafeLayoutNode};
-use script_layout_interface::{HTMLCanvasDataSource, StyleData};
+use script_layout_interface::HTMLCanvasDataSource;
 use servo_arc::Arc as ServoArc;
 use style::properties::ComputedValues;
 
@@ -24,7 +24,7 @@ use crate::replaced::{CanvasInfo, CanvasSource};
 
 /// The data that is stored in each DOM node that is used by layout.
 #[derive(Default)]
-pub struct DOMLayoutData {
+pub struct InnerDOMLayoutData {
     pub(super) self_box: ArcRefCell<Option<LayoutBox>>,
     pub(super) pseudo_before_box: ArcRefCell<Option<LayoutBox>>,
     pub(super) pseudo_after_box: ArcRefCell<Option<LayoutBox>>,
@@ -38,13 +38,14 @@ pub(super) enum LayoutBox {
     FlexLevel(ArcRefCell<FlexLevelBox>),
 }
 
+/// A wrapper for [`InnerDOMLayoutData`]. This is necessary to give the entire data
+/// structure interior mutability, as we will need to mutate the layout data of
+/// non-mutable DOM nodes.
+#[derive(Default)]
+pub struct DOMLayoutData(AtomicRefCell<InnerDOMLayoutData>);
+
 // The implementation of this trait allows the data to be stored in the DOM.
 impl LayoutDataTrait for DOMLayoutData {}
-
-pub struct StyleAndLayoutData<'dom> {
-    pub style_data: &'dom StyleData,
-    pub(super) layout_data: &'dom AtomicRefCell<DOMLayoutData>,
-}
 
 pub struct BoxSlot<'dom> {
     pub(crate) slot: Option<ArcRefCell<Option<LayoutBox>>>,
@@ -96,8 +97,8 @@ pub(crate) trait NodeExt<'dom>: 'dom + LayoutNode<'dom> {
     fn as_video(self) -> Option<(webrender_api::ImageKey, PhysicalSize<f64>)>;
     fn style(self, context: &LayoutContext) -> ServoArc<ComputedValues>;
 
-    fn get_style_and_layout_data(self) -> Option<StyleAndLayoutData<'dom>>;
-    fn layout_data_mut(self) -> AtomicRefMut<'dom, DOMLayoutData>;
+    fn layout_data_mut(self) -> AtomicRefMut<'dom, InnerDOMLayoutData>;
+    fn layout_data(self) -> Option<AtomicRef<'dom, InnerDOMLayoutData>>;
     fn element_box_slot(&self) -> BoxSlot<'dom>;
     fn pseudo_element_box_slot(&self, which: WhichPseudoElement) -> BoxSlot<'dom>;
     fn unset_pseudo_element_box(self, which: WhichPseudoElement);
@@ -166,10 +167,21 @@ where
         self.to_threadsafe().style(context.shared_context())
     }
 
-    fn layout_data_mut(self) -> AtomicRefMut<'dom, DOMLayoutData> {
-        self.get_style_and_layout_data()
-            .map(|d| d.layout_data.borrow_mut())
+    fn layout_data_mut(self) -> AtomicRefMut<'dom, InnerDOMLayoutData> {
+        if LayoutNode::layout_data(&self).is_none() {
+            self.initialize_layout_data::<DOMLayoutData>();
+        }
+        LayoutNode::layout_data(&self)
             .unwrap()
+            .downcast_ref::<DOMLayoutData>()
+            .unwrap()
+            .0
+            .borrow_mut()
+    }
+
+    fn layout_data(self) -> Option<AtomicRef<'dom, InnerDOMLayoutData>> {
+        LayoutNode::layout_data(&self)
+            .map(|data| data.downcast_ref::<DOMLayoutData>().unwrap().0.borrow())
     }
 
     fn element_box_slot(&self) -> BoxSlot<'dom> {
@@ -201,13 +213,5 @@ where
         *data.pseudo_after_box.borrow_mut() = None;
         // Stylo already takes care of removing all layout data
         // for DOM descendants of elements with `display: none`.
-    }
-
-    fn get_style_and_layout_data(self) -> Option<StyleAndLayoutData<'dom>> {
-        self.get_style_and_opaque_layout_data()
-            .map(|data| StyleAndLayoutData {
-                style_data: &data.style_data,
-                layout_data: data.generic_data.downcast_ref().unwrap(),
-            })
     }
 }

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -141,16 +141,13 @@ impl BoxTree {
                 return None;
             }
 
-            // Don't update unstyled nodes.
-            let data = node.get_style_and_layout_data()?;
-
-            // Don't update nodes that have pseudo-elements.
-            let element_data = data.style_data.element_data.borrow();
+            // Don't update unstyled nodes or nodes that have pseudo-elements.
+            let element_data = node.style_data()?.element_data.borrow();
             if !element_data.styles.pseudos.is_empty() {
                 return None;
             }
 
-            let layout_data = data.layout_data.borrow();
+            let layout_data = node.layout_data()?;
             if layout_data.pseudo_before_box.borrow().is_some() {
                 return None;
             }

--- a/components/layout_2020/traversal.rs
+++ b/components/layout_2020/traversal.rs
@@ -9,7 +9,7 @@ use style::dom::{NodeInfo, TElement, TNode};
 use style::traversal::{recalc_style_at, DomTraversal, PerLevelTraversalData};
 
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
+use crate::dom::DOMLayoutData;
 
 pub struct RecalcStyle<'a> {
     context: LayoutContext<'a>,
@@ -45,7 +45,7 @@ where
         F: FnMut(E::ConcreteNode),
     {
         unsafe {
-            node.initialize_data();
+            node.initialize_style_and_layout_data::<DOMLayoutData>();
             if !node.is_text_node() {
                 let el = node.as_element().unwrap();
                 let mut data = el.mutate_data().unwrap();
@@ -65,7 +65,7 @@ where
     }
 
     fn text_node_needs_traversal(node: E::ConcreteNode, parent_data: &ElementData) -> bool {
-        node.get_style_and_layout_data().is_none() || !parent_data.damage.is_empty()
+        node.layout_data().is_none() || !parent_data.damage.is_empty()
     }
 
     fn shared_context(&self) -> &SharedStyleContext {

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -47,7 +47,7 @@ use layout::traversal::{
     construct_flows_at_ancestors, ComputeStackingRelativePositions, PreorderFlowTraversal,
     RecalcStyleAndConstructFlows,
 };
-use layout::wrapper::LayoutNodeLayoutData;
+use layout::wrapper::ThreadSafeLayoutNodeHelpers;
 use layout::{layout_debug, layout_debug_scope, parallel, sequential, LayoutData};
 use lazy_static::lazy_static;
 use log::{debug, error, trace, warn};
@@ -761,7 +761,11 @@ impl LayoutThread {
     }
 
     fn try_get_layout_root<'dom>(&self, node: impl LayoutNode<'dom>) -> Option<FlowRef> {
-        let result = node.mutate_layout_data()?.flow_construction_result.get();
+        let result = node
+            .to_threadsafe()
+            .mutate_layout_data()?
+            .flow_construction_result
+            .get();
 
         let mut flow = match result {
             ConstructionResult::Flow(mut flow, abs_descendants) => {

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -47,6 +47,8 @@ use style::stylesheets::Stylesheet;
 use style_traits::CSSPixel;
 use webrender_api::{ExternalScrollId, ImageKey};
 
+pub type GenericLayoutData = dyn Any + Send + Sync;
+
 #[derive(MallocSizeOf)]
 pub struct StyleData {
     /// Data that the style system associates with a node. When the
@@ -66,33 +68,6 @@ impl Default for StyleData {
             element_data: AtomicRefCell::new(ElementData::default()),
             parallel: DomParallelInfo::default(),
         }
-    }
-}
-
-pub type StyleAndOpaqueLayoutData = StyleAndGenericData<dyn Any + Send + Sync>;
-
-#[derive(MallocSizeOf)]
-pub struct StyleAndGenericData<T>
-where
-    T: ?Sized,
-{
-    /// The style data.
-    pub style_data: StyleData,
-    /// The opaque layout data.
-    #[ignore_malloc_size_of = "Trait objects are hard"]
-    pub generic_data: T,
-}
-
-impl StyleAndOpaqueLayoutData {
-    #[inline]
-    pub fn new<T>(style_data: StyleData, layout_data: T) -> Box<Self>
-    where
-        T: Any + Send + Sync,
-    {
-        Box::new(StyleAndGenericData {
-            style_data,
-            generic_data: layout_data,
-        })
     }
 }
 

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -30,10 +30,10 @@ macro_rules! sizeof_checker (
 
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 48);
-sizeof_checker!(size_node, Node, 184);
-sizeof_checker!(size_element, Element, 360);
-sizeof_checker!(size_htmlelement, HTMLElement, 376);
-sizeof_checker!(size_div, HTMLDivElement, 376);
-sizeof_checker!(size_span, HTMLSpanElement, 376);
-sizeof_checker!(size_text, Text, 216);
-sizeof_checker!(size_characterdata, CharacterData, 216);
+sizeof_checker!(size_node, Node, 200);
+sizeof_checker!(size_element, Element, 376);
+sizeof_checker!(size_htmlelement, HTMLElement, 392);
+sizeof_checker!(size_div, HTMLDivElement, 392);
+sizeof_checker!(size_span, HTMLSpanElement, 392);
+sizeof_checker!(size_text, Text, 232);
+sizeof_checker!(size_characterdata, CharacterData, 232);


### PR DESCRIPTION
This change splits the style and layout data in DOM nodes that is
populated by style and layout passes. This makes Servo's data design
more like Gecko's. This allows:

1. Removing the various `StyleAndLayout` data structures used by layout.
2. Removing the `GetStyleAndLayoutData` and
   `GetStyleAndOpaqueLayoutData` traits. Accessing style and layout data
   are now just functions on the `LayoutNode` and `ThreadSafeLayoutNode`
   traits.
3. Styling now doesn't populate layout data. This is is postponed until
   layout itself.
4. Allows the DOM wrappers to no longer have to be generic over the
   layout data. This data was already stored using `std::any::Any` and
   the new code just makes layout responsible for downcasting. Cleaning
   up the generic type parameter in the DOM wrappers can happen in a
   followup change.

The main benefit to all of this is that we should be able to remove
unsafe creation of `ServoLayoutNode` in layout and
`TrustedLayoutNodeAddress` entirely, because `ServoLayoutNode` will be
able to be passed directly from script to layout. In addition, this
removes one more abstraction layer from the layout DOM wrappers, making
the code a lot more understandable.

Note: This increases the measured size of DOM types, but the same data
is stored. It's simply that before that data was stored behind a heap
pointer.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
