### PR TITLE
Fixed some clippy warning by adding default implementations

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -445,7 +445,7 @@ impl HTMLMediaElement {
             seeking: Cell::new(false),
             resource_url: DomRefCell::new(None),
             blob_url: DomRefCell::new(None),
-            played: DomRefCell::new(TimeRangesContainer::new()),
+            played: DomRefCell::new(TimeRangesContainer::default()),
             audio_tracks_list: Default::default(),
             video_tracks_list: Default::default(),
             text_tracks_list: Default::default(),
@@ -2346,7 +2346,7 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-media-buffered
     fn Buffered(&self) -> DomRoot<TimeRanges> {
-        let mut buffered = TimeRangesContainer::new();
+        let mut buffered = TimeRangesContainer::default();
         if let Some(ref player) = *self.player.borrow() {
             if let Ok(ranges) = player.lock().unwrap().buffered() {
                 for range in ranges {

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -64,8 +64,8 @@ pub struct Identities {
     dummy_hub: IdentityHub,
 }
 
-impl Identities {
-    pub fn new() -> Self {
+impl Default for Identities {
+    fn default() -> Self {
         Identities {
             _surface: IdentityManager::default(),
             #[cfg(any(target_os = "linux", target_os = "windows"))]
@@ -79,7 +79,9 @@ impl Identities {
             dummy_hub: IdentityHub::new(),
         }
     }
+}
 
+impl Identities {
     fn select(&mut self, backend: Backend) -> &mut IdentityHub {
         match backend {
             #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -11,7 +11,7 @@ use webgpu::wgpu::id::{
 use webgpu::wgpu::identity::IdentityManager;
 use webgpu::wgt::Backend;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IdentityHub {
     adapters: IdentityManager,
     devices: IdentityManager,
@@ -29,28 +29,7 @@ pub struct IdentityHub {
     render_bundles: IdentityManager,
 }
 
-impl IdentityHub {
-    fn new() -> Self {
-        IdentityHub {
-            adapters: IdentityManager::default(),
-            devices: IdentityManager::default(),
-            buffers: IdentityManager::default(),
-            bind_groups: IdentityManager::default(),
-            bind_group_layouts: IdentityManager::default(),
-            compute_pipelines: IdentityManager::default(),
-            pipeline_layouts: IdentityManager::default(),
-            shader_modules: IdentityManager::default(),
-            command_encoders: IdentityManager::default(),
-            textures: IdentityManager::default(),
-            texture_views: IdentityManager::default(),
-            samplers: IdentityManager::default(),
-            render_pipelines: IdentityManager::default(),
-            render_bundles: IdentityManager::default(),
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Identities {
     _surface: IdentityManager,
     #[cfg(any(target_os = "linux", target_os = "windows"))]
@@ -62,23 +41,6 @@ pub struct Identities {
     #[cfg(any(target_os = "ios", target_os = "macos"))]
     metal_hub: IdentityHub,
     dummy_hub: IdentityHub,
-}
-
-impl Default for Identities {
-    fn default() -> Self {
-        Identities {
-            _surface: IdentityManager::default(),
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
-            vk_hub: IdentityHub::new(),
-            #[cfg(target_os = "windows")]
-            dx12_hub: IdentityHub::new(),
-            #[cfg(target_os = "windows")]
-            dx11_hub: IdentityHub::new(),
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
-            metal_hub: IdentityHub::new(),
-            dummy_hub: IdentityHub::new(),
-        }
-    }
 }
 
 impl Identities {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -208,12 +208,6 @@ bitflags! {
     }
 }
 
-impl Default for NodeFlags {
-    fn default() -> NodeFlags {
-        NodeFlags::empty()
-    }
-}
-
 /// suppress observers flag
 /// <https://dom.spec.whatwg.org/#concept-node-insert>
 /// <https://dom.spec.whatwg.org/#concept-node-remove>
@@ -1805,15 +1799,12 @@ impl Node {
     }
 
     pub fn new_inherited(doc: &Document) -> Node {
-        Node::new_(NodeFlags::default(), Some(doc))
+        Node::new_(NodeFlags::empty(), Some(doc))
     }
 
     #[allow(crown::unrooted_must_root)]
     pub fn new_document_node() -> Node {
-        Node::new_(
-            NodeFlags::default() | NodeFlags::IS_IN_DOC | NodeFlags::IS_CONNECTED,
-            None,
-        )
+        Node::new_(NodeFlags::IS_IN_DOC | NodeFlags::IS_CONNECTED, None)
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -1832,7 +1823,7 @@ impl Node {
             children_count: Cell::new(0u32),
             flags: Cell::new(flags),
             inclusive_descendants_version: Cell::new(0),
-            ranges: WeakRangeVec::default(),
+            ranges: WeakRangeVec::new(),
 
             style_and_layout_data: Default::default(),
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -208,8 +208,8 @@ bitflags! {
     }
 }
 
-impl NodeFlags {
-    pub fn new() -> NodeFlags {
+impl Default for NodeFlags {
+    fn default() -> NodeFlags {
         NodeFlags::empty()
     }
 }
@@ -1805,13 +1805,13 @@ impl Node {
     }
 
     pub fn new_inherited(doc: &Document) -> Node {
-        Node::new_(NodeFlags::new(), Some(doc))
+        Node::new_(NodeFlags::default(), Some(doc))
     }
 
     #[allow(crown::unrooted_must_root)]
     pub fn new_document_node() -> Node {
         Node::new_(
-            NodeFlags::new() | NodeFlags::IS_IN_DOC | NodeFlags::IS_CONNECTED,
+            NodeFlags::default() | NodeFlags::IS_IN_DOC | NodeFlags::IS_CONNECTED,
             None,
         )
     }
@@ -1832,7 +1832,7 @@ impl Node {
             children_count: Cell::new(0u32),
             flags: Cell::new(flags),
             inclusive_descendants_version: Cell::new(0),
-            ranges: WeakRangeVec::new(),
+            ranges: WeakRangeVec::default(),
 
             style_and_layout_data: Default::default(),
         }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1083,14 +1083,17 @@ pub struct WeakRangeVec {
 }
 
 #[allow(unsafe_code)]
-impl WeakRangeVec {
+impl Default for WeakRangeVec {
     /// Create a new vector of weak references.
-    pub fn new() -> Self {
+    fn default() -> Self {
         WeakRangeVec {
             cell: UnsafeCell::new(WeakRefVec::new()),
         }
     }
+}
 
+#[allow(unsafe_code)]
+impl WeakRangeVec {
     /// Whether that vector of ranges is empty.
     pub fn is_empty(&self) -> bool {
         unsafe { (*self.cell.get()).is_empty() }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1082,9 +1082,7 @@ pub struct WeakRangeVec {
     cell: UnsafeCell<WeakRefVec<Range>>,
 }
 
-#[allow(unsafe_code)]
 impl Default for WeakRangeVec {
-    /// Create a new vector of weak references.
     fn default() -> Self {
         WeakRangeVec {
             cell: UnsafeCell::new(WeakRefVec::new()),
@@ -1094,6 +1092,11 @@ impl Default for WeakRangeVec {
 
 #[allow(unsafe_code)]
 impl WeakRangeVec {
+    /// Create a new vector of weak references.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Whether that vector of ranges is empty.
     pub fn is_empty(&self) -> bool {
         unsafe { (*self.cell.get()).is_empty() }

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -242,7 +242,7 @@ impl ServiceWorkerGlobalScope {
                 runtime,
                 from_devtools_receiver,
                 closing,
-                Arc::new(Mutex::new(Identities::new())),
+                Arc::new(Mutex::new(Identities::default())),
             ),
             task_queue: TaskQueue::new(receiver, own_sender.clone()),
             own_sender,

--- a/components/script/dom/timeranges.rs
+++ b/components/script/dom/timeranges.rs
@@ -61,11 +61,13 @@ pub struct TimeRangesContainer {
     ranges: Vec<TimeRange>,
 }
 
-impl TimeRangesContainer {
-    pub fn new() -> Self {
+impl Default for TimeRangesContainer {
+    fn default() -> Self {
         Self { ranges: Vec::new() }
     }
+}
 
+impl TimeRangesContainer {
     pub fn len(&self) -> u32 {
         self.ranges.len() as u32
     }

--- a/components/script/dom/timeranges.rs
+++ b/components/script/dom/timeranges.rs
@@ -56,15 +56,9 @@ pub enum TimeRangesError {
     OutOfRange,
 }
 
-#[derive(Clone, Debug, JSTraceable, MallocSizeOf)]
+#[derive(Clone, Debug, Default, JSTraceable, MallocSizeOf)]
 pub struct TimeRangesContainer {
     ranges: Vec<TimeRange>,
-}
-
-impl Default for TimeRangesContainer {
-    fn default() -> Self {
-        Self { ranges: Vec::new() }
-    }
 }
 
 impl TimeRangesContainer {

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -72,5 +72,5 @@ pub fn init() -> JSEngineSetup {
 
     perform_platform_specific_initialization();
 
-    JSEngineSetup::new()
+    JSEngineSetup::default()
 }

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -411,8 +411,8 @@ impl Deref for Runtime {
 
 pub struct JSEngineSetup(JSEngine);
 
-impl JSEngineSetup {
-    pub fn new() -> Self {
+impl Default for JSEngineSetup {
+    fn default() -> Self {
         let engine = JSEngine::init().unwrap();
         *JS_ENGINE.lock().unwrap() = Some(engine.handle());
         Self(engine)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -855,7 +855,7 @@ impl ScriptThreadFactory for ScriptThread {
 }
 
 impl ScriptThread {
-    pub fn with_layout<'a, T>(
+    pub fn with_layout<T>(
         pipeline_id: PipelineId,
         call: impl FnOnce(&mut dyn Layout) -> T,
     ) -> Result<T, ()> {
@@ -1426,7 +1426,7 @@ impl ScriptThread {
 
             node_ids: Default::default(),
             is_user_interacting: Cell::new(false),
-            gpu_id_hub: Arc::new(Mutex::new(Identities::new())),
+            gpu_id_hub: Arc::new(Mutex::new(Identities::default())),
             webgpu_port: RefCell::new(None),
             inherited_secure_context: state.inherited_secure_context,
             layouts: Default::default(),

--- a/tests/unit/script/timeranges.rs
+++ b/tests/unit/script/timeranges.rs
@@ -13,7 +13,7 @@ fn check(time_ranges: &TimeRangesContainer, expected: &'static str) {
 
 #[test]
 fn initial_state() {
-    let time_ranges = TimeRangesContainer::new();
+    let time_ranges = TimeRangesContainer::default();
     assert_eq!(time_ranges.len(), 0);
     assert!(time_ranges.start(0).is_err());
     assert!(time_ranges.end(0).is_err());
@@ -21,13 +21,13 @@ fn initial_state() {
 
 #[test]
 fn error_if_start_is_older_than_end() {
-    let mut time_ranges = TimeRangesContainer::new();
+    let mut time_ranges = TimeRangesContainer::default();
     assert!(time_ranges.add(2., 1.).is_err());
 }
 
 #[test]
 fn single_range() {
-    let mut time_ranges = TimeRangesContainer::new();
+    let mut time_ranges = TimeRangesContainer::default();
     time_ranges.add(1., 2.).unwrap();
     check(&time_ranges, "[1,2)");
     assert_eq!(time_ranges.start(0).unwrap(), 1.);
@@ -36,14 +36,14 @@ fn single_range() {
 
 #[test]
 fn add_order() {
-    let mut time_ranges_a = TimeRangesContainer::new();
+    let mut time_ranges_a = TimeRangesContainer::default();
     for range in vec![(0., 2.), (3., 4.), (5., 100.)].iter() {
         time_ranges_a.add(range.0, range.1).unwrap();
     }
     let expected = "[0,2), [3,4), [5,100)";
     check(&time_ranges_a, expected);
 
-    let mut time_ranges_b = TimeRangesContainer::new();
+    let mut time_ranges_b = TimeRangesContainer::default();
     // Add the values in time_ranges_a to time_ranges_b in reverse order.
     for i in (0..time_ranges_a.len()).rev() {
         time_ranges_b
@@ -58,7 +58,7 @@ fn add_order() {
 
 #[test]
 fn add_overlapping() {
-    let mut time_ranges = TimeRangesContainer::new();
+    let mut time_ranges = TimeRangesContainer::default();
 
     time_ranges.add(0., 2.).unwrap();
     time_ranges.add(10., 11.).unwrap();


### PR DESCRIPTION
This PR fixes clippy warnings that require creation of default implementations of structs or types by creating the default implementations.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because it doesn't touch functionality.

