### PR TITLE
android: add CI build for aarch64

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: ['armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
+        arch: ['aarch64-linux-android', 'armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'


### PR DESCRIPTION
I haven't tested the APK since I don't have a device with 64-bit ARM.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the PR only modifies CI workflow.