### PR TITLE
webgpu: Use safe callbacks & try_recv_timeout

### DIFF
--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -382,15 +382,5 @@ impl AsyncWGPUListener for GPUBuffer {
             None => unreachable!("Failed to get a response for BufferMapAsync"),
         }
         *self.map_promise.borrow_mut() = None;
-        if let Err(e) = self
-            .channel
-            .0
-            .send((None, WebGPURequest::BufferMapComplete(self.buffer.0)))
-        {
-            warn!(
-                "Failed to send BufferMapComplete({:?}) ({})",
-                self.buffer.0, e
-            );
-        }
     }
 }

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -420,7 +420,7 @@ impl WGPU {
                             match result {
                                 Ok(()) => {
                                     if let Err(e) = self_sender.send((
-                                        None,
+                                        scope_id,
                                         WebGPURequest::BufferMapComplete {
                                             sender: resp_sender,
                                             buffer_id,


### PR DESCRIPTION
It also removes the need for HashMaps and BufferMaps struct that keep data alive until it was used by C callback.

Callbacks now do not send request to self anymore so https://sagudev.github.io/briefcase/fastgame.html actually works now.

We now do try_recv_timeout instead of running loop continuously.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
