### PR TITLE
fonts: Rework platform font initialization

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -891,6 +891,18 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = key_sender.send(font_key);
             },
 
+            ForwardedToCompositorMsg::Font(FontToCompositorMsg::AddSystemFont(
+                key_sender,
+                native_handle,
+            )) => {
+                let font_key = self.webrender_api.generate_font_key();
+                let mut transaction = Transaction::new();
+                transaction.add_native_font(font_key, native_handle);
+                self.webrender_api
+                    .send_transaction(self.webrender_document, transaction);
+                let _ = key_sender.send(font_key);
+            },
+
             ForwardedToCompositorMsg::Canvas(CanvasToCompositorMsg::GenerateKey(sender)) => {
                 let _ = sender.send(self.webrender_api.generate_image_key());
             },

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -21,7 +21,7 @@ use embedder_traits::Cursor;
 use euclid::{Point2D, Rect, Scale, Transform3D, Vector2D};
 use fnv::{FnvHashMap, FnvHashSet};
 use gfx::rendering_context::RenderingContext;
-use gfx_traits::{Epoch, FontData, WebRenderEpochToU16};
+use gfx_traits::{Epoch, WebRenderEpochToU16};
 use image::{DynamicImage, ImageFormat};
 use ipc_channel::ipc;
 use libc::c_void;
@@ -877,16 +877,18 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(key);
             },
 
-            ForwardedToCompositorMsg::Font(FontToCompositorMsg::AddFont(data, sender)) => {
+            ForwardedToCompositorMsg::Font(FontToCompositorMsg::AddFont(
+                key_sender,
+                index,
+                bytes_receiver,
+            )) => {
                 let font_key = self.webrender_api.generate_font_key();
-                let mut txn = Transaction::new();
-                match data {
-                    FontData::Raw(bytes) => txn.add_raw_font(font_key, bytes, 0),
-                    FontData::Native(native_font) => txn.add_native_font(font_key, native_font),
-                }
+                let mut transaction = Transaction::new();
+                let bytes = bytes_receiver.recv().unwrap_or_default();
+                transaction.add_raw_font(font_key, bytes, index);
                 self.webrender_api
-                    .send_transaction(self.webrender_document, txn);
-                let _ = sender.send(font_key);
+                    .send_transaction(self.webrender_document, transaction);
+                let _ = key_sender.send(font_key);
             },
 
             ForwardedToCompositorMsg::Canvas(CanvasToCompositorMsg::GenerateKey(sender)) => {
@@ -938,7 +940,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(self.webrender_api.generate_font_instance_key());
             },
             CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddFont(_, sender),
+                FontToCompositorMsg::AddFont(sender, _, _),
             )) => {
                 let _ = sender.send(self.webrender_api.generate_font_key());
             },

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 use std::{f32, fmt, mem, thread};
 
 use app_units::Au;
-use gfx_traits::{FontData, WebrenderApi};
+use gfx_traits::WebrenderApi;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use log::{debug, trace};
 use net_traits::request::{Destination, Referrer, RequestBuilder};
@@ -25,11 +25,12 @@ use style::shared_lock::SharedRwLockReadGuard;
 use style::stylesheets::{Stylesheet, StylesheetInDocument};
 use webrender_api::{FontInstanceKey, FontKey};
 
-use crate::font::{FontFamilyDescriptor, FontFamilyName, FontSearchScope};
+use crate::font::{FontFamilyDescriptor, FontFamilyName, FontSearchScope, PlatformFontMethods};
 use crate::font_context::FontSource;
 use crate::font_template::{
     FontTemplate, FontTemplateDescriptor, FontTemplateRef, FontTemplateRefMethods,
 };
+use crate::platform::font::PlatformFont;
 use crate::platform::font_list::{
     for_each_available_family, for_each_variation, system_default_family, LocalFontIdentifier,
     SANS_SERIF_FONT_FAMILY,
@@ -59,10 +60,19 @@ pub enum FontIdentifier {
     Web(ServoUrl),
 }
 
+impl FontIdentifier {
+    pub fn index(&self) -> u32 {
+        match *self {
+            Self::Local(ref local_font_identifier) => local_font_identifier.index(),
+            Self::Web(_) => 0,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SerializedFontTemplate {
     identifier: FontIdentifier,
-    descriptor: Option<FontTemplateDescriptor>,
+    descriptor: FontTemplateDescriptor,
     bytes_receiver: ipc_channel::ipc::IpcBytesReceiver,
 }
 
@@ -73,7 +83,6 @@ impl SerializedFontTemplate {
             identifier: self.identifier.clone(),
             descriptor: self.descriptor,
             data: font_data.map(Arc::new),
-            is_valid: true,
         }
     }
 }
@@ -97,11 +106,10 @@ impl FontTemplates {
         // TODO(#190): Do a better job.
         let (mut best_template, mut best_distance) = (None, f32::MAX);
         for template in self.templates.iter() {
-            if let Some(distance) = template.descriptor_distance(desc) {
-                if distance < best_distance {
-                    best_template = Some(template);
-                    best_distance = distance
-                }
+            let distance = template.descriptor_distance(desc);
+            if distance < best_distance {
+                best_template = Some(template);
+                best_distance = distance
             }
         }
         if best_template.is_some() {
@@ -112,24 +120,22 @@ impl FontTemplates {
         // pick the first valid font in the family if we failed
         // to find an exact match for the descriptor.
         for template in &mut self.templates.iter() {
-            if template.is_valid() {
-                return Some(template.clone());
-            }
+            return Some(template.clone());
         }
 
         None
     }
 
-    pub fn add_template(&mut self, identifier: FontIdentifier, maybe_data: Option<Vec<u8>>) {
-        for template in &self.templates {
-            if *template.borrow().identifier() == identifier {
+    pub fn add_template(&mut self, new_template: FontTemplate) {
+        for existing_template in &self.templates {
+            let existing_template = existing_template.borrow();
+            if *existing_template.identifier() == new_template.identifier &&
+                existing_template.descriptor == new_template.descriptor
+            {
                 return;
             }
         }
-
-        if let Ok(template) = FontTemplate::new(identifier, maybe_data) {
-            self.templates.push(Rc::new(RefCell::new(template)));
-        }
+        self.templates.push(Rc::new(RefCell::new(new_template)));
     }
 }
 
@@ -245,7 +251,22 @@ impl FontCache {
                 },
                 Command::AddDownloadedWebFont(family_name, url, bytes, result) => {
                     let templates = &mut self.web_families.get_mut(&family_name).unwrap();
-                    templates.add_template(FontIdentifier::Web(url), Some(bytes));
+
+                    let data = Arc::new(bytes);
+                    let identifier = FontIdentifier::Web(url.clone());
+                    let Ok(handle) = PlatformFont::new_from_data(identifier, data.clone(), 0, None)
+                    else {
+                        drop(result.send(()));
+                        return;
+                    };
+
+                    let descriptor = FontTemplateDescriptor::new(
+                        handle.boldness(),
+                        handle.stretchiness(),
+                        handle.style(),
+                    );
+
+                    templates.add_template(FontTemplate::new_web_font(url, descriptor, data));
                     drop(result.send(()));
                 },
                 Command::Ping => (),
@@ -356,9 +377,9 @@ impl FontCache {
                 let font_face_name = LowercaseString::new(&font.name);
                 let templates = &mut self.web_families.get_mut(&family_name).unwrap();
                 let mut found = false;
-                for_each_variation(&font_face_name, |local_font_identifier| {
+                for_each_variation(&font_face_name, |font_template| {
                     found = true;
-                    templates.add_template(FontIdentifier::Local(local_font_identifier), None);
+                    templates.add_template(font_template);
                 });
                 if found {
                     sender.send(()).unwrap();
@@ -396,18 +417,18 @@ impl FontCache {
         // look up canonical name
         if self.local_families.contains_key(&family_name) {
             debug!("FontList: Found font family with name={}", &*family_name);
-            let s = self.local_families.get_mut(&family_name).unwrap();
+            let font_templates = self.local_families.get_mut(&family_name).unwrap();
 
-            if s.templates.is_empty() {
-                for_each_variation(&family_name, |local_font_identifier| {
-                    s.add_template(FontIdentifier::Local(local_font_identifier), None);
+            if font_templates.templates.is_empty() {
+                for_each_variation(&family_name, |font_template| {
+                    font_templates.add_template(font_template);
                 });
             }
 
             // TODO(Issue #192: handle generic font families, like 'serif' and 'sans-serif'.
             // if such family exists, try to match style to a font
 
-            s.find_font_for_style(template_descriptor)
+            font_templates.find_font_for_style(template_descriptor)
         } else {
             debug!(
                 "FontList: Couldn't find font family with name={}",
@@ -435,17 +456,12 @@ impl FontCache {
     fn get_font_key_for_template(&mut self, template: &FontTemplateRef) -> FontKey {
         let webrender_api = &self.webrender_api;
         let webrender_fonts = &mut self.webrender_fonts;
-        *webrender_fonts
-            .entry(template.borrow().identifier.clone())
-            .or_insert_with(|| {
-                let template = template.borrow();
-                let font = match (template.data_if_in_memory(), template.native_font_handle()) {
-                    (Some(bytes), _) => FontData::Raw((*bytes).clone()),
-                    (None, Some(native_font)) => FontData::Native(native_font),
-                    (None, None) => unreachable!("Font should either be local or a web font."),
-                };
-                webrender_api.add_font(font)
-            })
+        let identifier = template.borrow().identifier.clone();
+        let index = identifier.index();
+        *webrender_fonts.entry(identifier).or_insert_with(|| {
+            let bytes = template.data();
+            webrender_api.add_font(bytes, index)
+        })
     }
 
     fn find_font_template(

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -19,9 +19,9 @@ use webrender_api::{FontInstanceKey, FontKey};
 
 use crate::font::{Font, FontDescriptor, FontFamilyDescriptor, FontGroup, FontRef};
 use crate::font_cache_thread::FontTemplateAndWebRenderFontKey;
-#[cfg(target_os = "macos")]
-use crate::font_template::FontTemplate;
 use crate::font_template::FontTemplateDescriptor;
+#[cfg(target_os = "macos")]
+use crate::platform::core_text_font_cache::CoreTextFontCache;
 
 static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 
@@ -263,5 +263,5 @@ pub fn invalidate_font_caches() {
     FONT_CACHE_EPOCH.fetch_add(1, Ordering::SeqCst);
 
     #[cfg(target_os = "macos")]
-    FontTemplate::clear_core_text_font_cache();
+    CoreTextFontCache::clear_core_text_font_cache();
 }

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -9,6 +9,6 @@ pub mod font_cache_thread;
 pub mod font_context;
 pub mod font_template;
 #[allow(unsafe_code)]
-mod platform;
+pub mod platform;
 pub mod rendering_context;
 pub mod text;

--- a/components/gfx/platform/macos/core_text_font_cache.rs
+++ b/components/gfx/platform/macos/core_text_font_cache.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use app_units::Au;
 use core_graphics::data_provider::CGDataProvider;
@@ -12,36 +12,35 @@ use core_text::font::CTFont;
 use parking_lot::RwLock;
 
 use crate::font_cache_thread::FontIdentifier;
-use crate::font_template::{FontTemplate, FontTemplateRef, FontTemplateRefMethods};
 
-// A cache of `CTFont` to avoid having to create `CTFont` instances over and over. It is
-// always possible to create a `CTFont` using a `FontTemplate` even if it isn't in this
-// cache.
-static CTFONT_CACHE: OnceLock<RwLock<HashMap<FontIdentifier, CachedCTFont>>> = OnceLock::new();
+/// A cache of `CTFont` to avoid having to create `CTFont` instances over and over. It is
+/// always possible to create a `CTFont` using a `FontTemplate` even if it isn't in this
+/// cache.
+pub(crate) struct CoreTextFontCache(OnceLock<RwLock<HashMap<FontIdentifier, CachedCTFont>>>);
+
+/// The global [`CoreTextFontCache`].
+static CACHE: CoreTextFontCache = CoreTextFontCache(OnceLock::new());
 
 /// A [`HashMap`] of cached [`CTFont`] for a single [`FontIdentifier`]. There is one [`CTFont`]
 /// for each cached font size.
 type CachedCTFont = HashMap<Au, CTFont>;
 
-pub(crate) trait CoreTextFontTemplateMethods {
-    /// Retrieves a [`CTFont`] instance, instantiating it if necessary if it is not
-    /// stored in the shared Core Text font cache.
-    fn core_text_font(&self, pt_size: f64) -> Option<CTFont>;
-}
-
-impl CoreTextFontTemplateMethods for FontTemplateRef {
-    fn core_text_font(&self, pt_size: f64) -> Option<CTFont> {
+impl CoreTextFontCache {
+    pub(crate) fn core_text_font(
+        font_identifier: FontIdentifier,
+        data: Arc<Vec<u8>>,
+        pt_size: f64,
+    ) -> Option<CTFont> {
         //// If you pass a zero font size to one of the Core Text APIs, it'll replace it with
         //// 12.0. We don't want that! (Issue #10492.)
         let clamped_pt_size = pt_size.max(0.01);
         let au_size = Au::from_f64_px(clamped_pt_size);
 
-        let cache = CTFONT_CACHE.get_or_init(Default::default);
-        let identifier = self.borrow().identifier.clone();
+        let cache = CACHE.0.get_or_init(Default::default);
         {
             let cache = cache.read();
             if let Some(core_text_font) = cache
-                .get(&identifier)
+                .get(&font_identifier)
                 .and_then(|identifier_cache| identifier_cache.get(&au_size))
             {
                 return Some(core_text_font.clone());
@@ -49,7 +48,9 @@ impl CoreTextFontTemplateMethods for FontTemplateRef {
         }
 
         let mut cache = cache.write();
-        let identifier_cache = cache.entry(identifier).or_insert_with(Default::default);
+        let identifier_cache = cache
+            .entry(font_identifier)
+            .or_insert_with(Default::default);
 
         // It could be that between the time of the cache miss above and now, after the write lock
         // on the cache has been acquired, the cache was populated with the data that we need. Thus
@@ -58,17 +59,15 @@ impl CoreTextFontTemplateMethods for FontTemplateRef {
             return Some(core_text_font.clone());
         }
 
-        let provider = CGDataProvider::from_buffer(self.data());
+        let provider = CGDataProvider::from_buffer(data);
         let cgfont = CGFont::from_data_provider(provider).ok()?;
         let core_text_font = core_text::font::new_from_CGFont(&cgfont, clamped_pt_size);
         identifier_cache.insert(au_size, core_text_font.clone());
         Some(core_text_font)
     }
-}
 
-impl FontTemplate {
     pub(crate) fn clear_core_text_font_cache() {
-        let cache = CTFONT_CACHE.get_or_init(Default::default);
+        let cache = CACHE.0.get_or_init(Default::default);
         cache.write().clear();
     }
 }

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -10,6 +10,7 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 use style::Atom;
 use ucd::{Codepoint, UnicodeBlock};
+use webrender_api::NativeFontHandle;
 
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};
 use crate::platform::font::CoreTextFontTraitsMapping;
@@ -25,6 +26,13 @@ pub struct LocalFontIdentifier {
 }
 
 impl LocalFontIdentifier {
+    pub(crate) fn native_font_handle(&self) -> NativeFontHandle {
+        NativeFontHandle {
+            name: self.postscript_name.to_string(),
+            path: self.path.to_string(),
+        }
+    }
+
     pub(crate) fn index(&self) -> u32 {
         0
     }

--- a/components/gfx/platform/mod.rs
+++ b/components/gfx/platform/mod.rs
@@ -5,7 +5,7 @@
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use crate::platform::freetype::{font, font_list, library_handle};
 #[cfg(target_os = "macos")]
-pub use crate::platform::macos::{font, font_list, font_template};
+pub use crate::platform::macos::{core_text_font_cache, font, font_list};
 #[cfg(target_os = "windows")]
 pub use crate::platform::windows::{font, font_list};
 
@@ -41,9 +41,9 @@ mod freetype {
 
 #[cfg(target_os = "macos")]
 mod macos {
+    pub mod core_text_font_cache;
     pub mod font;
     pub mod font_list;
-    pub mod font_template;
 }
 
 #[cfg(target_os = "windows")]

--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use app_units::Au;
-use dwrote::{Font, FontFace, FontFile, FontStretch, FontStyle};
+use dwrote::{FontFace, FontFile};
 use log::debug;
 use style::computed_values::font_stretch::T as StyleFontStretch;
 use style::computed_values::font_weight::T as StyleFontWeight;
@@ -21,8 +21,6 @@ use style::values::specified::font::FontStretchKeyword;
 use crate::font::{
     FontMetrics, FontTableMethods, FontTableTag, FractionalPixel, PlatformFontMethods,
 };
-use crate::font_cache_thread::FontIdentifier;
-use crate::font_template::{FontTemplateRef, FontTemplateRefMethods};
 use crate::text::glyph::GlyphId;
 
 // 1em = 12pt = 16px, assuming 72 points per inch and 96 px per inch
@@ -57,11 +55,6 @@ impl FontTableMethods for FontTable {
     }
 }
 
-fn make_tag(tag_bytes: &[u8]) -> FontTableTag {
-    assert_eq!(tag_bytes.len(), 4);
-    unsafe { *(tag_bytes.as_ptr() as *const FontTableTag) }
-}
-
 // We need the font (DWriteFont) in order to be able to query things like
 // the family name, face name, weight, etc.  On Windows 10, the
 // DWriteFontFace3 interface provides this on the FontFace, but that's only
@@ -79,6 +72,16 @@ struct FontInfo {
     style: StyleFontStyle,
 }
 
+#[macro_export]
+/// Packs the components of a font tag name into 32 bytes, while respecting the
+/// necessary Rust 4-byte alignment for pointers. This is similar to
+/// [`crate::ot_tag`], but the bytes are reversed.
+macro_rules! font_tag {
+    ($t1:expr, $t2:expr, $t3:expr, $t4:expr) => {
+        (($t4 as u32) << 24) | (($t3 as u32) << 16) | (($t2 as u32) << 8) | ($t1 as u32)
+    };
+}
+
 impl FontInfo {
     fn new_from_face(face: &FontFace) -> Result<FontInfo, &'static str> {
         use std::cmp::{max, min};
@@ -89,8 +92,10 @@ impl FontInfo {
         use truetype::tables::WindowsMetrics;
         use truetype::value::Read;
 
-        let names_bytes = face.get_font_table(make_tag(b"name"));
-        let windows_metrics_bytes = face.get_font_table(make_tag(b"OS/2"));
+        let name_tag = font_tag!('n', 'a', 'm', 'e');
+        let os2_tag = font_tag!('O', 'S', '/', '2');
+        let names_bytes = face.get_font_table(name_tag);
+        let windows_metrics_bytes = face.get_font_table(os2_tag);
         if names_bytes.is_none() || windows_metrics_bytes.is_none() {
             return Err("No 'name' or 'OS/2' tables");
         }
@@ -166,36 +171,6 @@ impl FontInfo {
             style,
         })
     }
-
-    fn new_from_font(font: &Font) -> Result<FontInfo, &'static str> {
-        let style = match font.style() {
-            FontStyle::Normal => StyleFontStyle::NORMAL,
-            FontStyle::Oblique => StyleFontStyle::OBLIQUE,
-            FontStyle::Italic => StyleFontStyle::ITALIC,
-        };
-        let weight = StyleFontWeight::from_float(font.weight().to_u32() as f32);
-        let stretch = match font.stretch() {
-            FontStretch::Undefined => FontStretchKeyword::Normal,
-            FontStretch::UltraCondensed => FontStretchKeyword::UltraCondensed,
-            FontStretch::ExtraCondensed => FontStretchKeyword::ExtraCondensed,
-            FontStretch::Condensed => FontStretchKeyword::Condensed,
-            FontStretch::SemiCondensed => FontStretchKeyword::SemiCondensed,
-            FontStretch::Normal => FontStretchKeyword::Normal,
-            FontStretch::SemiExpanded => FontStretchKeyword::SemiExpanded,
-            FontStretch::Expanded => FontStretchKeyword::Expanded,
-            FontStretch::ExtraExpanded => FontStretchKeyword::ExtraExpanded,
-            FontStretch::UltraExpanded => FontStretchKeyword::UltraExpanded,
-        }
-        .compute();
-
-        Ok(FontInfo {
-            family_name: font.family_name(),
-            face_name: font.face_name(),
-            style,
-            weight,
-            stretch,
-        })
-    }
 }
 
 #[derive(Debug)]
@@ -203,7 +178,7 @@ pub struct PlatformFont {
     face: Nondebug<FontFace>,
     /// A reference to this data used to create this [`PlatformFont`], ensuring the
     /// data stays alive of the lifetime of this struct.
-    data: Option<Arc<Vec<u8>>>,
+    _data: Arc<Vec<u8>>,
     info: FontInfo,
     em_size: f32,
     du_to_px: f32,
@@ -226,32 +201,17 @@ impl<T> Deref for Nondebug<T> {
 }
 
 impl PlatformFontMethods for PlatformFont {
-    fn new_from_template(
-        font_template: FontTemplateRef,
+    fn new_from_data(
+        _font_identifier: FontIdentifier,
+        data: Arc<Vec<u8>>,
+        face_index: u32,
         pt_size: Option<Au>,
     ) -> Result<Self, &'static str> {
-        let direct_write_font = match font_template.borrow().identifier {
-            FontIdentifier::Local(ref local_identifier) => local_identifier.direct_write_font(),
-            FontIdentifier::Web(_) => None,
-        };
-
-        let (face, info, data) = match direct_write_font {
-            Some(font) => (
-                font.create_font_face(),
-                FontInfo::new_from_font(&font)?,
-                None,
-            ),
-            None => {
-                let bytes = font_template.data();
-                let font_file =
-                    FontFile::new_from_data(bytes).ok_or("Could not create FontFile")?;
-                let face = font_file
-                    .create_face(0, dwrote::DWRITE_FONT_SIMULATIONS_NONE)
-                    .map_err(|_| "Could not create FontFace")?;
-                let info = FontInfo::new_from_face(&face)?;
-                (face, info, font_template.borrow().data_if_in_memory())
-            },
-        };
+        let font_file = FontFile::new_from_data(data.clone()).ok_or("Could not create FontFile")?;
+        let face = font_file
+            .create_face(face_index, dwrote::DWRITE_FONT_SIMULATIONS_NONE)
+            .map_err(|_| "Could not create FontFace")?;
+        let info = FontInfo::new_from_face(&face)?;
 
         let pt_size = pt_size.unwrap_or(au_from_pt(12.));
         let du_per_em = face.metrics().metrics0().designUnitsPerEm as f32;
@@ -264,7 +224,7 @@ impl PlatformFontMethods for PlatformFont {
 
         Ok(PlatformFont {
             face: Nondebug(face),
-            data,
+            _data: data,
             info,
             em_size,
             du_to_px: design_units_to_pixels,

--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -21,6 +21,7 @@ use style::values::specified::font::FontStretchKeyword;
 use crate::font::{
     FontMetrics, FontTableMethods, FontTableTag, FractionalPixel, PlatformFontMethods,
 };
+use crate::font_cache_thread::FontIdentifier;
 use crate::text::glyph::GlyphId;
 
 // 1em = 12pt = 16px, assuming 72 points per inch and 96 px per inch

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1050,13 +1050,16 @@ impl gfx_traits::WebrenderApi for FontCacheWR {
             )));
         receiver.recv().unwrap()
     }
-    fn add_font(&self, data: gfx_traits::FontData) -> FontKey {
+    fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey {
         let (sender, receiver) = unbounded();
+        let (bytes_sender, bytes_receiver) =
+            ipc::bytes_channel().expect("failed to create IPC channel");
         let _ = self
             .0
             .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddFont(data, sender),
+                FontToCompositorMsg::AddFont(sender, index, bytes_receiver),
             )));
+        let _ = bytes_sender.send(&data);
         receiver.recv().unwrap()
     }
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -89,7 +89,9 @@ use surfman::{GLApi, GLVersion};
 #[cfg(target_os = "linux")]
 use surfman::{NativeConnection, NativeContext};
 use webrender::{RenderApiSender, ShaderPrecacheFlags};
-use webrender_api::{ColorF, DocumentId, FontInstanceKey, FontKey, FramePublishId, ImageKey};
+use webrender_api::{
+    ColorF, DocumentId, FontInstanceKey, FontKey, FramePublishId, ImageKey, NativeFontHandle,
+};
 use webrender_traits::{
     WebrenderExternalImageHandlers, WebrenderExternalImageRegistry, WebrenderImageHandlerType,
 };
@@ -1060,6 +1062,16 @@ impl gfx_traits::WebrenderApi for FontCacheWR {
                 FontToCompositorMsg::AddFont(sender, index, bytes_receiver),
             )));
         let _ = bytes_sender.send(&data);
+        receiver.recv().unwrap()
+    }
+
+    fn add_system_font(&self, handle: NativeFontHandle) -> FontKey {
+        let (sender, receiver) = unbounded();
+        let _ = self
+            .0
+            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
+                FontToCompositorMsg::AddSystemFont(sender, handle),
+            )));
         receiver.recv().unwrap()
     }
 }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -140,7 +140,7 @@ pub struct CompositionPipeline {
 
 pub enum FontToCompositorMsg {
     AddFontInstance(FontKey, f32, Sender<FontInstanceKey>),
-    AddFont(gfx_traits::FontData, Sender<FontKey>),
+    AddFont(Sender<FontKey>, u32, ipc_channel::ipc::IpcBytesReceiver),
 }
 
 pub enum CanvasToCompositorMsg {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -25,7 +25,7 @@ use script_traits::{
 };
 use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize, DeviceRect};
-use webrender_api::{self, FontInstanceKey, FontKey, ImageKey};
+use webrender_api::{self, FontInstanceKey, FontKey, ImageKey, NativeFontHandle};
 
 /// Sends messages to the compositor.
 pub struct CompositorProxy {
@@ -141,6 +141,7 @@ pub struct CompositionPipeline {
 pub enum FontToCompositorMsg {
     AddFontInstance(FontKey, f32, Sender<FontInstanceKey>),
     AddFont(Sender<FontKey>, u32, ipc_channel::ipc::IpcBytesReceiver),
+    AddSystemFont(Sender<FontKey>, NativeFontHandle),
 }
 
 pub enum CanvasToCompositorMsg {

--- a/components/shared/gfx/lib.rs
+++ b/components/shared/gfx/lib.rs
@@ -120,12 +120,8 @@ pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
     None
 }
 
-pub enum FontData {
-    Raw(Vec<u8>),
-    Native(NativeFontHandle),
-}
-
 pub trait WebrenderApi {
     fn add_font_instance(&self, font_key: FontKey, size: f32) -> FontInstanceKey;
     fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey;
+    fn add_system_font(&self, handle: NativeFontHandle) -> FontKey;
 }

--- a/components/shared/gfx/lib.rs
+++ b/components/shared/gfx/lib.rs
@@ -9,6 +9,7 @@
 pub mod print_tree;
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use malloc_size_of_derive::MallocSizeOf;
 use range::{int_range_index, RangeIndex};
@@ -126,5 +127,5 @@ pub enum FontData {
 
 pub trait WebrenderApi {
     fn add_font_instance(&self, font_key: FontKey, size: f32) -> FontInstanceKey;
-    fn add_font(&self, data: FontData) -> FontKey;
+    fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey;
 }


### PR DESCRIPTION
This change reworks the way that platform fonts are created and
descriptor data is on `FontTemplate` is initialized.

The main change here is that platform fonts for local font faces are
always initialized using the font data loaded into memory from disk.
This means that there is now only a single path for creating platform
fonts.

In addition, the font list is now responsible for getting the
`FontTemplateDescriptor` for local `FontTemplate`s. Before the font had
to be loaded into memory to get the weight, style, and width used for
the descriptor. This is what fonts lists are for though, so for every
platform we have that information before needing to load the font. In
the future, hopefully this will allow discarding fonts before needing to
load them into memory. Web fonts still get the descriptor from the
platform handle, but hopefully that can be done with skrifa in the
future.

Thsese two fixes together allow properly loading indexed font variations
on Linux machines. Before only the first variation could be
instantiated.

Fixes https://github.com/servo/servo/issues/13317.
Fixes https://github.com/servo/servo/issues/24554.

Co-authored-by: Martin Robinson <mrobinson@igalia.com>

----

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13317 and #24554 
- [x] There are tests for these changes

