### PR TITLE
clippy: Fix `redundant_*` warnings

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -695,9 +695,9 @@ impl CustomElementDefinition {
             observed_attributes,
             callbacks,
             construction_stack: Default::default(),
-            form_associated: form_associated,
-            disable_internals: disable_internals,
-            disable_shadow: disable_shadow,
+            form_associated,
+            disable_internals,
+            disable_shadow,
         }
     }
 

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -238,7 +238,7 @@ impl ElementInternalsMethods for ElementInternals {
         if bits.is_empty() {
             self.set_validation_message(DOMString::new());
         } else {
-            self.set_validation_message(message.unwrap_or_else(|| DOMString::new()));
+            self.set_validation_message(message.unwrap_or_else(DOMString::new));
         }
 
         // Step 6: If element's customError validity flag is true, then set element's custom validity error

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -161,14 +161,14 @@ impl ElementInternals {
             SubmissionValue::USVString(string) => {
                 entry_list.push(FormDatum {
                     ty: DOMString::from("string"),
-                    name: name,
+                    name,
                     value: FormDatumValue::String(DOMString::from(string.to_string())),
                 });
             },
             SubmissionValue::File(file) => {
                 entry_list.push(FormDatum {
                     ty: DOMString::from("file"),
-                    name: name,
+                    name,
                     value: FormDatumValue::File(DomRoot::from_ref(&*file)),
                 });
             },

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -984,7 +984,7 @@ impl HTMLMediaElement {
                         SrcObject::MediaStream(ref stream) => {
                             let tracks = &*stream.get_tracks();
                             for (pos, track) in tracks.iter().enumerate() {
-                                if let Err(_) = self
+                                if self
                                     .player
                                     .borrow()
                                     .as_ref()
@@ -992,6 +992,7 @@ impl HTMLMediaElement {
                                     .lock()
                                     .unwrap()
                                     .set_stream(&track.id(), pos == tracks.len() - 1)
+                                    .is_err()
                                 {
                                     self.queue_dedicated_media_source_failure_steps();
                                 }

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -137,7 +137,7 @@ impl MediaListMethods for MediaList {
         );
         let m = MediaQuery::parse(&context, &mut parser);
         // Step 2
-        if let Err(_) = m {
+        if m.is_err() {
             return;
         }
         // Step 3
@@ -176,7 +176,7 @@ impl MediaListMethods for MediaList {
         );
         let m = MediaQuery::parse(&context, &mut parser);
         // Step 2
-        if let Err(_) = m {
+        if m.is_err() {
             return;
         }
         // Step 3

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -59,13 +59,13 @@ impl MediaList {
 }
 
 impl MediaListMethods for MediaList {
-    // https://drafts.csswg.org/cssom/#dom-medialist-mediatext
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
     fn MediaText(&self) -> DOMString {
         let guard = self.shared_lock().read();
         DOMString::from(self.media_queries.read_with(&guard).to_css_string())
     }
 
-    // https://drafts.csswg.org/cssom/#dom-medialist-mediatext
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-mediatext>
     fn SetMediaText(&self, value: DOMString) {
         let mut guard = self.shared_lock().write();
         let media_queries = self.media_queries.write_with(&mut guard);
@@ -101,7 +101,7 @@ impl MediaListMethods for MediaList {
         self.media_queries.read_with(&guard).media_queries.len() as u32
     }
 
-    // https://drafts.csswg.org/cssom/#dom-medialist-item
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-item>
     fn Item(&self, index: u32) -> Option<DOMString> {
         let guard = self.shared_lock().read();
         self.media_queries
@@ -111,12 +111,12 @@ impl MediaListMethods for MediaList {
             .map(|query| query.to_css_string().into())
     }
 
-    // https://drafts.csswg.org/cssom/#dom-medialist-item
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-item>
     fn IndexedGetter(&self, index: u32) -> Option<DOMString> {
         self.Item(index)
     }
 
-    // https://drafts.csswg.org/cssom/#dom-medialist-appendmedium
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-appendmedium>
     fn AppendMedium(&self, medium: DOMString) {
         // Step 1
         let mut input = ParserInput::new(&medium);
@@ -155,7 +155,7 @@ impl MediaListMethods for MediaList {
         mq.media_queries.push(m.unwrap());
     }
 
-    // https://drafts.csswg.org/cssom/#dom-medialist-deletemedium
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-deletemedium>
     fn DeleteMedium(&self, medium: DOMString) {
         // Step 1
         let mut input = ParserInput::new(&medium);

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -129,12 +129,8 @@ impl URL {
                 },
             },
         };
-        match ServoUrl::parse_with_base(parsed_base.as_ref(), &url.0) {
-            // Step 3
-            Ok(_) => true,
-            // Step 2.2
-            Err(_) => false,
-        }
+        // Step 2.2, 3
+        ServoUrl::parse_with_base(parsed_base.as_ref(), &url.0).is_ok()
     }
 
     // https://w3c.github.io/FileAPI/#dfn-createObjectURL

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -24,16 +24,16 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::urlhelper::UrlHelper;
 use crate::dom::urlsearchparams::URLSearchParams;
 
-// https://url.spec.whatwg.org/#url
+/// <https://url.spec.whatwg.org/#url>
 #[dom_struct]
 pub struct URL {
     reflector_: Reflector,
 
-    // https://url.spec.whatwg.org/#concept-url-url
+    /// <https://url.spec.whatwg.org/#concept-url-url>
     #[no_trace]
     url: DomRefCell<ServoUrl>,
 
-    // https://url.spec.whatwg.org/#dom-url-searchparams
+    /// <https://url.spec.whatwg.org/#dom-url-searchparams>
     search_params: MutNullableDom<URLSearchParams>,
 }
 
@@ -75,7 +75,7 @@ impl URL {
 
 #[allow(non_snake_case)]
 impl URL {
-    // https://url.spec.whatwg.org/#constructors
+    /// <https://url.spec.whatwg.org/#constructors>
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -116,7 +116,7 @@ impl URL {
         Ok(URL::new(global, proto, parsed_url))
     }
 
-    // https://url.spec.whatwg.org/#dom-url-canparse
+    /// <https://url.spec.whatwg.org/#dom-url-canparse>
     pub fn CanParse(_global: &GlobalScope, url: USVString, base: Option<USVString>) -> bool {
         // Step 1.
         let parsed_base = match base {
@@ -133,7 +133,7 @@ impl URL {
         ServoUrl::parse_with_base(parsed_base.as_ref(), &url.0).is_ok()
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-createObjectURL
+    /// <https://w3c.github.io/FileAPI/#dfn-createObjectURL>
     pub fn CreateObjectURL(global: &GlobalScope, blob: &Blob) -> DOMString {
         // XXX: Second field is an unicode-serialized Origin, it is a temporary workaround
         //      and should not be trusted. See issue https://github.com/servo/servo/issues/11722
@@ -144,7 +144,7 @@ impl URL {
         DOMString::from(URL::unicode_serialization_blob_url(&origin, &id))
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-revokeObjectURL
+    /// <https://w3c.github.io/FileAPI/#dfn-revokeObjectURL>
     pub fn RevokeObjectURL(global: &GlobalScope, url: DOMString) {
         // If the value provided for the url argument is not a Blob URL OR
         // if the value provided for the url argument does not have an entry in the Blob URL Store,
@@ -165,7 +165,7 @@ impl URL {
         }
     }
 
-    // https://w3c.github.io/FileAPI/#unicodeSerializationOfBlobURL
+    /// <https://w3c.github.io/FileAPI/#unicodeSerializationOfBlobURL>
     fn unicode_serialization_blob_url(origin: &str, id: &Uuid) -> String {
         // Step 1, 2
         let mut result = "blob:".to_string();
@@ -184,42 +184,42 @@ impl URL {
 }
 
 impl URLMethods for URL {
-    // https://url.spec.whatwg.org/#dom-url-hash
+    /// <https://url.spec.whatwg.org/#dom-url-hash>
     fn Hash(&self) -> USVString {
         UrlHelper::Hash(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-hash
+    /// <https://url.spec.whatwg.org/#dom-url-hash>
     fn SetHash(&self, value: USVString) {
         UrlHelper::SetHash(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-host
+    /// <https://url.spec.whatwg.org/#dom-url-host>
     fn Host(&self) -> USVString {
         UrlHelper::Host(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-host
+    /// <https://url.spec.whatwg.org/#dom-url-host>
     fn SetHost(&self, value: USVString) {
         UrlHelper::SetHost(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-hostname
+    /// <https://url.spec.whatwg.org/#dom-url-hostname>
     fn Hostname(&self) -> USVString {
         UrlHelper::Hostname(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-hostname
+    /// <https://url.spec.whatwg.org/#dom-url-hostname>
     fn SetHostname(&self, value: USVString) {
         UrlHelper::SetHostname(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-href
+    /// <https://url.spec.whatwg.org/#dom-url-href>
     fn Href(&self) -> USVString {
         UrlHelper::Href(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-href
+    /// <https://url.spec.whatwg.org/#dom-url-href>
     fn SetHref(&self, value: USVString) -> ErrorResult {
         match ServoUrl::parse(&value.0) {
             Ok(url) => {
@@ -231,57 +231,57 @@ impl URLMethods for URL {
         }
     }
 
-    // https://url.spec.whatwg.org/#dom-url-password
+    /// <https://url.spec.whatwg.org/#dom-url-password>
     fn Password(&self) -> USVString {
         UrlHelper::Password(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-password
+    /// <https://url.spec.whatwg.org/#dom-url-password>
     fn SetPassword(&self, value: USVString) {
         UrlHelper::SetPassword(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-pathname
+    /// <https://url.spec.whatwg.org/#dom-url-pathname>
     fn Pathname(&self) -> USVString {
         UrlHelper::Pathname(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-pathname
+    /// <https://url.spec.whatwg.org/#dom-url-pathname>
     fn SetPathname(&self, value: USVString) {
         UrlHelper::SetPathname(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-port
+    /// <https://url.spec.whatwg.org/#dom-url-port>
     fn Port(&self) -> USVString {
         UrlHelper::Port(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-port
+    /// <https://url.spec.whatwg.org/#dom-url-port>
     fn SetPort(&self, value: USVString) {
         UrlHelper::SetPort(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-protocol
+    /// <https://url.spec.whatwg.org/#dom-url-protocol>
     fn Protocol(&self) -> USVString {
         UrlHelper::Protocol(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-protocol
+    /// <https://url.spec.whatwg.org/#dom-url-protocol>
     fn SetProtocol(&self, value: USVString) {
         UrlHelper::SetProtocol(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-origin
+    /// <https://url.spec.whatwg.org/#dom-url-origin>
     fn Origin(&self) -> USVString {
         UrlHelper::Origin(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-search
+    /// <https://url.spec.whatwg.org/#dom-url-search>
     fn Search(&self) -> USVString {
         UrlHelper::Search(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-search
+    /// <https://url.spec.whatwg.org/#dom-url-search>
     fn SetSearch(&self, value: USVString) {
         UrlHelper::SetSearch(&mut self.url.borrow_mut(), value);
         if let Some(search_params) = self.search_params.get() {
@@ -289,23 +289,23 @@ impl URLMethods for URL {
         }
     }
 
-    // https://url.spec.whatwg.org/#dom-url-searchparams
+    /// <https://url.spec.whatwg.org/#dom-url-searchparams>
     fn SearchParams(&self) -> DomRoot<URLSearchParams> {
         self.search_params
             .or_init(|| URLSearchParams::new(&self.global(), Some(self)))
     }
 
-    // https://url.spec.whatwg.org/#dom-url-username
+    /// <https://url.spec.whatwg.org/#dom-url-username>
     fn Username(&self) -> USVString {
         UrlHelper::Username(&self.url.borrow())
     }
 
-    // https://url.spec.whatwg.org/#dom-url-username
+    /// <https://url.spec.whatwg.org/#dom-url-username>
     fn SetUsername(&self, value: USVString) {
         UrlHelper::SetUsername(&mut self.url.borrow_mut(), value);
     }
 
-    // https://url.spec.whatwg.org/#dom-url-tojson
+    /// <https://url.spec.whatwg.org/#dom-url-tojson>
     fn ToJSON(&self) -> USVString {
         self.Href()
     }

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -79,7 +79,7 @@ impl URLSearchParams {
             USVStringSequenceSequenceOrUSVStringUSVStringRecordOrUSVString::USVString(init) => {
                 // Step 4.
                 let init_bytes = match init.0.chars().next() {
-                    Some(first_char) if first_char == '?' => {
+                    Some('?') => {
                         let (_, other_bytes) = init.0.as_bytes().split_at(1);
 
                         other_bytes

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -18,13 +18,13 @@ use crate::dom::bindings::weakref::MutableWeakRef;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::url::URL;
 
-// https://url.spec.whatwg.org/#interface-urlsearchparams
+/// <https://url.spec.whatwg.org/#interface-urlsearchparams>
 #[dom_struct]
 pub struct URLSearchParams {
     reflector_: Reflector,
-    // https://url.spec.whatwg.org/#concept-urlsearchparams-list
+    /// <https://url.spec.whatwg.org/#concept-urlsearchparams-list>
     list: DomRefCell<Vec<(String, String)>>,
-    // https://url.spec.whatwg.org/#concept-urlsearchparams-url-object
+    /// <https://url.spec.whatwg.org/#concept-urlsearchparams-url-object>
     url: MutableWeakRef<URL>,
 }
 
@@ -49,7 +49,7 @@ impl URLSearchParams {
         reflect_dom_object_with_proto(Box::new(URLSearchParams::new_inherited(url)), global, proto)
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams>
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
@@ -102,12 +102,12 @@ impl URLSearchParams {
 }
 
 impl URLSearchParamsMethods for URLSearchParams {
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-size
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-size>
     fn Size(&self) -> u32 {
         self.list.borrow().len() as u32
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-append
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-append>
     fn Append(&self, name: USVString, value: USVString) {
         // Step 1.
         self.list.borrow_mut().push((name.0, value.0));
@@ -115,7 +115,7 @@ impl URLSearchParamsMethods for URLSearchParams {
         self.update_steps();
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-delete
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-delete>
     fn Delete(&self, name: USVString, value: Option<USVString>) {
         // Step 1.
         self.list.borrow_mut().retain(|(k, v)| match &value {
@@ -126,7 +126,7 @@ impl URLSearchParamsMethods for URLSearchParams {
         self.update_steps();
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-get
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-get>
     fn Get(&self, name: USVString) -> Option<USVString> {
         let list = self.list.borrow();
         list.iter()
@@ -134,7 +134,7 @@ impl URLSearchParamsMethods for URLSearchParams {
             .map(|kv| USVString(kv.1.clone()))
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-getall
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-getall>
     fn GetAll(&self, name: USVString) -> Vec<USVString> {
         let list = self.list.borrow();
         list.iter()
@@ -148,7 +148,7 @@ impl URLSearchParamsMethods for URLSearchParams {
             .collect()
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-has
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-has>
     fn Has(&self, name: USVString, value: Option<USVString>) -> bool {
         let list = self.list.borrow();
         list.iter().any(|(k, v)| match &value {
@@ -157,7 +157,7 @@ impl URLSearchParamsMethods for URLSearchParams {
         })
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-set
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-set>
     fn Set(&self, name: USVString, value: USVString) {
         {
             // Step 1.
@@ -185,7 +185,7 @@ impl URLSearchParamsMethods for URLSearchParams {
         self.update_steps();
     }
 
-    // https://url.spec.whatwg.org/#dom-urlsearchparams-sort
+    /// <https://url.spec.whatwg.org/#dom-urlsearchparams-sort>
     fn Sort(&self) {
         // Step 1.
         self.list
@@ -196,14 +196,14 @@ impl URLSearchParamsMethods for URLSearchParams {
         self.update_steps();
     }
 
-    // https://url.spec.whatwg.org/#stringification-behavior
+    /// <https://url.spec.whatwg.org/#stringification-behavior>
     fn Stringifier(&self) -> DOMString {
         DOMString::from(self.serialize_utf8())
     }
 }
 
 impl URLSearchParams {
-    // https://url.spec.whatwg.org/#concept-urlencoded-serializer
+    /// <https://url.spec.whatwg.org/#concept-urlencoded-serializer>
     pub fn serialize_utf8(&self) -> String {
         let list = self.list.borrow();
         form_urlencoded::Serializer::new(String::new())
@@ -211,7 +211,7 @@ impl URLSearchParams {
             .finish()
     }
 
-    // https://url.spec.whatwg.org/#concept-urlsearchparams-update
+    /// <https://url.spec.whatwg.org/#concept-urlsearchparams-update>
     fn update_steps(&self) {
         if let Some(url) = self.url.root() {
             url.set_query_pairs(&self.list.borrow())

--- a/components/script/dom/xrrenderstate.rs
+++ b/components/script/dom/xrrenderstate.rs
@@ -93,10 +93,7 @@ impl XRRenderState {
         self.base_layer.set(layer)
     }
     pub fn set_layers(&self, layers: Vec<&XRLayer>) {
-        *self.layers.borrow_mut() = layers
-            .into_iter()
-            .map(|layer| Dom::from_ref(layer))
-            .collect();
+        *self.layers.borrow_mut() = layers.into_iter().map(Dom::from_ref).collect();
     }
     pub fn with_layers<F, R>(&self, f: F) -> R
     where

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3567,11 +3567,12 @@ impl ScriptThread {
                 // We might have to reset the anchor state
                 if !state_already_changed {
                     if let Some(target) = prev_mouse_over_target {
-                        if let Some(_) = target
+                        if target
                             .upcast::<Node>()
                             .inclusive_ancestors(ShadowIncluding::No)
                             .filter_map(DomRoot::downcast::<HTMLAnchorElement>)
                             .next()
+                            .is_some()
                         {
                             let event = EmbedderMsg::Status(None);
                             window.send_to_embedder(event);


### PR DESCRIPTION
Fixes `redundant_*` clippy warnings. Also updates the spec comments in the files changed to be propper rustdoc.

- [`redundant_file_names`](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_field_names): Removes duplicate field names in struct initialization to avoid.
- [`redundant_closure`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure): Functions can be passed directly instead of wrapping them in a closure.
- [`redundant_pattern_matching`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching): `is_ok` and `is_err` can be used instead. Here the only part I'm unsure is what to do about the steps in `components/script/dom/url.rs`, since this merges step 2.2 and 3 together.
- [`redundant_guards`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_guards): The pattern can be added directly to the `Some(...)` pattern instead of checked with an extra `if`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500
- [x] These changes do not require tests because they don't modify behaviour