### PR TITLE
clippy: Fix `collapsible_if` warning in `components/layout_2020`

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -745,11 +745,10 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
         if inline_box_state
             .base_fragment_info
             .flags
-            .contains(FragmentFlags::IS_BR_ELEMENT)
+            .contains(FragmentFlags::IS_BR_ELEMENT) &&
+            self.deferred_br_clear == Clear::None
         {
-            if self.deferred_br_clear == Clear::None {
-                self.deferred_br_clear = inline_box_state.base.style.clone_clear();
-            }
+            self.deferred_br_clear = inline_box_state.base.style.clone_clear();
         }
 
         let line_item = inline_box_state


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Collapse the nested `if` statement to fix the [`collapsible_if`](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if) warning.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
