### PR TITLE
clippy: Fix warnings in `components/compositing`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1189,8 +1189,8 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         }
 
         self.send_root_pipeline_display_list();
-        self.create_or_update_pipeline_details_with_frame_tree(&frame_tree, None);
-        self.reset_scroll_tree_for_unattached_pipelines(&frame_tree);
+        self.create_or_update_pipeline_details_with_frame_tree(frame_tree, None);
+        self.reset_scroll_tree_for_unattached_pipelines(frame_tree);
 
         self.frame_tree_id.next();
     }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -242,13 +242,13 @@ pub struct EmbedderCoordinates {
 impl EmbedderCoordinates {
     /// Get the unflipped viewport rectangle for use with the WebRender API.
     pub fn get_viewport(&self) -> DeviceIntRect {
-        self.viewport.clone()
+        self.viewport
     }
 
     /// Flip the given rect.
     /// This should be used when drawing directly to the framebuffer with OpenGL commands.
     pub fn flip_rect(&self, rect: &DeviceIntRect) -> DeviceIntRect {
-        let mut result = rect.clone();
+        let mut result = *rect;
         result.min.y = self.framebuffer.height - result.min.y - result.size().height;
         result
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Resolved following warnings in components/compositing 
by running suggested command:`./mach cargo-clippy --fix --lib -p compositing`:
```
warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> components/compositing/compositor.rs:1192:64
     |
1192 |         self.create_or_update_pipeline_details_with_frame_tree(&frame_tree, None);
     |                                                                ^^^^^^^^^^^ help: change this to: `frame_tree`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
     = note: `#[warn(clippy::needless_borrow)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> components/compositing/compositor.rs:1193:57
     |
1193 |         self.reset_scroll_tree_for_unattached_pipelines(&frame_tree);
     |                                                         ^^^^^^^^^^^ help: change this to: `frame_tree`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: using `clone` on type `Box2D<i32, DevicePixel>` which implements the `Copy` trait
   --> components/compositing/windowing.rs:245:9
    |
245 |         self.viewport.clone()
    |         ^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `self.viewport`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
    = note: `#[warn(clippy::clone_on_copy)]` on by default

warning: using `clone` on type `Box2D<i32, DevicePixel>` which implements the `Copy` trait
   --> components/compositing/windowing.rs:251:26
    |
251 |         let mut result = rect.clone();
    |                          ^^^^^^^^^^^^ help: try dereferencing it: `*rect`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: `compositing` (lib) generated 4 warnings (run `cargo clippy --fix --lib -p compositing` to apply 4 suggestions)

```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
