### PR TITLE
Treat indefinite percentages as auto for margin collapse

### DIFF
--- a/tests/wpt/meta/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html.ini
@@ -1,2 +1,0 @@
-[margin-collapse-through-percentage-height-block.html]
-  expected: FAIL


### PR DESCRIPTION
The top and bottom margins of an element can collapse through if its height is auto or zero. Indefinite percentages behave as auto, so they shouldn't prevent the margins from collapsing.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
