### PR TITLE
Fixed some clippy warnings in components

### DIFF
--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -1043,7 +1043,7 @@ impl FormControl for HTMLElement {
             .set_form_owner(form);
     }
 
-    fn to_element<'a>(&'a self) -> &'a Element {
+    fn to_element(&self) -> &Element {
         debug_assert!(self.is_form_associated_custom_element());
         self.as_element()
     }

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -98,10 +98,7 @@ impl LayoutHTMLTextAreaElementHelpers for LayoutDom<'_, HTMLTextAreaElement> {
         if text.is_empty() {
             // FIXME(nox): Would be cool to not allocate a new string if the
             // placeholder is single line, but that's an unimportant detail.
-            self.placeholder()
-                .replace("\r\n", "\n")
-                .replace('\r', "\n")
-                .into()
+            self.placeholder().replace("\r\n", "\n").replace('\r', "\n")
         } else {
             text.into()
         }

--- a/components/script/dom/mediafragmentparser.rs
+++ b/components/script/dom/mediafragmentparser.rs
@@ -128,14 +128,11 @@ impl MediaFragmentParser {
     fn parse_utc_timestamp(&self, input: &str) -> Result<(Option<f64>, Option<f64>), ()> {
         if input.ends_with('-') || input.starts_with(',') || !input.contains('-') {
             let sec = parse_hms(
-                NaiveDateTime::parse_from_str(
-                    &input.replace('-', "").replace(',', ""),
-                    "%Y%m%dT%H%M%S%.fZ",
-                )
-                .map_err(|_| ())?
-                .time()
-                .to_string()
-                .as_ref(),
+                NaiveDateTime::parse_from_str(&input.replace(['-', ','], ""), "%Y%m%dT%H%M%S%.fZ")
+                    .map_err(|_| ())?
+                    .time()
+                    .to_string()
+                    .as_ref(),
             )?;
             if input.starts_with(',') {
                 Ok((Some(0.), Some(sec)))

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -719,15 +719,11 @@ impl Node {
         other: &Node,
         shadow_including: ShadowIncluding,
     ) -> Option<DomRoot<Node>> {
-        for ancestor in self.inclusive_ancestors(shadow_including) {
-            if other
+        self.inclusive_ancestors(shadow_including).find(|ancestor| {
+            other
                 .inclusive_ancestors(shadow_including)
-                .any(|node| node == ancestor)
-            {
-                return Some(ancestor);
-            }
-        }
-        None
+                .any(|node| node == *ancestor)
+        })
     }
 
     pub fn is_inclusive_ancestor_of(&self, parent: &Node) -> bool {

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -438,6 +438,6 @@ impl ElementsByNameList {
     pub fn item(&self, index: u32) -> Option<DomRoot<Node>> {
         self.document
             .nth_element_by_name(index, &self.name)
-            .and_then(|n| Some(DomRoot::from_ref(&*n)))
+            .map(|n| DomRoot::from_ref(&*n))
     }
 }

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -557,9 +557,9 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     fn AddIceCandidate(&self, candidate: &RTCIceCandidateInit, comp: InRealm) -> Rc<Promise> {
         let p = Promise::new_in_current_realm(comp);
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
-            p.reject_error(Error::Type(format!(
-                "one of sdpMid and sdpMLineIndex must be set"
-            )));
+            p.reject_error(Error::Type(
+                "one of sdpMid and sdpMLineIndex must be set".to_string(),
+            ));
             return p;
         }
 

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -2953,8 +2953,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
 
         if pbo_offset < 0 || pbo_offset as usize > pixel_unpack_buffer.capacity() {
-                self.base.webgl_error(InvalidValue);
-               return Ok(());
+            self.base.webgl_error(InvalidValue);
+            return Ok(());
         }
 
         let unpacking_alignment = self.base.texture_unpacking_alignment();

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -2953,10 +2953,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
 
         if pbo_offset < 0 || pbo_offset as usize > pixel_unpack_buffer.capacity() {
-            return {
                 self.base.webgl_error(InvalidValue);
-                Ok(())
-            };
+               return Ok(());
         }
 
         let unpacking_alignment = self.base.texture_unpacking_alignment();

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -2953,7 +2953,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
 
         if pbo_offset < 0 || pbo_offset as usize > pixel_unpack_buffer.capacity() {
-            return Ok(self.base.webgl_error(InvalidValue));
+            return {
+                self.base.webgl_error(InvalidValue);
+                Ok(())
+            };
         }
 
         let unpacking_alignment = self.base.texture_unpacking_alignment();
@@ -4119,7 +4122,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         handle_potential_webgl_error!(
             self.base,
             program.get_uniform_block_index(block_name),
-            return constants::INVALID_INDEX
+            constants::INVALID_INDEX
         )
     }
 

--- a/components/script/dom/webgl_extensions/extensions.rs
+++ b/components/script/dom/webgl_extensions/extensions.rs
@@ -406,7 +406,7 @@ impl WebGLExtensions {
             .borrow()
             .tex_compression_formats
             .keys()
-            .map(|&k| k)
+            .copied()
             .collect()
     }
 

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -6,6 +6,7 @@
 
 use std::cell::Cell;
 use std::cmp;
+use std::cmp::Ordering;
 
 use canvas_traits::webgl::{
     webgl_channel, TexDataType, TexFormat, TexParameter, TexParameterBool, TexParameterInt,
@@ -326,7 +327,7 @@ impl WebGLTexture {
             },
             EXTTextureFilterAnisotropicConstants::TEXTURE_MAX_ANISOTROPY_EXT => {
                 // NaN is not less than 1., what a time to be alive.
-                if !(float_value >= 1.) {
+                if float_value.partial_cmp(&1.) == Some(Ordering::Less) {
                     return Err(WebGLError::InvalidValue);
                 }
                 self.upcast::<WebGLObject>()

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -6,7 +6,6 @@
 
 use std::cell::Cell;
 use std::cmp;
-use std::cmp::Ordering;
 
 use canvas_traits::webgl::{
     webgl_channel, TexDataType, TexFormat, TexParameter, TexParameterBool, TexParameterInt,
@@ -327,7 +326,7 @@ impl WebGLTexture {
             },
             EXTTextureFilterAnisotropicConstants::TEXTURE_MAX_ANISOTROPY_EXT => {
                 // NaN is not less than 1., what a time to be alive.
-                if float_value.partial_cmp(&1.) == Some(Ordering::Less) {
+                if float_value < 1. || !float_value.is_normal() {
                     return Err(WebGLError::InvalidValue);
                 }
                 self.upcast::<WebGLObject>()


### PR DESCRIPTION
This PR includes fixes to some clippy warnings:

- Elides timelines
- Removes useless use of format!
- Removes unneeded return statement
- Eliminates use of an explicit closure for copying elements.
- Replaces the use of negated comparison with ```partial_cmp```
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because it touches not functionality