### PR TITLE
Fixed some clippy warnings in components

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1021,7 +1021,7 @@ impl RangeMethods for Range {
 
         // Step 4.
         let ancestor = self.CommonAncestorContainer();
-        let mut iter = start_node
+        let iter = start_node
             .following_nodes(&ancestor)
             .filter_map(DomRoot::downcast::<Text>);
 
@@ -1190,7 +1190,7 @@ impl WeakRangeVec {
                 let move_end = node_is_end && range.end_offset() == offset;
 
                 let remove_from_node =
-                    !(!move_start || !move_end && node_is_end) || move_end && !node_is_start;
+                    move_start && (move_end || !node_is_end) || move_end && !node_is_start;
 
                 let already_in_child = range.start().node() == child || range.end().node() == child;
                 let push_to_child = !already_in_child && (move_start || move_end);
@@ -1252,7 +1252,7 @@ impl WeakRangeVec {
                 let move_end = node_is_end && end_offset > offset;
 
                 let remove_from_node =
-                    !(!move_start || !move_end && node_is_end) || move_end && !node_is_start;
+                    move_start && (move_end || !node_is_end) || move_end && !node_is_start;
 
                 let already_in_sibling =
                     range.start().node() == sibling || range.end().node() == sibling;

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1025,7 +1025,7 @@ impl RangeMethods for Range {
             .following_nodes(&ancestor)
             .filter_map(DomRoot::downcast::<Text>);
 
-        while let Some(child) = iter.next() {
+        for child in iter {
             if self.contains(child.upcast()) {
                 s.push_str(&child.upcast::<CharacterData>().Data());
             }
@@ -1189,9 +1189,8 @@ impl WeakRangeVec {
                 let move_start = node_is_start && range.start_offset() == offset;
                 let move_end = node_is_end && range.end_offset() == offset;
 
-                let remove_from_node = move_start && move_end ||
-                    move_start && !node_is_end ||
-                    move_end && !node_is_start;
+                let remove_from_node =
+                    !(!move_start || !move_end && node_is_end) || move_end && !node_is_start;
 
                 let already_in_child = range.start().node() == child || range.end().node() == child;
                 let push_to_child = !already_in_child && (move_start || move_end);
@@ -1252,9 +1251,8 @@ impl WeakRangeVec {
                 let move_start = node_is_start && start_offset > offset;
                 let move_end = node_is_end && end_offset > offset;
 
-                let remove_from_node = move_start && move_end ||
-                    move_start && !node_is_end ||
-                    move_end && !node_is_start;
+                let remove_from_node =
+                    !(!move_start || !move_end && node_is_end) || move_end && !node_is_start;
 
                 let already_in_sibling =
                     range.start().node() == sibling || range.end().node() == sibling;

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -84,9 +84,9 @@ impl RTCIceCandidate {
         config: &RTCIceCandidateInit,
     ) -> Fallible<DomRoot<RTCIceCandidate>> {
         if config.sdpMid.is_none() && config.sdpMLineIndex.is_none() {
-            return Err(Error::Type(format!(
-                "one of sdpMid and sdpMLineIndex must be set"
-            )));
+            return Err(Error::Type(
+                "one of sdpMid and sdpMLineIndex must be set".to_string(),
+            ));
         }
         Ok(RTCIceCandidate::new_with_proto(
             &window.global(),

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -565,9 +565,9 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
 
         // XXXManishearth add support for sdpMid
         if candidate.sdpMLineIndex.is_none() {
-            p.reject_error(Error::Type(format!(
-                "servo only supports sdpMLineIndex right now"
-            )));
+            p.reject_error(Error::Type(
+                "servo only supports sdpMLineIndex right now".to_string(),
+            ));
             return p;
         }
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -291,7 +291,7 @@ impl WindowProxy {
             .currently_active
             .get()
             .and_then(ScriptThread::find_document)
-            .and_then(|doc| Some(DomRoot::from_ref(doc.window())))
+            .map(|doc| DomRoot::from_ref(doc.window()))
             .unwrap();
         let msg = EmbedderMsg::AllowOpeningWebView(chan);
         window.send_to_embedder(msg);

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1616,13 +1616,12 @@ impl XMLHttpRequest {
     /// <https://xhr.spec.whatwg.org/#response-mime-type>
     fn response_mime_type(&self) -> Option<Mime> {
         return extract_mime_type(&self.response_headers.borrow())
-            .map(|mime_as_bytes| {
+            .and_then(|mime_as_bytes| {
                 String::from_utf8(mime_as_bytes)
                     .unwrap_or_default()
                     .parse()
                     .ok()
             })
-            .flatten()
             .or(Some(mime::TEXT_XML));
     }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1314,7 +1314,7 @@ impl ScriptFetchOptions {
 }
 
 #[allow(unsafe_code)]
-unsafe fn module_script_from_reference_private<'a>(
+unsafe fn module_script_from_reference_private(
     reference_private: &RawHandle<JSVal>,
 ) -> Option<&ModuleScript> {
     if reference_private.get().is_undefined() {


### PR DESCRIPTION
This PR fixes some clippy warnings by; 

- Removing unused lifetimes
- Simplifying boolean expressions
- Removing useless use of format!
- Replacing the use Option.and_then() with .map()
- Replacing the call of Option.map().flatten() with .and_then()

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because it doesn't touch functionality.

