### PR TITLE
script: Fixed some clippy warnings

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -484,12 +484,11 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         if form_associated {
             let _ac = JSAutoRealm::new(*cx, proto_object.get());
             unsafe {
-                match self.add_form_associated_callbacks(proto_object.handle(), &mut callbacks) {
-                    Err(error) => {
-                        self.element_definition_is_running.set(false);
-                        return Err(error);
-                    },
-                    Ok(()) => {},
+                if let Err(error) =
+                    self.add_form_associated_callbacks(proto_object.handle(), &mut callbacks)
+                {
+                    self.element_definition_is_running.set(false);
+                    return Err(error);
                 }
             }
         }
@@ -673,6 +672,7 @@ pub struct CustomElementDefinition {
 }
 
 impl CustomElementDefinition {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         name: LocalName,
         local_name: LocalName,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -743,8 +743,10 @@ impl Document {
                 .parent()
                 .and_then(|parent| parent.document())
                 .map(|document| document.base_url());
-            if document_url.as_str() == "about:srcdoc" && container_base_url.is_some() {
-                return container_base_url.unwrap();
+            if document_url.as_str() == "about:srcdoc" {
+                if let Some(base_url) = container_base_url {
+                    return base_url;
+                }
             }
             // Step 2: If document's URL is about:blank, and document's browsing
             // context's creator base URL is non-null, then return that creator base URL.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1286,8 +1286,8 @@ impl GlobalScope {
                     // If the port is not enabled yet, or if is awaiting the completion of it's transfer,
                     // the task will be buffered and dispatched upon enablement or completion of the transfer.
                     if let Some(port_impl) = managed_port.port_impl.as_mut() {
-                        port_impl.handle_incoming(task).and_then(|to_dispatch| {
-                            Some((DomRoot::from_ref(&*managed_port.dom_port), to_dispatch))
+                        port_impl.handle_incoming(task).map(|to_dispatch| {
+                            (DomRoot::from_ref(&*managed_port.dom_port), to_dispatch)
                         })
                     } else {
                         panic!("managed-port has no port-impl.");

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -61,27 +61,24 @@ impl Clone for HTMLCanvasElementOrOffscreenCanvas {
 
 impl malloc_size_of::MallocSizeOf for GPUTextureDescriptor {
     fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
-        match self {
-            Self {
-                parent,
-                dimension,
-                format,
-                mipLevelCount,
-                sampleCount,
-                size,
-                usage,
-                viewFormats,
-            } => {
-                parent.size_of(ops) +
-                    dimension.size_of(ops) +
-                    format.size_of(ops) +
-                    mipLevelCount.size_of(ops) +
-                    sampleCount.size_of(ops) +
-                    size.size_of(ops) +
-                    usage.size_of(ops) +
-                    viewFormats.size_of(ops)
-            },
-        }
+        let Self {
+            parent,
+            dimension,
+            format,
+            mipLevelCount,
+            sampleCount,
+            size,
+            usage,
+            viewFormats,
+        } = self;
+        parent.size_of(ops) +
+            dimension.size_of(ops) +
+            format.size_of(ops) +
+            mipLevelCount.size_of(ops) +
+            sampleCount.size_of(ops) +
+            size.size_of(ops) +
+            usage.size_of(ops) +
+            viewFormats.size_of(ops)
     }
 }
 

--- a/components/script/dom/htmllabelelement.rs
+++ b/components/script/dom/htmllabelelement.rs
@@ -156,11 +156,8 @@ impl VirtualMethods for HTMLLabelElement {
 
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         self.super_type().unwrap().attribute_mutated(attr, mutation);
-        match *attr.local_name() {
-            local_name!("form") => {
-                self.form_attribute_mutated(mutation);
-            },
-            _ => {},
+        if *attr.local_name() == local_name!("form") {
+            self.form_attribute_mutated(mutation);
         }
     }
 }


### PR DESCRIPTION
This PR fixes some clippy warnings.

- Replaces ```match``` with ```if let``` or ```if```
- Replaces ```.and_then()``` with ```.map()```
- Replaces negated comparison with ```partial_cmp()```
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [x] These changes do not require tests because it touches not functionality.
