### PR TITLE
Keep 1st collapsible space after a preserved one

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2306,7 +2306,8 @@ struct ContentSizesComputation<'a> {
     current_line: ContentSizes,
     /// Size for whitepsace pending to be added to this line.
     pending_whitespace: Au,
-    /// Whether or not this IFC has seen any content, excluding collapsed whitespace.
+    /// Whether or not the current line has seen any content (excluding collapsed whitespace),
+    /// when sizing under a max-content constraint.
     had_content_yet: bool,
     /// Stack of ending padding, margin, and border to add to the length
     /// when an inline box finishes.
@@ -2366,7 +2367,6 @@ impl<'a> ContentSizesComputation<'a> {
                             // If this run is a forced line break, we *must* break the line
                             // and start measuring from the inline origin once more.
                             if text_run.glyph_run_is_preserved_newline(run) {
-                                self.had_content_yet = true;
                                 self.forced_line_break();
                                 self.current_line = ContentSizes::zero();
                                 continue;
@@ -2375,12 +2375,12 @@ impl<'a> ContentSizesComputation<'a> {
                             let white_space =
                                 text_run.parent_style.get_inherited_text().white_space;
                             if !white_space.preserve_spaces() {
-                                // Discard any leading whitespace in the IFC. This will always be trimmed.
+                                // TODO: need to handle !white_space.allow_wrap().
+                                self.line_break_opportunity();
+                                // Discard any leading whitespace in the line. This will always be trimmed.
                                 if self.had_content_yet {
                                     // Wait to take into account other whitespace until we see more content.
-                                    // Whitespace at the end of the IFC will always be trimmed.
-                                    // TODO: need to handle !white_space.allow_wrap().
-                                    self.line_break_opportunity();
+                                    // Whitespace at the end of the line will always be trimmed.
                                     self.pending_whitespace += advance;
                                 }
                                 continue;
@@ -2433,6 +2433,7 @@ impl<'a> ContentSizesComputation<'a> {
         self.paragraph.max_content =
             std::cmp::max(self.paragraph.max_content, self.current_line.max_content);
         self.current_line.max_content = Au::zero();
+        self.had_content_yet = false;
     }
 
     fn commit_pending_whitespace(&mut self) {

--- a/tests/wpt/meta/css/CSS2/text/white-space-mixed-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/white-space-mixed-002.xht.ini
@@ -1,2 +1,0 @@
-[white-space-mixed-002.xht]
-  expected: FAIL


### PR DESCRIPTION
The logic was to remove any collapsible white space preceded by other white space. However, this should only happen if the preceding space is also collapsible.

Also fixing the logic in ContentSizesComputation, which was wrong but previously it didn't matter.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
