### PR TITLE
clippy: Fix `clone_on_copy` warnings in `components/gfx`

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -71,7 +71,7 @@ impl SerializedFontTemplate {
         let font_data = self.bytes_receiver.recv().ok();
         FontTemplate {
             identifier: self.identifier.clone(),
-            descriptor: self.descriptor.clone(),
+            descriptor: self.descriptor,
             data: font_data.map(Arc::new),
             is_valid: true,
         }
@@ -213,7 +213,7 @@ impl FontCache {
                         ipc::bytes_channel().expect("failed to create IPC channel");
                     let serialized_font_template = SerializedFontTemplate {
                         identifier: font_template_info.font_template.borrow().identifier.clone(),
-                        descriptor: font_template_info.font_template.borrow().descriptor.clone(),
+                        descriptor: font_template_info.font_template.borrow().descriptor,
                         bytes_receiver,
                     };
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Remove `clone()` calls on the `Option<FontTemplateDescriptor>` type to fix the [`clone_on_copy`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy) warnings.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
