### PR TITLE
layout: Have `TextRun::glyph_run_is_preserved_newline` take into account `TextRunSegment` offset

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -2397,7 +2397,7 @@ impl<'a> ContentSizesComputation<'a> {
                         if run.glyph_store.is_whitespace() {
                             // If this run is a forced line break, we *must* break the line
                             // and start measuring from the inline origin once more.
-                            if text_run.glyph_run_is_preserved_newline(run) {
+                            if text_run.glyph_run_is_preserved_newline(segment, run) {
                                 self.forced_line_break();
                                 self.current_line = ContentSizes::zero();
                                 continue;

--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -150,7 +150,7 @@ impl TextRunSegment {
             // If this whitespace forces a line break, queue up a hard line break the next time we
             // see any content. We don't line break immediately, because we'd like to finish processing
             // any ongoing inline boxes before ending the line.
-            if text_run.glyph_run_is_preserved_newline(run) {
+            if text_run.glyph_run_is_preserved_newline(self, run) {
                 ifc.defer_forced_line_break();
                 continue;
             }
@@ -429,7 +429,11 @@ impl TextRun {
             self.prevent_soft_wrap_opportunity_at_end;
     }
 
-    pub(super) fn glyph_run_is_preserved_newline(&self, run: &GlyphRun) -> bool {
+    pub(super) fn glyph_run_is_preserved_newline(
+        &self,
+        text_run_segment: &TextRunSegment,
+        run: &GlyphRun,
+    ) -> bool {
         if !run.glyph_store.is_whitespace() || run.range.length() != ByteIndex(1) {
             return false;
         }
@@ -442,7 +446,8 @@ impl TextRun {
             return false;
         }
 
-        let byte = self.text.as_bytes().get(run.range.begin().to_usize());
+        let byte_offset = (text_run_segment.range.begin() + run.range.begin()).to_usize();
+        let byte = self.text.as_bytes().get(byte_offset);
         byte == Some(&b'\n')
     }
 }

--- a/tests/wpt/meta/css/css-text/bidi/bidi-lines-001.html.ini
+++ b/tests/wpt/meta/css/css-text/bidi/bidi-lines-001.html.ini
@@ -1,2 +1,0 @@
-[bidi-lines-001.html]
-  expected: FAIL


### PR DESCRIPTION
A `TextRun` is composed of `TextRunSegment`s that are composed of `GlyphRun`s.
`TextRun::glyph_run_is_preserved_newline` is indexing into the `TextRun`
text, but the `GlyphRun` indexes that it uses are relative to the `TextRunSegment`
offset. Before the code was using the offset without incorporating the
`TextRunSegment` offset. This led to miscalculation of preserved newline
location while processing text content.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
