### PR TITLE
Implement special table sizing for floats

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -950,12 +950,26 @@ impl FloatBox {
                             &containing_block_for_children,
                             containing_block,
                         );
+                        let (block_size, inline_size) =
+                            match independent_layout.content_inline_size_for_table {
+                                Some(inline_size) => (
+                                    independent_layout.content_block_size.into(),
+                                    inline_size.into(),
+                                ),
+                                None => (
+                                    box_size.block.auto_is(|| {
+                                        Length::from(independent_layout.content_block_size)
+                                            .clamp_between_extremums(
+                                                min_box_size.block,
+                                                max_box_size.block,
+                                            )
+                                    }),
+                                    inline_size,
+                                ),
+                            };
                         content_size = LogicalVec2 {
                             inline: inline_size,
-                            block: block_size.auto_is(|| {
-                                Length::from(independent_layout.content_block_size)
-                                    .clamp_between_extremums(min_box_size.block, max_box_size.block)
-                            }),
+                            block: block_size,
                         };
                         children = independent_layout.fragments;
                     },

--- a/tests/wpt/meta/css/CSS2/floats/floated-table-wider-than-specified.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/floated-table-wider-than-specified.html.ini
@@ -1,2 +1,0 @@
-[floated-table-wider-than-specified.html]
-  expected: FAIL


### PR DESCRIPTION
Tables should always be at least as big as their min-content size, even if we would expect a smaller size according to CSS sizing properties.

#31455 implemented it for in-flow tables participting in flow layout, but a few cases remained. This patch addresses floated tables.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
