### PR TITLE
clippy: Fix warnings in `components/script`

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2826,7 +2826,7 @@ impl GlobalScope {
             },
             _ => {
                 p.reject_error(Error::NotSupported);
-                return p;
+                p
             },
         }
     }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -708,11 +708,10 @@ impl HTMLInputElement {
                 },
             };
         } else {
-            value = value +
-                match dir {
-                    StepDirection::Down => -f64::from(n) * allowed_value_step,
-                    StepDirection::Up => f64::from(n) * allowed_value_step,
-                };
+            value += match dir {
+                StepDirection::Down => -f64::from(n) * allowed_value_step,
+                StepDirection::Up => f64::from(n) * allowed_value_step,
+            };
         }
 
         // Step 8
@@ -2085,8 +2084,7 @@ impl HTMLInputElement {
         if self.upcast::<Element>().click_in_progress() {
             return;
         }
-        let submit_button;
-        submit_button = node
+        let submit_button = node
             .query_selector_iter(DOMString::from("input[type=submit]"))
             .unwrap()
             .filter_map(DomRoot::downcast::<HTMLInputElement>)
@@ -2102,7 +2100,7 @@ impl HTMLInputElement {
                 }
             },
             None => {
-                let inputs = node
+                let mut inputs = node
                     .query_selector_iter(DOMString::from("input"))
                     .unwrap()
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
@@ -2125,7 +2123,7 @@ impl HTMLInputElement {
                             )
                     });
 
-                if inputs.skip(1).next().is_some() {
+                if inputs.nth(1).is_some() {
                     // lazily test for > 1 submission-blocking inputs
                     return;
                 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed following warnings:
```
warning: in an if condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a let
   --> components/script/serviceworker_manager.rs:502:28
    |
502 |               .spawn(move || {
    |  ____________________________^
503 | |                 ServiceWorkerManager::new(
504 | |                     own_sender,
505 | |                     from_constellation,
...   |
509 | |                 .handle_message();
510 | |             })
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_if_conditions
    = note: #[warn(clippy::blocks_in_if_conditions)] on by default
```

```
warning: unneeded late initialization
    --> components/script/dom/htmlinputelement.rs:2088:9
     |
2088 |           let submit_button;
     |           ^^^^^^^^^^^^^^^^^^ created here
2089 | /         submit_button = node
2090 | |             .query_selector_iter(DOMString::from("input[type=submit]"))
2091 | |             .unwrap()
2092 | |             .filter_map(DomRoot::downcast::<HTMLInputElement>)
2093 | |             .find(|r| r.form_owner() == owner);
     | |______________________________________________^ initialised here
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
help: declare submit_button here
     |
2089 |         let submit_button = node
     |         ~~~~~~~~~~~~~
```
```
warning: called skip(..).next() on an iterator
    --> components/script/dom/htmlinputelement.rs:2128:26
     |
2128 |                 if inputs.skip(1).next().is_some() {
     |                          ^^^^^^^^^^^^^^^ help: use nth instead: .nth(1)
     |
help: for this change inputs has to be mutable
    --> components/script/dom/htmlinputelement.rs:2105:21
     |
2105 |                 let inputs = node
     |                     ^^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_next
     = note: #[warn(clippy::iter_skip_next)] on by default
     
```
- needless_return https://rust-lang.github.io/rust-clippy/master/index.html#/needless-return
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500

<!-- Either: -->
- [x] These changes do not require tests because they do not modify functionality

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
