### PR TITLE
clippy: Fix `iter_cloned_collect` warning in `components/script`

### DIFF
--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -51,10 +51,6 @@ impl DOMStringMapMethods for DOMStringMap {
 
     // https://html.spec.whatwg.org/multipage/#the-domstringmap-interface:supported-property-names
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
-        self.element
-            .supported_prop_names_custom_attr()
-            .iter()
-            .cloned()
-            .collect()
+        self.element.supported_prop_names_custom_attr().to_vec()
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace the `.iter().cloned().collect()` call with `.to_vec()` to fix the `iter_cloned_collect` warning.

**ref:** https://rust-lang.github.io/rust-clippy/master/index.html#iter_cloned_collect

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
