### PR TITLE
fix: Handle table.deleteRow with no rows

### DIFF
--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -398,16 +398,20 @@ impl HTMLTableElementMethods for HTMLTableElement {
     // https://html.spec.whatwg.org/multipage/#dom-table-deleterow
     fn DeleteRow(&self, mut index: i32) -> Fallible<()> {
         let rows = self.Rows();
+
         // Step 1.
-        if index == -1 {
-            index = rows.Length() as i32 - 1;
-        }
-        // Step 2.
-        if index < 0 || index as u32 >= rows.Length() {
+        if index < -1 || index >= rows.Length() as i32 {
             return Err(Error::IndexSize);
         }
-        // Step 3.
-        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self();
+
+        // Step 2
+        if index == -1 && rows.Length() > 0 {
+            index = rows.Length() as i32 - 1;
+
+            // Step 3.
+            DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self();
+        }
+
         Ok(())
     }
 

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -395,22 +395,31 @@ impl HTMLTableElementMethods for HTMLTableElement {
         Ok(new_row)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-table-deleterow
+    /// <https://html.spec.whatwg.org/multipage/#dom-table-deleterow>
     fn DeleteRow(&self, mut index: i32) -> Fallible<()> {
         let rows = self.Rows();
+        let num_rows = rows.Length() as i32;
 
-        // Step 1.
-        if index < -1 || index >= rows.Length() as i32 {
+        // Step 1: If index is less than −1 or greater than or equal to the number of elements
+        // in the rows collection, then throw an "IndexSizeError".
+        if !(-1..num_rows).contains(&index) {
             return Err(Error::IndexSize);
         }
 
-        // Step 2
-        if index == -1 && rows.Length() > 0 {
-            index = rows.Length() as i32 - 1;
+        let num_rows = rows.Length() as i32;
 
-            // Step 3.
-            DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self();
+        // Step 2: If index is −1, then remove the last element in the rows collection from its
+        // parent, or do nothing if the rows collection is empty.
+        if index == -1 {
+            index = num_rows - 1;
         }
+
+        if num_rows == 0 {
+            return Ok(());
+        }
+
+        // Step 3: Otherwise, remove the indexth element in the rows collection from its parent.
+        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self();
 
         Ok(())
     }

--- a/tests/wpt/meta-legacy-layout/html/semantics/tabular-data/the-table-element/remove-row.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/tabular-data/the-table-element/remove-row.html.ini
@@ -1,5 +1,0 @@
-[remove-row.html]
-  type: testharness
-  [deleteRow(-1) with no rows]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/tabular-data/the-table-element/remove-row.html.ini
+++ b/tests/wpt/meta/html/semantics/tabular-data/the-table-element/remove-row.html.ini
@@ -1,3 +1,0 @@
-[remove-row.html]
-  [deleteRow(-1) with no rows]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixes a case where `[table].deleteRow(-1)` is called when it has no child rows.

Spec: https://html.spec.whatwg.org/multipage/tables.html#dom-table-deleterow

WPT failure: https://wpt.fyi/results/html/semantics/tabular-data/the-table-element/remove-row.html?label=master&product=servo

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
