### PR TITLE
clippy: Fix `needless_late_init` warning in `components/script`

### DIFF
--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -129,8 +129,7 @@ impl CharacterDataMethods for CharacterData {
         let data = self.data.borrow();
         // Step 1.
         let mut substring = String::new();
-        let remaining;
-        match split_at_utf16_code_unit_offset(&data, offset, replace_surrogates) {
+        let remaining = match split_at_utf16_code_unit_offset(&data, offset, replace_surrogates) {
             Ok((_, astral, s)) => {
                 // As if we had split the UTF-16 surrogate pair in half
                 // and then transcoded that to UTF-8 lossily,
@@ -138,11 +137,11 @@ impl CharacterDataMethods for CharacterData {
                 if astral.is_some() {
                     substring += "\u{FFFD}";
                 }
-                remaining = s;
+                s
             },
             // Step 2.
             Err(()) => return Err(Error::IndexSize),
-        }
+        };
         match split_at_utf16_code_unit_offset(remaining, count, replace_surrogates) {
             // Steps 3.
             Err(()) => substring += remaining,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Merge late variable initialization with its `let` statement to fix the `needless_late_init` warning.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
