### PR TITLE
webgpu: Update wgpu to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,12 +1112,11 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+version = "0.19.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
 dependencies = [
  "bitflags 2.5.0",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -1410,7 +1409,7 @@ dependencies = [
  "egui",
  "instant",
  "log",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "smithay-clipboard",
  "winit",
 ]
@@ -3845,10 +3844,10 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "naga"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae585df4b6514cf8842ac0f1ab4992edc975892704835b549cf818dc0191249e"
+version = "0.19.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
 dependencies = [
+ "arrayvec",
  "bit-set",
  "bitflags 2.5.0",
  "codespan-reporting",
@@ -3874,7 +3873,7 @@ dependencies = [
  "jni-sys",
  "ndk-sys",
  "num_enum",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "thiserror",
 ]
 
@@ -4723,6 +4722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5557,7 +5562,7 @@ dependencies = [
  "libc",
  "libservo",
  "log",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "servo-media",
  "servo_allocator",
  "shellwords",
@@ -5763,12 +5768,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 1.3.2",
- "num-traits",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -5963,7 +5967,7 @@ dependencies = [
  "mach2",
  "metal 0.24.0",
  "objc",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "servo-display-link",
  "sparkle",
  "wayland-sys 0.30.1",
@@ -7080,16 +7084,18 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu-core"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91c1d62d1e9e81c79e600131a258edf75c9531cbdbde09c44a011a47312726"
+version = "0.19.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.5.0",
+ "cfg_aliases",
  "codespan-reporting",
+ "indexmap 2.2.6",
  "log",
  "naga",
+ "once_cell",
  "parking_lot",
  "profiling",
  "ron",
@@ -7104,9 +7110,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84ecc802da3eb67b4cf3dd9ea6fe45bbb47ef13e6c49c5c3240868a9cc6cdd9"
+version = "0.19.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7114,6 +7119,7 @@ dependencies = [
  "bit-set",
  "bitflags 2.5.0",
  "block",
+ "cfg_aliases",
  "core-graphics-types",
  "d3d12",
  "gpu-alloc",
@@ -7121,7 +7127,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "log",
  "metal 0.27.0",
  "naga",
@@ -7130,7 +7136,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle",
+ "raw-window-handle 0.6.0",
  "rustc-hash",
  "smallvec",
  "thiserror",
@@ -7142,9 +7148,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5ed5f0edf0de351fe311c53304986315ce866f394a2e6df0c4b3c70774bcdd"
+version = "0.19.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
 dependencies = [
  "bitflags 2.5.0",
  "js-sys",
@@ -7439,7 +7444,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
  "redox_syscall 0.3.5",
  "sctk-adwaita",
  "smithay-client-toolkit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.64", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
 webrender_traits = { path = "components/shared/webrender" }
-wgpu-core = "0.18"
-wgpu-types = "0.18"
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "32e70bc1635905c508d408eb1cf22b2aa062ffe1" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "32e70bc1635905c508d408eb1cf22b2aa062ffe1" }
 winapi = "0.3"
 xi-unicode = "0.1.0"
 xml5ever = "0.17"

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -130,8 +130,18 @@ impl GPUBuffer {
 
 impl Drop for GPUBuffer {
     fn drop(&mut self) {
-        if let Err(e) = self.Destroy() {
-            error!("GPUBuffer destruction failed with {e:?}!"); // TODO: should we allow panic here?
+        if matches!(self.state(), GPUBufferState::Destroyed) {
+            return;
+        }
+        if let Err(e) = self
+            .channel
+            .0
+            .send((None, WebGPURequest::DropBuffer(self.buffer.0)))
+        {
+            warn!(
+                "Failed to send WebGPURequest::DropBuffer({:?}) ({})",
+                self.buffer.0, e
+            );
         };
     }
 }

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -287,7 +287,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
             .expect("Failed to create WebGPU SwapChain");
 
         self.texture
-            .set(Some(&descriptor.device.CreateTexture(&text_desc)));
+            .set(Some(&descriptor.device.CreateTexture(&text_desc).unwrap()));
 
         self.webrender_image.set(Some(receiver.recv().unwrap()));
     }

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -74,10 +74,10 @@ impl Drop for GPUCommandBuffer {
     fn drop(&mut self) {
         if let Err(e) = self.channel.0.send((
             None,
-            WebGPURequest::FreeCommandBuffer(self.command_buffer.0),
+            WebGPURequest::DropCommandBuffer(self.command_buffer.0),
         )) {
             warn!(
-                "Failed to send FreeCommandBuffer({:?}) ({})",
+                "Failed to send DropCommandBuffer({:?}) ({})",
                 self.command_buffer.0, e
             );
         }

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -393,7 +393,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .expect("Failed to send Finish");
 
         *self.state.borrow_mut() = GPUCommandEncoderState::Closed;
-        let buffer = webgpu::WebGPUCommandBuffer(self.encoder.0);
+        let buffer = webgpu::WebGPUCommandBuffer(self.encoder.0.transmute());
         GPUCommandBuffer::new(
             &self.global(),
             self.channel.clone(),

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -3,6 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use smallvec::SmallVec;
+use webgpu::wgpu::id::markers::{
+    Adapter, BindGroup, BindGroupLayout, Buffer, CommandEncoder, ComputePipeline, Device,
+    PipelineLayout, RenderBundle, RenderPipeline, Sampler, ShaderModule, Texture, TextureView,
+};
 use webgpu::wgpu::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandEncoderId, ComputePipelineId,
     DeviceId, PipelineLayoutId, RenderBundleId, RenderPipelineId, SamplerId, ShaderModuleId,
@@ -11,39 +15,71 @@ use webgpu::wgpu::id::{
 use webgpu::wgpu::identity::IdentityManager;
 use webgpu::wgt::Backend;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct IdentityHub {
-    adapters: IdentityManager,
-    devices: IdentityManager,
-    buffers: IdentityManager,
-    bind_groups: IdentityManager,
-    bind_group_layouts: IdentityManager,
-    compute_pipelines: IdentityManager,
-    pipeline_layouts: IdentityManager,
-    shader_modules: IdentityManager,
-    command_encoders: IdentityManager,
-    textures: IdentityManager,
-    texture_views: IdentityManager,
-    samplers: IdentityManager,
-    render_pipelines: IdentityManager,
-    render_bundles: IdentityManager,
+    adapters: IdentityManager<Adapter>,
+    devices: IdentityManager<Device>,
+    buffers: IdentityManager<Buffer>,
+    bind_groups: IdentityManager<BindGroup>,
+    bind_group_layouts: IdentityManager<BindGroupLayout>,
+    compute_pipelines: IdentityManager<ComputePipeline>,
+    pipeline_layouts: IdentityManager<PipelineLayout>,
+    shader_modules: IdentityManager<ShaderModule>,
+    command_encoders: IdentityManager<CommandEncoder>,
+    textures: IdentityManager<Texture>,
+    texture_views: IdentityManager<TextureView>,
+    samplers: IdentityManager<Sampler>,
+    render_pipelines: IdentityManager<RenderPipeline>,
+    render_bundles: IdentityManager<RenderBundle>,
 }
 
-#[derive(Debug, Default)]
+impl IdentityHub {
+    fn new() -> Self {
+        IdentityHub {
+            adapters: IdentityManager::new(),
+            devices: IdentityManager::new(),
+            buffers: IdentityManager::new(),
+            bind_groups: IdentityManager::new(),
+            bind_group_layouts: IdentityManager::new(),
+            compute_pipelines: IdentityManager::new(),
+            pipeline_layouts: IdentityManager::new(),
+            shader_modules: IdentityManager::new(),
+            command_encoders: IdentityManager::new(),
+            textures: IdentityManager::new(),
+            texture_views: IdentityManager::new(),
+            samplers: IdentityManager::new(),
+            render_pipelines: IdentityManager::new(),
+            render_bundles: IdentityManager::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct Identities {
-    _surface: IdentityManager,
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     vk_hub: IdentityHub,
     #[cfg(target_os = "windows")]
     dx12_hub: IdentityHub,
-    #[cfg(target_os = "windows")]
-    dx11_hub: IdentityHub,
     #[cfg(any(target_os = "ios", target_os = "macos"))]
     metal_hub: IdentityHub,
     dummy_hub: IdentityHub,
 }
 
 impl Identities {
+    pub fn new() -> Self {
+        Identities {
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            vk_hub: IdentityHub::new(),
+            #[cfg(target_os = "windows")]
+            dx12_hub: IdentityHub::new(),
+            #[cfg(target_os = "windows")]
+            dx11_hub: IdentityHub::new(),
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            metal_hub: IdentityHub::new(),
+            dummy_hub: IdentityHub::new(),
+        }
+    }
+
     fn select(&mut self, backend: Backend) -> &mut IdentityHub {
         match backend {
             #[cfg(any(target_os = "linux", target_os = "windows"))]
@@ -73,7 +109,7 @@ impl Identities {
     }
 
     pub fn create_device_id(&mut self, backend: Backend) -> DeviceId {
-        self.select(backend).devices.alloc(backend)
+        self.select(backend).devices.process(backend)
     }
 
     pub fn kill_device_id(&mut self, id: DeviceId) {
@@ -83,7 +119,7 @@ impl Identities {
     pub fn create_adapter_ids(&mut self) -> SmallVec<[AdapterId; 4]> {
         let mut ids = SmallVec::new();
         for hubs in self.hubs() {
-            ids.push(hubs.0.adapters.alloc(hubs.1));
+            ids.push(hubs.0.adapters.process(hubs.1));
         }
         ids
     }
@@ -93,7 +129,7 @@ impl Identities {
     }
 
     pub fn create_buffer_id(&mut self, backend: Backend) -> BufferId {
-        self.select(backend).buffers.alloc(backend)
+        self.select(backend).buffers.process(backend)
     }
 
     pub fn kill_buffer_id(&mut self, id: BufferId) {
@@ -101,7 +137,7 @@ impl Identities {
     }
 
     pub fn create_bind_group_id(&mut self, backend: Backend) -> BindGroupId {
-        self.select(backend).bind_groups.alloc(backend)
+        self.select(backend).bind_groups.process(backend)
     }
 
     pub fn kill_bind_group_id(&mut self, id: BindGroupId) {
@@ -109,7 +145,7 @@ impl Identities {
     }
 
     pub fn create_bind_group_layout_id(&mut self, backend: Backend) -> BindGroupLayoutId {
-        self.select(backend).bind_group_layouts.alloc(backend)
+        self.select(backend).bind_group_layouts.process(backend)
     }
 
     pub fn kill_bind_group_layout_id(&mut self, id: BindGroupLayoutId) {
@@ -117,7 +153,7 @@ impl Identities {
     }
 
     pub fn create_compute_pipeline_id(&mut self, backend: Backend) -> ComputePipelineId {
-        self.select(backend).compute_pipelines.alloc(backend)
+        self.select(backend).compute_pipelines.process(backend)
     }
 
     pub fn kill_compute_pipeline_id(&mut self, id: ComputePipelineId) {
@@ -125,7 +161,7 @@ impl Identities {
     }
 
     pub fn create_pipeline_layout_id(&mut self, backend: Backend) -> PipelineLayoutId {
-        self.select(backend).pipeline_layouts.alloc(backend)
+        self.select(backend).pipeline_layouts.process(backend)
     }
 
     pub fn kill_pipeline_layout_id(&mut self, id: PipelineLayoutId) {
@@ -133,7 +169,7 @@ impl Identities {
     }
 
     pub fn create_shader_module_id(&mut self, backend: Backend) -> ShaderModuleId {
-        self.select(backend).shader_modules.alloc(backend)
+        self.select(backend).shader_modules.process(backend)
     }
 
     pub fn kill_shader_module_id(&mut self, id: ShaderModuleId) {
@@ -141,7 +177,7 @@ impl Identities {
     }
 
     pub fn create_command_encoder_id(&mut self, backend: Backend) -> CommandEncoderId {
-        self.select(backend).command_encoders.alloc(backend)
+        self.select(backend).command_encoders.process(backend)
     }
 
     pub fn kill_command_buffer_id(&mut self, id: CommandEncoderId) {
@@ -149,7 +185,7 @@ impl Identities {
     }
 
     pub fn create_sampler_id(&mut self, backend: Backend) -> SamplerId {
-        self.select(backend).samplers.alloc(backend)
+        self.select(backend).samplers.process(backend)
     }
 
     pub fn kill_sampler_id(&mut self, id: SamplerId) {
@@ -157,7 +193,7 @@ impl Identities {
     }
 
     pub fn create_render_pipeline_id(&mut self, backend: Backend) -> RenderPipelineId {
-        self.select(backend).render_pipelines.alloc(backend)
+        self.select(backend).render_pipelines.process(backend)
     }
 
     pub fn kill_render_pipeline_id(&mut self, id: RenderPipelineId) {
@@ -165,7 +201,9 @@ impl Identities {
     }
 
     pub fn create_texture_id(&mut self, backend: Backend) -> TextureId {
-        self.select(backend).textures.alloc(backend)
+        let r = self.select(backend).textures.process(backend);
+        warn!("TEXTURE: {r:?}");
+        r
     }
 
     pub fn kill_texture_id(&mut self, id: TextureId) {
@@ -173,7 +211,7 @@ impl Identities {
     }
 
     pub fn create_texture_view_id(&mut self, backend: Backend) -> TextureViewId {
-        self.select(backend).texture_views.alloc(backend)
+        self.select(backend).texture_views.process(backend)
     }
 
     pub fn kill_texture_view_id(&mut self, id: TextureViewId) {
@@ -181,7 +219,7 @@ impl Identities {
     }
 
     pub fn create_render_bundle_id(&mut self, backend: Backend) -> RenderBundleId {
-        self.select(backend).render_bundles.alloc(backend)
+        self.select(backend).render_bundles.process(backend)
     }
 
     pub fn kill_render_bundle_id(&mut self, id: RenderBundleId) {

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -72,8 +72,6 @@ impl Identities {
             vk_hub: IdentityHub::new(),
             #[cfg(target_os = "windows")]
             dx12_hub: IdentityHub::new(),
-            #[cfg(target_os = "windows")]
-            dx11_hub: IdentityHub::new(),
             #[cfg(any(target_os = "ios", target_os = "macos"))]
             metal_hub: IdentityHub::new(),
             dummy_hub: IdentityHub::new(),
@@ -86,8 +84,6 @@ impl Identities {
             Backend::Vulkan => &mut self.vk_hub,
             #[cfg(target_os = "windows")]
             Backend::Dx12 => &mut self.dx12_hub,
-            #[cfg(target_os = "windows")]
-            Backend::Dx11 => &mut self.dx11_hub,
             #[cfg(any(target_os = "ios", target_os = "macos"))]
             Backend::Metal => &mut self.metal_hub,
             _ => &mut self.dummy_hub,
@@ -100,8 +96,6 @@ impl Identities {
             (&mut self.vk_hub, Backend::Vulkan),
             #[cfg(target_os = "windows")]
             (&mut self.dx12_hub, Backend::Dx12),
-            #[cfg(target_os = "windows")]
-            (&mut self.dx11_hub, Backend::Dx11),
             #[cfg(any(target_os = "ios", target_os = "macos"))]
             (&mut self.metal_hub, Backend::Metal),
             (&mut self.dummy_hub, Backend::Empty),

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -201,9 +201,7 @@ impl Identities {
     }
 
     pub fn create_texture_id(&mut self, backend: Backend) -> TextureId {
-        let r = self.select(backend).textures.process(backend);
-        warn!("TEXTURE: {r:?}");
-        r
+        self.select(backend).textures.process(backend)
     }
 
     pub fn kill_texture_id(&mut self, id: TextureId) {

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -242,7 +242,7 @@ impl ServiceWorkerGlobalScope {
                 runtime,
                 from_devtools_receiver,
                 closing,
-                Arc::new(Mutex::new(Identities::default())),
+                Arc::new(Mutex::new(Identities::new())),
             ),
             task_queue: TaskQueue::new(receiver, own_sender.clone()),
             own_sender,

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -129,7 +129,7 @@ interface GPUDevice: EventTarget {
 
     [NewObject, Throws]
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
-    [NewObject]
+    [NewObject, Throws]
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     [NewObject]
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1430,7 +1430,7 @@ impl ScriptThread {
 
             node_ids: Default::default(),
             is_user_interacting: Cell::new(false),
-            gpu_id_hub: Arc::new(Mutex::new(Identities::default())),
+            gpu_id_hub: Arc::new(Mutex::new(Identities::new())),
             webgpu_port: RefCell::new(None),
             inherited_secure_context: state.inherited_secure_context,
             layouts: Default::default(),
@@ -2122,7 +2122,10 @@ impl ScriptThread {
             WebGPUMsg::FreeBindGroupLayout(id) => {
                 self.gpu_id_hub.lock().kill_bind_group_layout_id(id)
             },
-            WebGPUMsg::FreeCommandBuffer(id) => self.gpu_id_hub.lock().kill_command_buffer_id(id),
+            WebGPUMsg::FreeCommandBuffer(id) => self
+                .gpu_id_hub
+                .lock()
+                .kill_command_buffer_id(id.transmute()),
             WebGPUMsg::FreeSampler(id) => self.gpu_id_hub.lock().kill_sampler_id(id),
             WebGPUMsg::FreeShaderModule(id) => self.gpu_id_hub.lock().kill_shader_module_id(id),
             WebGPUMsg::FreeRenderBundle(id) => self.gpu_id_hub.lock().kill_render_bundle_id(id),

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -23,17 +23,20 @@ smallvec = { workspace = true, features = ["serde"] }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
-wgpu-core = { workspace = true, features = ["replay", "trace", "serial-pass", "wgsl"] }
+wgpu-core = { workspace = true, features = ["replay", "trace", "wgsl"] }
 wgpu-types = { workspace = true }
 
+# We want the wgpu-core Metal backend on macOS and iOS.
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies.wgpu-core]
 workspace = true
-features = ["replay", "trace", "serial-pass", "metal"]
+features = ["metal"]
 
-[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies.wgpu-core]
+# We want the wgpu-core Vulkan backend on Linux and Windows.
+[target.'cfg(any(windows, all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies.wgpu-core]
 workspace = true
-features = ["replay", "trace", "serial-pass", "vulkan"]
+features = ["vulkan"]
 
+# We want the wgpu-core Direct3D backends on Windows.
 [target.'cfg(windows)'.dependencies.wgpu-core]
 workspace = true
-features = ["replay", "trace", "serial-pass", "dx11", "dx12", "vulkan"]
+features = ["dx12", "vulkan"]

--- a/components/webgpu/identity.rs
+++ b/components/webgpu/identity.rs
@@ -2,20 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
 use serde::{Deserialize, Serialize};
 
 use crate::wgpu::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, ComputePipelineId,
     DeviceId, PipelineLayoutId, QuerySetId, RenderBundleId, RenderPipelineId, SamplerId,
-    ShaderModuleId, StagingBufferId, SurfaceId, TextureId, TextureViewId, TypedId,
+    ShaderModuleId, StagingBufferId, SurfaceId, TextureId, TextureViewId,
 };
-use crate::wgpu::identity::{
-    GlobalIdentityHandlerFactory, IdentityHandler, IdentityHandlerFactory,
-};
-use crate::wgt::Backend;
-use crate::{ErrorScopeId, WebGPUDevice, WebGPURequest};
+use crate::{ErrorScopeId, WebGPUDevice};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum WebGPUOpResult {
@@ -54,118 +49,4 @@ pub enum WebGPUMsg {
         pipeline_id: PipelineId,
     },
     Exit,
-}
-
-#[derive(Debug)]
-pub struct IdentityRecycler {
-    sender: IpcSender<WebGPUMsg>,
-    self_sender: IpcSender<(Option<ErrorScopeId>, WebGPURequest)>,
-}
-
-pub struct IdentityRecyclerFactory {
-    pub sender: IpcSender<WebGPUMsg>,
-    pub self_sender: IpcSender<(Option<ErrorScopeId>, WebGPURequest)>,
-}
-
-macro_rules! impl_identity_handler {
-    ($id:ty, $st:tt, $($var:tt)*) => {
-        impl IdentityHandler<$id> for IdentityRecycler {
-            type Input = $id;
-            fn process(&self, id: $id, _backend: Backend) -> Self::Input {
-                log::debug!("process {} {:?}", $st, id);
-                //debug_assert_eq!(id.unzip().2, backend);
-                id
-            }
-            fn free(&self, id: $id) {
-                log::debug!("free {} {:?}", $st, id);
-                let msg = $($var)*(id);
-                if self.sender.send(msg.clone()).is_err() {
-                    log::error!("Failed to send {:?}", msg);
-                }
-            }
-        }
-    };
-}
-
-impl_identity_handler!(AdapterId, "adapter", WebGPUMsg::FreeAdapter);
-impl_identity_handler!(SurfaceId, "surface", WebGPUMsg::FreeSurface);
-impl_identity_handler!(SamplerId, "sampler", WebGPUMsg::FreeSampler);
-impl_identity_handler!(TextureId, "texture", WebGPUMsg::FreeTexture);
-impl_identity_handler!(TextureViewId, "texture_view", WebGPUMsg::FreeTextureView);
-impl_identity_handler!(BufferId, "buffer", WebGPUMsg::FreeBuffer);
-impl_identity_handler!(BindGroupId, "bind_group", WebGPUMsg::FreeBindGroup);
-impl_identity_handler!(ShaderModuleId, "shader_module", WebGPUMsg::FreeShaderModule);
-impl_identity_handler!(RenderBundleId, "render_bundle", WebGPUMsg::FreeRenderBundle);
-impl_identity_handler!(
-    StagingBufferId,
-    "staging_buffer",
-    WebGPUMsg::FreeStagingBuffer
-);
-impl_identity_handler!(QuerySetId, "quary_set", WebGPUMsg::FreeQuerySet);
-impl_identity_handler!(
-    RenderPipelineId,
-    "render_pipeline",
-    WebGPUMsg::FreeRenderPipeline
-);
-impl_identity_handler!(
-    ComputePipelineId,
-    "compute_pipeline",
-    WebGPUMsg::FreeComputePipeline
-);
-impl_identity_handler!(
-    CommandBufferId,
-    "command_buffer",
-    WebGPUMsg::FreeCommandBuffer
-);
-impl_identity_handler!(
-    BindGroupLayoutId,
-    "bind_group_layout",
-    WebGPUMsg::FreeBindGroupLayout
-);
-impl_identity_handler!(
-    PipelineLayoutId,
-    "pipeline_layout",
-    WebGPUMsg::FreePipelineLayout
-);
-
-impl IdentityHandler<DeviceId> for IdentityRecycler {
-    type Input = DeviceId;
-    fn process(&self, id: DeviceId, _backend: Backend) -> Self::Input {
-        log::debug!("process device {:?}", id);
-        //debug_assert_eq!(id.unzip().2, backend);
-        id
-    }
-    fn free(&self, id: DeviceId) {
-        log::debug!("free device {:?}", id);
-        if self.sender.send(WebGPUMsg::FreeDevice(id)).is_err() {
-            log::error!("Failed to send FreeDevice({:?}) to script", id);
-        }
-        if self
-            .self_sender
-            .send((None, WebGPURequest::FreeDevice(id)))
-            .is_err()
-        {
-            log::error!("Failed to send FreeDevice({:?}) to server", id);
-        }
-    }
-}
-
-impl<I: TypedId + Clone + std::fmt::Debug> IdentityHandlerFactory<I> for IdentityRecyclerFactory
-where
-    I: TypedId + Clone + std::fmt::Debug,
-    IdentityRecycler: IdentityHandler<I>,
-{
-    type Filter = IdentityRecycler;
-    fn spawn(&self) -> Self::Filter {
-        IdentityRecycler {
-            sender: self.sender.clone(),
-            self_sender: self.self_sender.clone(),
-        }
-    }
-}
-
-impl GlobalIdentityHandlerFactory for IdentityRecyclerFactory {
-    fn ids_are_generated_in_wgpu() -> bool {
-        false
-    }
 }

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -52,6 +52,7 @@ packages = [
     "foreign-types",
     "foreign-types-shared",
     "metal",
+    "raw-window-handle",
 
     # Duplicated by indexmap.
     "hashbrown",

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -987,8 +987,17 @@
 
 
 [cts.https.html?q=webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
+  [:format="depth16unorm"]
+
+  [:format="depth24plus"]
+
+  [:format="depth24plus-stencil8"]
+
+  [:format="depth32float"]
+
+  [:format="depth32float-stencil8"]
+
+  [:format="stencil8"]
 
 
 [cts.https.html?q=webgpu:api,operation,command_buffer,copyTextureToTexture:copy_multisampled_color:*]
@@ -2067,28 +2076,16 @@
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:large_dispatch:*]
   [:dispatchSize="maximum"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:dispatchSize=2048]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:dispatchSize=2179]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:dispatchSize=256]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:dispatchSize=315]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:dispatchSize=628]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:memcpy:*]
@@ -2355,58 +2352,38 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:multiple_pairs_of_dispatches_in_one_compute_pass:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:multiple_pairs_of_draws_in_one_render_bundle:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:multiple_pairs_of_draws_in_one_render_pass:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:rw:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
@@ -2429,92 +2406,48 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2533,38 +2466,22 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2573,44 +2490,26 @@
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2625,160 +2524,84 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:wr:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
     expected:
@@ -2793,34 +2616,20 @@
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2831,142 +2640,74 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2975,44 +2716,26 @@
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3027,174 +2750,92 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:ww:*]
   [:boundary="command-buffer";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
     expected:
@@ -3205,12 +2846,8 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
     expected:
@@ -3223,98 +2860,56 @@
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="dispatch";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["b2b-copy","write-buffer"\];contexts=["command-encoder","queue"\]]
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","write-buffer"\];contexts=["compute-pass-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","write-buffer"\];contexts=["render-bundle-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","write-buffer"\];contexts=["render-pass-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
@@ -3323,16 +2918,10 @@
   [:boundary="queue-op";writeOps=["write-buffer","b2b-copy"\];contexts=["queue","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","t2b-copy"\];contexts=["queue","command-encoder"\]]
 
@@ -3343,46 +2932,28 @@
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
@@ -3397,136 +2968,76 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
 
@@ -3537,40 +3048,24 @@
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
@@ -3587,216 +3082,120 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:two_dispatches_in_the_same_compute_pass:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:two_draws_in_the_same_render_bundle:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:two_draws_in_the_same_render_pass:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,buffer,single_buffer:wr:*]
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3807,136 +3206,72 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
 
@@ -3947,40 +3282,24 @@
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="queue-op";readOp="b2t-copy";readContext="command-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
@@ -3997,146 +3316,76 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-indirect-index";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-vertex";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="compute-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="storage-read";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
@@ -4145,22 +3394,14 @@
   [:boundary="command-buffer";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
     expected:
@@ -4171,116 +3412,66 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="dispatch";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["b2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["b2b-copy","write-buffer"\];contexts=["command-encoder","queue"\]]
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","write-buffer"\];contexts=["compute-pass-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","write-buffer"\];contexts=["render-bundle-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["storage","write-buffer"\];contexts=["render-pass-encoder","queue"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","compute-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","storage"\];contexts=["command-encoder","render-pass-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["t2b-copy","t2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
@@ -4291,8 +3482,6 @@
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","compute-pass-encoder"\]]
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","render-bundle-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";writeOps=["write-buffer","storage"\];contexts=["queue","render-pass-encoder"\]]
 
@@ -4421,8 +3610,6 @@
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"attachment-store","in":"command-encoder"}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
     expected:
@@ -4435,8 +3622,6 @@
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"render-pass-encoder"}]
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
 
@@ -4547,8 +3732,6 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-bundle-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-pass-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
     expected:
@@ -5915,8 +5098,6 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,color_target_state:blend_constant,setting:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,color_target_state:blending,GPUBlendComponent:*]
@@ -5939,12 +5120,8 @@
   [:format="rg16float";srcValue=0.8;dstValue=0.4]
 
   [:format="rg16float";srcValue=1;dstValue=0.2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg16float";srcValue=1;dstValue=0.4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";srcValue=0.4;dstValue=0.2]
 
@@ -5959,12 +5136,8 @@
   [:format="rgba8unorm";srcValue=0.8;dstValue=0.4]
 
   [:format="rgba8unorm";srcValue=1;dstValue=0.2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";srcValue=1;dstValue=0.4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,color_target_state:blending,formats:*]
@@ -5993,72 +5166,40 @@
   [:disabled=false]
 
   [:disabled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,color_target_state:color_write_mask,channel_work:*]
   [:mask=0]
 
   [:mask=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=10]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=11]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=12]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=13]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=14]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=15]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=5]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=6]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=7]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:mask=9]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:depth_compare_func:*]
@@ -6545,8 +5686,6 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:depth_disabled:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:depth_test_fail:*]
@@ -6565,20 +5704,12 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:depth_write_disabled:*]
   [:depthWriteEnabled=false;lastDepth=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:depthWriteEnabled=false;lastDepth=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:depthWriteEnabled=true;lastDepth=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:depthWriteEnabled=true;lastDepth=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:reverse_depth:*]
@@ -6671,12 +5802,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus";unclippedDepth="_undef_";writeDepth=false;multisampled=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus";unclippedDepth="_undef_";writeDepth=false;multisampled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus";unclippedDepth="_undef_";writeDepth=true;multisampled=false]
     expected:
@@ -6687,12 +5814,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus";unclippedDepth=false;writeDepth=false;multisampled=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus";unclippedDepth=false;writeDepth=false;multisampled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus";unclippedDepth=false;writeDepth=true;multisampled=false]
     expected:
@@ -6719,12 +5842,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";unclippedDepth="_undef_";writeDepth=false;multisampled=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";unclippedDepth="_undef_";writeDepth=false;multisampled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";unclippedDepth="_undef_";writeDepth=true;multisampled=false]
     expected:
@@ -6735,12 +5854,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";unclippedDepth=false;writeDepth=false;multisampled=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";unclippedDepth=false;writeDepth=false;multisampled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";unclippedDepth=false;writeDepth=true;multisampled=false]
     expected:
@@ -6769,8 +5884,6 @@
   [:format="depth32float";unclippedDepth="_undef_";writeDepth=false;multisampled=false]
 
   [:format="depth32float";unclippedDepth="_undef_";writeDepth=false;multisampled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float";unclippedDepth="_undef_";writeDepth=true;multisampled=false]
     expected:
@@ -6781,12 +5894,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth32float";unclippedDepth=false;writeDepth=false;multisampled=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float";unclippedDepth=false;writeDepth=false;multisampled=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float";unclippedDepth=false;writeDepth=true;multisampled=false]
     expected:
@@ -6965,252 +6074,132 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,draw:vertex_attributes,basic:*]
   [:vertex_attribute_count=16;vertex_buffer_count=1;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=1;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=1;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=1;vertex_format="uint32";step_mode="_undef_"]
 
   [:vertex_attribute_count=16;vertex_buffer_count=1;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=1;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="float32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="uint32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="uint32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=4;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="float32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="uint32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="uint32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=16;vertex_buffer_count=8;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=1;vertex_buffer_count=1;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=1;vertex_buffer_count=1;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=1;vertex_buffer_count=1;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=1;vertex_buffer_count=1;vertex_format="uint32";step_mode="_undef_"]
 
   [:vertex_attribute_count=1;vertex_buffer_count=1;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=1;vertex_buffer_count=1;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=1;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=1;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=1;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=1;vertex_format="uint32";step_mode="_undef_"]
 
   [:vertex_attribute_count=4;vertex_buffer_count=1;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=1;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="float32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="uint32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="uint32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=4;vertex_buffer_count=4;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=1;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=1;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=1;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=1;vertex_format="uint32";step_mode="_undef_"]
 
   [:vertex_attribute_count=8;vertex_buffer_count=1;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=1;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="float32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="uint32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="uint32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=4;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="float32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="float32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="float32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="float32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="uint32";step_mode="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="uint32";step_mode="instance"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="uint32";step_mode="mixed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:vertex_attribute_count=8;vertex_buffer_count=8;vertex_format="uint32";step_mode="vertex"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,draw:vertex_attributes,formats:*]
@@ -7783,52 +6772,28 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,stencil:stencil_passOp_operation:*]
   [:format="depth24plus-stencil8";passOp="decrement-clamp";initialStencil=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="decrement-clamp";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="decrement-wrap";initialStencil=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="decrement-wrap";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="increment-clamp";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="increment-clamp";initialStencil=255]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="increment-wrap";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="increment-wrap";initialStencil=255]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="invert";initialStencil=240]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="keep";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="replace";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";passOp="zero";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";passOp="decrement-clamp";initialStencil=0]
     expected:
@@ -7979,8 +6944,6 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,stencil:stencil_reference_initialized:*]
   [:format="depth24plus-stencil8"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8"]
     expected:
@@ -8011,8 +6974,6 @@
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:indirect_buffer_for_dispatch_indirect:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:indirect_buffer_for_draw_indirect:*]
@@ -8054,8 +7015,6 @@
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:readonly_storage_buffer:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:resolve_query_set_to_partial_buffer:*]
@@ -8066,14 +7025,10 @@
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:storage_buffer:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:uniform_buffer:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,resource_init,buffer:vertex_buffer:*]
@@ -8479,16 +7434,12 @@
 
 [cts.https.html?q=webgpu:api,operation,texture_view,format_reinterpretation:render_and_resolve_attachment:*]
   [:format="bgra8unorm";viewFormat="bgra8unorm-srgb";sampleCount=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";viewFormat="bgra8unorm-srgb";sampleCount=4]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm-srgb";viewFormat="bgra8unorm";sampleCount=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm-srgb";viewFormat="bgra8unorm";sampleCount=4]
     expected:
@@ -8501,8 +7452,6 @@
       if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm-srgb";viewFormat="rgba8unorm";sampleCount=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm-srgb";viewFormat="rgba8unorm";sampleCount=4]
     expected:
@@ -8511,18 +7460,12 @@
 
 [cts.https.html?q=webgpu:api,operation,texture_view,format_reinterpretation:texture_binding:*]
   [:format="bgra8unorm";viewFormat="bgra8unorm-srgb"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm-srgb";viewFormat="bgra8unorm"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";viewFormat="rgba8unorm-srgb"]
 
   [:format="rgba8unorm-srgb";viewFormat="rgba8unorm"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,texture_view,read:aspect:*]
@@ -8953,12 +7896,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
@@ -8983,8 +7922,6 @@
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:buffers_with_varying_step_mode:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:discontiguous_location_and_attribs:*]
@@ -8995,68 +7932,36 @@
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:max_buffers_and_attribs:*]
   [:format="float16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm8x2"]
     expected:
@@ -9067,54 +7972,32 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="unorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:non_zero_array_stride_and_attribute_offset:*]
@@ -9215,12 +8098,8 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
@@ -9245,68 +8124,36 @@
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:overlapping_attributes:*]
   [:format="float16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm8x2"]
     expected:
@@ -9317,120 +8164,66 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="unorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*]
   [:format="float16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm8x2"]
     expected:
@@ -9441,122 +8234,66 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="unorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:vertex_buffer_used_multiple_times_interleaved:*]
   [:format="float16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm8x2"]
     expected:
@@ -9567,122 +8304,66 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="unorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:vertex_buffer_used_multiple_times_overlapped:*]
   [:format="float16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="float32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="sint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="snorm8x2"]
     expected:
@@ -9693,56 +8374,32 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint32x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="uint8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="unorm16x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm16x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:vertex_format_to_shader_format_conversion:*]
@@ -10234,8 +8891,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,buffer,mapping:mapAsync,state,destroyed:*]
-  expected:
-    if os == "linux" and not debug: [OK, ERROR]
   [:]
     expected:
       if os == "linux" and not debug: FAIL
@@ -11654,12 +10309,8 @@
   [:limitTest="atDefault";testValueName="atLimit";createPipelineType="createRenderPipeline";async=true]
 
   [:limitTest="atDefault";testValueName="atLimit";createPipelineType="createRenderPipelineWithFragmentStage";async=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";createPipelineType="createRenderPipelineWithFragmentStage";async=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";createPipelineType="createComputePipeline";async=false]
     expected:
@@ -11694,12 +10345,8 @@
   [:limitTest="atMaximum";testValueName="atLimit";createPipelineType="createRenderPipeline";async=true]
 
   [:limitTest="atMaximum";testValueName="atLimit";createPipelineType="createRenderPipelineWithFragmentStage";async=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="atLimit";createPipelineType="createRenderPipelineWithFragmentStage";async=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="overLimit";createPipelineType="createComputePipeline";async=false]
     expected:
@@ -11734,12 +10381,8 @@
   [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";createPipelineType="createRenderPipeline";async=true]
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";createPipelineType="createRenderPipelineWithFragmentStage";async=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";createPipelineType="createRenderPipelineWithFragmentStage";async=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";createPipelineType="createComputePipeline";async=false]
     expected:
@@ -13604,12 +12247,8 @@
       if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="atLimit";async=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="atLimit";async=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="overLimit";async=false]
     expected:
@@ -16412,100 +15051,52 @@
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="compute";order="shiftByHalf";bindGroupTest="sameGroup"]
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="fragment";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="fragment";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="fragment";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="fragment";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="fragment";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="fragment";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertex";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertex";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertex";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertex";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertex";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertex";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=false;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="compute";order="backward";bindGroupTest="differentGroups"]
 
@@ -16520,100 +15111,52 @@
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="compute";order="shiftByHalf";bindGroupTest="sameGroup"]
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="fragment";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="fragment";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="fragment";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="fragment";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="fragment";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="fragment";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertex";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertex";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertex";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertex";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertex";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertex";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleFragmentStageOverflow";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="backward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="backward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="forward";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="forward";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="shiftByHalf";bindGroupTest="differentGroups"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="atLimit";async=true;bindingCombination="vertexAndFragmentWithPossibleVertexStageOverflow";order="shiftByHalf";bindGroupTest="sameGroup"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="compute";order="backward";bindGroupTest="differentGroups"]
     expected:
@@ -20750,8 +19293,7 @@
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:texture,resource_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:texture_binding_must_have_correct_usage:*]
@@ -28045,8 +26587,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,createView:format:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:textureFormatFeature="_undef_";viewFormatFeature="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -28135,8 +26675,7 @@
 
 
 [cts.https.html?q=webgpu:api,validation,createView:texture_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:api,validation,debugMarker:push_pop_call_count_unbalance,command_encoder:*]
@@ -28984,8 +27523,7 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_within_same_texture:*]
@@ -29188,20 +27726,12 @@
   [:indexCount=1;firstIndex=6;instanceCount=10000]
 
   [:indexCount=2;firstIndex=4294967295;instanceCount=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:indexCount=2;firstIndex=4294967295;instanceCount=10000]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=2;instanceCount=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=2;instanceCount=10000]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=4294967295;instanceCount=1]
 
@@ -29371,11 +27901,24 @@
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*]
   expected:
     if os == "linux" and not debug: CRASH
+  [:smallIndexBuffer=false;smallVertexBuffer=false;smallInstanceBuffer=false]
+
+  [:smallIndexBuffer=false;smallVertexBuffer=false;smallInstanceBuffer=true]
+
+  [:smallIndexBuffer=false;smallVertexBuffer=true;smallInstanceBuffer=false]
+
+  [:smallIndexBuffer=false;smallVertexBuffer=true;smallInstanceBuffer=true]
+
+  [:smallIndexBuffer=true;smallVertexBuffer=false;smallInstanceBuffer=false]
+
+  [:smallIndexBuffer=true;smallVertexBuffer=false;smallInstanceBuffer=true]
+
+  [:smallIndexBuffer=true;smallVertexBuffer=true;smallInstanceBuffer=false]
+
+  [:smallIndexBuffer=true;smallVertexBuffer=true;smallInstanceBuffer=true]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:vertex_buffer_OOB:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:type="draw";VBSize="exact";IBSize="exact";AStride="exact"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -29725,8 +28268,6 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:slot:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:vertex_buffer,device_mismatch:*]
@@ -43353,26 +41894,18 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:beginRenderPass:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:copyBufferToTexture:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:copyTextureToBuffer:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:copyTextureToTexture:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:setBindGroup:*]
@@ -43383,8 +41916,6 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:writeTexture:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*]
@@ -43425,8 +41956,6 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,writeTexture:texture,device_mismatch:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,writeTexture:texture_state:*]
@@ -49972,8 +48501,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:format="float16x2"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -67792,8 +66319,59 @@
 
 
 [cts.https.html?q=webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"]
+
+  [:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="valid"]
 
 
 [cts.https.html?q=webgpu:api,validation,texture,destroy:twice:*]
@@ -68858,74 +67436,42 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:greater_equals:*]
   [:inputSource="const";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:greater_than:*]
   [:inputSource="const";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:less_equals:*]
   [:inputSource="const";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:less_than:*]
   [:inputSource="const";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:not_equals:*]
@@ -69234,46 +67780,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -69292,52 +67818,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_and_compound:*]
@@ -69360,46 +67862,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -69418,52 +67900,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_exclusive_or:*]
@@ -69486,46 +67944,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -69544,52 +67982,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_exclusive_or_compound:*]
@@ -69612,46 +68026,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -69670,52 +68064,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_or:*]
@@ -69738,46 +68108,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -69796,52 +68146,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise:bitwise_or_compound:*]
@@ -69864,46 +68190,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -69922,52 +68228,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_left_concrete:*]
@@ -69996,46 +68278,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -70054,52 +68316,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_right_concrete:*]
@@ -70122,46 +68360,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -70180,52 +68398,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bitwise_shift:shift_right_concrete_compound:*]
@@ -70248,46 +68442,26 @@
   [:type="i32";inputSource="storage_r";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize="_undef_"]
 
   [:type="i32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="const";vectorize="_undef_"]
     expected:
@@ -70306,52 +68480,28 @@
       if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:and:*]
@@ -70374,44 +68524,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:and_compound:*]
@@ -70434,44 +68566,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:and_short_circuit:*]
@@ -70506,44 +68620,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:not_equals:*]
@@ -70566,44 +68662,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:or:*]
@@ -70626,44 +68704,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:or_compound:*]
@@ -70686,44 +68746,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,bool_logical:or_short_circuit:*]
@@ -72698,44 +70740,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar_vector:*]
@@ -72754,32 +70778,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector:*]
@@ -72798,32 +70810,20 @@
   [:inputSource="storage_r";vectorize=2]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector_scalar:*]
@@ -72840,40 +70840,22 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:vector_scalar_compound:*]
@@ -72892,32 +70874,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:equals:*]
@@ -72940,44 +70910,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_equals:*]
@@ -73000,44 +70952,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_than:*]
@@ -73060,44 +70994,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:less_equals:*]
@@ -73120,44 +71036,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:less_than:*]
@@ -73180,44 +71078,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:not_equals:*]
@@ -73240,44 +71120,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar:*]
@@ -73312,44 +71174,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_vector:*]
@@ -73366,40 +71210,22 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector:*]
@@ -73418,32 +71244,20 @@
   [:inputSource="storage_r";vectorize=2]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector_scalar:*]
@@ -73462,32 +71276,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector_scalar_compound:*]
@@ -73506,32 +71308,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_addition:matrix:*]
@@ -73576,90 +71366,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_addition:matrix_compound:*]
@@ -73704,95 +71458,57 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_matrix_multiplication:matrix_matrix:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73902,328 +71618,166 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=2;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=2;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=2;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=3;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=3;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=3;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";common_dim=2;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";common_dim=2;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";common_dim=3;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";common_dim=3;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4;y_cols=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4;y_cols=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4;y_cols=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_matrix_multiplication:matrix_matrix_compound:*]
@@ -74264,112 +71818,58 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=2;x_rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=2;x_rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=2;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=3;x_rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=3;x_rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";common_dim=3;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";common_dim=4;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=2;x_rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=2;x_rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=2;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=3;x_rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=3;x_rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";common_dim=3;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";common_dim=4;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";common_dim=2;x_rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=2;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=3;x_rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";common_dim=3;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";common_dim=4;x_rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:matrix_scalar:*]
@@ -74414,94 +71914,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:matrix_scalar_compound:*]
@@ -74546,94 +72006,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:scalar_matrix:*]
@@ -74678,94 +72098,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix:*]
@@ -74810,90 +72190,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix_compound:*]
@@ -74938,90 +72282,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:matrix_vector:*]
@@ -75066,94 +72374,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix:*]
@@ -75194,112 +72462,58 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=2;rows=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform";cols=2;rows=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=3;rows=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix_compound:*]
@@ -75320,26 +72534,18 @@
   [:inputSource="storage_r";dim=3]
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar:*]
@@ -75374,44 +72580,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_vector:*]
@@ -75430,32 +72618,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector:*]
@@ -75474,32 +72650,20 @@
   [:inputSource="storage_r";vectorize=2]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar:*]
@@ -75518,32 +72682,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar_compound:*]
@@ -75562,32 +72714,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:scalar:*]
@@ -75622,44 +72762,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:scalar_vector:*]
@@ -75678,32 +72800,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:vector:*]
@@ -75722,32 +72832,20 @@
   [:inputSource="storage_r";vectorize=2]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:vector_scalar:*]
@@ -75766,32 +72864,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:vector_scalar_compound:*]
@@ -75810,32 +72896,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:scalar:*]
@@ -75870,44 +72944,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:scalar_vector:*]
@@ -75926,32 +72982,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector:*]
@@ -75970,32 +73014,20 @@
   [:inputSource="storage_r";vectorize=2]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar:*]
@@ -76014,32 +73046,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar_compound:*]
@@ -76058,32 +73078,20 @@
   [:inputSource="storage_r";dim=2]
 
   [:inputSource="storage_r";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition:*]
@@ -76106,46 +73114,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_compound:*]
@@ -76168,46 +73156,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_scalar_vector:*]
@@ -76226,34 +73194,20 @@
   [:inputSource="storage_r";vectorize_rhs=2]
 
   [:inputSource="storage_r";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar:*]
@@ -76272,34 +73226,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar_compound:*]
@@ -76318,34 +73258,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division:*]
@@ -76648,52 +73574,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_compound:*]
@@ -76716,46 +73618,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_scalar_vector:*]
@@ -76774,34 +73656,20 @@
   [:inputSource="storage_r";vectorize_rhs=2]
 
   [:inputSource="storage_r";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar:*]
@@ -76818,40 +73686,22 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar_compound:*]
@@ -76870,34 +73720,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder:*]
@@ -77202,46 +74038,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_compound:*]
@@ -77262,52 +74078,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_scalar_vector:*]
@@ -77324,40 +74116,22 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_vector_scalar:*]
@@ -77374,40 +74148,22 @@
       if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_vector_scalar_compound:*]
@@ -77426,34 +74182,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:equals:*]
@@ -77476,44 +74218,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:greater_equals:*]
@@ -77536,44 +74260,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:greater_than:*]
@@ -77596,44 +74302,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:less_equals:*]
@@ -77656,44 +74344,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:less_than:*]
@@ -77716,44 +74386,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:not_equals:*]
@@ -77776,44 +74428,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:addition:*]
@@ -77836,44 +74470,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:addition_compound:*]
@@ -77896,44 +74512,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:addition_scalar_vector:*]
@@ -77952,34 +74550,20 @@
   [:inputSource="storage_r";vectorize_rhs=2]
 
   [:inputSource="storage_r";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:addition_vector_scalar:*]
@@ -77998,34 +74582,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:addition_vector_scalar_compound:*]
@@ -78044,34 +74614,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division:*]
@@ -78376,44 +74932,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_compound:*]
@@ -78436,44 +74974,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_scalar_vector:*]
@@ -78492,34 +75012,20 @@
   [:inputSource="storage_r";vectorize_rhs=2]
 
   [:inputSource="storage_r";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_vector_scalar:*]
@@ -78538,34 +75044,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_vector_scalar_compound:*]
@@ -78584,34 +75076,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:remainder:*]
@@ -78916,44 +75394,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_compound:*]
@@ -78976,44 +75436,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_scalar_vector:*]
@@ -79032,34 +75474,20 @@
   [:inputSource="storage_r";vectorize_rhs=2]
 
   [:inputSource="storage_r";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=2]
 
   [:inputSource="storage_rw";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_rhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_vector_scalar:*]
@@ -79078,34 +75506,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_vector_scalar_compound:*]
@@ -79124,34 +75538,20 @@
   [:inputSource="storage_r";vectorize_lhs=2]
 
   [:inputSource="storage_r";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=2]
 
   [:inputSource="storage_rw";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize_lhs=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:equals:*]
@@ -79174,44 +75574,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:greater_equals:*]
@@ -79234,44 +75616,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:greater_than:*]
@@ -79294,44 +75658,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_equals:*]
@@ -79352,52 +75698,28 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_than:*]
@@ -79420,44 +75742,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:not_equals:*]
@@ -79478,52 +75782,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,abs:abstract_float:*]
@@ -79632,44 +75912,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,abs:i32:*]
@@ -79692,44 +75954,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,abs:u32:*]
@@ -79752,44 +75996,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acos:abstract_float:*]
@@ -79880,46 +76106,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acosh:abstract_float:*]
@@ -80010,46 +76216,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,all:bool:*]
@@ -80072,44 +76258,26 @@
   [:inputSource="storage_r";overload="scalar"]
 
   [:inputSource="storage_r";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="scalar"]
 
   [:inputSource="storage_rw";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="scalar"]
 
   [:inputSource="uniform";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,any:bool:*]
@@ -80132,44 +76300,26 @@
   [:inputSource="storage_r";overload="scalar"]
 
   [:inputSource="storage_r";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="scalar"]
 
   [:inputSource="storage_rw";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="scalar"]
 
   [:inputSource="uniform";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,arrayLength:binding_subregion:*]
@@ -80178,342 +76328,204 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,arrayLength:multiple_elements:*]
   [:buffer_size=1004;type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="array%3Cf16,4%3E";stride=8]
 
   [:buffer_size=1004;type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="f16";stride=2]
 
   [:buffer_size=1004;type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat2x2%3Cf16%3E";stride=8]
 
   [:buffer_size=1004;type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat2x3%3Cf16%3E";stride=16]
 
   [:buffer_size=1004;type="mat2x3%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat2x4%3Cf16%3E";stride=16]
 
   [:buffer_size=1004;type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat3x2%3Cf16%3E";stride=12]
 
   [:buffer_size=1004;type="mat3x2%3Cf32%3E";stride=24]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat3x3%3Cf16%3E";stride=24]
 
   [:buffer_size=1004;type="mat3x3%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat3x4%3Cf16%3E";stride=24]
 
   [:buffer_size=1004;type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat4x2%3Cf16%3E";stride=16]
 
   [:buffer_size=1004;type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat4x3%3Cf16%3E";stride=32]
 
   [:buffer_size=1004;type="mat4x3%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="mat4x4%3Cf16%3E";stride=32]
 
   [:buffer_size=1004;type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="u32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec2%3Cf16%3E";stride=4]
 
   [:buffer_size=1004;type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec2%3Cu32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec3%3Cf16%3E";stride=8]
 
   [:buffer_size=1004;type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec3%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec4%3Cf16%3E";stride=8]
 
   [:buffer_size=1004;type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1004;type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="array%3Cf16,4%3E";stride=8]
 
   [:buffer_size=1048576;type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="f16";stride=2]
 
   [:buffer_size=1048576;type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat2x2%3Cf16%3E";stride=8]
 
   [:buffer_size=1048576;type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat2x3%3Cf16%3E";stride=16]
 
   [:buffer_size=1048576;type="mat2x3%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat2x4%3Cf16%3E";stride=16]
 
   [:buffer_size=1048576;type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat3x2%3Cf16%3E";stride=12]
 
   [:buffer_size=1048576;type="mat3x2%3Cf32%3E";stride=24]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat3x3%3Cf16%3E";stride=24]
 
   [:buffer_size=1048576;type="mat3x3%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat3x4%3Cf16%3E";stride=24]
 
   [:buffer_size=1048576;type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat4x2%3Cf16%3E";stride=16]
 
   [:buffer_size=1048576;type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat4x3%3Cf16%3E";stride=32]
 
   [:buffer_size=1048576;type="mat4x3%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="mat4x4%3Cf16%3E";stride=32]
 
   [:buffer_size=1048576;type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="u32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec2%3Cf16%3E";stride=4]
 
   [:buffer_size=1048576;type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec2%3Cu32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec3%3Cf16%3E";stride=8]
 
   [:buffer_size=1048576;type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec3%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec4%3Cf16%3E";stride=8]
 
   [:buffer_size=1048576;type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=1048576;type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="array%3Cf16,4%3E";stride=8]
 
   [:buffer_size=640;type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="f16";stride=2]
 
   [:buffer_size=640;type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="mat2x2%3Cf16%3E";stride=8]
 
   [:buffer_size=640;type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="mat2x3%3Cf16%3E";stride=16]
 
@@ -80522,8 +76534,6 @@
   [:buffer_size=640;type="mat2x4%3Cf16%3E";stride=16]
 
   [:buffer_size=640;type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="mat3x2%3Cf16%3E";stride=12]
 
@@ -80536,14 +76546,10 @@
   [:buffer_size=640;type="mat3x4%3Cf16%3E";stride=24]
 
   [:buffer_size=640;type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="mat4x2%3Cf16%3E";stride=16]
 
   [:buffer_size=640;type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="mat4x3%3Cf16%3E";stride=32]
 
@@ -80552,48 +76558,32 @@
   [:buffer_size=640;type="mat4x4%3Cf16%3E";stride=32]
 
   [:buffer_size=640;type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="u32";stride=4]
 
   [:buffer_size=640;type="vec2%3Cf16%3E";stride=4]
 
   [:buffer_size=640;type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="vec2%3Cu32%3E";stride=8]
 
   [:buffer_size=640;type="vec3%3Cf16%3E";stride=8]
 
   [:buffer_size=640;type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="vec3%3Cu32%3E";stride=16]
 
   [:buffer_size=640;type="vec4%3Cf16%3E";stride=8]
 
   [:buffer_size=640;type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:buffer_size=640;type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,arrayLength:read_only:*]
@@ -80602,54 +76592,32 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,arrayLength:single_element:*]
   [:type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="array%3Cf16,4%3E";stride=8]
 
   [:type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="f16";stride=2]
 
   [:type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="mat2x2%3Cf16%3E";stride=8]
 
   [:type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="mat2x3%3Cf16%3E";stride=16]
 
@@ -80658,8 +76626,6 @@
   [:type="mat2x4%3Cf16%3E";stride=16]
 
   [:type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="mat3x2%3Cf16%3E";stride=12]
 
@@ -80672,14 +76638,10 @@
   [:type="mat3x4%3Cf16%3E";stride=24]
 
   [:type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="mat4x2%3Cf16%3E";stride=16]
 
   [:type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="mat4x3%3Cf16%3E";stride=32]
 
@@ -80688,100 +76650,62 @@
   [:type="mat4x4%3Cf16%3E";stride=32]
 
   [:type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="u32";stride=4]
 
   [:type="vec2%3Cf16%3E";stride=4]
 
   [:type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="vec2%3Cu32%3E";stride=8]
 
   [:type="vec3%3Cf16%3E";stride=8]
 
   [:type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="vec3%3Cu32%3E";stride=16]
 
   [:type="vec4%3Cf16%3E";stride=8]
 
   [:type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,arrayLength:struct_member:*]
   [:member_offset=0;type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="array%3Cf16,4%3E";stride=8]
 
   [:member_offset=0;type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="f16";stride=2]
 
   [:member_offset=0;type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="mat2x2%3Cf16%3E";stride=8]
 
   [:member_offset=0;type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="mat2x3%3Cf16%3E";stride=16]
 
@@ -80790,8 +76714,6 @@
   [:member_offset=0;type="mat2x4%3Cf16%3E";stride=16]
 
   [:member_offset=0;type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="mat3x2%3Cf16%3E";stride=12]
 
@@ -80804,14 +76726,10 @@
   [:member_offset=0;type="mat3x4%3Cf16%3E";stride=24]
 
   [:member_offset=0;type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="mat4x2%3Cf16%3E";stride=16]
 
   [:member_offset=0;type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="mat4x3%3Cf16%3E";stride=32]
 
@@ -80820,260 +76738,158 @@
   [:member_offset=0;type="mat4x4%3Cf16%3E";stride=32]
 
   [:member_offset=0;type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="u32";stride=4]
 
   [:member_offset=0;type="vec2%3Cf16%3E";stride=4]
 
   [:member_offset=0;type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="vec2%3Cu32%3E";stride=8]
 
   [:member_offset=0;type="vec3%3Cf16%3E";stride=8]
 
   [:member_offset=0;type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="vec3%3Cu32%3E";stride=16]
 
   [:member_offset=0;type="vec4%3Cf16%3E";stride=8]
 
   [:member_offset=0;type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=0;type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="array%3Cf16,4%3E";stride=8]
 
   [:member_offset=20;type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="f16";stride=2]
 
   [:member_offset=20;type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat2x2%3Cf16%3E";stride=8]
 
   [:member_offset=20;type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat2x3%3Cf16%3E";stride=16]
 
   [:member_offset=20;type="mat2x3%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat2x4%3Cf16%3E";stride=16]
 
   [:member_offset=20;type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat3x2%3Cf16%3E";stride=12]
 
   [:member_offset=20;type="mat3x2%3Cf32%3E";stride=24]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat3x3%3Cf16%3E";stride=24]
 
   [:member_offset=20;type="mat3x3%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat3x4%3Cf16%3E";stride=24]
 
   [:member_offset=20;type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat4x2%3Cf16%3E";stride=16]
 
   [:member_offset=20;type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat4x3%3Cf16%3E";stride=32]
 
   [:member_offset=20;type="mat4x3%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="mat4x4%3Cf16%3E";stride=32]
 
   [:member_offset=20;type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="u32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec2%3Cf16%3E";stride=4]
 
   [:member_offset=20;type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec2%3Cu32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec3%3Cf16%3E";stride=8]
 
   [:member_offset=20;type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec3%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec4%3Cf16%3E";stride=8]
 
   [:member_offset=20;type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=20;type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="ElemStruct";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="ElemStruct_ExplicitPadding";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="ElemStruct_ImplicitPadding";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="array%3Cf16,4%3E";stride=8]
 
   [:member_offset=4;type="array%3Cf32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="array%3Ci32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="array%3Cu32,4%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="atomic%3Ci32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="atomic%3Cu32%3E";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="f16";stride=2]
 
   [:member_offset=4;type="f32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="i32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat2x2%3Cf16%3E";stride=8]
 
   [:member_offset=4;type="mat2x2%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat2x3%3Cf16%3E";stride=16]
 
   [:member_offset=4;type="mat2x3%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat2x4%3Cf16%3E";stride=16]
 
   [:member_offset=4;type="mat2x4%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat3x2%3Cf16%3E";stride=12]
 
   [:member_offset=4;type="mat3x2%3Cf32%3E";stride=24]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat3x3%3Cf16%3E";stride=24]
 
@@ -81082,14 +76898,10 @@
   [:member_offset=4;type="mat3x4%3Cf16%3E";stride=24]
 
   [:member_offset=4;type="mat3x4%3Cf32%3E";stride=48]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat4x2%3Cf16%3E";stride=16]
 
   [:member_offset=4;type="mat4x2%3Cf32%3E";stride=32]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="mat4x3%3Cf16%3E";stride=32]
 
@@ -81098,54 +76910,32 @@
   [:member_offset=4;type="mat4x4%3Cf16%3E";stride=32]
 
   [:member_offset=4;type="mat4x4%3Cf32%3E";stride=64]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="u32";stride=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec2%3Cf16%3E";stride=4]
 
   [:member_offset=4;type="vec2%3Cf32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec2%3Ci32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec2%3Cu32%3E";stride=8]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec3%3Cf16%3E";stride=8]
 
   [:member_offset=4;type="vec3%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec3%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec3%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec4%3Cf16%3E";stride=8]
 
   [:member_offset=4;type="vec4%3Cf32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec4%3Ci32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:member_offset=4;type="vec4%3Cu32%3E";stride=16]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asin:abstract_float:*]
@@ -81236,46 +77026,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asinh:abstract_float:*]
@@ -81366,44 +77136,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan2:abstract_float:*]
@@ -81494,46 +77246,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:abstract_float:*]
@@ -81624,46 +77356,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atanh:abstract_float:*]
@@ -81754,52 +77466,30 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicAdd:add_storage:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
     expected:
@@ -81812,112 +77502,84 @@
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
     expected:
@@ -81926,128 +77588,96 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicAdd:add_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
     expected:
@@ -82056,518 +77686,262 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicAnd:and_storage:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicAnd:and_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicCompareExchangeWeak:compare_exchange_weak_storage_advanced:*]
@@ -83494,258 +78868,132 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_storage_basic:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_advanced:*]
@@ -84008,1806 +79256,916 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_basic:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicLoad:load_storage:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicLoad:load_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicMax:max_storage:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="u32"]
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicMax:max_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicMin:min_storage:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="u32"]
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicMin:min_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicOr:or_storage:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicOr:or_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_advanced:*]
@@ -86070,258 +80428,132 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_basic:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_advanced:*]
@@ -86584,266 +80816,136 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_basic:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicSub:sub_storage:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
     expected:
@@ -86856,112 +80958,84 @@
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
     expected:
@@ -86970,128 +81044,96 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicSub:sub_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;scalarType="u32"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;scalarType="u32"]
     expected:
@@ -87100,518 +81142,262 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicXor:xor_storage:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicXor:xor_workgroup:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:af_to_f32:*]
@@ -87814,94 +81600,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:f32_to_i32:*]
@@ -87940,94 +81682,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:f32_to_u32:*]
@@ -88066,94 +81764,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:f32_to_vec2h:*]
@@ -88210,92 +81864,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:i32_to_i32:*]
@@ -88334,92 +81946,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:i32_to_u32:*]
@@ -88458,92 +82028,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:i32_to_vec2h:*]
@@ -88600,92 +82128,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:u32_to_i32:*]
@@ -88724,92 +82210,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:u32_to_u32:*]
@@ -88848,92 +82292,50 @@
   [:inputSource="storage_r";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_r";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=false]
 
   [:inputSource="storage_rw";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";alias=false]
 
   [:inputSource="uniform";vectorize="_undef_";alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;alias=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,bitcast:u32_to_vec2h:*]
@@ -89218,46 +82620,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:abstract_float:*]
@@ -89364,52 +82746,28 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:i32:*]
@@ -89432,46 +82790,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:u32:*]
@@ -89494,46 +82832,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:abstract_float:*]
@@ -89624,46 +82942,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:abstract_float:*]
@@ -89752,52 +83050,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,countLeadingZeros:i32:*]
@@ -89820,44 +83094,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,countLeadingZeros:u32:*]
@@ -89880,44 +83136,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,countOneBits:i32:*]
@@ -89940,44 +83178,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,countOneBits:u32:*]
@@ -90000,44 +83220,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,countTrailingZeros:i32:*]
@@ -90060,44 +83262,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,countTrailingZeros:u32:*]
@@ -90120,44 +83304,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:abstract_float:*]
@@ -90260,44 +83426,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,determinant:abstract_float:*]
@@ -90370,24 +83518,18 @@
   [:inputSource="storage_r";dim=3]
 
   [:inputSource="storage_r";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";dim=2]
 
   [:inputSource="storage_rw";dim=3]
 
   [:inputSource="storage_rw";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";dim=2]
 
   [:inputSource="uniform";dim=3]
 
   [:inputSource="uniform";dim=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:abstract_float:*]
@@ -90474,13 +83616,9 @@
   [:inputSource="storage_rw"]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -90493,8 +83631,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -90507,8 +83643,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec4:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -90954,46 +84088,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp:abstract_float:*]
@@ -91084,46 +84198,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,extractBits:i32:*]
@@ -91324,8 +84418,6 @@
   [:inputSource="storage_rw"]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,faceForward:f32_vec3:*]
@@ -91334,16 +84426,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,faceForward:f32_vec4:*]
@@ -91352,16 +84438,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,firstLeadingBit:i32:*]
@@ -91384,46 +84464,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,firstLeadingBit:u32:*]
@@ -91446,44 +84506,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,firstTrailingBit:i32:*]
@@ -91506,44 +84548,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,firstTrailingBit:u32:*]
@@ -91566,44 +84590,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,floor:abstract_float:*]
@@ -91678,46 +84684,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:abstract_float:*]
@@ -91792,46 +84778,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fract:abstract_float:*]
@@ -91922,46 +84888,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,frexp:f16_exp:*]
@@ -92460,46 +85406,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,ldexp:abstract_float:*]
@@ -92590,46 +85516,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:abstract_float:*]
@@ -92724,16 +85630,10 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec3:*]
@@ -92848,46 +85748,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:abstract_float:*]
@@ -92976,52 +85856,28 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:abstract_float:*]
@@ -93111,8 +85967,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT, CRASH]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -93130,52 +85984,28 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:i32:*]
@@ -93198,44 +86028,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:u32:*]
@@ -93256,52 +86068,28 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:abstract_float:*]
@@ -93391,8 +86179,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f32:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93412,46 +86198,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:i32:*]
@@ -93474,44 +86240,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:u32:*]
@@ -93534,44 +86282,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_matching:*]
@@ -93692,52 +86422,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec2:*]
@@ -93746,16 +86452,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec3:*]
@@ -93764,16 +86464,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec4:*]
@@ -93782,16 +86476,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_fract:*]
@@ -93952,16 +86640,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec3_fract:*]
@@ -94130,16 +86812,10 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="storage_rw"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack2x16snorm:pack:*]
@@ -94350,46 +87026,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,quantizeToF16:f32:*]
@@ -94530,44 +87186,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:abstract_float:*]
@@ -94728,8 +87366,6 @@
   [:inputSource="storage_rw"]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec3:*]
@@ -94742,8 +87378,6 @@
   [:inputSource="storage_rw"]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec4:*]
@@ -94756,8 +87390,6 @@
   [:inputSource="storage_rw"]
 
   [:inputSource="uniform"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reverseBits:i32:*]
@@ -94780,44 +87412,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reverseBits:u32:*]
@@ -94840,44 +87454,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:abstract_float:*]
@@ -94952,44 +87548,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,saturate:abstract_float:*]
@@ -95064,46 +87642,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,select:scalar:*]
@@ -95206,32 +87764,18 @@
   [:inputSource="storage_r";component="b";overload="scalar"]
 
   [:inputSource="storage_r";component="b";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="b";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="b";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="h";overload="scalar"]
 
@@ -95242,36 +87786,20 @@
   [:inputSource="storage_r";component="h";overload="vec4"]
 
   [:inputSource="storage_r";component="i";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="i";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="i";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="i";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="af";overload="scalar"]
 
@@ -95284,32 +87812,18 @@
   [:inputSource="storage_rw";component="b";overload="scalar"]
 
   [:inputSource="storage_rw";component="b";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="b";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="b";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="h";overload="scalar"]
 
@@ -95320,36 +87834,20 @@
   [:inputSource="storage_rw";component="h";overload="vec4"]
 
   [:inputSource="storage_rw";component="i";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="i";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="i";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="i";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="af";overload="scalar"]
 
@@ -95362,32 +87860,18 @@
   [:inputSource="uniform";component="b";overload="scalar"]
 
   [:inputSource="uniform";component="b";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="b";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="b";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="h";overload="scalar"]
 
@@ -95398,36 +87882,20 @@
   [:inputSource="uniform";component="h";overload="vec4"]
 
   [:inputSource="uniform";component="i";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="i";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="i";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="i";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="scalar"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,select:vector:*]
@@ -95506,24 +87974,14 @@
   [:inputSource="storage_r";component="b";overload="vec2"]
 
   [:inputSource="storage_r";component="b";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="b";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="f";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="h";overload="vec2"]
 
@@ -95532,28 +87990,16 @@
   [:inputSource="storage_r";component="h";overload="vec4"]
 
   [:inputSource="storage_r";component="i";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="i";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="i";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";component="u";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="af";overload="vec2"]
 
@@ -95564,24 +88010,14 @@
   [:inputSource="storage_rw";component="b";overload="vec2"]
 
   [:inputSource="storage_rw";component="b";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="b";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="f";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="h";overload="vec2"]
 
@@ -95590,28 +88026,16 @@
   [:inputSource="storage_rw";component="h";overload="vec4"]
 
   [:inputSource="storage_rw";component="i";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="i";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="i";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";component="u";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="af";overload="vec2"]
 
@@ -95622,24 +88046,14 @@
   [:inputSource="uniform";component="b";overload="vec2"]
 
   [:inputSource="uniform";component="b";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="b";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="f";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="h";overload="vec2"]
 
@@ -95648,28 +88062,16 @@
   [:inputSource="uniform";component="h";overload="vec4"]
 
   [:inputSource="uniform";component="i";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="i";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="i";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="vec2"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="vec3"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";component="u";overload="vec4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sign:abstract_float:*]
@@ -95778,44 +88180,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sign:i32:*]
@@ -95838,44 +88222,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sin:abstract_float:*]
@@ -95966,46 +88332,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:abstract_float:*]
@@ -96094,52 +88440,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,smoothstep:abstract_float:*]
@@ -96230,46 +88552,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:abstract_float:*]
@@ -96358,52 +88660,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,step:abstract_float:*]
@@ -96494,46 +88772,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,storageBarrier:barrier:*]
@@ -96636,46 +88894,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tanh:abstract_float:*]
@@ -96766,44 +89004,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,textureDimension:depth:*]
@@ -97916,90 +90136,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,trunc:abstract_float:*]
@@ -98074,44 +90258,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack2x16float:unpack:*]
@@ -98228,74 +90394,40 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,user,ptr_params:read_full_object:*]
   [:address_space="function";call_indirection=0;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=0;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=0;type="vec4i"]
 
   [:address_space="function";call_indirection=1;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=1;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=1;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=2;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=2;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=2;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=0;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=0;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=0;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=1;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=1;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=1;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=2;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=2;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=2;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="storage";call_indirection=0;type="array"]
 
@@ -98378,74 +90510,40 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,user,ptr_params:write_full_object:*]
   [:address_space="function";call_indirection=0;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=0;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=0;type="vec4i"]
 
   [:address_space="function";call_indirection=1;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=1;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=1;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=2;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=2;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="function";call_indirection=2;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=0;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=0;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=0;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=1;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=1;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=1;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=2;type="array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=2;type="struct"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="private";call_indirection=2;type="vec4i"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:address_space="storage";call_indirection=0;type="array"]
 
@@ -98534,8 +90632,6 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_assignment:f32:*]
   [:inputSource="const"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,ai_assignment:abstract:*]
@@ -98576,44 +90672,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_conversion:f16:*]
@@ -98670,44 +90748,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_conversion:i32:*]
@@ -98730,44 +90790,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_conversion:u32:*]
@@ -98790,44 +90832,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_logical:negation:*]
@@ -98850,44 +90874,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f16_arithmetic:negation:*]
@@ -99262,46 +91268,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:bool:*]
@@ -99324,44 +91310,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:f16:*]
@@ -99492,44 +91460,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:f32_mat:*]
@@ -99574,90 +91524,54 @@
   [:inputSource="storage_r";cols=2;rows=3]
 
   [:inputSource="storage_r";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=3;rows=3]
 
   [:inputSource="storage_r";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=2;rows=2]
 
   [:inputSource="storage_rw";cols=2;rows=3]
 
   [:inputSource="storage_rw";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=3;rows=3]
 
   [:inputSource="storage_rw";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=2;rows=2]
 
   [:inputSource="uniform";cols=2;rows=3]
 
   [:inputSource="uniform";cols=2;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=3;rows=3]
 
   [:inputSource="uniform";cols=3;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";cols=4;rows=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:i32:*]
@@ -99680,44 +91594,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:u32:*]
@@ -99740,44 +91636,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_arithmetic:negation:*]
@@ -99800,44 +91678,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_complement:i32_complement:*]
@@ -99860,44 +91720,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_conversion:bool:*]
@@ -99920,44 +91762,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_conversion:f16:*]
@@ -100080,44 +91904,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_conversion:u32:*]
@@ -100140,340 +91946,180 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,indirection:deref:*]
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="u32";derefType="deref_address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="u32";derefType="deref_address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="u32";derefType="deref_address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="u32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="u32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,indirection:deref_index:*]
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="pointer"]
 
@@ -100482,92 +92128,62 @@
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="pointer"]
 
@@ -100576,92 +92192,62 @@
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="pointer"]
 
@@ -100670,80 +92256,54 @@
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="pointer"]
 
@@ -100752,12 +92312,8 @@
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="f32";derefType="pointer"]
 
@@ -100766,92 +92322,62 @@
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize="_undef_";scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=2;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="f32";derefType="pointer"]
 
@@ -100860,92 +92386,62 @@
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_";scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=2;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3;scalarType="i32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="f32";derefType="pointer"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4;scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="f32";derefType="pointer"]
 
@@ -100954,80 +92450,54 @@
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_address_of_identifier"]
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_";scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="f32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=2;scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="f32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3;scalarType="i32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="f32";derefType="pointer"]
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="address_of_identifier"]
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="deref_address_of_identifier"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="deref_pointer"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4;scalarType="i32";derefType="pointer"]
 
@@ -101052,44 +92522,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:abstract_int:*]
@@ -101146,44 +92598,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:f16:*]
@@ -101306,44 +92740,26 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:u32:*]
@@ -101366,62 +92782,36 @@
   [:inputSource="storage_r";vectorize="_undef_"]
 
   [:inputSource="storage_r";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize="_undef_"]
 
   [:inputSource="storage_rw";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize="_undef_"]
 
   [:inputSource="uniform";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,float_parse:valid:*]
   [:value="large_number_small_exp"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:value="no_exp"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:value="pos_exp_neg_result"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:value="small_pos_non_zero_exp"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:value="small_pos_zero_exp"]
 
@@ -102264,78 +93654,46 @@
 
 [cts.https.html?q=webgpu:shader,execution,padding:array_of_matCx3:*]
   [:columns=2;use_struct=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=2;use_struct=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=3;use_struct=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=3;use_struct=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=4;use_struct=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=4;use_struct=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,padding:array_of_struct:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,padding:array_of_vec3:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,padding:matCx3:*]
   [:columns=2;use_struct=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=2;use_struct=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=3;use_struct=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=3;use_struct=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=4;use_struct=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:columns=4;use_struct=true]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,padding:struct_explicit:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,padding:struct_implicit:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,padding:struct_nested:*]
@@ -102344,8 +93702,6 @@
 
 [cts.https.html?q=webgpu:shader,execution,padding:vec3:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,robust_access:linear_memory:*]
@@ -102355,8 +93711,645 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+
+  [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
 
 
 [cts.https.html?q=webgpu:shader,execution,shader_io,compute_builtins:inputs:*]
@@ -103117,8 +95110,6 @@
 
 [cts.https.html?q=webgpu:shader,execution,stage:basic_compute:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,stage:basic_render:*]
@@ -106851,24 +98842,18 @@
 
 [cts.https.html?q=webgpu:util,texture,texel_data:float_texel_data_in_shader:*]
   [:format="r16float"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="r32float"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="rg16float"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg32float"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="rgba16float"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba32float"]
     expected:
@@ -106877,54 +98862,30 @@
 
 [cts.https.html?q=webgpu:util,texture,texel_data:sint_texel_data_in_shader:*]
   [:format="r16sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="r32sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="r8sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg16sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg32sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg8sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba16sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba32sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8sint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:util,texture,texel_data:snorm_texel_data_in_shader:*]
   [:format="r8snorm"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg8snorm"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8snorm"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:util,texture,texel_data:ufloat_texel_data_in_shader:*]
@@ -106939,44 +98900,26 @@
 
 [cts.https.html?q=webgpu:util,texture,texel_data:uint_texel_data_in_shader:*]
   [:format="r16uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="r32uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="r8uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg16uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg32uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rg8uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="rgba16uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba32uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8uint"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:util,texture,texel_data:unorm_texel_data_in_shader:*]
@@ -106997,8 +98940,6 @@
       if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2unorm"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm"]
     expected:
@@ -107144,6 +99085,101 @@
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:drawTo2DCanvas:*]
   expected:
     if os == "linux" and not debug: CRASH
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:offscreenCanvas,snapshot:*]
@@ -107223,11 +99259,129 @@
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:onscreenCanvas,snapshot:*]
   expected:
     if os == "linux" and not debug: CRASH
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
+
+  [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
+
+  [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
+
+  [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
+
+  [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:onscreenCanvas,uploadToWebGL:*]
   expected:
     if os == "linux" and not debug: CRASH
+  [:format="bgra8unorm";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
+
+  [:format="bgra8unorm";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
+
+  [:format="bgra8unorm";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
+
+  [:format="bgra8unorm";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
+
+  [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
+
+  [:format="rgba16float";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
+
+  [:format="rgba16float";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
+
+  [:format="rgba16float";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
+
+  [:format="rgba16float";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
+
+  [:format="rgba16float";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
+
+  [:format="rgba16float";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
+
+  [:format="rgba16float";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
+
+  [:format="rgba16float";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
+
+  [:format="rgba8unorm";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
+
+  [:format="rgba8unorm";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
+
+  [:format="rgba8unorm";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
+
+  [:format="rgba8unorm";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
+
+  [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:transferToImageBitmap_huge_size:*]

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -422,7 +422,42 @@
 
 [cts.https.html?q=webgpu:api,operation,buffers,map:mapAsync,read:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: [TIMEOUT, CRASH]
+  [:mapAsyncRegionLeft="default-expand";mapAsyncRegionRight="default-expand"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:mapAsyncRegionLeft="default-expand";mapAsyncRegionRight="explicit-expand"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:mapAsyncRegionLeft="default-expand";mapAsyncRegionRight="minimal"]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
+
+  [:mapAsyncRegionLeft="explicit-expand";mapAsyncRegionRight="default-expand"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:mapAsyncRegionLeft="explicit-expand";mapAsyncRegionRight="explicit-expand"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:mapAsyncRegionLeft="explicit-expand";mapAsyncRegionRight="minimal"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:mapAsyncRegionLeft="minimal";mapAsyncRegionRight="default-expand"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:mapAsyncRegionLeft="minimal";mapAsyncRegionRight="explicit-expand"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:mapAsyncRegionLeft="minimal";mapAsyncRegionRight="minimal"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,operation,buffers,map:mapAsync,write,unchanged_ranges_preserved:*]
@@ -988,16 +1023,22 @@
 
 [cts.https.html?q=webgpu:api,operation,command_buffer,copyTextureToTexture:copy_depth_stencil:*]
   [:format="depth16unorm"]
+    expected: FAIL
 
   [:format="depth24plus"]
+    expected: FAIL
 
   [:format="depth24plus-stencil8"]
+    expected: FAIL
 
   [:format="depth32float"]
+    expected: FAIL
 
   [:format="depth32float-stencil8"]
+    expected: FAIL
 
   [:format="stencil8"]
+    expected: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,command_buffer,copyTextureToTexture:copy_multisampled_color:*]
@@ -2075,17 +2116,31 @@
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:large_dispatch:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:dispatchSize="maximum"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=2048]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=2179]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=256]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
 
   [:dispatchSize=315]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=628]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:memcpy:*]
@@ -2384,18 +2439,20 @@
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -2455,11 +2512,11 @@
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
@@ -2605,11 +2662,11 @@
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2618,8 +2675,12 @@
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2698,6 +2759,8 @@
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -2851,11 +2914,11 @@
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
@@ -2950,14 +3013,20 @@
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
@@ -3013,15 +3082,19 @@
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="dispatch";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -3174,8 +3247,12 @@
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -3184,8 +3261,12 @@
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -3222,8 +3303,12 @@
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -3264,6 +3349,8 @@
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -3405,19 +3492,23 @@
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
@@ -3566,14 +3657,24 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,texture,same_subresource:rw:*]
   [:boundary="command-buffer";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"sample","in":"render-bundle-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
     expected:
@@ -3592,64 +3693,116 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"storage","in":"render-bundle-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"compute-pass-encoder"};write={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"render-bundle-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"render-bundle-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"render-bundle-encoder"};write={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"render-pass-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"render-pass-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"sample","in":"render-pass-encoder"};write={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
 
@@ -3658,18 +3811,24 @@
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"b2t-copy","in":"command-encoder"}]
 
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"storage","in":"render-bundle-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
 
   [:boundary="queue-op";read={"op":"t2b-copy","in":"command-encoder"};write={"op":"write-texture","in":"queue"}]
 
   [:boundary="queue-op";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"attachment-store","in":"command-encoder"}]
     expected:
@@ -3680,10 +3839,16 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";read={"op":"t2t-copy","in":"command-encoder"};write={"op":"t2t-copy","in":"command-encoder"}]
     expected:
@@ -3696,42 +3861,64 @@
 
 [cts.https.html?q=webgpu:api,operation,memory_sync,texture,same_subresource:wr:*]
   [:boundary="command-buffer";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
 
   [:boundary="command-buffer";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"attachment-store","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"attachment-store","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
 
   [:boundary="command-buffer";write={"op":"attachment-store","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-bundle-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-bundle-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-pass-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
     expected:
@@ -3742,76 +3929,120 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-bundle-encoder"}]
 
   [:boundary="command-buffer";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-pass-encoder"}]
 
   [:boundary="command-buffer";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
 
   [:boundary="pass";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
 
   [:boundary="queue-op";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
 
   [:boundary="queue-op";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"attachment-store","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"attachment-store","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
 
   [:boundary="queue-op";write={"op":"attachment-store","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"b2t-copy","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"render-bundle-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"render-bundle-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"render-pass-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"storage","in":"render-pass-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-bundle-encoder"}]
 
   [:boundary="queue-op";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"sample","in":"render-pass-encoder"}]
 
   [:boundary="queue-op";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"t2t-copy","in":"command-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"write-texture","in":"queue"};read={"op":"sample","in":"compute-pass-encoder"}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"write-texture","in":"queue"};read={"op":"sample","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"write-texture","in":"queue"};read={"op":"sample","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";write={"op":"write-texture","in":"queue"};read={"op":"t2b-copy","in":"command-encoder"}]
 
@@ -3846,28 +4077,52 @@
   [:boundary="command-buffer";first={"op":"attachment-store","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"storage","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"storage","in":"render-bundle-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
     expected:
@@ -3888,8 +4143,12 @@
   [:boundary="command-buffer";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
 
   [:boundary="command-buffer";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
 
@@ -3898,80 +4157,154 @@
   [:boundary="command-buffer";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"storage","in":"render-pass-encoder"}]
 
   [:boundary="command-buffer";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="pass";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-resolve","in":"command-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-resolve","in":"command-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-resolve","in":"command-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-resolve","in":"command-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-resolve","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-resolve","in":"command-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-store","in":"command-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-store","in":"command-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-store","in":"command-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-store","in":"command-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-store","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"attachment-store","in":"command-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"storage","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"b2t-copy","in":"command-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"compute-pass-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"render-bundle-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"render-bundle-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"render-bundle-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"render-pass-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"render-pass-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"storage","in":"render-pass-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"attachment-resolve","in":"command-encoder"}]
 
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"attachment-store","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"b2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"storage","in":"compute-pass-encoder"}]
 
@@ -3980,8 +4313,12 @@
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"storage","in":"render-pass-encoder"}]
 
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"t2t-copy","in":"command-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"t2t-copy","in":"command-encoder"};second={"op":"write-texture","in":"queue"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"write-texture","in":"queue"};second={"op":"attachment-resolve","in":"command-encoder"}]
 
@@ -3990,10 +4327,16 @@
   [:boundary="queue-op";first={"op":"write-texture","in":"queue"};second={"op":"b2t-copy","in":"command-encoder"}]
 
   [:boundary="queue-op";first={"op":"write-texture","in":"queue"};second={"op":"storage","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"write-texture","in":"queue"};second={"op":"storage","in":"render-bundle-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"write-texture","in":"queue"};second={"op":"storage","in":"render-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";first={"op":"write-texture","in":"queue"};second={"op":"t2t-copy","in":"command-encoder"}]
 
@@ -4925,91 +5268,91 @@
 
   [:interpolated=false;sampleCount=4;rasterizationMask=1]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=10]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=false;sampleCount=4;rasterizationMask=11]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=false;sampleCount=4;rasterizationMask=12]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=false;sampleCount=4;rasterizationMask=13]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=false;sampleCount=4;rasterizationMask=14]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=false;sampleCount=4;rasterizationMask=15]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=false;sampleCount=4;rasterizationMask=2]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=3]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=4]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=5]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=6]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=7]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=8]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=9]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=0]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=1]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=10]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=11]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=12]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=13]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=14]
     expected:
-      if os == "linux" and not debug: [FAIL, TIMEOUT]
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=15]
     expected:
@@ -5017,35 +5360,35 @@
 
   [:interpolated=true;sampleCount=4;rasterizationMask=2]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=3]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=4]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=5]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=6]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=7]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=8]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:interpolated=true;sampleCount=4;rasterizationMask=9]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,operation,render_pipeline,sample_mask:fragment_output_mask:*]
@@ -5690,16 +6033,10 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:depth_test_fail:*]
   [:secondDepth=0;lastDepth=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:secondDepth=1;lastDepth=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:secondDepth=2;lastDepth=0.9]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,rendering,depth:depth_write_disabled:*]
@@ -6218,100 +6555,52 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,stencil:stencil_compare_func:*]
   [:format="depth24plus-stencil8";stencilCompare="always";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="always";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="always";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="equal";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="equal";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="equal";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="greater";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="greater";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="greater";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="greater-equal";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="greater-equal";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="greater-equal";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="less";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="less";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="less";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="less-equal";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="less-equal";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="less-equal";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="never";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="never";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="never";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="not-equal";stencilRefValue=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="not-equal";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";stencilCompare="not-equal";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";stencilCompare="always";stencilRefValue=0]
     expected:
@@ -6508,56 +6797,30 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,stencil:stencil_depthFailOp_operation:*]
   [:format="depth24plus-stencil8";depthFailOp="decrement-clamp";initialStencil=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="decrement-clamp";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="decrement-wrap";initialStencil=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="decrement-wrap";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="decrement-wrap";initialStencil=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="increment-clamp";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="increment-clamp";initialStencil=255]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="increment-wrap";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="increment-wrap";initialStencil=255]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="invert";initialStencil=240]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="keep";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="replace";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";depthFailOp="zero";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";depthFailOp="decrement-clamp";initialStencil=0]
     expected:
@@ -6614,56 +6877,30 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,stencil:stencil_failOp_operation:*]
   [:format="depth24plus-stencil8";failOp="decrement-clamp";initialStencil=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="decrement-clamp";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="decrement-wrap";initialStencil=0]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="decrement-wrap";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="decrement-wrap";initialStencil=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="increment-clamp";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="increment-clamp";initialStencil=255]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="increment-wrap";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="increment-wrap";initialStencil=255]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="invert";initialStencil=240]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="keep";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="replace";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";failOp="zero";initialStencil=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";failOp="decrement-clamp";initialStencil=0]
     expected:
@@ -6894,20 +7131,12 @@
 
 [cts.https.html?q=webgpu:api,operation,rendering,stencil:stencil_read_write_mask:*]
   [:format="depth24plus-stencil8";maskType="read";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";maskType="read";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";maskType="write";stencilRefValue=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";maskType="write";stencilRefValue=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";maskType="read";stencilRefValue=1]
     expected:
@@ -7248,19 +7477,23 @@
 
 
 [cts.https.html?q=webgpu:api,operation,sampling,filter_mode:mipmapFilter:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="bgra8unorm-srgb"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="r16float"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:format="r32float"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm"]
     expected:
@@ -7268,31 +7501,35 @@
 
   [:format="rg16float"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:format="rgb10a2unorm"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="rgba8unorm-srgb"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:api,operation,shader_module,compilation_info:getCompilationInfo_returns:*]
@@ -7916,8 +8153,6 @@
       if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:buffers_with_varying_step_mode:*]
@@ -8194,36 +8429,68 @@
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*]
   [:format="float16x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="float16x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="float32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="float32x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="float32x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint16x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint16x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint32x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint32x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint32x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint8x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="sint8x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="snorm16x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="snorm8x2"]
     expected:
@@ -8234,32 +8501,54 @@
       if os == "linux" and not debug: FAIL
 
   [:format="uint16x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="uint16x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="uint32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="uint32x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="uint32x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="uint32x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="uint8x2"]
 
   [:format="uint8x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="unorm10-10-10-2"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="unorm16x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="unorm16x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="unorm8x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,vertex_state,correctness:vertex_buffer_used_multiple_times_interleaved:*]
@@ -15163,18 +15452,24 @@
       if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="compute";order="backward";bindGroupTest="sameGroup"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="compute";order="forward";bindGroupTest="differentGroups"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="compute";order="forward";bindGroupTest="sameGroup"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="compute";order="shiftByHalf";bindGroupTest="differentGroups"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="compute";order="shiftByHalf";bindGroupTest="sameGroup"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="atDefault";testValueName="overLimit";async=false;bindingCombination="fragment";order="backward";bindGroupTest="differentGroups"]
     expected:
@@ -17642,7 +17937,62 @@
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,limits,maxVertexBuffers:setVertexBuffer,at_over:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: [TIMEOUT, CRASH]
+  [:limitTest="atDefault";testValueName="atLimit";encoderType="render"]
+
+  [:limitTest="atDefault";testValueName="atLimit";encoderType="renderBundle"]
+
+  [:limitTest="atDefault";testValueName="overLimit";encoderType="render"]
+
+  [:limitTest="atDefault";testValueName="overLimit";encoderType="renderBundle"]
+
+  [:limitTest="atMaximum";testValueName="atLimit";encoderType="render"]
+
+  [:limitTest="atMaximum";testValueName="atLimit";encoderType="renderBundle"]
+
+  [:limitTest="atMaximum";testValueName="overLimit";encoderType="render"]
+
+  [:limitTest="atMaximum";testValueName="overLimit";encoderType="renderBundle"]
+
+  [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";encoderType="render"]
+
+  [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";encoderType="renderBundle"]
+
+  [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";encoderType="render"]
+
+  [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";encoderType="renderBundle"]
+
+  [:limitTest="overMaximum";testValueName="atLimit";encoderType="render"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:limitTest="overMaximum";testValueName="atLimit";encoderType="renderBundle"]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
+
+  [:limitTest="overMaximum";testValueName="overLimit";encoderType="render"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:limitTest="overMaximum";testValueName="overLimit";encoderType="renderBundle"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
+
+  [:limitTest="underDefault";testValueName="atLimit";encoderType="render"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:limitTest="underDefault";testValueName="atLimit";encoderType="renderBundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";encoderType="render"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:limitTest="underDefault";testValueName="overLimit";encoderType="renderBundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,limits,maxVertexBuffers:validate,maxBindGroupsPlusVertexBuffers:*]
@@ -18630,6 +18980,8 @@
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:binding_resources,device_mismatch:*]
+  expected:
+    if os == "linux" and not debug: CRASH
   [:entry={"buffer":{"type":"storage"}}]
 
   [:entry={"sampler":{"type":"filtering"}}]
@@ -18676,8 +19028,7 @@
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:buffer,resource_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:buffer,usage:*]
@@ -19294,6 +19645,8 @@
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:texture,resource_state:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:texture_binding_must_have_correct_usage:*]
@@ -26821,8 +27174,9 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,compute_pass:indirect_dispatch_buffer_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,compute_pass:pipeline,device_mismatch:*]
@@ -26842,8 +27196,23 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:srcBufferState="destroyed";dstBufferState="destroyed"]
+
+  [:srcBufferState="destroyed";dstBufferState="invalid"]
+
+  [:srcBufferState="destroyed";dstBufferState="valid"]
+
+  [:srcBufferState="invalid";dstBufferState="destroyed"]
+
+  [:srcBufferState="invalid";dstBufferState="invalid"]
+
+  [:srcBufferState="invalid";dstBufferState="valid"]
+
+  [:srcBufferState="valid";dstBufferState="destroyed"]
+
+  [:srcBufferState="valid";dstBufferState="invalid"]
+
+  [:srcBufferState="valid";dstBufferState="valid"]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer_usage:*]
@@ -27524,6 +27893,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_with_invalid_or_destroyed_texture:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_within_same_texture:*]
@@ -27669,6 +28040,8 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:*]
+  expected:
+    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="compute%20pass"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -27679,7 +28052,7 @@
 
   [:encoderType="render%20bundle"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:encoderType="render%20pass"]
     expected:
@@ -27811,21 +28184,39 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexedIndirect"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexedIndirect"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexedIndirect"]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexedIndirect"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:last_buffer_setting_take_account:*]
@@ -27900,22 +28291,38 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
   [:smallIndexBuffer=false;smallVertexBuffer=false;smallInstanceBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:smallIndexBuffer=false;smallVertexBuffer=false;smallInstanceBuffer=true]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
 
   [:smallIndexBuffer=false;smallVertexBuffer=true;smallInstanceBuffer=false]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=false;smallVertexBuffer=true;smallInstanceBuffer=true]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=false;smallInstanceBuffer=false]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=false;smallInstanceBuffer=true]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=true;smallInstanceBuffer=false]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=true;smallInstanceBuffer=true]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:vertex_buffer_OOB:*]
@@ -28201,8 +28608,9 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer_usage:*]
@@ -28226,8 +28634,9 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setIndexBuffer:index_buffer_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setIndexBuffer:index_buffer_usage:*]
@@ -28275,8 +28684,9 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:vertex_buffer_state:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:vertex_buffer_usage:*]
@@ -28489,7 +28899,70 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: [OK, TIMEOUT]
+  [:encoderType="compute%20pass";state="destroyed";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:encoderType="compute%20pass";state="destroyed";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:encoderType="compute%20pass";state="invalid";resourceType="buffer"]
+
+  [:encoderType="compute%20pass";state="invalid";resourceType="texture"]
+
+  [:encoderType="compute%20pass";state="valid";resourceType="buffer"]
+
+  [:encoderType="compute%20pass";state="valid";resourceType="texture"]
+
+  [:encoderType="render%20bundle";state="destroyed";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: [FAIL, NOTRUN]
+
+  [:encoderType="render%20bundle";state="destroyed";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: [FAIL, NOTRUN]
+
+  [:encoderType="render%20bundle";state="invalid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
+
+  [:encoderType="render%20bundle";state="invalid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
+
+  [:encoderType="render%20bundle";state="valid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
+
+  [:encoderType="render%20bundle";state="valid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
+
+  [:encoderType="render%20pass";state="destroyed";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: [FAIL, NOTRUN]
+
+  [:encoderType="render%20pass";state="destroyed";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: [FAIL, NOTRUN]
+
+  [:encoderType="render%20pass";state="invalid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: [PASS, TIMEOUT, NOTRUN]
+
+  [:encoderType="render%20pass";state="invalid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
+
+  [:encoderType="render%20pass";state="valid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
+
+  [:encoderType="render%20pass";state="valid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:*]
@@ -29670,7 +30143,7 @@
 
 [cts.https.html?q=webgpu:api,validation,error_scope:current_scope:*]
   expected:
-    if os == "linux" and not debug: [TIMEOUT, CRASH]
+    if os == "linux" and not debug: [OK, TIMEOUT, CRASH]
   [:errorFilter="out-of-memory";stackDepth=1]
 
   [:errorFilter="out-of-memory";stackDepth=10]
@@ -29683,23 +30156,23 @@
 
   [:errorFilter="validation";stackDepth=1]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: [PASS, TIMEOUT]
 
   [:errorFilter="validation";stackDepth=10]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:errorFilter="validation";stackDepth=100]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:errorFilter="validation";stackDepth=1000]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:errorFilter="validation";stackDepth=100000]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:empty:*]
@@ -29707,13 +30180,35 @@
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:parent_scope:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:errorFilter="out-of-memory";stackDepth=1]
+
+  [:errorFilter="out-of-memory";stackDepth=10]
+
+  [:errorFilter="out-of-memory";stackDepth=100]
+
+  [:errorFilter="out-of-memory";stackDepth=1000]
+
+  [:errorFilter="validation";stackDepth=1]
+
+  [:errorFilter="validation";stackDepth=10]
+
+  [:errorFilter="validation";stackDepth=100]
+
+  [:errorFilter="validation";stackDepth=1000]
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:simple:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:errorType="out-of-memory";errorFilter="internal"]
+
+  [:errorType="out-of-memory";errorFilter="out-of-memory"]
+
+  [:errorType="out-of-memory";errorFilter="validation"]
+
+  [:errorType="validation";errorFilter="internal"]
+
+  [:errorType="validation";errorFilter="out-of-memory"]
+
+  [:errorType="validation";errorFilter="validation"]
 
 
 [cts.https.html?q=webgpu:api,validation,getBindGroupLayout:index_range,auto_layout:*]
@@ -41853,19 +42348,19 @@
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:setBindGroup:*]
   [:]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:setIndexBuffer:*]
   [:]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:setVertexBuffer:*]
   [:]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:writeBuffer:*]
@@ -41894,6 +42389,8 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:beginRenderPass:*]
   [:]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:copyBufferToTexture:*]
@@ -42016,6 +42513,8 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,color_format:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:encoderType="render%20bundle"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -42032,21 +42531,23 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_format:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:encoderType="render%20bundle";encoderFormatFeature="_undef_";pipelineFormatFeature="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:encoderType="render%20bundle";encoderFormatFeature="_undef_";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:encoderType="render%20bundle";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:encoderType="render%20bundle";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:encoderType="render%20pass";encoderFormatFeature="_undef_";pipelineFormatFeature="_undef_"]
     expected:
@@ -42054,79 +42555,95 @@
 
   [:encoderType="render%20pass";encoderFormatFeature="_undef_";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: TIMEOUT
 
   [:encoderType="render%20pass";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="_undef_"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:encoderType="render%20pass";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:*]
+  expected:
+    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="render%20bundle";format="_undef_"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20bundle";format="depth16unorm"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20bundle";format="depth24plus"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20bundle";format="depth24plus-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20bundle";format="depth32float"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20bundle";format="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20bundle";format="stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20pass";format="_undef_"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:encoderType="render%20pass";format="depth16unorm"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";format="depth24plus"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";format="depth24plus-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";format="depth32float"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";format="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";format="stencil8"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,sample_count:*]
+  expected:
+    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="render%20bundle";attachmentType="color"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20bundle";attachmentType="depthstencil"]
+    expected:
+      if os == "linux" and not debug: [PASS, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20pass";attachmentType="color"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:encoderType="render%20pass";attachmentType="depthstencil"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,color_depth_mismatch:*]
@@ -66322,56 +66839,94 @@
   [:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"]
 
   [:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="all";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"]
 
   [:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="all";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"]
 
   [:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="all";colorTextureState="valid";depthStencilTextureState="valid"]
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"]
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"]
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"]
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="depth-only";colorTextureState="valid";depthStencilTextureState="valid"]
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedAfterEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedAfterEncode";depthStencilTextureState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedAfterEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="destroyedBeforeEncode";depthStencilTextureState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedAfterEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="destroyedBeforeEncode"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:depthStencilTextureAspect="stencil-only";colorTextureState="valid";depthStencilTextureState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,texture,destroy:twice:*]
@@ -78609,25 +79164,27 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_storage_advanced:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: TIMEOUT
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
@@ -78635,235 +79192,235 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_storage_basic:*]
@@ -78997,25 +79554,27 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_advanced:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
@@ -79023,235 +79582,235 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_basic:*]
@@ -80169,25 +80728,27 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_advanced:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
@@ -80195,235 +80756,235 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_basic:*]
@@ -80557,25 +81118,27 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_advanced:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
@@ -80583,235 +81146,235 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_basic:*]
@@ -86179,6 +86742,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f32:*]
+  expected:
+    if os == "linux" and not debug: CRASH
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87007,6 +87572,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pow:f32:*]
+  expected:
+    if os == "linux" and not debug: CRASH
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88753,6 +89320,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,step:f32:*]
+  expected:
+    if os == "linux" and not debug: CRASH
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93712,678 +94281,1320 @@
 
 [cts.https.html?q=webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:*]
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="firstVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=false;indirect=true;drawCallTestParameter="vertexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=false;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="baseVertex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="firstIndex";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="indexCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="instanceCount";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x2";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x3";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=0;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=false;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexed=true;indirect=true;drawCallTestParameter="vertexCountInIndexBuffer";type="float32x4";additionalBuffers=4;partialLastNumber=true;offsetVertexBuffer=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,shader_io,compute_builtins:inputs:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:method="mixed";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="direct";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="direct";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="indirect";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="mixed";dispatch="indirect";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="param";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
@@ -94391,63 +95602,63 @@
 
   [:method="param";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: TIMEOUT
 
   [:method="param";dispatch="direct";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="param";dispatch="direct";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="param";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="param";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="param";dispatch="indirect";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="param";dispatch="indirect";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="direct";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="direct";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="indirect";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:method="struct";dispatch="indirect";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:shader,execution,shader_io,fragment_builtins:inputs,front_facing:*]
@@ -99084,102 +100295,198 @@
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:drawTo2DCanvas:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:offscreenCanvas,snapshot:*]
@@ -99258,130 +100565,250 @@
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:onscreenCanvas,snapshot:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: TIMEOUT
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:onscreenCanvas,uploadToWebGL:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
   [:format="bgra8unorm";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: [PASS, TIMEOUT, NOTRUN]
 
   [:format="bgra8unorm";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
+    expected:
+      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:transferToImageBitmap_huge_size:*]

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: [CRASH, PASS]
+    if os == "linux" and not debug: [CRASH, PASS, FAIL]


### PR DESCRIPTION
Instead of using 0.19, we use even newer version that removed IdentityFactories completely (also needed for #32008). I implemented proper drops for GPU* structs that are analogues to [Cleanup functions in firefox](https://searchfox.org/mozilla-central/rev/6121b33709dd80979a6806ff59096a561e348ae8/dom/webgpu/Adapter.cpp#206).

Relevant FF commit: https://github.com/mozilla/gecko-dev/commit/62af8e706eb426c60bf0f15db658dea1e507300a

try run: https://github.com/sagudev/servo/actions/runs/8820854175/job/24217313911 (crashes on `webgpu:shader,execution,expression,*` are #31397, timeouts are due too same problem as in #32008)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
