### PR TITLE
feat: use set_poll, set_wait, set_exit of control_flow

### DIFF
--- a/ports/servoshell/app.rs
+++ b/ports/servoshell/app.rs
@@ -267,9 +267,9 @@ impl App {
 
             // Block until the window gets an event
             if !animating || app.suspended.get() {
-                *control_flow = winit::event_loop::ControlFlow::Wait;
+                control_flow.set_wait();
             } else {
-                *control_flow = winit::event_loop::ControlFlow::Poll;
+                control_flow.set_poll();
             }
 
             // Consume and handle any events from the Minibrowser.
@@ -281,7 +281,7 @@ impl App {
 
             match app.handle_events() {
                 PumpResult::Shutdown => {
-                    *control_flow = winit::event_loop::ControlFlow::Exit;
+                    control_flow.set_exit();
                     app.servo.take().unwrap().deinit();
                     if let Some(mut minibrowser) = app.minibrowser() {
                         minibrowser.context.destroy();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

servo now use winit of version 0.28.7, and the use of control_flow has updated yet, just see the doc here https://docs.rs/winit/0.28.7/winit/index.html
