### PR TITLE
Fixes for HTTP header compliance.

### DIFF
--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1350,19 +1350,28 @@ fn test_fetch_with_devtools() {
     //Creating default headers for request
     let mut headers = HeaderMap::new();
 
-    headers.insert(
-        header::ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br"),
-    );
-
     headers.insert(header::ACCEPT, HeaderValue::from_static("*/*"));
 
     headers.insert(
         header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US, en; q=0.5"),
+        HeaderValue::from_static("en-US,en;q=0.5"),
     );
 
     headers.typed_insert::<UserAgent>(DEFAULT_USER_AGENT.parse().unwrap());
+
+    let host = if url.port().is_none() {
+        url.host_str().unwrap().to_string()
+    } else {
+        format!("{}:{}", url.host_str().unwrap(), url.port().unwrap())
+    };
+    headers.typed_insert(headers::Host::from(
+        host.parse::<http::uri::Authority>().unwrap(),
+    ));
+
+    headers.insert(
+        header::ACCEPT_ENCODING,
+        HeaderValue::from_static("gzip, deflate, br"),
+    );
 
     let httprequest = DevtoolsHttpRequest {
         url: url,

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -136,14 +136,12 @@ fn test_check_default_headers_loaded_in_every_request() {
 
     headers.insert(
         header::ACCEPT,
-        HeaderValue::from_static(
-            "text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8",
-        ),
+        HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
 
     headers.insert(
         header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US, en; q=0.5"),
+        HeaderValue::from_static("en-US,en;q=0.5"),
     );
 
     headers.typed_insert::<UserAgent>(crate::DEFAULT_USER_AGENT.parse().unwrap());
@@ -268,24 +266,24 @@ fn test_request_and_response_data_with_network_messages() {
     //Creating default headers for request
     let mut headers = HeaderMap::new();
 
-    headers.insert(
-        header::ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br"),
-    );
+    headers.insert(header::HOST, HeaderValue::from_static("bar.foo"));
 
     headers.insert(
         header::ACCEPT,
-        HeaderValue::from_static(
-            "text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8",
-        ),
+        HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
 
     headers.insert(
         header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US, en; q=0.5"),
+        HeaderValue::from_static("en-US,en;q=0.5"),
     );
 
     headers.typed_insert::<UserAgent>(crate::DEFAULT_USER_AGENT.parse().unwrap());
+
+    headers.insert(
+        header::ACCEPT_ENCODING,
+        HeaderValue::from_static("gzip, deflate, br"),
+    );
 
     let httprequest = DevtoolsHttpRequest {
         url: url,
@@ -902,7 +900,7 @@ fn test_load_sets_default_accept_to_html_xhtml_xml_and_then_anything_else() {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            "text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8"
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
         );
         *response.body_mut() = b"Yay!".to_vec().into();
     };

--- a/components/shared/net/quality.rs
+++ b/components/shared/net/quality.rs
@@ -59,9 +59,9 @@ where
         fmt::Display::fmt(&self.item, fmt)?;
         match self.quality.0 {
             1000 => Ok(()),
-            0 => fmt.write_str("; q=0"),
+            0 => fmt.write_str(";q=0"),
             mut x => {
-                fmt.write_str("; q=0.")?;
+                fmt.write_str(";q=0.")?;
                 let mut digits = *b"000";
                 digits[2] = (x % 10) as u8 + b'0';
                 x /= 10;
@@ -81,7 +81,7 @@ pub fn quality_to_value(q: Vec<QualityItem<Mime>>) -> HeaderValue {
         &q.iter()
             .map(|q| q.to_string())
             .collect::<Vec<String>>()
-            .join(", "),
+            .join(","),
     )
     .unwrap()
 }


### PR DESCRIPTION
- Fix 400 errors from nginx in response to Servo requests by implementing conformant albeit non-normative removal of whitespace from `Accept` and `Accept-Language` HTTP headers. (To match behaviour of Firefox, Safari, and Chrome) https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
- Provide `Host` header as REQUIRED by HTTP protocol https://www.rfc-editor.org/rfc/rfc9110#field.host

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
