### PR TITLE
Nix: allow nix-shell without explicit path to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+etc/shell.nix


### PR DESCRIPTION
This patch creates a symlink to etc/shell.nix in the root of the repo, making nix-shell more ergonomic and hinting more obviously that you can build Servo on NixOS or other Linux distros with Nix.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes