### PR TITLE
Element collapsing thru should collapse with its children

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -641,9 +641,6 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     let computed_block_size = style.content_block_size();
     let start_margin_can_collapse_with_children =
         pbm.padding.block_start == Au::zero() && pbm.border.block_start == Au::zero();
-    let end_margin_can_collapse_with_children = pbm.padding.block_end == Au::zero() &&
-        pbm.border.block_end == Au::zero() &&
-        computed_block_size.is_auto();
 
     let mut clearance = None;
     let parent_containing_block_position_info;
@@ -745,6 +742,17 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
                 ));
         }
     }
+
+    let collapsed_through = collapsible_margins_in_children.collapsed_through &&
+        pbm.padding_border_sums.block == Au::zero() &&
+        block_size_is_zero_or_auto(computed_block_size, containing_block) &&
+        block_size_is_zero_or_auto(style.min_block_size(), containing_block);
+    block_margins_collapsed_with_children.collapsed_through = collapsed_through;
+
+    let end_margin_can_collapse_with_children = collapsed_through ||
+        (pbm.padding.block_end == Au::zero() &&
+            pbm.border.block_end == Au::zero() &&
+            computed_block_size.is_auto());
     if end_margin_can_collapse_with_children {
         block_margins_collapsed_with_children
             .end
@@ -752,12 +760,6 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     } else {
         content_block_size += collapsible_margins_in_children.end.solve().into();
     }
-
-    block_margins_collapsed_with_children.collapsed_through = collapsible_margins_in_children
-        .collapsed_through &&
-        pbm.padding_border_sums.block == Au::zero() &&
-        block_size_is_zero_or_auto(computed_block_size, containing_block) &&
-        block_size_is_zero_or_auto(style.min_block_size(), containing_block);
 
     let block_size = containing_block_for_children.block_size.auto_is(|| {
         content_block_size

--- a/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-collapse-clear-011-ref.xht
+++ b/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-collapse-clear-011-ref.xht
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com"/>
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+ </head>
+ <body style="font: 25px/1 Ahem">
+  <div style="margin-bottom: 1em">X</div>
+  <div style="color: cyan;">X</div>
+  <div style="color: magenta">X</div>
+ </body>
+</html>

--- a/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-collapse-clear-011.xht
+++ b/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-collapse-clear-011.xht
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Test: Margin Collapsing with Clearance</title>
+  <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#flow-control"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#collapsing-margins"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#floats"/>
+  <link rel="match" href="margin-collapse-clear-011-ref.xht"/>
+  <meta name="assert" content="The magenta X appears below the cyan X due to clearance"/>
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+ </head>
+ <body style="font: 25px/1 Ahem">
+  <div style="margin-bottom: 1em">X</div>
+  <div style="float: left; color: cyan;">X</div>
+  <div style="margin-bottom: 1em; height: 0px;">
+    <div style="margin-bottom: -1em;"></div>
+  </div>
+  <div style="clear: both; color: magenta">X</div>
+ </body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
If the top and bottom margins of an element collapse through, then this patch treats the bottom margin as collapsing with its children, even if `height` doesn't compute to zero.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
