### PR TITLE
clippy: Fix `vec_box` warnings in `components/script`

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -294,7 +294,9 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#about-to-be-notified-rejected-promises-list>
     #[ignore_malloc_size_of = "mozjs"]
-    uncaught_rejections: DomRefCell<Vec<Heap<*mut JSObject>>>,
+    #[allow(clippy::vec_box)]
+    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    uncaught_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
     /// Promises in this list have previously been reported as rejected
     /// (because they were in the above list), but the rejection was handled
@@ -302,7 +304,9 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#outstanding-rejected-promises-weak-set>
     #[ignore_malloc_size_of = "mozjs"]
-    consumed_rejections: DomRefCell<Vec<Heap<*mut JSObject>>>,
+    #[allow(clippy::vec_box)]
+    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    consumed_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
     /// True if headless mode.
     is_headless: bool,
@@ -2180,7 +2184,7 @@ impl GlobalScope {
     pub fn add_uncaught_rejection(&self, rejection: HandleObject) {
         self.uncaught_rejections
             .borrow_mut()
-            .push(*Heap::boxed(rejection.get()));
+            .push(Heap::boxed(rejection.get()));
     }
 
     pub fn remove_uncaught_rejection(&self, rejection: HandleObject) {
@@ -2188,20 +2192,22 @@ impl GlobalScope {
 
         if let Some(index) = uncaught_rejections
             .iter()
-            .position(|promise| *promise == *Heap::boxed(rejection.get()))
+            .position(|promise| *promise == Heap::boxed(rejection.get()))
         {
             uncaught_rejections.remove(index);
         }
     }
 
-    pub fn get_uncaught_rejections(&self) -> &DomRefCell<Vec<Heap<*mut JSObject>>> {
+    #[allow(clippy::vec_box)]
+    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    pub fn get_uncaught_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
         &self.uncaught_rejections
     }
 
     pub fn add_consumed_rejection(&self, rejection: HandleObject) {
         self.consumed_rejections
             .borrow_mut()
-            .push(*Heap::boxed(rejection.get()));
+            .push(Heap::boxed(rejection.get()));
     }
 
     pub fn remove_consumed_rejection(&self, rejection: HandleObject) {
@@ -2209,13 +2215,15 @@ impl GlobalScope {
 
         if let Some(index) = consumed_rejections
             .iter()
-            .position(|promise| *promise == *Heap::boxed(rejection.get()))
+            .position(|promise| *promise == Heap::boxed(rejection.get()))
         {
             consumed_rejections.remove(index);
         }
     }
 
-    pub fn get_consumed_rejections(&self) -> &DomRefCell<Vec<Heap<*mut JSObject>>> {
+    #[allow(clippy::vec_box)]
+    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    pub fn get_consumed_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
         &self.consumed_rejections
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -294,8 +294,8 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#about-to-be-notified-rejected-promises-list>
     #[ignore_malloc_size_of = "mozjs"]
-    #[allow(clippy::vec_box)]
     // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    #[allow(clippy::vec_box)]
     uncaught_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
     /// Promises in this list have previously been reported as rejected
@@ -304,8 +304,8 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#outstanding-rejected-promises-weak-set>
     #[ignore_malloc_size_of = "mozjs"]
-    #[allow(clippy::vec_box)]
     // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    #[allow(clippy::vec_box)]
     consumed_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
     /// True if headless mode.
@@ -2198,8 +2198,8 @@ impl GlobalScope {
         }
     }
 
-    #[allow(clippy::vec_box)]
     // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    #[allow(clippy::vec_box)]
     pub fn get_uncaught_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
         &self.uncaught_rejections
     }
@@ -2221,8 +2221,8 @@ impl GlobalScope {
         }
     }
 
-    #[allow(clippy::vec_box)]
     // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    #[allow(clippy::vec_box)]
     pub fn get_consumed_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
         &self.consumed_rejections
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -294,7 +294,8 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#about-to-be-notified-rejected-promises-list>
     #[ignore_malloc_size_of = "mozjs"]
-    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    // `Heap` values must stay boxed, as they need semantics like `Pin`
+    // (that is, they cannot be moved).
     #[allow(clippy::vec_box)]
     uncaught_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
@@ -304,7 +305,8 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#outstanding-rejected-promises-weak-set>
     #[ignore_malloc_size_of = "mozjs"]
-    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    // `Heap` values must stay boxed, as they need semantics like `Pin`
+    // (that is, they cannot be moved).
     #[allow(clippy::vec_box)]
     consumed_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
 
@@ -2198,7 +2200,8 @@ impl GlobalScope {
         }
     }
 
-    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    // `Heap` values must stay boxed, as they need semantics like `Pin`
+    // (that is, they cannot be moved).
     #[allow(clippy::vec_box)]
     pub fn get_uncaught_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
         &self.uncaught_rejections
@@ -2221,7 +2224,8 @@ impl GlobalScope {
         }
     }
 
-    // `Heap` values must stay boxed, as they need semantics like `Pin` ie they cannot be moved
+    // `Heap` values must stay boxed, as they need semantics like `Pin`
+    // (that is, they cannot be moved).
     #[allow(clippy::vec_box)]
     pub fn get_consumed_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
         &self.consumed_rejections

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -294,7 +294,7 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#about-to-be-notified-rejected-promises-list>
     #[ignore_malloc_size_of = "mozjs"]
-    uncaught_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
+    uncaught_rejections: DomRefCell<Vec<Heap<*mut JSObject>>>,
 
     /// Promises in this list have previously been reported as rejected
     /// (because they were in the above list), but the rejection was handled
@@ -302,7 +302,7 @@ pub struct GlobalScope {
     ///
     /// <https://html.spec.whatwg.org/multipage/#outstanding-rejected-promises-weak-set>
     #[ignore_malloc_size_of = "mozjs"]
-    consumed_rejections: DomRefCell<Vec<Box<Heap<*mut JSObject>>>>,
+    consumed_rejections: DomRefCell<Vec<Heap<*mut JSObject>>>,
 
     /// True if headless mode.
     is_headless: bool,
@@ -2180,7 +2180,7 @@ impl GlobalScope {
     pub fn add_uncaught_rejection(&self, rejection: HandleObject) {
         self.uncaught_rejections
             .borrow_mut()
-            .push(Heap::boxed(rejection.get()));
+            .push(*Heap::boxed(rejection.get()));
     }
 
     pub fn remove_uncaught_rejection(&self, rejection: HandleObject) {
@@ -2188,20 +2188,20 @@ impl GlobalScope {
 
         if let Some(index) = uncaught_rejections
             .iter()
-            .position(|promise| *promise == Heap::boxed(rejection.get()))
+            .position(|promise| *promise == *Heap::boxed(rejection.get()))
         {
             uncaught_rejections.remove(index);
         }
     }
 
-    pub fn get_uncaught_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
+    pub fn get_uncaught_rejections(&self) -> &DomRefCell<Vec<Heap<*mut JSObject>>> {
         &self.uncaught_rejections
     }
 
     pub fn add_consumed_rejection(&self, rejection: HandleObject) {
         self.consumed_rejections
             .borrow_mut()
-            .push(Heap::boxed(rejection.get()));
+            .push(*Heap::boxed(rejection.get()));
     }
 
     pub fn remove_consumed_rejection(&self, rejection: HandleObject) {
@@ -2209,13 +2209,13 @@ impl GlobalScope {
 
         if let Some(index) = consumed_rejections
             .iter()
-            .position(|promise| *promise == Heap::boxed(rejection.get()))
+            .position(|promise| *promise == *Heap::boxed(rejection.get()))
         {
             consumed_rejections.remove(index);
         }
     }
 
-    pub fn get_consumed_rejections(&self) -> &DomRefCell<Vec<Box<Heap<*mut JSObject>>>> {
+    pub fn get_consumed_rejections(&self) -> &DomRefCell<Vec<Heap<*mut JSObject>>> {
         &self.consumed_rejections
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove the unnecessary boxing of `Vec`'s content to fix the `vec_box` warnings.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#vec_box

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
