### PR TITLE
clippy: Fix `question_mark` warning in `components/script`

### DIFF
--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -91,9 +91,7 @@ impl AudioBufferSourceNode {
         };
         if let Some(ref buffer) = options.buffer {
             if let Some(ref buffer) = buffer {
-                if let Err(err) = node.SetBuffer(Some(&**buffer)) {
-                    return Err(err);
-                }
+                node.SetBuffer(Some(&**buffer))?
             }
         }
         Ok(node)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace `if` block with a question mark expression to fix the `question_mark` warning.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#question_mark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
