### PR TITLE
Treat % as 0 for the min-content contribution of replaced elements

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -431,6 +431,7 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                     containing_block,
                     &LogicalVec2::zero(),
                     false, /* auto_block_size_stretches_to_containing_block */
+                    false, /* is_replaced */
                     false, /* is_table */
                     !matches!(base.style.pseudo(), Some(PseudoElement::ServoAnonymousBox)),
                     |_| None, /* TODO: support preferred aspect ratios on non-replaced boxes */

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -215,6 +215,7 @@ impl IndependentFormattingContext {
             containing_block,
             auto_minimum,
             auto_block_size_stretches_to_containing_block,
+            self.is_replaced(),
             is_table,
             true, /* establishes_containing_block */
             |padding_border_sums| self.preferred_aspect_ratio(padding_border_sums),

--- a/tests/wpt/meta/css/css-sizing/keyword-sizes-on-abspos.html.ini
+++ b/tests/wpt/meta/css/css-sizing/keyword-sizes-on-abspos.html.ini
@@ -1,9 +1,0 @@
-[keyword-sizes-on-abspos.html]
-  [.test 17]
-    expected: FAIL
-
-  [.test 22]
-    expected: FAIL
-
-  [.test 27]
-    expected: FAIL

--- a/tests/wpt/tests/css/css-sizing/intrinsic-percent-replaced-028.html
+++ b/tests/wpt/tests/css/css-sizing/intrinsic-percent-replaced-028.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#replaced-percentage-min-contribution">
+<meta name="assert" content="A preferred or max inline size property set to a percentage is treated as zero when computing the min-content contribution.">
+
+<style>
+.wrapper {
+  display: inline-block;
+  border: solid;
+  margin: 5px;
+}
+</style>
+
+<div style="width: 0px">
+  <!-- Set 'width' to a percentage -->
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 0%; max-width: 100px"></canvas>
+  </div>
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 50%; max-width: 100px"></canvas>
+  </div>
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 100%; max-width: 100px"></canvas>
+  </div>
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 200%; max-width: 100px"></canvas>
+  </div>
+
+  <!-- Set 'max-width' to a percentage -->
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 100px; max-width: 0%"></canvas>
+  </div>
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 100px; max-width: 50%"></canvas>
+  </div>
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 100px; max-width: 100%"></canvas>
+  </div>
+  <div class="wrapper" data-expected-client-width="0">
+    <canvas style="width: 100px; max-width: 200%"></canvas>
+  </div>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".wrapper");
+</script>


### PR DESCRIPTION
`width` and `max-width` typically treat expressions with percentages as their initial value, but for the min-content contribution of replaced elements, they should instead be treated as zero.

https://drafts.csswg.org/css-sizing-3/#replaced-percentage-min-contribution

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #10464
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
