### PR TITLE
Backout `Host`-header related change from #32024.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1225,20 +1225,7 @@ async fn http_network_or_cache_fetch(
 
     // Step 5.16
     let current_url = http_request.current_url();
-    if !http_request.headers.contains_key(header::HOST) {
-        let host = if current_url.port().is_none() {
-            current_url.host_str().unwrap().to_string()
-        } else {
-            format!(
-                "{}:{}",
-                current_url.host_str().unwrap(),
-                current_url.port().unwrap()
-            )
-        };
-        http_request.headers.typed_insert(headers::Host::from(
-            host.parse::<http::uri::Authority>().unwrap(),
-        ));
-    }
+    http_request.headers.remove(header::HOST);
 
     // unlike http_loader, we should not set the accept header
     // here, according to the fetch spec

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1359,15 +1359,6 @@ fn test_fetch_with_devtools() {
 
     headers.typed_insert::<UserAgent>(DEFAULT_USER_AGENT.parse().unwrap());
 
-    let host = if url.port().is_none() {
-        url.host_str().unwrap().to_string()
-    } else {
-        format!("{}:{}", url.host_str().unwrap(), url.port().unwrap())
-    };
-    headers.typed_insert(headers::Host::from(
-        host.parse::<http::uri::Authority>().unwrap(),
-    ));
-
     headers.insert(
         header::ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -266,8 +266,6 @@ fn test_request_and_response_data_with_network_messages() {
     //Creating default headers for request
     let mut headers = HeaderMap::new();
 
-    headers.insert(header::HOST, HeaderValue::from_static("bar.foo"));
-
     headers.insert(
         header::ACCEPT,
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Partial backout of #32024.

#32024 broke a different set of nginx sites, and a more sophisticated fix for the case of a missing HTTP 1.1 `Host` header is required. Until then, revert to previous behaviour.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
