### PR TITLE
layout: Resolve definite percentages when determining margin collapse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7844,7 +7844,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8423,12 +8423,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "bitflags 2.9.4",
  "stylo_malloc_size_of",
@@ -8449,7 +8449,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8466,12 +8466,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
@@ -8886,7 +8886,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8899,7 +8899,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#2f19a2679ed7fd1063d5965b7c2926ef90369bbc"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/sizing.rs
+++ b/components/layout/sizing.rs
@@ -609,6 +609,14 @@ impl SizeConstraint {
             _ => None,
         }
     }
+
+    #[inline]
+    pub(crate) fn definite_or_min(self) -> Au {
+        match self {
+            Self::Definite(size) => size,
+            Self::MinMax(min, _) => min,
+        }
+    }
 }
 
 impl From<Option<Au>> for SizeConstraint {

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -1472,10 +1472,7 @@ impl<'a> TableLayout<'a> {
         // space for the entire table wrapper, but here we are using that amount for the table grid.
         // Therefore, if there is a caption, this will cause overflow. Gecko and WebKit have the
         // same problem, but not Blink.
-        let table_height_from_style = match containing_block_for_children.size.block {
-            SizeConstraint::Definite(size) => size,
-            SizeConstraint::MinMax(min, _) => min,
-        };
+        let table_height_from_style = containing_block_for_children.size.block.definite_or_min();
 
         let block_border_spacing = self.table.total_border_spacing().block;
         let table_height_from_rows = row_sizes.iter().sum::<Au>() + block_border_spacing;

--- a/tests/wpt/tests/css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/margin-collapse-through-for-various-height-values.tentative.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/box.html#collapsing-margins">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/8919">
+<link rel="help" href="https://github.com/servo/servo/pull/32064">
+<meta name="assert" content="
+  Margins can collapse through when the used height is zero, regardless of the computed values
+  of `height`, `min-height` and `max-height`.
+
+  Note that this test uses sizing values which didn't exist in CSS2, but since the expectations
+  only depend on the used height, the test can still pass on implementations that don't support
+  these values.
+">
+
+<style>
+.before, .after {
+  overflow: hidden;
+}
+.wrapper {
+  border: 1px solid;
+  margin-bottom: 2em;
+}
+.test {
+  margin: 50px;
+}
+</style>
+
+<div id="log"></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let testcases = [
+  // Tests for `height`
+  { height: "auto" },
+  { height: "0px" },
+  { height: "1px" },
+  { height: "0%", parentHeight: "auto" },
+  { height: "0%", parentHeight: "0px" },
+  { height: "0%", parentHeight: "100px" },
+  { height: "1%", parentHeight: "auto" },
+  { height: "1%", parentHeight: "0px" },
+  { height: "1%", parentHeight: "100px" },
+  { height: "calc(0px + 0%)", parentHeight: "auto" },
+  { height: "calc(0px + 0%)", parentHeight: "0px" },
+  { height: "calc(0px + 0%)", parentHeight: "100px" },
+  { height: "calc(0px + 1%)", parentHeight: "auto" },
+  { height: "calc(0px + 1%)", parentHeight: "0px" },
+  { height: "calc(0px + 1%)", parentHeight: "100px" },
+  { height: "calc(1px + 0%)", parentHeight: "auto" },
+  { height: "calc(1px + 0%)", parentHeight: "0px" },
+  { height: "calc(1px + 0%)", parentHeight: "100px" },
+  { height: "calc(1px + 1%)", parentHeight: "auto" },
+  { height: "calc(1px + 1%)", parentHeight: "0px" },
+  { height: "calc(1px + 1%)", parentHeight: "100px" },
+  { height: "stretch", parentHeight: "auto" },
+  { height: "stretch", parentHeight: "0px" },
+  { height: "stretch", parentHeight: "100px" },
+
+  // Tests for `min-height` (with `height: auto`)
+  { minHeight: "auto" },
+  { minHeight: "0px" },
+  { minHeight: "1px" },
+  { minHeight: "0%", parentHeight: "auto" },
+  { minHeight: "0%", parentHeight: "0px" },
+  { minHeight: "0%", parentHeight: "100px" },
+  { minHeight: "1%", parentHeight: "auto" },
+  { minHeight: "1%", parentHeight: "0px" },
+  { minHeight: "1%", parentHeight: "100px" },
+  { minHeight: "calc(0px + 0%)", parentHeight: "auto" },
+  { minHeight: "calc(0px + 0%)", parentHeight: "0px" },
+  { minHeight: "calc(0px + 0%)", parentHeight: "100px" },
+  { minHeight: "calc(0px + 1%)", parentHeight: "auto" },
+  { minHeight: "calc(0px + 1%)", parentHeight: "0px" },
+  { minHeight: "calc(0px + 1%)", parentHeight: "100px" },
+  { minHeight: "calc(1px + 0%)", parentHeight: "auto" },
+  { minHeight: "calc(1px + 0%)", parentHeight: "0px" },
+  { minHeight: "calc(1px + 0%)", parentHeight: "100px" },
+  { minHeight: "calc(1px + 1%)", parentHeight: "auto" },
+  { minHeight: "calc(1px + 1%)", parentHeight: "0px" },
+  { minHeight: "calc(1px + 1%)", parentHeight: "100px" },
+  { minHeight: "stretch", parentHeight: "auto" },
+  { minHeight: "stretch", parentHeight: "0px" },
+  { minHeight: "stretch", parentHeight: "100px" },
+
+  // Tests for `max-height` (with `height: 1px`)
+  { height: "1px", maxHeight: "none" },
+  { height: "1px", maxHeight: "0px" },
+  { height: "1px", maxHeight: "1px" },
+  { height: "1px", maxHeight: "0%", parentHeight: "auto" },
+  { height: "1px", maxHeight: "0%", parentHeight: "0px" },
+  { height: "1px", maxHeight: "0%", parentHeight: "100px" },
+  { height: "1px", maxHeight: "1%", parentHeight: "auto" },
+  { height: "1px", maxHeight: "1%", parentHeight: "0px" },
+  { height: "1px", maxHeight: "1%", parentHeight: "100px" },
+  { height: "1px", maxHeight: "calc(0px + 0%)", parentHeight: "auto" },
+  { height: "1px", maxHeight: "calc(0px + 0%)", parentHeight: "0px" },
+  { height: "1px", maxHeight: "calc(0px + 0%)", parentHeight: "100px" },
+  { height: "1px", maxHeight: "calc(0px + 1%)", parentHeight: "auto" },
+  { height: "1px", maxHeight: "calc(0px + 1%)", parentHeight: "0px" },
+  { height: "1px", maxHeight: "calc(0px + 1%)", parentHeight: "100px" },
+  { height: "1px", maxHeight: "calc(1px + 0%)", parentHeight: "auto" },
+  { height: "1px", maxHeight: "calc(1px + 0%)", parentHeight: "0px" },
+  { height: "1px", maxHeight: "calc(1px + 0%)", parentHeight: "100px" },
+  { height: "1px", maxHeight: "calc(1px + 1%)", parentHeight: "auto" },
+  { height: "1px", maxHeight: "calc(1px + 1%)", parentHeight: "0px" },
+  { height: "1px", maxHeight: "calc(1px + 1%)", parentHeight: "100px" },
+  { height: "1px", maxHeight: "stretch", parentHeight: "auto" },
+  { height: "1px", maxHeight: "stretch", parentHeight: "0px" },
+  { height: "1px", maxHeight: "stretch", parentHeight: "100px" },
+];
+
+function generate(testcase, serialization) {
+  let { height, minHeight, maxHeight, parentHeight, ...unrecognized } = testcase;
+  assert_array_equals(Object.keys(unrecognized), [], "No unrecognized key.");
+  let wrapper = document.createElement("div");
+  wrapper.className = "wrapper";
+  wrapper.style.height = parentHeight || "";
+  let before = document.createElement("div");
+  before.className = "before";
+  before.textContent = serialization;
+  let after = document.createElement("div");
+  after.className = "after";
+  let test = document.createElement("div");
+  test.className = "test";
+  test.style.height = height || "";
+  test.style.minHeight = minHeight || "";
+  test.style.maxHeight = maxHeight || "";
+  wrapper.append(before, test, after);
+  document.body.append(wrapper);
+  return [before, test, after];
+}
+function round(value) {
+  return Math.round(value * 10) / 10;
+}
+
+let resolveDomReady;
+let domReady = new Promise(resolve => {
+  resolveDomReady = resolve;
+});
+for (let testcase of testcases) {
+  let serialization = JSON.stringify(testcase);
+  promise_test(async () => {
+    let [before, test, after] = generate(testcase, serialization);
+
+    // The checks below force layout, so as an optimization, run them asynchronously after generating all tests.
+    await domReady;
+    let height = round(test.getBoundingClientRect().height);
+    let marginSum = round(after.getBoundingClientRect().top - before.getBoundingClientRect().bottom) - height;
+    if (height === 0) {
+      assert_equals(marginSum, 50, "margins should collapse through");
+    } else {
+      assert_equals(marginSum, 100, "margins should NOT collapse through when height is " + height);
+    }
+  }, serialization);
+}
+resolveDomReady();
+</script>


### PR DESCRIPTION
Previously we were treating a definite 0% as zero, but a definite 100% that resolved into 0px as non-zero.

That didn't make much sense, so this patch stops checking the computed values, and instead checks the layout values which have already resolved percentages. This also implies that we will now take `max-block-size` into account.

This brings Servo closer to Blink, but differs from Gecko and WebKit.

Testing: Adding new test

Stylo PR: https://github.com/servo/stylo/pull/254