### PR TITLE
script: Prevent "scroll to fragment" from scrolling offscreen

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2560,6 +2560,12 @@ impl Window {
             pipelineid,
             script_chan: Arc::new(Mutex::new(control_chan)),
         };
+
+        let initial_viewport = f32_rect_to_au_rect(UntypedRect::new(
+            Point2D::zero(),
+            window_size.initial_viewport.to_untyped(),
+        ));
+
         let win = Box::new(Self {
             globalscope: GlobalScope::new_inherited(
                 pipelineid,
@@ -2602,7 +2608,7 @@ impl Window {
             page_clip_rect: Cell::new(MaxRect::max_rect()),
             resize_event: Default::default(),
             window_size: Cell::new(window_size),
-            current_viewport: Cell::new(Rect::zero()),
+            current_viewport: Cell::new(initial_viewport.to_untyped()),
             suppress_reflow: Cell::new(true),
             pending_reflow_count: Default::default(),
             current_state: Cell::new(WindowState::Alive),

--- a/tests/wpt/meta-legacy-layout/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-vertical-lr.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-vertical-lr.html.ini
@@ -1,0 +1,3 @@
+[scroll-position-vertical-lr.html]
+  [Fragment Navigation: Scroll to block start position in vertical-lr writing mode]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-vertical-lr.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-vertical-lr.html.ini
@@ -1,0 +1,3 @@
+[scroll-position-vertical-lr.html]
+  [Fragment Navigation: Scroll to block start position in vertical-lr writing mode]
+    expected: FAIL

--- a/tests/wpt/tests/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-inline-nearest.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/scroll-to-fragid/scroll-position-inline-nearest.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html style="writing-mode: vertical-lr;">
+<head>
+<meta charset="UTF-8">
+<title>Fragment Navigation: inline start position should not scroll out of content range</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier">
+<link rel="author" href="mailto:mrobinson@igalia.com" title="Martin Robinson">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <!-- When scrolling to this fragment the viewport inline position should not
+        change because, it is already fully enclosed by the viewport and page width. -->
+    <div id="test1" style="position: absolute; top: 5000px; left: 100px; height: 100px; width: 100px;"></div>
+<script>
+
+var t = async_test("ScrollToFragment");
+t.step(() => {
+    location.hash = "test1";
+    setTimeout(t.step_func(() => {
+        assert_true(window.scrollY > 0);
+        assert_true(window.scrollY < 5000);
+        assert_equals(window.scrollX, 0);
+        t.done();
+    }));
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Previously, the "scroll to fragment" operation could scroll past the edge
of the screen, because the scroll position was not clamped to viewport
boundaries. Correct this by using the `Window::scroll()` method which
handles this case.
    
In addition, ensure that `Window`'s `current_viewport` member is
initialized properly when it is created.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31316.
- [x] There are tests for these changes
