### PR TITLE
fonts: Merge multiple methods into `PlatformFont::descriptor()`

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -18,7 +18,7 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 use servo_atoms::{atom, Atom};
 use smallvec::SmallVec;
-use style::computed_values::{font_stretch, font_style, font_variant_caps, font_weight};
+use style::computed_values::font_variant_caps;
 use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font::{GenericFontFamily, SingleFontFamily};
 use unicode_script::Script;
@@ -70,12 +70,9 @@ pub trait PlatformFontMethods: Sized {
         pt_size: Option<Au>,
     ) -> Result<PlatformFont, &'static str>;
 
-    fn family_name(&self) -> Option<String>;
-    fn face_name(&self) -> Option<String>;
-
-    fn style(&self) -> font_style::T;
-    fn boldness(&self) -> font_weight::T;
-    fn stretchiness(&self) -> font_stretch::T;
+    /// Get a [`FontTemplateDescriptor`] from a [`PlatformFont`]. This is used to get
+    /// descriptors for web fonts.
+    fn descriptor(&self) -> FontTemplateDescriptor;
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId>;
     fn glyph_h_advance(&self, _: GlyphId) -> Option<FractionalPixel>;
@@ -349,15 +346,11 @@ impl Font {
         };
 
         debug!(
-            "{} font table[{}] with family={}, face={}",
+            "{} font table[{}] in {:?},",
             status,
             tag.tag_to_str(),
-            self.handle
-                .family_name()
-                .unwrap_or("unavailable".to_owned()),
-            self.handle.face_name().unwrap_or("unavailable".to_owned())
+            self.identifier()
         );
-
         result
     }
 

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -260,12 +260,7 @@ impl FontCache {
                         return;
                     };
 
-                    let descriptor = FontTemplateDescriptor::new(
-                        handle.boldness(),
-                        handle.stretchiness(),
-                        handle.style(),
-                    );
-
+                    let descriptor = handle.descriptor();
                     templates.add_template(FontTemplate::new_web_font(url, descriptor, data));
                     drop(result.send(()));
                 },

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -31,6 +31,16 @@ pub struct FontTemplateDescriptor {
     pub style: FontStyle,
 }
 
+impl Default for FontTemplateDescriptor {
+    fn default() -> Self {
+        FontTemplateDescriptor {
+            weight: FontWeight::normal(),
+            stretch: FontStretch::NORMAL,
+            style: FontStyle::NORMAL,
+        }
+    }
+}
+
 /// FontTemplateDescriptor contains floats, which are not Eq because of NaN. However,
 /// we know they will never be NaN, so we can manually implement Eq.
 impl Eq for FontTemplateDescriptor {}

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -26,6 +26,7 @@ use crate::font::{
     FractionalPixel, PlatformFontMethods, GPOS, GSUB, KERN,
 };
 use crate::font_cache_thread::FontIdentifier;
+use crate::font_template::FontTemplateDescriptor;
 use crate::text::glyph::GlyphId;
 
 const KERN_PAIR_LEN: usize = 6;
@@ -187,24 +188,13 @@ impl PlatformFontMethods for PlatformFont {
         Ok(handle)
     }
 
-    fn family_name(&self) -> Option<String> {
-        Some(self.ctfont.family_name())
-    }
-
-    fn face_name(&self) -> Option<String> {
-        Some(self.ctfont.face_name())
-    }
-
-    fn style(&self) -> FontStyle {
-        self.ctfont.all_traits().style()
-    }
-
-    fn boldness(&self) -> FontWeight {
-        self.ctfont.all_traits().weight()
-    }
-
-    fn stretchiness(&self) -> FontStretch {
-        self.ctfont.all_traits().stretch()
+    fn descriptor(&self) -> FontTemplateDescriptor {
+        let traits = self.ctfont.all_traits();
+        FontTemplateDescriptor {
+            weight: traits.weight(),
+            stretch: traits.stretch(),
+            style: traits.style(),
+        }
     }
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId> {

--- a/components/gfx/tests/font_context.rs
+++ b/components/gfx/tests/font_context.rs
@@ -86,11 +86,9 @@ impl TestFontSource {
             None,
         )
         .unwrap();
-        let descriptor =
-            FontTemplateDescriptor::new(handle.boldness(), handle.stretchiness(), handle.style());
         family.add_template(FontTemplate::new_web_font(
             Self::url_for_font_name(name),
-            descriptor,
+            handle.descriptor(),
             data,
         ));
     }

--- a/components/gfx/tests/font_template.rs
+++ b/components/gfx/tests/font_template.rs
@@ -34,7 +34,7 @@ fn test_font_template_descriptor() {
         let file = File::open(path.clone()).unwrap();
         let data = file.bytes().map(|b| b.unwrap()).collect();
         let handle = PlatformFont::new_from_data(identifier, Arc::new(data), 0, None).unwrap();
-        FontTemplateDescriptor::new(handle.boldness(), handle.stretchiness(), handle.style())
+        handle.descriptor()
     }
 
     assert_eq!(


### PR DESCRIPTION
This combines `style()`, `boldness()`, `stretchiness()` into a
`descriptor()` method which is used when creating `FontTemplate`s for
web fonts. Eventually this method will simply read font tables using
skrifa. This is the first step.

In addition, `family_name()` and `face_name()` are removed. They were
only used for debugging and the `FontIdentifier` serves for that. On
Windows, this was adding another way in which font loading could fail,
without buying us very much. The path or URL to the font is more
important when debugging than the names in the font tables.

Closes #15103.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change observable behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
