### PR TITLE
Rename `FontTemplateInfo` to `FontTemplateAndWebRenderFontKey`

### DIFF
--- a/components/gfx/tests/font_context.rs
+++ b/components/gfx/tests/font_context.rs
@@ -14,7 +14,7 @@ use gfx::font::{
     fallback_font_families, FontDescriptor, FontFamilyDescriptor, FontFamilyName,
     FontHandleMethods, FontSearchScope,
 };
-use gfx::font_cache_thread::{FontIdentifier, FontTemplateInfo, FontTemplates};
+use gfx::font_cache_thread::{FontIdentifier, FontTemplateAndWebRenderFontKey, FontTemplates};
 use gfx::font_context::{FontContext, FontSource};
 use gfx::font_template::FontTemplateDescriptor;
 use servo_arc::Arc;
@@ -88,12 +88,12 @@ impl FontSource for TestFontSource {
         &mut self,
         template_descriptor: FontTemplateDescriptor,
         family_descriptor: FontFamilyDescriptor,
-    ) -> Option<FontTemplateInfo> {
+    ) -> Option<FontTemplateAndWebRenderFontKey> {
         self.find_font_count.set(self.find_font_count.get() + 1);
         self.families
             .get_mut(family_descriptor.name())
             .and_then(|family| family.find_font_for_style(&template_descriptor))
-            .map(|template| FontTemplateInfo {
+            .map(|template| FontTemplateAndWebRenderFontKey {
                 font_template: template,
                 font_key: FontKey(IdNamespace(0), 0),
             })


### PR DESCRIPTION
This clarifies what this type does a bit. Based on a suggestion by
@mukilan.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's a simple rename.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
