### PR TITLE
clippy: fix several lint warns

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -608,7 +608,7 @@ impl LayoutThread {
     }
 
     /// Receives and dispatches messages from the script and constellation threads
-    fn handle_request<'a, 'b>(&mut self, request: Request) {
+    fn handle_request(&mut self, request: Request) {
         match request {
             Request::FromPipeline(LayoutControlMsg::SetScrollStates(new_scroll_states)) => {
                 self.handle_request_helper(Msg::SetScrollStates(new_scroll_states))
@@ -754,7 +754,7 @@ impl LayoutThread {
     }
 
     /// Sets quirks mode for the document, causing the quirks mode stylesheet to be used.
-    fn handle_set_quirks_mode<'a, 'b>(&mut self, quirks_mode: QuirksMode) {
+    fn handle_set_quirks_mode(&mut self, quirks_mode: QuirksMode) {
         self.stylist.set_quirks_mode(quirks_mode);
     }
 
@@ -1339,7 +1339,7 @@ impl LayoutThread {
             profile_time::ProfilerCategory::LayoutGeneratedContent,
             self.profiler_metadata(),
             self.time_profiler_chan.clone(),
-            || sequential::resolve_generated_content(FlowRef::deref_mut(root_flow), &context),
+            || sequential::resolve_generated_content(FlowRef::deref_mut(root_flow), context),
         );
 
         // Guess float placement.
@@ -1375,7 +1375,7 @@ impl LayoutThread {
                         );
                     } else {
                         //Sequential mode
-                        LayoutThread::solve_constraints(FlowRef::deref_mut(root_flow), &context)
+                        LayoutThread::solve_constraints(FlowRef::deref_mut(root_flow), context)
                     }
                 },
             );
@@ -1396,7 +1396,7 @@ impl LayoutThread {
     fn perform_post_main_layout_passes(
         &self,
         data: &Reflow,
-        mut root_flow: &mut FlowRef,
+        root_flow: &mut FlowRef,
         reflow_goal: &ReflowGoal,
         document: Option<&ServoLayoutDocument>,
         layout_context: &mut LayoutContext,
@@ -1406,7 +1406,7 @@ impl LayoutThread {
             data,
             reflow_goal,
             document,
-            FlowRef::deref_mut(&mut root_flow),
+            FlowRef::deref_mut(root_flow),
             &mut *layout_context,
         );
 

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -555,7 +555,7 @@ impl LayoutThread {
     }
 
     /// Receives and dispatches messages from the script and constellation threads
-    fn handle_request<'a, 'b>(&mut self, request: Request) {
+    fn handle_request(&mut self, request: Request) {
         match request {
             Request::FromPipeline(LayoutControlMsg::SetScrollStates(new_scroll_states)) => {
                 self.handle_request_helper(Msg::SetScrollStates(new_scroll_states))
@@ -629,13 +629,13 @@ impl LayoutThread {
     ) {
         // Find all font-face rules and notify the font cache of them.
         // GWTODO: Need to handle unloading web fonts.
-        if stylesheet.is_effective_for_device(self.stylist.device(), &guard) {
+        if stylesheet.is_effective_for_device(self.stylist.device(), guard) {
             let newly_loading_font_count = self
                 .font_cache_thread
                 .lock()
                 .add_all_web_fonts_from_stylesheet(
-                    &*stylesheet,
-                    &guard,
+                    stylesheet,
+                    guard,
                     self.stylist.device(),
                     &self.font_cache_sender,
                     self.debug.load_webfonts_synchronously,
@@ -658,7 +658,7 @@ impl LayoutThread {
     }
 
     /// Sets quirks mode for the document, causing the quirks mode stylesheet to be used.
-    fn handle_set_quirks_mode<'a, 'b>(&mut self, quirks_mode: QuirksMode) {
+    fn handle_set_quirks_mode(&mut self, quirks_mode: QuirksMode) {
         self.stylist.set_quirks_mode(quirks_mode);
     }
 
@@ -1048,7 +1048,7 @@ impl LayoutThread {
             .borrow()
             .iter()
             .filter_map(|(browsing_context_id, size)| {
-                match old_iframe_sizes.get(&browsing_context_id) {
+                match old_iframe_sizes.get(browsing_context_id) {
                     Some(old_size) if old_size != size => Some(IFrameSizeMsg {
                         browsing_context_id: *browsing_context_id,
                         size: *size,
@@ -1145,17 +1145,17 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
     //        (Does it make a difference?)
     let mut user_or_user_agent_stylesheets = vec![
         parse_ua_stylesheet(
-            &shared_lock,
+            shared_lock,
             "user-agent.css",
             &resources::read_bytes(Resource::UserAgentCSS),
         )?,
         parse_ua_stylesheet(
-            &shared_lock,
+            shared_lock,
             "servo.css",
             &resources::read_bytes(Resource::ServoCSS),
         )?,
         parse_ua_stylesheet(
-            &shared_lock,
+            shared_lock,
             "presentational-hints.css",
             &resources::read_bytes(Resource::PresentationalHintsCSS),
         )?,
@@ -1164,7 +1164,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
     for &(ref contents, ref url) in &opts::get().user_stylesheets {
         user_or_user_agent_stylesheets.push(DocumentStyleSheet(ServoArc::new(
             Stylesheet::from_bytes(
-                &contents,
+                contents,
                 UrlExtraData(url.get_arc()),
                 None,
                 None,
@@ -1179,7 +1179,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
     }
 
     let quirks_mode_stylesheet = parse_ua_stylesheet(
-        &shared_lock,
+        shared_lock,
         "quirks-mode.css",
         &resources::read_bytes(Resource::QuirksModeCSS),
     )?;
@@ -1248,7 +1248,7 @@ struct RegisteredPaintersImpl(FnvHashMap<Atom, RegisteredPainterImpl>);
 impl RegisteredSpeculativePainters for RegisteredPaintersImpl {
     fn get(&self, name: &Atom) -> Option<&dyn RegisteredSpeculativePainter> {
         self.0
-            .get(&name)
+            .get(name)
             .map(|painter| painter as &dyn RegisteredSpeculativePainter)
     }
 }

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -89,10 +89,8 @@ impl AudioBufferSourceNode {
             loop_start: Cell::new(*options.loopStart),
             loop_end: Cell::new(*options.loopEnd),
         };
-        if let Some(ref buffer) = options.buffer {
-            if let Some(ref buffer) = buffer {
-                node.SetBuffer(Some(&**buffer))?
-            }
+        if let Some(Some(ref buffer)) = options.buffer {
+            node.SetBuffer(Some(buffer))?;
         }
         Ok(node)
     }
@@ -267,15 +265,10 @@ impl AudioBufferSourceNodeMethods for AudioBufferSourceNode {
 impl<'a> From<&'a AudioBufferSourceOptions> for AudioBufferSourceNodeOptions {
     fn from(options: &'a AudioBufferSourceOptions) -> Self {
         Self {
-            buffer: if let Some(ref buffer) = options.buffer {
-                if let Some(ref buffer) = buffer {
-                    (*buffer.get_channels()).clone()
-                } else {
-                    None
-                }
-            } else {
-                None
-            },
+            buffer: options
+                .buffer
+                .as_ref()
+                .and_then(|b| (*b.as_ref()?.get_channels()).clone()),
             detune: *options.detune,
             loop_enabled: options.loop_,
             loop_end: Some(*options.loopEnd),

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -197,18 +197,18 @@ pub fn blob_parts_to_bytes(
     let mut ret = vec![];
     for blobpart in &mut blobparts {
         match blobpart {
-            &mut ArrayBufferOrArrayBufferViewOrBlobOrString::String(ref s) => {
+            ArrayBufferOrArrayBufferViewOrBlobOrString::String(s) => {
                 ret.extend(s.as_bytes());
             },
-            &mut ArrayBufferOrArrayBufferViewOrBlobOrString::Blob(ref b) => {
+            ArrayBufferOrArrayBufferViewOrBlobOrString::Blob(b) => {
                 let bytes = b.get_bytes().unwrap_or(vec![]);
                 ret.extend(bytes);
             },
-            &mut ArrayBufferOrArrayBufferViewOrBlobOrString::ArrayBuffer(ref mut a) => unsafe {
+            ArrayBufferOrArrayBufferViewOrBlobOrString::ArrayBuffer(a) => unsafe {
                 let bytes = a.as_slice();
                 ret.extend(bytes);
             },
-            &mut ArrayBufferOrArrayBufferViewOrBlobOrString::ArrayBufferView(ref mut a) => unsafe {
+            ArrayBufferOrArrayBufferViewOrBlobOrString::ArrayBufferView(a) => unsafe {
                 let bytes = a.as_slice();
                 ret.extend(bytes);
             },

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -51,18 +51,13 @@ use crate::script_runtime::JSContext;
 use crate::script_thread::ScriptThread;
 
 /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
-#[derive(Clone, Copy, Eq, JSTraceable, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, JSTraceable, MallocSizeOf, PartialEq)]
 pub enum CustomElementState {
     Undefined,
     Failed,
+    #[default]
     Uncustomized,
     Custom,
-}
-
-impl Default for CustomElementState {
-    fn default() -> CustomElementState {
-        CustomElementState::Uncustomized
-    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#customelementregistry>

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1305,10 +1305,7 @@ impl Element {
         match xmlSerialize::serialize(
             &mut writer,
             &self.upcast::<Node>(),
-            XmlSerializeOpts {
-                traversal_scope,
-                ..Default::default()
-            },
+            XmlSerializeOpts { traversal_scope },
         ) {
             Ok(()) => Ok(DOMString::from(String::from_utf8(writer).unwrap())),
             Err(_) => panic!("Cannot serialize element"),
@@ -3065,10 +3062,10 @@ impl VirtualMethods for Element {
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
-        match name {
-            &local_name!("id") => AttrValue::from_atomic(value.into()),
-            &local_name!("name") => AttrValue::from_atomic(value.into()),
-            &local_name!("class") => AttrValue::from_serialized_tokenlist(value.into()),
+        match *name {
+            local_name!("id") => AttrValue::from_atomic(value.into()),
+            local_name!("name") => AttrValue::from_atomic(value.into()),
+            local_name!("class") => AttrValue::from_serialized_tokenlist(value.into()),
             _ => self
                 .super_type()
                 .unwrap()
@@ -3198,7 +3195,7 @@ impl VirtualMethods for Element {
     }
 }
 
-impl<'a> SelectorsElement for DomRoot<Element> {
+impl SelectorsElement for DomRoot<Element> {
     type Impl = SelectorImpl;
 
     #[allow(unsafe_code)]

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -143,7 +143,7 @@ impl ElementInternals {
         }
 
         if let SubmissionValue::FormData(datums) = &*self.submission_value.borrow() {
-            entry_list.extend(datums.iter().map(|d| d.clone()));
+            entry_list.extend(datums.iter().cloned());
             return;
         }
         let name = self
@@ -169,7 +169,7 @@ impl ElementInternals {
                 entry_list.push(FormDatum {
                     ty: DOMString::from("file"),
                     name,
-                    value: FormDatumValue::File(DomRoot::from_ref(&*file)),
+                    value: FormDatumValue::File(DomRoot::from_ref(file)),
                 });
             },
         }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -264,16 +264,8 @@ impl Event {
             }
         }
 
-        let timeline_window = match DomRoot::downcast::<Window>(target.global()) {
-            Some(window) => {
-                if window.need_emit_timeline_marker(TimelineMarkerType::DOMEvent) {
-                    Some(window)
-                } else {
-                    None
-                }
-            },
-            _ => None,
-        };
+        let timeline_window = DomRoot::downcast::<Window>(target.global())
+            .filter(|window| window.need_emit_timeline_marker(TimelineMarkerType::DOMEvent));
 
         // Step 5.13
         for object in event_path.iter().rev() {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -954,7 +954,7 @@ impl VirtualMethods for HTMLElement {
     }
 
     fn bind_to_tree(&self, context: &BindContext) {
-        if let Some(ref super_type) = self.super_type() {
+        if let Some(super_type) = self.super_type() {
             super_type.bind_to_tree(context);
         }
         let element = self.as_element();
@@ -975,7 +975,7 @@ impl VirtualMethods for HTMLElement {
     }
 
     fn unbind_from_tree(&self, context: &UnbindContext) {
-        if let Some(ref super_type) = self.super_type() {
+        if let Some(super_type) = self.super_type() {
             super_type.unbind_from_tree(context);
         }
 

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1569,10 +1569,9 @@ pub trait FormControl: DomObject {
                 if html_elem.is_form_associated_custom_element() {
                     ScriptThread::enqueue_callback_reaction(
                         elem,
-                        CallbackReaction::FormAssociated(match new_owner {
-                            None => None,
-                            Some(ref form) => Some(DomRoot::from_ref(&**form)),
-                        }),
+                        CallbackReaction::FormAssociated(
+                            new_owner.as_ref().map(|form| DomRoot::from_ref(&**form)),
+                        ),
                         None,
                     )
                 }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -86,7 +86,7 @@ const DEFAULT_SUBMIT_VALUE: &str = "Submit";
 const DEFAULT_RESET_VALUE: &str = "Reset";
 const PASSWORD_REPLACEMENT_CHAR: char = '●';
 
-#[derive(Clone, Copy, JSTraceable, PartialEq)]
+#[derive(Clone, Copy, Default, JSTraceable, PartialEq)]
 #[allow(dead_code)]
 #[derive(MallocSizeOf)]
 pub enum InputType {
@@ -108,6 +108,7 @@ pub enum InputType {
     Search,
     Submit,
     Tel,
+    #[default]
     Text,
     Time,
     Url,
@@ -221,12 +222,6 @@ impl<'a> From<&'a Atom> for InputType {
             atom!("week") => InputType::Week,
             _ => Self::default(),
         }
-    }
-}
-
-impl Default for InputType {
-    fn default() -> InputType {
-        InputType::Text
     }
 }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -120,8 +120,8 @@ impl Navigator {
     fn shrink_gamepads_list(&self) {
         let mut gamepad_list = self.gamepads.borrow_mut();
         for i in (0..gamepad_list.len()).rev() {
-            if gamepad_list.get(i as usize).is_none() {
-                gamepad_list.remove(i as usize);
+            if gamepad_list.get(i).is_none() {
+                gamepad_list.remove(i);
             } else {
                 break;
             }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3455,7 +3455,7 @@ impl UniqueId {
             if (*ptr).is_none() {
                 *ptr = Some(Box::new(Uuid::new_v4()));
             }
-            (&*ptr).as_ref().unwrap()
+            (*ptr).as_ref().unwrap()
         }
     }
 }

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -202,7 +202,7 @@ impl Iterator for SerializationIterator {
         if let Some(SerializationCommand::OpenElement(ref e)) = res {
             self.stack
                 .push(SerializationCommand::CloseElement(e.clone()));
-            for c in rev_children_iter(&*e.upcast::<Node>()) {
+            for c in rev_children_iter(e.upcast::<Node>()) {
                 self.push_node(&c);
             }
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1910,7 +1910,7 @@ impl Window {
 
             let mut images = self.pending_layout_images.borrow_mut();
             let nodes = images.entry(id).or_default();
-            if !nodes.iter().any(|n| &**n as *const _ == &*node as *const _) {
+            if !nodes.iter().any(|n| std::ptr::eq(&**n, &*node)) {
                 let (responder, responder_listener) =
                     ProfiledIpc::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let image_cache_chan = self.image_cache_chan.clone();

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -201,7 +201,7 @@ impl WindowProxy {
             SetProxyReservedSlot(
                 js_proxy.get(),
                 0,
-                &PrivateValue((&*window_proxy).as_void_ptr()),
+                &PrivateValue((*window_proxy).as_void_ptr()),
             );
 
             // Notify the JS engine about the new window proxy binding.

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -837,7 +837,7 @@ impl XRSessionMethods for XRSession {
             .borrow()
             .granted_features()
             .iter()
-            .any(|f| &*f == "hit-test")
+            .any(|f| f == "hit-test")
         {
             p.reject_error(Error::NotSupported);
             return p;


### PR DESCRIPTION
As seems #31500 still remain opened here's the next partial fix.

Fixed list: `unused_mut`, `clippy::needless_borrow`, `clippy::match_ref_pats`, `clippy::borrow_deref_ref`, `clippy::ptr_eq`, `clippy::unnecessary_cast`, `clippy::derivable_impls`, `clippy::collapsible_match`, `clippy::extra_unused_lifetimes`, `clippy::map_clone`, `clippy::manual_filter`.


- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500.
- [x] These changes do not require tests because are only cosmetic.
