### PR TITLE
Upgrade stylo to include servo/style#33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5242,7 +5242,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "bitflags 2.5.0",
  "cssparser",
@@ -5530,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "nodrop",
  "serde",
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5738,7 +5738,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "static_assertions",
 ]
@@ -5879,7 +5879,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 
 [[package]]
 name = "strict-num"
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5975,7 +5975,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "lazy_static",
 ]
@@ -5983,7 +5983,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "darling",
  "derive_common",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "app_units",
  "bitflags 2.5.0",
@@ -6377,7 +6377,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-04-16#ac65c5a27c1b9faf9e7bb5bbcb3a4837a810ef6b"
+source = "git+https://github.com/servo/stylo?branch=2024-04-16#d481c573aaa9ad6776b1149a5a44a045e6399157"
 dependencies = [
  "darling",
  "derive_common",

--- a/tests/wpt/meta-legacy-layout/css/css-pseudo/target-text-text-decoration-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-pseudo/target-text-text-decoration-001.html.ini
@@ -1,0 +1,2 @@
+[target-text-text-decoration-001.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/parsing/text-decoration-computed.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/parsing/text-decoration-computed.html.ini
@@ -56,36 +56,11 @@
   [Property text-decoration value 'auto']
     expected: FAIL
 
-  [Property text-decoration value 'currentcolor']
-    expected: FAIL
-
-  [Property text-decoration value 'double overline underline']
-    expected: FAIL
-
-  [Property text-decoration value 'line-through']
-    expected: FAIL
-
-  [Property text-decoration value 'underline dashed rgb(0, 255, 0)']
-    expected: FAIL
-
-  [Property text-decoration value 'underline overline line-through red']
-    expected: FAIL
-
-  [Property text-decoration value 'rgba(10, 20, 30, 0.4) dotted']
-    expected: FAIL
-
-  [Property text-decoration value 'none']
-    expected: FAIL
-
   [Property text-decoration value '10px']
     expected: FAIL
 
   [Property text-decoration value 'underline red from-font']
     expected: FAIL
 
-  [Property text-decoration value 'solid']
-    expected: FAIL
-
   [Property text-decoration value 'from-font']
     expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/parsing/text-decoration-valid.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/parsing/text-decoration-valid.html.ini
@@ -1,22 +1,4 @@
 [text-decoration-valid.html]
-  [e.style['text-decoration'\] = "underline dashed green" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "rgba(10, 20, 30, 0.4) dotted" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "solid" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "underline overline line-through red" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "currentcolor" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "double overline underline" should set the property value]
-    expected: FAIL
-
   [e.style['text-decoration'\] = "underline auto" should set the property value]
     expected: FAIL
 
@@ -37,4 +19,3 @@
 
   [e.style['text-decoration'\] = "overline green from-font" should set the property value]
     expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-line-recalc.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-line-recalc.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-line-recalc.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-serialization.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-serialization.tentative.html.ini
@@ -1,4 +1,0 @@
-[text-decoration-serialization.tentative.html]
-  [text-decoration shorthand serialization]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-shorthands-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-shorthands-001.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-shorthands-001.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-shorthands-002.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-shorthands-002.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-shorthands-002.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-skip-ink-003.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-skip-ink-003.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-skip-ink-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/target-text-text-decoration-001.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/target-text-text-decoration-001.html.ini
@@ -1,0 +1,2 @@
+[target-text-text-decoration-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/parsing/text-decoration-computed.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/parsing/text-decoration-computed.html.ini
@@ -2,36 +2,11 @@
   [Property text-decoration value 'auto']
     expected: FAIL
 
-  [Property text-decoration value 'currentcolor']
-    expected: FAIL
-
-  [Property text-decoration value 'double overline underline']
-    expected: FAIL
-
-  [Property text-decoration value 'line-through']
-    expected: FAIL
-
-  [Property text-decoration value 'underline dashed rgb(0, 255, 0)']
-    expected: FAIL
-
-  [Property text-decoration value 'underline overline line-through red']
-    expected: FAIL
-
-  [Property text-decoration value 'rgba(10, 20, 30, 0.4) dotted']
-    expected: FAIL
-
-  [Property text-decoration value 'none']
-    expected: FAIL
-
   [Property text-decoration value '10px']
     expected: FAIL
 
   [Property text-decoration value 'underline red from-font']
     expected: FAIL
 
-  [Property text-decoration value 'solid']
-    expected: FAIL
-
   [Property text-decoration value 'from-font']
     expected: FAIL
-

--- a/tests/wpt/meta/css/css-text-decor/parsing/text-decoration-valid.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/parsing/text-decoration-valid.html.ini
@@ -5,31 +5,13 @@
   [e.style['text-decoration'\] = "auto" should set the property value]
     expected: FAIL
 
-  [e.style['text-decoration'\] = "underline dashed green" should set the property value]
-    expected: FAIL
-
   [e.style['text-decoration'\] = "10px" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "double overline underline" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "rgba(10, 20, 30, 0.4) dotted" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "solid" should set the property value]
     expected: FAIL
 
   [e.style['text-decoration'\] = "line-through 20px" should set the property value]
     expected: FAIL
 
-  [e.style['text-decoration'\] = "underline overline line-through red" should set the property value]
-    expected: FAIL
-
   [e.style['text-decoration'\] = "overline 3em" should set the property value]
-    expected: FAIL
-
-  [e.style['text-decoration'\] = "currentcolor" should set the property value]
     expected: FAIL
 
   [e.style['text-decoration'\] = "from-font" should set the property value]
@@ -37,4 +19,3 @@
 
   [e.style['text-decoration'\] = "overline green from-font" should set the property value]
     expected: FAIL
-

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-dotted-002.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-dotted-002.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-dotted-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-line-recalc.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-line-recalc.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-line-recalc.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-serialization.tentative.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-serialization.tentative.html.ini
@@ -1,4 +1,0 @@
-[text-decoration-serialization.tentative.html]
-  [text-decoration shorthand serialization]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-shorthands-001.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-shorthands-001.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-shorthands-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-shorthands-002.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-shorthands-002.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-shorthands-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-style-multiple.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-style-multiple.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-style-multiple.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/text-decoration-subelements-003.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/text-decoration-subelements-003.html.ini
@@ -1,0 +1,2 @@
+[text-decoration-subelements-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-variables/variable-reference-visited.html.ini
+++ b/tests/wpt/meta/css/css-variables/variable-reference-visited.html.ini
@@ -1,2 +1,0 @@
-[variable-reference-visited.html]
-  expected: FAIL


### PR DESCRIPTION
This version of stylo includes support for text decoration style and color from servo/style#33.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes.


