### PR TITLE
docs: update README instructions for updating WPT

### DIFF
--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -199,12 +199,22 @@ next synced.
 Updating the upstream tests
 ===========================
 
-In order to update the tests from upstream use the same mach update
-commands. e.g. to update the web-platform-tests:
+In order to update the tests from upstream, use the same mach update
+commands. E.g. to update the web-platform-tests:
 
-    ./mach update-wpt --sync
+    ./mach update-wpt --sync --patch
+
+Then, to update the test results:
+
     ./mach test-wpt --log-raw=update.log
     ./mach update-wpt update.log
+
+You'll also need to do the same for the legacy layout engine:
+
+    ./mach test-wpt --legacy-layout --log-raw=legacy.log
+    ./mach update-wpt --legacy-layout legacy.log
+
+Finally, commit the results from `tests/wpt/meta/` and `tests/wpt/meta-legacy-layout/`.
 
 This should create two commits in your servo repository with the
 updated tests and updated metadata.

--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -162,10 +162,21 @@ remove `.ini` files that no longer contain any expectations.
 
 When a larger number of changes is required, this process can be automated.
 This first requires saving the raw, unformatted log from a test run, for
-example by running `./mach test-wpt --log-raw /tmp/servo.log`. Once the
-log is saved, run from the root directory:
+example by running:
+
+    ./mach test-wpt --log-raw /tmp/servo.log
+
+Once the log is saved, run from the root directory:
 
     ./mach update-wpt /tmp/servo.log
+
+The same process can be done for the legacy layout engine:
+
+    ./mach test-wpt --legacy-layout --log-raw /tmp/servo-legacy.log
+    ./mach update-wpt --legacy-layout /tmp/servo-legacy.log
+
+The updated expectations will be in `tests/wpt/meta/` and
+`tests/wpt/meta-legacy-layout/` respectively.
 
 Writing new tests
 =================
@@ -195,29 +206,6 @@ Editing tests
 web-platform-tests may be edited in-place and the changes committed to
 the servo tree. These changes will be upstreamed when the tests are
 next synced.
-
-Updating the upstream tests
-===========================
-
-In order to update the tests from upstream, use the same mach update
-commands. E.g. to update the web-platform-tests:
-
-    ./mach update-wpt --sync --patch
-
-Then, to update the test results:
-
-    ./mach test-wpt --log-raw=update.log
-    ./mach update-wpt update.log
-
-You'll also need to do the same for the legacy layout engine:
-
-    ./mach test-wpt --legacy-layout --log-raw=legacy.log
-    ./mach update-wpt --legacy-layout legacy.log
-
-Finally, commit the results from `tests/wpt/meta/` and `tests/wpt/meta-legacy-layout/`.
-
-This should create two commits in your servo repository with the
-updated tests and updated metadata.
 
 Servo-specific tests
 ====================


### PR DESCRIPTION
I noticed in #32123 that there are two issues with the docs for updating Web Platform Tests:

- `./mach update-wpt --sync` fails with an error (`Are you sure you don't want a patch?`) because it expects a `--patch` arg.
- The `tests/wpt/meta-legacy-layout/` test results need to be updated with a separate command.

This updates `tests/wpt/README.md` with more complete instructions.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a docs-only change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
