### PR TITLE
clippy: Fix `comparison_*` warnings

### DIFF
--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -68,7 +68,7 @@ impl DOMTokenList {
         }
     }
 
-    // https://dom.spec.whatwg.org/#concept-dtl-update
+    /// <https://dom.spec.whatwg.org/#concept-dtl-update>
     fn perform_update_steps(&self, atoms: Vec<Atom>) {
         // Step 1
         if !self.element.has_attribute(&self.local_name) && atoms.is_empty() {
@@ -79,7 +79,7 @@ impl DOMTokenList {
             .set_atomic_tokenlist_attribute(&self.local_name, atoms)
     }
 
-    // https://dom.spec.whatwg.org/#concept-domtokenlist-validation
+    /// <https://dom.spec.whatwg.org/#concept-domtokenlist-validation>
     fn validation_steps(&self, token: &str) -> Fallible<bool> {
         match &self.supported_tokens {
             None => Err(Error::Type(
@@ -99,15 +99,15 @@ impl DOMTokenList {
     }
 }
 
-// https://dom.spec.whatwg.org/#domtokenlist
+/// <https://dom.spec.whatwg.org/#domtokenlist>
 impl DOMTokenListMethods for DOMTokenList {
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-length
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-length>
     fn Length(&self) -> u32 {
         self.attribute()
             .map_or(0, |attr| attr.value().as_tokens().len()) as u32
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-item
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-item>
     fn Item(&self, index: u32) -> Option<DOMString> {
         self.attribute().and_then(|attr| {
             // FIXME(ajeffrey): Convert directly from Atom to DOMString
@@ -118,7 +118,7 @@ impl DOMTokenListMethods for DOMTokenList {
         })
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-contains
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-contains>
     fn Contains(&self, token: DOMString) -> bool {
         let token = Atom::from(token);
         self.attribute().map_or(false, |attr| {
@@ -129,7 +129,7 @@ impl DOMTokenListMethods for DOMTokenList {
         })
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-add
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-add>
     fn Add(&self, tokens: Vec<DOMString>) -> ErrorResult {
         let mut atoms = self.element.get_tokenlist_attribute(&self.local_name);
         for token in &tokens {
@@ -142,7 +142,7 @@ impl DOMTokenListMethods for DOMTokenList {
         Ok(())
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-remove
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-remove>
     fn Remove(&self, tokens: Vec<DOMString>) -> ErrorResult {
         let mut atoms = self.element.get_tokenlist_attribute(&self.local_name);
         for token in &tokens {
@@ -156,7 +156,7 @@ impl DOMTokenListMethods for DOMTokenList {
         Ok(())
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-toggle
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-toggle>
     fn Toggle(&self, token: DOMString, force: Option<bool>) -> Fallible<bool> {
         let mut atoms = self.element.get_tokenlist_attribute(&self.local_name);
         let token = self.check_token_exceptions(&token)?;
@@ -180,18 +180,18 @@ impl DOMTokenListMethods for DOMTokenList {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-value
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-value>
     fn Value(&self) -> DOMString {
         self.element.get_string_attribute(&self.local_name)
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-value
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-value>
     fn SetValue(&self, value: DOMString) {
         self.element
             .set_tokenlist_attribute(&self.local_name, value);
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-replace
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-replace>
     fn Replace(&self, token: DOMString, new_token: DOMString) -> Fallible<bool> {
         if token.is_empty() || new_token.is_empty() {
             // Step 1.
@@ -207,23 +207,27 @@ impl DOMTokenListMethods for DOMTokenList {
         let mut atoms = self.element.get_tokenlist_attribute(&self.local_name);
         let mut result = false;
         if let Some(pos) = atoms.iter().position(|atom| *atom == token) {
-            if let Some(redundant_pos) = atoms.iter().position(|atom| *atom == new_token) {
-                if redundant_pos > pos {
+            match atoms.iter().position(|atom| *atom == new_token) {
+                Some(redundant_pos) if redundant_pos > pos => {
                     // The replacement is already in the list, later,
                     // so we perform the replacement and remove the
                     // later copy.
                     atoms[pos] = new_token;
                     atoms.remove(redundant_pos);
-                } else if redundant_pos < pos {
+                },
+                Some(redundant_pos) if redundant_pos < pos => {
                     // The replacement is already in the list, earlier,
                     // so we remove the index where we'd be putting the
                     // later copy.
                     atoms.remove(pos);
-                }
-            // else we are replacing the token with itself, nothing to change
-            } else {
-                // The replacement is not in the list already
-                atoms[pos] = new_token;
+                },
+                Some(_) => {
+                    // Else we are replacing the token with itself, nothing to change
+                },
+                None => {
+                    // The replacement is not in the list already
+                    atoms[pos] = new_token;
+                },
             }
 
             // Step 5.
@@ -233,7 +237,7 @@ impl DOMTokenListMethods for DOMTokenList {
         Ok(result)
     }
 
-    // https://dom.spec.whatwg.org/#dom-domtokenlist-supports
+    /// <https://dom.spec.whatwg.org/#dom-domtokenlist-supports>
     fn Supports(&self, token: DOMString) -> Fallible<bool> {
         self.validation_steps(&token)
     }

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -85,7 +85,7 @@ impl HTMLMetaElement {
             if name == "referrer" {
                 self.apply_referrer();
             }
-        } else if &*self.HttpEquiv() != "" {
+        } else if !self.HttpEquiv().is_empty() {
             self.declarative_refresh();
         }
     }

--- a/components/script/dom/htmloptionscollection.rs
+++ b/components/script/dom/htmloptionscollection.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cmp::Ordering;
+
 use dom_struct::dom_struct;
 use html5ever::local_name;
 
@@ -120,27 +122,31 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length
+    /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length>
     fn Length(&self) -> u32 {
         self.upcast().Length()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length
+    /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length>
     fn SetLength(&self, length: u32) {
         let current_length = self.upcast().Length();
         let delta = length as i32 - current_length as i32;
-        if delta < 0 {
-            // new length is lower - deleting last option elements
-            for index in (length..current_length).rev() {
-                self.Remove(index as i32)
-            }
-        } else if delta > 0 {
-            // new length is higher - adding new option elements
-            self.add_new_elements(delta as u32).unwrap();
+        match delta.cmp(&0) {
+            Ordering::Less => {
+                // new length is lower - deleting last option elements
+                for index in (length..current_length).rev() {
+                    self.Remove(index as i32)
+                }
+            },
+            Ordering::Greater => {
+                // new length is higher - adding new option elements
+                self.add_new_elements(delta as u32).unwrap();
+            },
+            _ => {},
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-add
+    /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-add>
     fn Add(
         &self,
         element: HTMLOptionElementOrHTMLOptGroupElement,
@@ -195,14 +201,14 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
         Node::pre_insert(node, &parent, reference_node.as_deref()).map(|_| ())
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-remove
+    /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-remove>
     fn Remove(&self, index: i32) {
         if let Some(element) = self.upcast().IndexedGetter(index as u32) {
             element.Remove();
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex
+    /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex>
     fn SelectedIndex(&self) -> i32 {
         self.upcast()
             .root_node()
@@ -211,7 +217,7 @@ impl HTMLOptionsCollectionMethods for HTMLOptionsCollection {
             .SelectedIndex()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex
+    /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex>
     fn SetSelectedIndex(&self, index: i32) {
         self.upcast()
             .root_node()


### PR DESCRIPTION
Fixes `comparison_*` clippy warnings. Also updates the spec comments in the files changed to be propper rustdoc.

- [`comparison_to_empty`](https://rust-lang.github.io/rust-clippy/master/index.html#comparison_to_empty): Use `is_empty` instead of an explicit comparison to an empty string.
- [`comparison_chain`](https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain): Use `match` and `cmp::Ordering` instead of an `if` / `else if` statements for comparing if a value is greater, lower and equal than other. This is a [controversial](https://github.com/rust-lang/rust-clippy/issues/4531) lint, so I'm fine with changing it back and adding an allow.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #31500
- [x] These changes do not require tests because they don't modify behaviour