### PR TITLE
layout: Add support for `clear` on `<br>` elements

### DIFF
--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-000.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-000.html.ini
@@ -1,2 +1,0 @@
-[floats-clear-multicol-000.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-001.html.ini
@@ -1,2 +1,0 @@
-[floats-clear-multicol-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-balancing-000.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-balancing-000.html.ini
@@ -1,2 +1,0 @@
-[floats-clear-multicol-balancing-000.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-balancing-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/floats-clear-multicol-balancing-001.html.ini
@@ -1,2 +1,0 @@
-[floats-clear-multicol-balancing-001.html]
-  expected: FAIL


### PR DESCRIPTION
`<br>` elements are a bit "special" in the sense that they defer a
linebreak, but can also have `clear` applied to them. The `clear` that
they supply should be applied *after* the linebreak is processed. This
change adds special processing for this situation.

Fixes #15402.
Fixes #8960.
Fixes #7311.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15402.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
