### PR TITLE
layout: Add support for `<object>` with image data URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3091,6 +3091,7 @@ dependencies = [
  "bitflags 2.5.0",
  "canvas_traits",
  "cssparser",
+ "data-url",
  "embedder_traits",
  "euclid",
  "fnv",
@@ -3119,6 +3120,7 @@ dependencies = [
  "style_traits",
  "unicode-script",
  "unicode-segmentation",
+ "url",
  "webrender_api",
  "xi-unicode",
 ]

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -44,6 +44,8 @@ style = { workspace = true }
 style_traits = { workspace = true }
 unicode-script = { workspace = true }
 unicode-segmentation = { workspace = true }
+url = { workspace = true }
+data-url = { workspace = true }
 webrender_api = { workspace = true }
 xi-unicode = { workspace = true }
 

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -175,7 +175,7 @@ fn traverse_element<'dom, Node>(
 ) where
     Node: NodeExt<'dom>,
 {
-    let replaced = ReplacedContent::for_element(element);
+    let replaced = ReplacedContent::for_element(element, context);
     let style = element.style(context);
     match Display::from(style.get_box().display) {
         Display::None => element.unset_all_boxes(),

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -204,7 +204,7 @@ impl BoxTree {
 
         loop {
             if let Some((primary_style, display_inside, update_point)) = update_point(dirty_node) {
-                let contents = ReplacedContent::for_element(dirty_node)
+                let contents = ReplacedContent::for_element(dirty_node, context)
                     .map_or(Contents::OfElement, Contents::Replaced);
                 let info = NodeAndStyleInfo::new(dirty_node, Arc::clone(&primary_style));
                 let out_of_flow_absolutely_positioned_box = ArcRefCell::new(
@@ -262,8 +262,8 @@ fn construct_for_root_element<'dom>(
         Display::GeneratingBox(display_generating_box) => display_generating_box.display_inside(),
     };
 
-    let contents =
-        ReplacedContent::for_element(root_element).map_or(Contents::OfElement, Contents::Replaced);
+    let contents = ReplacedContent::for_element(root_element, context)
+        .map_or(Contents::OfElement, Contents::Replaced);
     let root_box = if box_style.position.is_absolutely_positioned() {
         BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
             AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),

--- a/tests/wpt/meta/quirks/table-cell-width-calculation.html.ini
+++ b/tests/wpt/meta/quirks/table-cell-width-calculation.html.ini
@@ -34,3 +34,6 @@
 
   [The table cell width calculation quirk, non-auto width on cell]
     expected: FAIL
+
+  [The table cell width calculation quirk, the quirk shouldn't apply for <object>]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/css/object_element_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/object_element_a.html.ini
@@ -1,2 +1,0 @@
-[object_element_a.html]
-  expected: FAIL


### PR DESCRIPTION
This is enough support for `<object>` to get Acid2 working.

<!-- Please describe your changes on the following line: -->

Co-authored-by: Oriol Brufau <obrufau@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
