### PR TITLE
test: add WPT user-timing tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -222,6 +222,8 @@ skip: true
   skip: false
 [url]
   skip: false
+[user-timing]
+  skip: false
 [wasm]
   skip: false
 [webaudio]

--- a/tests/wpt/meta-legacy-layout/user-timing/clearMarks.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/clearMarks.html.ini
@@ -1,0 +1,12 @@
+[clearMarks.html]
+  [First loop: checking entries after removing "". There should be 2 entries.]
+    expected: FAIL
+
+  [First loop: checking entries after removing "1". There should be 1 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "". There should be 4 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "1". There should be 2 entries.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/clearMeasures.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/clearMeasures.html.ini
@@ -1,0 +1,15 @@
+[clearMeasures.html]
+  [First loop: checking entries after removing "". There should be 2 entries.]
+    expected: FAIL
+
+  [First loop: checking entries after removing "2". There should be 1 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "". There should be 4 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "2". There should be 2 entries.]
+    expected: FAIL
+
+  [Nothing should happen if we clear a non-exist measure]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/clear_non_existent_mark.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/clear_non_existent_mark.any.js.ini
@@ -1,0 +1,8 @@
+[clear_non_existent_mark.any.html]
+  [Clearing a non-existent mark doesn't affect existing marks]
+    expected: FAIL
+
+
+[clear_non_existent_mark.any.worker.html]
+  [Clearing a non-existent mark doesn't affect existing marks]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/clear_non_existent_measure.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/clear_non_existent_measure.any.js.ini
@@ -1,0 +1,8 @@
+[clear_non_existent_measure.any.worker.html]
+  [Clearing a non-existent measure doesn't affect existing measures]
+    expected: FAIL
+
+
+[clear_non_existent_measure.any.html]
+  [Clearing a non-existent measure doesn't affect existing measures]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/clear_one_mark.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/clear_one_mark.any.js.ini
@@ -1,0 +1,8 @@
+[clear_one_mark.any.html]
+  [Clearing an existent mark doesn't affect other existing marks]
+    expected: FAIL
+
+
+[clear_one_mark.any.worker.html]
+  [Clearing an existent mark doesn't affect other existing marks]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/clear_one_measure.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/clear_one_measure.any.js.ini
@@ -1,0 +1,8 @@
+[clear_one_measure.any.worker.html]
+  [Clearing an existent measure doesn't affect other existing measures]
+    expected: FAIL
+
+
+[clear_one_measure.any.html]
+  [Clearing an existent measure doesn't affect other existing measures]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/idlharness-shadowrealm.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/idlharness-shadowrealm.window.js.ini
@@ -1,0 +1,2 @@
+[idlharness-shadowrealm.window.html]
+  expected: ERROR

--- a/tests/wpt/meta-legacy-layout/user-timing/idlharness.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/idlharness.any.js.ini
@@ -1,0 +1,39 @@
+[idlharness.any.serviceworker.html]
+  expected: ERROR
+
+[idlharness.any.worker.html]
+  [PerformanceMark interface object length]
+    expected: FAIL
+
+  [PerformanceMark interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMark interface: mark must inherit property "detail" with the proper type]
+    expected: FAIL
+
+  [PerformanceMeasure interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMeasure interface: measure must inherit property "detail" with the proper type]
+    expected: FAIL
+
+
+[idlharness.any.html]
+  [PerformanceMark interface object length]
+    expected: FAIL
+
+  [PerformanceMark interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMark interface: mark must inherit property "detail" with the proper type]
+    expected: FAIL
+
+  [PerformanceMeasure interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMeasure interface: measure must inherit property "detail" with the proper type]
+    expected: FAIL
+
+
+[idlharness.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta-legacy-layout/user-timing/mark-entry-constructor.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/mark-entry-constructor.any.js.ini
@@ -1,0 +1,38 @@
+[mark-entry-constructor.any.html]
+  [Mark entry can be created by 'new PerformanceMark(string)'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {detail})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime, detail})'.]
+    expected: FAIL
+
+  [Using new PerformanceMark() shouldn't add the entry to performance timeline.]
+    expected: FAIL
+
+
+[mark-entry-constructor.any.worker.html]
+  [Mark entry can be created by 'new PerformanceMark(string)'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {detail})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime, detail})'.]
+    expected: FAIL
+
+  [Using new PerformanceMark() shouldn't add the entry to performance timeline.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/mark-l3.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/mark-l3.any.js.ini
@@ -1,0 +1,8 @@
+[mark-l3.any.html]
+  [mark entries' detail and startTime are customizable.]
+    expected: FAIL
+
+
+[mark-l3.any.worker.html]
+  [mark entries' detail and startTime are customizable.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/mark-measure-return-objects.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/mark-measure-return-objects.any.js.ini
@@ -1,0 +1,32 @@
+[mark-measure-return-objects.any.html]
+  [L3: performance.measure(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1, param2) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name, param) should return an entry.]
+    expected: FAIL
+
+
+[mark-measure-return-objects.any.worker.html]
+  [L3: performance.measure(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1, param2) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name, param) should return an entry.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure-exceptions.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure-exceptions.html.ini
@@ -1,0 +1,39 @@
+[measure-exceptions.html]
+  [Passing 'unloadEventStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'unloadEventEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'redirectStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'redirectEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'secureConnectionStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domInteractive' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domContentLoadedEventStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domContentLoadedEventEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domComplete' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'loadEventStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'loadEventEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 51.15 as a mark to measure API should cause error.]
+    expected: FAIL
+
+  [Passing DoesNotExist as a mark to measure API should cause error.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure-l3.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure-l3.any.js.ini
@@ -1,0 +1,20 @@
+[measure-l3.any.html]
+  [When the end mark is given and the start is unprovided, the end time of the measure entry should be the end mark's time, the start time should be 0.]
+    expected: FAIL
+
+  [When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now.]
+    expected: FAIL
+
+  [When start and end mark are both given, the start time and end time of the measure entry should be the the marks' time, repectively]
+    expected: FAIL
+
+
+[measure-l3.any.worker.html]
+  [When the end mark is given and the start is unprovided, the end time of the measure entry should be the end mark's time, the start time should be 0.]
+    expected: FAIL
+
+  [When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now.]
+    expected: FAIL
+
+  [When start and end mark are both given, the start time and end time of the measure entry should be the the marks' time, repectively]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure-with-dict.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure-with-dict.any.js.ini
@@ -1,0 +1,14 @@
+[measure-with-dict.any.html]
+  [measure entries' detail and start/end are customizable]
+    expected: FAIL
+
+  [measure should throw a TypeError when passed an invalid argument combination]
+    expected: FAIL
+
+
+[measure-with-dict.any.worker.html]
+  [measure entries' detail and start/end are customizable]
+    expected: FAIL
+
+  [measure should throw a TypeError when passed an invalid argument combination]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure.html.ini
@@ -1,0 +1,46 @@
+[measure.html]
+  expected: ERROR
+  [window.performance.getEntriesByName("measure_no_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_no_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_no_start_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_no_start_no_end")[1\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_no_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_start_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_no_start_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_no_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_start_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_no_start_end" measure.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure_associated_with_navigation_timing.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure_associated_with_navigation_timing.html.ini
@@ -1,0 +1,12 @@
+[measure_associated_with_navigation_timing.html]
+  [Measure of navigationStart to loadEventEnd should be positive value.]
+    expected: FAIL
+
+  [Measure of current mark to navigationStart should be negative value.]
+    expected: FAIL
+
+  [Measure from domComplete event to most recent mark "a" should have longer duration.]
+    expected: FAIL
+
+  [Measure from most recent mark to navigationStart should have longer duration.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure_exception.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure_exception.html.ini
@@ -1,0 +1,27 @@
+[measure_exception.html]
+  [Invocation of performance.measure("Exception1", "NonExistMark1") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception2", "NonExistMark1", "navigationStart") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception3", "navigationStart", "NonExistMark1") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception4", "NonExistMark1", "ExistMark") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception5", "ExistMark", "NonExistMark1") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception6", "NonExistMark1", "NonExistMark2") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception7", "redirectStart") should throw INVALID_ACCESS_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception8", {"detail": "non-empty"}) should throw TypeError Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception9", {"start": 1, "duration": 2, "end": 3}) should throw TypeError Exception.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure_exceptions_navigation_timing.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure_exceptions_navigation_timing.html.ini
@@ -1,0 +1,12 @@
+[measure_exceptions_navigation_timing.html]
+  [window.performance.measure("measure", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL
+
+  [window.performance.measure("measure", "loadEventEnd", "responseEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL
+
+  [window.performance.measure("measure", "navigationStart", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL
+
+  [window.performance.measure("measure", "loadEventEnd", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure_navigation_timing.html.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure_navigation_timing.html.ini
@@ -1,0 +1,24 @@
+[measure_navigation_timing.html]
+  [window.performance.getEntriesByName("measure_nav_start_no_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_mark_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_mark_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_mark_start_nav_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_mark_start_nav_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_nav_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_nav_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/measure_syntax_err.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/measure_syntax_err.any.js.ini
@@ -1,0 +1,26 @@
+[measure_syntax_err.any.html]
+  [self.performance.measure("measure", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "existing_mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "existing_mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+
+[measure_syntax_err.any.worker.html]
+  [self.performance.measure("measure", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "existing_mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "existing_mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/performance-measure-invalid.worker.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/performance-measure-invalid.worker.js.ini
@@ -1,0 +1,6 @@
+[performance-measure-invalid.worker.html]
+  [When converting 'navigationStart' to a timestamp, the global object has to be a Window object.]
+    expected: FAIL
+
+  [When converting 'navigationStart' to a timestamp and a mark named 'navigationStart' exists, the global object has to be a Window object.]
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/user-timing/structured-serialize-detail.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/user-timing/structured-serialize-detail.any.js.ini
@@ -1,0 +1,56 @@
+[structured-serialize-detail.any.worker.html]
+  [The detail property in the mark constructor should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the mark method should be structured-clone.]
+    expected: FAIL
+
+  [When accessing detail from a mark entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Mark: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail property in the measure method should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the measure method should be the same reference.]
+    expected: FAIL
+
+  [When accessing detail from a measure entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Measure: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail object is cloned when passed to mark API.]
+    expected: FAIL
+
+
+[structured-serialize-detail.any.html]
+  [The detail property in the mark constructor should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the mark method should be structured-clone.]
+    expected: FAIL
+
+  [When accessing detail from a mark entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Mark: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail property in the measure method should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the measure method should be the same reference.]
+    expected: FAIL
+
+  [When accessing detail from a measure entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Measure: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail object is cloned when passed to mark API.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/clearMarks.html.ini
+++ b/tests/wpt/meta/user-timing/clearMarks.html.ini
@@ -1,0 +1,12 @@
+[clearMarks.html]
+  [First loop: checking entries after removing "". There should be 2 entries.]
+    expected: FAIL
+
+  [First loop: checking entries after removing "1". There should be 1 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "". There should be 4 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "1". There should be 2 entries.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/clearMeasures.html.ini
+++ b/tests/wpt/meta/user-timing/clearMeasures.html.ini
@@ -1,0 +1,15 @@
+[clearMeasures.html]
+  [First loop: checking entries after removing "". There should be 2 entries.]
+    expected: FAIL
+
+  [First loop: checking entries after removing "2". There should be 1 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "". There should be 4 entries.]
+    expected: FAIL
+
+  [Second loop: checking entries after removing "2". There should be 2 entries.]
+    expected: FAIL
+
+  [Nothing should happen if we clear a non-exist measure]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/clear_non_existent_mark.any.js.ini
+++ b/tests/wpt/meta/user-timing/clear_non_existent_mark.any.js.ini
@@ -1,0 +1,8 @@
+[clear_non_existent_mark.any.html]
+  [Clearing a non-existent mark doesn't affect existing marks]
+    expected: FAIL
+
+
+[clear_non_existent_mark.any.worker.html]
+  [Clearing a non-existent mark doesn't affect existing marks]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/clear_non_existent_measure.any.js.ini
+++ b/tests/wpt/meta/user-timing/clear_non_existent_measure.any.js.ini
@@ -1,0 +1,8 @@
+[clear_non_existent_measure.any.worker.html]
+  [Clearing a non-existent measure doesn't affect existing measures]
+    expected: FAIL
+
+
+[clear_non_existent_measure.any.html]
+  [Clearing a non-existent measure doesn't affect existing measures]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/clear_one_mark.any.js.ini
+++ b/tests/wpt/meta/user-timing/clear_one_mark.any.js.ini
@@ -1,0 +1,8 @@
+[clear_one_mark.any.html]
+  [Clearing an existent mark doesn't affect other existing marks]
+    expected: FAIL
+
+
+[clear_one_mark.any.worker.html]
+  [Clearing an existent mark doesn't affect other existing marks]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/clear_one_measure.any.js.ini
+++ b/tests/wpt/meta/user-timing/clear_one_measure.any.js.ini
@@ -1,0 +1,8 @@
+[clear_one_measure.any.worker.html]
+  [Clearing an existent measure doesn't affect other existing measures]
+    expected: FAIL
+
+
+[clear_one_measure.any.html]
+  [Clearing an existent measure doesn't affect other existing measures]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/idlharness-shadowrealm.window.js.ini
+++ b/tests/wpt/meta/user-timing/idlharness-shadowrealm.window.js.ini
@@ -1,0 +1,2 @@
+[idlharness-shadowrealm.window.html]
+  expected: ERROR

--- a/tests/wpt/meta/user-timing/idlharness.any.js.ini
+++ b/tests/wpt/meta/user-timing/idlharness.any.js.ini
@@ -1,0 +1,39 @@
+[idlharness.any.serviceworker.html]
+  expected: ERROR
+
+[idlharness.any.worker.html]
+  [PerformanceMark interface object length]
+    expected: FAIL
+
+  [PerformanceMark interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMark interface: mark must inherit property "detail" with the proper type]
+    expected: FAIL
+
+  [PerformanceMeasure interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMeasure interface: measure must inherit property "detail" with the proper type]
+    expected: FAIL
+
+
+[idlharness.any.html]
+  [PerformanceMark interface object length]
+    expected: FAIL
+
+  [PerformanceMark interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMark interface: mark must inherit property "detail" with the proper type]
+    expected: FAIL
+
+  [PerformanceMeasure interface: attribute detail]
+    expected: FAIL
+
+  [PerformanceMeasure interface: measure must inherit property "detail" with the proper type]
+    expected: FAIL
+
+
+[idlharness.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/user-timing/mark-entry-constructor.any.js.ini
+++ b/tests/wpt/meta/user-timing/mark-entry-constructor.any.js.ini
@@ -1,0 +1,38 @@
+[mark-entry-constructor.any.html]
+  [Mark entry can be created by 'new PerformanceMark(string)'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {detail})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime, detail})'.]
+    expected: FAIL
+
+  [Using new PerformanceMark() shouldn't add the entry to performance timeline.]
+    expected: FAIL
+
+
+[mark-entry-constructor.any.worker.html]
+  [Mark entry can be created by 'new PerformanceMark(string)'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {detail})'.]
+    expected: FAIL
+
+  [Mark entry can be created by 'new PerformanceMark(string, {startTime, detail})'.]
+    expected: FAIL
+
+  [Using new PerformanceMark() shouldn't add the entry to performance timeline.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/mark-l3.any.js.ini
+++ b/tests/wpt/meta/user-timing/mark-l3.any.js.ini
@@ -1,0 +1,8 @@
+[mark-l3.any.html]
+  [mark entries' detail and startTime are customizable.]
+    expected: FAIL
+
+
+[mark-l3.any.worker.html]
+  [mark entries' detail and startTime are customizable.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/mark-measure-return-objects.any.js.ini
+++ b/tests/wpt/meta/user-timing/mark-measure-return-objects.any.js.ini
@@ -1,0 +1,32 @@
+[mark-measure-return-objects.any.html]
+  [L3: performance.measure(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1, param2) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name, param) should return an entry.]
+    expected: FAIL
+
+
+[mark-measure-return-objects.any.worker.html]
+  [L3: performance.measure(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.measure(name, param1, param2) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name) should return an entry.]
+    expected: FAIL
+
+  [L3: performance.mark(name, param) should return an entry.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure-exceptions.html.ini
+++ b/tests/wpt/meta/user-timing/measure-exceptions.html.ini
@@ -1,0 +1,39 @@
+[measure-exceptions.html]
+  [Passing 'unloadEventStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'unloadEventEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'redirectStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'redirectEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'secureConnectionStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domInteractive' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domContentLoadedEventStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domContentLoadedEventEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'domComplete' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'loadEventStart' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 'loadEventEnd' as a mark to measure API should cause error when the mark is empty.]
+    expected: FAIL
+
+  [Passing 51.15 as a mark to measure API should cause error.]
+    expected: FAIL
+
+  [Passing DoesNotExist as a mark to measure API should cause error.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure-l3.any.js.ini
+++ b/tests/wpt/meta/user-timing/measure-l3.any.js.ini
@@ -1,0 +1,20 @@
+[measure-l3.any.html]
+  [When the end mark is given and the start is unprovided, the end time of the measure entry should be the end mark's time, the start time should be 0.]
+    expected: FAIL
+
+  [When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now.]
+    expected: FAIL
+
+  [When start and end mark are both given, the start time and end time of the measure entry should be the the marks' time, repectively]
+    expected: FAIL
+
+
+[measure-l3.any.worker.html]
+  [When the end mark is given and the start is unprovided, the end time of the measure entry should be the end mark's time, the start time should be 0.]
+    expected: FAIL
+
+  [When the start mark is given and the end is unprovided, the start time of the measure entry should be the start mark's time, the end should be now.]
+    expected: FAIL
+
+  [When start and end mark are both given, the start time and end time of the measure entry should be the the marks' time, repectively]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure-with-dict.any.js.ini
+++ b/tests/wpt/meta/user-timing/measure-with-dict.any.js.ini
@@ -1,0 +1,14 @@
+[measure-with-dict.any.html]
+  [measure entries' detail and start/end are customizable]
+    expected: FAIL
+
+  [measure should throw a TypeError when passed an invalid argument combination]
+    expected: FAIL
+
+
+[measure-with-dict.any.worker.html]
+  [measure entries' detail and start/end are customizable]
+    expected: FAIL
+
+  [measure should throw a TypeError when passed an invalid argument combination]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure.html.ini
+++ b/tests/wpt/meta/user-timing/measure.html.ini
@@ -1,0 +1,46 @@
+[measure.html]
+  expected: ERROR
+  [window.performance.getEntriesByName("measure_no_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_no_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_start_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_no_start_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_no_start_no_end")[1\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_no_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_start_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntries() returns an object containing the "measure_no_start_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_no_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_start_no_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_start_end" measure.]
+    expected: FAIL
+
+  [window.performance.getEntriesByType("measure") returns an object containing the "measure_no_start_end" measure.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_associated_with_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_associated_with_navigation_timing.html.ini
@@ -1,0 +1,12 @@
+[measure_associated_with_navigation_timing.html]
+  [Measure of navigationStart to loadEventEnd should be positive value.]
+    expected: FAIL
+
+  [Measure of current mark to navigationStart should be negative value.]
+    expected: FAIL
+
+  [Measure from domComplete event to most recent mark "a" should have longer duration.]
+    expected: FAIL
+
+  [Measure from most recent mark to navigationStart should have longer duration.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_exception.html.ini
+++ b/tests/wpt/meta/user-timing/measure_exception.html.ini
@@ -1,0 +1,27 @@
+[measure_exception.html]
+  [Invocation of performance.measure("Exception1", "NonExistMark1") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception2", "NonExistMark1", "navigationStart") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception3", "navigationStart", "NonExistMark1") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception4", "NonExistMark1", "ExistMark") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception5", "ExistMark", "NonExistMark1") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception6", "NonExistMark1", "NonExistMark2") should throw SYNTAX_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception7", "redirectStart") should throw INVALID_ACCESS_ERR Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception8", {"detail": "non-empty"}) should throw TypeError Exception.]
+    expected: FAIL
+
+  [Invocation of performance.measure("Exception9", {"start": 1, "duration": 2, "end": 3}) should throw TypeError Exception.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_exceptions_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_exceptions_navigation_timing.html.ini
@@ -1,0 +1,12 @@
+[measure_exceptions_navigation_timing.html]
+  [window.performance.measure("measure", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL
+
+  [window.performance.measure("measure", "loadEventEnd", "responseEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL
+
+  [window.performance.measure("measure", "navigationStart", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL
+
+  [window.performance.measure("measure", "loadEventEnd", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_navigation_timing.html.ini
@@ -1,0 +1,24 @@
+[measure_navigation_timing.html]
+  [window.performance.getEntriesByName("measure_nav_start_no_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_mark_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_mark_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_mark_start_nav_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_mark_start_nav_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_nav_end")[0\].startTime is correct]
+    expected: FAIL
+
+  [window.performance.getEntriesByName("measure_nav_start_nav_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_syntax_err.any.js.ini
+++ b/tests/wpt/meta/user-timing/measure_syntax_err.any.js.ini
@@ -1,0 +1,26 @@
+[measure_syntax_err.any.html]
+  [self.performance.measure("measure", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "existing_mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "existing_mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+
+[measure_syntax_err.any.worker.html]
+  [self.performance.measure("measure", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "existing_mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "existing_mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL
+
+  [self.performance.measure("measure", "mark", "mark"), where "mark" is a non-existent mark, throws a SyntaxError exception.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/performance-measure-invalid.worker.js.ini
+++ b/tests/wpt/meta/user-timing/performance-measure-invalid.worker.js.ini
@@ -1,0 +1,6 @@
+[performance-measure-invalid.worker.html]
+  [When converting 'navigationStart' to a timestamp, the global object has to be a Window object.]
+    expected: FAIL
+
+  [When converting 'navigationStart' to a timestamp and a mark named 'navigationStart' exists, the global object has to be a Window object.]
+    expected: FAIL

--- a/tests/wpt/meta/user-timing/structured-serialize-detail.any.js.ini
+++ b/tests/wpt/meta/user-timing/structured-serialize-detail.any.js.ini
@@ -1,0 +1,56 @@
+[structured-serialize-detail.any.worker.html]
+  [The detail property in the mark constructor should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the mark method should be structured-clone.]
+    expected: FAIL
+
+  [When accessing detail from a mark entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Mark: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail property in the measure method should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the measure method should be the same reference.]
+    expected: FAIL
+
+  [When accessing detail from a measure entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Measure: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail object is cloned when passed to mark API.]
+    expected: FAIL
+
+
+[structured-serialize-detail.any.html]
+  [The detail property in the mark constructor should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the mark method should be structured-clone.]
+    expected: FAIL
+
+  [When accessing detail from a mark entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Mark: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail property in the measure method should be structured-clone.]
+    expected: FAIL
+
+  [The detail property in the measure method should be the same reference.]
+    expected: FAIL
+
+  [When accessing detail from a measure entry and the detail is not provided, just return a null value.]
+    expected: FAIL
+
+  [Measure: Throw an exception when the detail property cannot be structured-serialized.]
+    expected: FAIL
+
+  [The detail object is cloned when passed to mark API.]
+    expected: FAIL


### PR DESCRIPTION
As discussed in https://github.com/servo/servo/pull/32120#issuecomment-2068017033, this adds the WPT `user-timing` tests to the default list of WPT tests, and also commits the current status of the `user-timing` tests.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
