### PR TITLE
Fixed some clippy warnings by replacing 'match' with 'if'

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2766,15 +2766,12 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             // restart the download later from where we left, we cancel
             // the current request. Otherwise, we continue the request
             // assuming that we may drop some frames.
-            match e {
-                PlayerError::EnoughData => {
-                    if let Some(ref mut current_fetch_context) =
-                        *elem.current_fetch_context.borrow_mut()
-                    {
-                        current_fetch_context.cancel(CancelReason::Backoff);
-                    }
-                },
-                _ => (),
+            if e == PlayerError::EnoughData {
+                if let Some(ref mut current_fetch_context) =
+                    *elem.current_fetch_context.borrow_mut()
+                {
+                    current_fetch_context.cancel(CancelReason::Backoff);
+                }
             }
             warn!("Could not push input data to player {:?}", e);
             return;

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -87,38 +87,35 @@ impl VirtualMethods for HTMLOptGroupElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("disabled") => {
-                let disabled_state = match mutation {
-                    AttributeMutation::Set(None) => true,
-                    AttributeMutation::Set(Some(_)) => {
-                        // Option group was already disabled.
-                        return;
-                    },
-                    AttributeMutation::Removed => false,
-                };
-                let el = self.upcast::<Element>();
-                el.set_disabled_state(disabled_state);
-                el.set_enabled_state(!disabled_state);
-                let options = el
-                    .upcast::<Node>()
-                    .children()
-                    .filter(|child| child.is::<HTMLOptionElement>())
-                    .map(|child| DomRoot::from_ref(child.downcast::<HTMLOptionElement>().unwrap()));
-                if disabled_state {
-                    for option in options {
-                        let el = option.upcast::<Element>();
-                        el.set_disabled_state(true);
-                        el.set_enabled_state(false);
-                    }
-                } else {
-                    for option in options {
-                        let el = option.upcast::<Element>();
-                        el.check_disabled_attribute();
-                    }
+        if attr.local_name() == &local_name!("disabled") {
+            let disabled_state = match mutation {
+                AttributeMutation::Set(None) => true,
+                AttributeMutation::Set(Some(_)) => {
+                    // Option group was already disabled.
+                    return;
+                },
+                AttributeMutation::Removed => false,
+            };
+            let el = self.upcast::<Element>();
+            el.set_disabled_state(disabled_state);
+            el.set_enabled_state(!disabled_state);
+            let options = el
+                .upcast::<Node>()
+                .children()
+                .filter(|child| child.is::<HTMLOptionElement>())
+                .map(|child| DomRoot::from_ref(child.downcast::<HTMLOptionElement>().unwrap()));
+            if disabled_state {
+                for option in options {
+                    let el = option.upcast::<Element>();
+                    el.set_disabled_state(true);
+                    el.set_enabled_state(false);
                 }
-            },
-            _ => {},
+            } else {
+                for option in options {
+                    let el = option.upcast::<Element>();
+                    el.check_disabled_attribute();
+                }
+            }
         }
     }
 

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -158,11 +158,8 @@ impl VirtualMethods for HTMLOutputElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match attr.local_name() {
-            &local_name!("form") => {
-                self.form_attribute_mutated(mutation);
-            },
-            _ => {},
+        if attr.local_name() == &local_name!("form") {
+            self.form_attribute_mutated(mutation);
         }
     }
 }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -657,21 +657,20 @@ impl HTMLScriptElement {
         if script_type == ScriptType::Classic {
             let for_attribute = element.get_attribute(&ns!(), &local_name!("for"));
             let event_attribute = element.get_attribute(&ns!(), &local_name!("event"));
-            match (for_attribute, event_attribute) {
-                (Some(ref for_attribute), Some(ref event_attribute)) => {
-                    let for_value = for_attribute.value().to_ascii_lowercase();
-                    let for_value = for_value.trim_matches(HTML_SPACE_CHARACTERS);
-                    if for_value != "window" {
-                        return;
-                    }
+            if let (Some(ref for_attribute), Some(ref event_attribute)) =
+                (for_attribute, event_attribute)
+            {
+                let for_value = for_attribute.value().to_ascii_lowercase();
+                let for_value = for_value.trim_matches(HTML_SPACE_CHARACTERS);
+                if for_value != "window" {
+                    return;
+                }
 
-                    let event_value = event_attribute.value().to_ascii_lowercase();
-                    let event_value = event_value.trim_matches(HTML_SPACE_CHARACTERS);
-                    if event_value != "onload" && event_value != "onload()" {
-                        return;
-                    }
-                },
-                (_, _) => (),
+                let event_value = event_attribute.value().to_ascii_lowercase();
+                let event_value = event_value.trim_matches(HTML_SPACE_CHARACTERS);
+                if event_value != "onload" && event_value != "onload()" {
+                    return;
+                }
             }
         }
 
@@ -1239,15 +1238,12 @@ impl VirtualMethods for HTMLScriptElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match *attr.local_name() {
-            local_name!("src") => {
-                if let AttributeMutation::Set(_) = mutation {
-                    if !self.parser_inserted.get() && self.upcast::<Node>().is_connected() {
-                        self.prepare();
-                    }
+        if *attr.local_name() == local_name!("src") {
+            if let AttributeMutation::Set(_) = mutation {
+                if !self.parser_inserted.get() && self.upcast::<Node>().is_connected() {
+                    self.prepare();
                 }
-            },
-            _ => {},
+            }
         }
     }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -288,10 +288,9 @@ impl FetchResponseListener for FetchContext {
 
     fn submit_resource_timing(&mut self) {
         // navigation submission is handled in servoparser/mod.rs
-        match self.resource_timing.timing_type {
-            ResourceTimingType::Resource => network_listener::submit_timing(self),
-            _ => {},
-        };
+        if self.resource_timing.timing_type == ResourceTimingType::Resource {
+            network_listener::submit_timing(self)
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes clippy warnings that arose from the use of 'match' with a suggestion to use 'if'.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because it doesn't touch functionality.

