### PR TITLE
clippy: Fix `map_flatten` warning in `components/script`

### DIFF
--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -134,7 +134,7 @@ impl CSSRuleList {
         Ok(idx)
     }
 
-    // In case of a keyframe rule, index must be valid.
+    /// In case of a keyframe rule, index must be valid.
     pub fn remove_rule(&self, index: u32) -> ErrorResult {
         let index = index as usize;
         let mut guard = self.parent_stylesheet.shared_lock().write();
@@ -162,7 +162,7 @@ impl CSSRuleList {
         }
     }
 
-    // Remove parent stylesheets from all children
+    /// Remove parent stylesheets from all children
     pub fn deparent_all(&self) {
         for rule in self.dom_rules.borrow().iter() {
             if let Some(r) = rule.get() {

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -112,8 +112,7 @@ impl CSSRuleList {
         let owner = self
             .parent_stylesheet
             .get_owner()
-            .map(DomRoot::downcast::<HTMLElement>)
-            .flatten();
+            .and_then(DomRoot::downcast::<HTMLElement>);
         let loader = owner
             .as_ref()
             .map(|element| StylesheetLoader::for_element(element));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

* Replace `.map().flatten()` call with `.and_then()` to fix the [`map_flatten`](https://rust-lang.github.io/rust-clippy/master/index.html#map_flatten) warning.
* Update functions' comments from plain to rustdoc syntax.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500
- [X] These changes do not require tests because they only resolve clippy warnings. They do not change functionalities.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
