### PR TITLE
fonts: Add support for more `@font-face` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "core-foundation",
  "core-graphics 0.22.3",
  "core-text 19.2.0",
+ "cssparser",
  "dwrote",
  "euclid",
  "fnv",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 [dependencies]
 app_units = { workspace = true }
 bitflags = { workspace = true }
+cssparser = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }
 fontsan = { git = "https://github.com/servo/fontsan" }

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -15,11 +15,11 @@ use log::debug;
 use servo_arc::Arc;
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
 use style::properties::style_structs::Font as FontStyleStruct;
-use webrender_api::{FontInstanceKey, FontKey};
+use webrender_api::FontInstanceKey;
 
 use crate::font::{Font, FontDescriptor, FontFamilyDescriptor, FontGroup, FontRef};
-use crate::font_cache_thread::FontTemplateAndWebRenderFontKey;
-use crate::font_template::FontTemplateDescriptor;
+use crate::font_cache_thread::FontIdentifier;
+use crate::font_template::{FontTemplateRef, FontTemplateRefMethods};
 #[cfg(target_os = "macos")]
 use crate::platform::core_text_font_cache::CoreTextFontCache;
 
@@ -30,13 +30,12 @@ static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 static FONT_CACHE_EPOCH: AtomicUsize = AtomicUsize::new(0);
 
 pub trait FontSource {
-    fn get_font_instance(&mut self, key: FontKey, size: Au) -> FontInstanceKey;
-
-    fn font_template(
+    fn get_font_instance(&mut self, font_identifier: FontIdentifier, size: Au) -> FontInstanceKey;
+    fn find_matching_font_templates(
         &mut self,
-        template_descriptor: FontTemplateDescriptor,
+        descriptor_to_match: &FontDescriptor,
         family_descriptor: FontFamilyDescriptor,
-    ) -> Option<FontTemplateAndWebRenderFontKey>;
+    ) -> Vec<FontTemplateRef>;
 }
 
 /// The FontContext represents the per-thread/thread state necessary for
@@ -51,7 +50,7 @@ pub struct FontContext<S: FontSource> {
     // so they will never be released. Find out a good time to drop them.
     // See bug https://github.com/servo/servo/issues/3300
     font_cache: HashMap<FontCacheKey, Option<FontRef>>,
-    font_template_cache: HashMap<FontTemplateCacheKey, Option<FontTemplateAndWebRenderFontKey>>,
+    font_template_cache: HashMap<FontTemplateCacheKey, Vec<FontTemplateRef>>,
 
     font_group_cache:
         HashMap<FontGroupCacheKey, Rc<RefCell<FontGroup>>, BuildHasherDefault<FnvHasher>>,
@@ -115,20 +114,20 @@ impl<S: FontSource> FontContext<S> {
     /// reference to the same underlying `Font`.
     pub fn font(
         &mut self,
+        font_template: FontTemplateRef,
         font_descriptor: &FontDescriptor,
-        family_descriptor: &FontFamilyDescriptor,
     ) -> Option<FontRef> {
         self.get_font_maybe_synthesizing_small_caps(
+            font_template,
             font_descriptor,
-            family_descriptor,
             true, /* synthesize_small_caps */
         )
     }
 
     fn get_font_maybe_synthesizing_small_caps(
         &mut self,
+        font_template: FontTemplateRef,
         font_descriptor: &FontDescriptor,
-        family_descriptor: &FontFamilyDescriptor,
         synthesize_small_caps: bool,
     ) -> Option<FontRef> {
         // TODO: (Bug #3463): Currently we only support fake small-caps
@@ -140,8 +139,8 @@ impl<S: FontSource> FontContext<S> {
                 small_caps_descriptor.pt_size =
                     font_descriptor.pt_size.scale_by(SMALL_CAPS_SCALE_FACTOR);
                 self.get_font_maybe_synthesizing_small_caps(
+                    font_template.clone(),
                     &small_caps_descriptor,
-                    family_descriptor,
                     false, /* synthesize_small_caps */
                 )
             } else {
@@ -149,52 +148,48 @@ impl<S: FontSource> FontContext<S> {
             };
 
         let cache_key = FontCacheKey {
+            font_identifier: font_template.identifier(),
             font_descriptor: font_descriptor.clone(),
-            family_descriptor: family_descriptor.clone(),
         };
 
         self.font_cache.get(&cache_key).cloned().unwrap_or_else(|| {
             debug!(
-                "FontContext::font cache miss for font_descriptor={:?} family_descriptor={:?}",
-                font_descriptor, family_descriptor
+                "FontContext::font cache miss for font_template={:?} font_descriptor={:?}",
+                font_template, font_descriptor
             );
 
             let font = self
-                .font_template(&font_descriptor.template_descriptor, family_descriptor)
-                .and_then(|template_info| {
-                    self.create_font(
-                        template_info,
-                        font_descriptor.to_owned(),
-                        synthesized_small_caps_font,
-                    )
-                    .ok()
-                })
-                .map(|font| Rc::new(RefCell::new(font)));
-
+                .create_font(
+                    font_template,
+                    font_descriptor.to_owned(),
+                    synthesized_small_caps_font,
+                )
+                .ok();
             self.font_cache.insert(cache_key, font.clone());
+
             font
         })
     }
 
-    fn font_template(
+    pub fn matching_templates(
         &mut self,
-        template_descriptor: &FontTemplateDescriptor,
+        descriptor_to_match: &FontDescriptor,
         family_descriptor: &FontFamilyDescriptor,
-    ) -> Option<FontTemplateAndWebRenderFontKey> {
+    ) -> Vec<FontTemplateRef> {
         let cache_key = FontTemplateCacheKey {
-            template_descriptor: *template_descriptor,
+            font_descriptor: descriptor_to_match.clone(),
             family_descriptor: family_descriptor.clone(),
         };
 
         self.font_template_cache.get(&cache_key).cloned().unwrap_or_else(|| {
             debug!(
                 "FontContext::font_template cache miss for template_descriptor={:?} family_descriptor={:?}",
-                template_descriptor,
+                descriptor_to_match,
                 family_descriptor
             );
 
-            let template_info = self.font_source.font_template(
-                *template_descriptor,
+            let template_info = self.font_source.find_matching_font_templates(
+                descriptor_to_match,
                 family_descriptor.clone(),
             );
 
@@ -207,31 +202,32 @@ impl<S: FontSource> FontContext<S> {
     /// cache thread and a `FontDescriptor` which contains the styling parameters.
     fn create_font(
         &mut self,
-        info: FontTemplateAndWebRenderFontKey,
-        descriptor: FontDescriptor,
+        font_template: FontTemplateRef,
+        font_descriptor: FontDescriptor,
         synthesized_small_caps: Option<FontRef>,
-    ) -> Result<Font, &'static str> {
+    ) -> Result<FontRef, &'static str> {
         let font_instance_key = self
             .font_source
-            .get_font_instance(info.font_key, descriptor.pt_size);
-        Font::new(
-            info.font_template,
-            descriptor,
+            .get_font_instance(font_template.identifier(), font_descriptor.pt_size);
+
+        Ok(Rc::new(RefCell::new(Font::new(
+            font_template,
+            font_descriptor,
             font_instance_key,
             synthesized_small_caps,
-        )
+        )?)))
     }
 }
 
 #[derive(Debug, Eq, Hash, PartialEq)]
 struct FontCacheKey {
+    font_identifier: FontIdentifier,
     font_descriptor: FontDescriptor,
-    family_descriptor: FontFamilyDescriptor,
 }
 
 #[derive(Debug, Eq, Hash, PartialEq)]
 struct FontTemplateCacheKey {
-    template_descriptor: FontTemplateDescriptor,
+    font_descriptor: FontDescriptor,
     family_descriptor: FontFamilyDescriptor,
 }
 

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -4,6 +4,7 @@
 
 use std::cell::RefCell;
 use std::fmt::{Debug, Error, Formatter};
+use std::ops::RangeInclusive;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -11,33 +12,33 @@ use serde::{Deserialize, Serialize};
 use servo_url::ServoUrl;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
-use style::properties::style_structs::Font as FontStyleStruct;
 use style::values::computed::font::FontWeight;
 
-use crate::font_cache_thread::FontIdentifier;
+use crate::font::{FontDescriptor, PlatformFontMethods};
+use crate::font_cache_thread::{
+    CSSFontFaceDescriptors, ComputedFontStyleDescriptor, FontIdentifier,
+};
+use crate::platform::font::PlatformFont;
 use crate::platform::font_list::LocalFontIdentifier;
 
 /// A reference to a [`FontTemplate`] with shared ownership and mutability.
-pub(crate) type FontTemplateRef = Rc<RefCell<FontTemplate>>;
+pub type FontTemplateRef = Rc<RefCell<FontTemplate>>;
 
 /// Describes how to select a font from a given family. This is very basic at the moment and needs
 /// to be expanded or refactored when we support more of the font styling parameters.
 ///
 /// NB: If you change this, you will need to update `style::properties::compute_font_hash()`.
-#[derive(Clone, Copy, Debug, Deserialize, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 pub struct FontTemplateDescriptor {
-    pub weight: FontWeight,
-    pub stretch: FontStretch,
-    pub style: FontStyle,
+    pub weight: (FontWeight, FontWeight),
+    pub stretch: (FontStretch, FontStretch),
+    pub style: (FontStyle, FontStyle),
+    pub unicode_range: Option<Vec<RangeInclusive<u32>>>,
 }
 
 impl Default for FontTemplateDescriptor {
     fn default() -> Self {
-        FontTemplateDescriptor {
-            weight: FontWeight::normal(),
-            stretch: FontStretch::NORMAL,
-            style: FontStyle::NORMAL,
-        }
+        Self::new(FontWeight::normal(), FontStretch::NORMAL, FontStyle::NORMAL)
     }
 }
 
@@ -57,9 +58,10 @@ impl FontTemplateDescriptor {
     #[inline]
     pub fn new(weight: FontWeight, stretch: FontStretch, style: FontStyle) -> Self {
         Self {
-            weight,
-            stretch,
-            style,
+            weight: (weight, weight),
+            stretch: (stretch, stretch),
+            style: (style, style),
+            unicode_range: None,
         }
     }
 
@@ -71,24 +73,51 @@ impl FontTemplateDescriptor {
     ///
     /// The policy is to care most about differences in italicness, then weight, then stretch
     #[inline]
-    fn distance_from(&self, other: &FontTemplateDescriptor) -> f32 {
+    fn distance_from(&self, other: &FontDescriptor) -> f32 {
+        let weight = self.weight.0;
+        let style = self.style.0;
+        let stretch = self.stretch.0;
+
         // 0 <= style_part <= 180, since font-style obliqueness should be
         // between -90 and +90deg.
-        let style_part = (style_to_number(&self.style) - style_to_number(&other.style)).abs();
+        let style_part = (style_to_number(&style) - style_to_number(&other.style)).abs();
         // 0 <= weightPart <= 800
-        let weight_part = (self.weight.value() - other.weight.value()).abs();
+        let weight_part = (weight.value() - other.weight.value()).abs();
         // 0 <= stretchPart <= 8
-        let stretch_part = (self.stretch.to_percentage().0 - other.stretch.to_percentage().0).abs();
+        let stretch_part = (stretch.to_percentage().0 - other.stretch.to_percentage().0).abs();
         style_part + weight_part + stretch_part
     }
-}
 
-impl<'a> From<&'a FontStyleStruct> for FontTemplateDescriptor {
-    fn from(style: &'a FontStyleStruct) -> Self {
-        FontTemplateDescriptor {
-            weight: style.font_weight,
-            stretch: style.font_stretch,
-            style: style.font_style,
+    fn matches(&self, descriptor_to_match: &FontDescriptor) -> bool {
+        self.weight.0 <= descriptor_to_match.weight &&
+            self.weight.1 >= descriptor_to_match.weight &&
+            self.style.0 <= descriptor_to_match.style &&
+            self.style.1 >= descriptor_to_match.style &&
+            self.stretch.0 <= descriptor_to_match.stretch &&
+            self.stretch.1 >= descriptor_to_match.stretch
+    }
+
+    fn override_values_with_css_font_template_descriptors(
+        &mut self,
+        css_font_template_descriptors: CSSFontFaceDescriptors,
+    ) {
+        if let Some(weight) = css_font_template_descriptors.weight {
+            self.weight = weight;
+        }
+        self.style = match css_font_template_descriptors.style {
+            Some(ComputedFontStyleDescriptor::Italic) => (FontStyle::ITALIC, FontStyle::ITALIC),
+            Some(ComputedFontStyleDescriptor::Normal) => (FontStyle::NORMAL, FontStyle::NORMAL),
+            Some(ComputedFontStyleDescriptor::Oblique(angle_1, angle_2)) => (
+                FontStyle::oblique(angle_1.to_float()),
+                FontStyle::oblique(angle_2.to_float()),
+            ),
+            None => self.style,
+        };
+        if let Some(stretch) = css_font_template_descriptors.stretch {
+            self.stretch = stretch;
+        }
+        if let Some(unicode_range) = css_font_template_descriptors.unicode_range {
+            self.unicode_range = Some(unicode_range);
         }
     }
 }
@@ -129,14 +158,22 @@ impl FontTemplate {
 
     pub fn new_web_font(
         url: ServoUrl,
-        descriptor: FontTemplateDescriptor,
         data: Arc<Vec<u8>>,
-    ) -> FontTemplate {
-        FontTemplate {
+        css_font_template_descriptors: CSSFontFaceDescriptors,
+    ) -> Result<FontTemplate, &'static str> {
+        let identifier = FontIdentifier::Web(url.clone());
+        let Ok(handle) = PlatformFont::new_from_data(identifier, data.clone(), 0, None) else {
+            return Err("Could not initialize platform font data for: {url:?}");
+        };
+
+        let mut descriptor = handle.descriptor();
+        descriptor
+            .override_values_with_css_font_template_descriptors(css_font_template_descriptors);
+        Ok(FontTemplate {
             identifier: FontIdentifier::Web(url),
             descriptor,
             data: Some(data),
-        }
+        })
     }
 
     pub fn identifier(&self) -> &FontIdentifier {
@@ -155,26 +192,35 @@ pub trait FontTemplateRefMethods {
     /// operation (depending on the platform) which performs synchronous disk I/O
     /// and should never be done lightly.
     fn data(&self) -> Arc<Vec<u8>>;
-    /// Get the descriptor. Returns `None` when instantiating the data fails.
+    /// Get the descriptor.
     fn descriptor(&self) -> FontTemplateDescriptor;
+    /// Get the [`FontIdentifier`] for this template.
+    fn identifier(&self) -> FontIdentifier;
     /// Returns true if the given descriptor matches the one in this [`FontTemplate`].
-    fn descriptor_matches(&self, requested_desc: &FontTemplateDescriptor) -> bool;
+    fn matches_font_descriptor(&self, descriptor_to_match: &FontDescriptor) -> bool;
     /// Calculate the distance from this [`FontTemplate`]s descriptor and return it
     /// or None if this is not a valid [`FontTemplate`].
-    fn descriptor_distance(&self, requested_descriptor: &FontTemplateDescriptor) -> f32;
+    fn descriptor_distance(&self, descriptor_to_match: &FontDescriptor) -> f32;
+    /// Whether or not this character is in the unicode ranges specified in
+    /// this temlates `@font-face` definition, if any.
+    fn char_in_unicode_range(&self, character: char) -> bool;
 }
 
 impl FontTemplateRefMethods for FontTemplateRef {
     fn descriptor(&self) -> FontTemplateDescriptor {
-        self.borrow().descriptor
+        self.borrow().descriptor.clone()
     }
 
-    fn descriptor_matches(&self, requested_descriptor: &FontTemplateDescriptor) -> bool {
-        self.descriptor() == *requested_descriptor
+    fn identifier(&self) -> FontIdentifier {
+        self.borrow().identifier.clone()
     }
 
-    fn descriptor_distance(&self, requested_descriptor: &FontTemplateDescriptor) -> f32 {
-        self.descriptor().distance_from(requested_descriptor)
+    fn matches_font_descriptor(&self, descriptor_to_match: &FontDescriptor) -> bool {
+        self.descriptor().matches(descriptor_to_match)
+    }
+
+    fn descriptor_distance(&self, descriptor_to_match: &FontDescriptor) -> f32 {
+        self.descriptor().distance_from(descriptor_to_match)
     }
 
     fn data(&self) -> Arc<Vec<u8>> {
@@ -189,5 +235,16 @@ impl FontTemplateRefMethods for FontTemplateRef {
                 FontIdentifier::Web(_) => unreachable!("Web fonts should always have data."),
             })
             .clone()
+    }
+
+    fn char_in_unicode_range(&self, character: char) -> bool {
+        let character = character as u32;
+        self.borrow()
+            .descriptor
+            .unicode_range
+            .as_ref()
+            .map_or(true, |ranges| {
+                ranges.iter().any(|range| range.contains(&character))
+            })
     }
 }

--- a/components/gfx/platform/freetype/android/font_list.rs
+++ b/components/gfx/platform/freetype/android/font_list.rs
@@ -485,11 +485,7 @@ where
             },
             None => StyleFontStyle::NORMAL,
         };
-        let descriptor = FontTemplateDescriptor {
-            weight,
-            stretch,
-            style,
-        };
+        let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
         callback(FontTemplate::new_local(local_font_identifier, descriptor));
     };
 

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -173,11 +173,7 @@ impl PlatformFontMethods for PlatformFont {
             })
             .unwrap_or(FontStretch::NORMAL);
 
-        FontTemplateDescriptor {
-            weight,
-            stretch,
-            style,
-        }
+        FontTemplateDescriptor::new(weight, stretch, style)
     }
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId> {

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -148,11 +148,7 @@ where
                 path: Atom::from(c_str_to_string(path as *const c_char)),
                 variation_index: index as i32,
             };
-            let descriptor = FontTemplateDescriptor {
-                weight,
-                stretch,
-                style,
-            };
+            let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
 
             callback(FontTemplate::new_local(local_font_identifier, descriptor))
         }

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -190,11 +190,7 @@ impl PlatformFontMethods for PlatformFont {
 
     fn descriptor(&self) -> FontTemplateDescriptor {
         let traits = self.ctfont.all_traits();
-        FontTemplateDescriptor {
-            weight: traits.weight(),
-            stretch: traits.stretch(),
-            style: traits.style(),
-        }
+        FontTemplateDescriptor::new(traits.weight(), traits.stretch(), traits.style())
     }
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId> {

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -74,11 +74,8 @@ where
                 };
 
                 let traits = family_descriptor.traits();
-                let descriptor = FontTemplateDescriptor {
-                    weight: traits.weight(),
-                    stretch: traits.stretch(),
-                    style: traits.style(),
-                };
+                let descriptor =
+                    FontTemplateDescriptor::new(traits.weight(), traits.stretch(), traits.style());
                 let identifier = LocalFontIdentifier {
                     postscript_name: Atom::from(family_descriptor.font_name()),
                     path: Atom::from(path),

--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -186,11 +186,7 @@ impl PlatformFontMethods for PlatformFont {
             StyleFontStyle::NORMAL
         };
 
-        FontTemplateDescriptor {
-            weight,
-            stretch,
-            style,
-        }
+        FontTemplateDescriptor::new(weight, stretch, style)
     }
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId> {

--- a/components/gfx/tests/font_template.rs
+++ b/components/gfx/tests/font_template.rs
@@ -39,37 +39,33 @@ fn test_font_template_descriptor() {
 
     assert_eq!(
         descriptor("DejaVuSans"),
-        FontTemplateDescriptor {
-            weight: FontWeight::NORMAL,
-            stretch: FontStretch::hundred(),
-            style: FontStyle::NORMAL,
-        }
+        FontTemplateDescriptor::new(
+            FontWeight::NORMAL,
+            FontStretch::hundred(),
+            FontStyle::NORMAL,
+        )
     );
 
     assert_eq!(
         descriptor("DejaVuSans-Bold"),
-        FontTemplateDescriptor {
-            weight: FontWeight::BOLD,
-            stretch: FontStretch::hundred(),
-            style: FontStyle::NORMAL,
-        }
+        FontTemplateDescriptor::new(FontWeight::BOLD, FontStretch::hundred(), FontStyle::NORMAL,)
     );
 
     assert_eq!(
         descriptor("DejaVuSans-Oblique"),
-        FontTemplateDescriptor {
-            weight: FontWeight::NORMAL,
-            stretch: FontStretch::hundred(),
-            style: FontStyle::ITALIC,
-        }
+        FontTemplateDescriptor::new(
+            FontWeight::NORMAL,
+            FontStretch::hundred(),
+            FontStyle::ITALIC,
+        )
     );
 
     assert_eq!(
         descriptor("DejaVuSansCondensed-BoldOblique"),
-        FontTemplateDescriptor {
-            weight: FontWeight::BOLD,
-            stretch: FontStretch::from_percentage(0.875),
-            style: FontStyle::ITALIC,
-        }
+        FontTemplateDescriptor::new(
+            FontWeight::BOLD,
+            FontStretch::from_percentage(0.875),
+            FontStyle::ITALIC,
+        )
     );
 }

--- a/tests/wpt/meta-legacy-layout/css/CSS2/visudet/content-height-004.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/CSS2/visudet/content-height-004.html.ini
@@ -1,0 +1,2 @@
+[content-height-004.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/CSS2/visudet/line-height-201.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/CSS2/visudet/line-height-201.html.ini
@@ -1,0 +1,2 @@
+[line-height-201.html]
+  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/first-available-font-003.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/first-available-font-003.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-003.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/first-available-font-004.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/first-available-font-004.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-004.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/first-available-font-005.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/first-available-font-005.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-005.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-face-unicode-range-nbsp.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-face-unicode-range-nbsp.html.ini
@@ -1,2 +1,0 @@
-[font-face-unicode-range-nbsp.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-size-adjust-014.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-size-adjust-014.html.ini
@@ -1,2 +1,0 @@
-[font-size-adjust-014.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-01.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-01.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-01.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-02.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-02.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-02.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-03.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-03.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-03.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-04.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-04.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-04.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-05.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-05.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-05.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-06.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-06.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-06.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-07.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-07.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-07.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-08.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-08.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-08.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-09.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-09.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-09.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-10.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-10.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-10.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-11.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-stretch-11.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-11.html]
-  expected: FAIL

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/variations/font-weight-matching.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/variations/font-weight-matching.html.ini
@@ -2,16 +2,7 @@
   [Test @font-face matching for weight 600]
     expected: FAIL
 
-  [Test @font-face matching for weight 750]
-    expected: FAIL
-
   [Test @font-face matching for weight 751]
-    expected: FAIL
-
-  [Test @font-face matching for weight 900]
-    expected: FAIL
-
-  [Test @font-face matching for weight 1000]
     expected: FAIL
 
   [Test @font-face matching for weight 399]
@@ -20,23 +11,8 @@
   [Test @font-face matching for weight 470]
     expected: FAIL
 
-  [Test @font-face matching for weight 99]
-    expected: FAIL
-
   [Test @font-face matching for weight 249]
     expected: FAIL
 
-  [Test @font-face matching for weight 500]
-    expected: FAIL
-
-  [Test @font-face matching for weight 250]
-    expected: FAIL
-
-  [Test @font-face matching for weight 400]
-    expected: FAIL
-
   [Test @font-face matching for weight 420]
-    expected: FAIL
-
-  [Test @font-face matching for weight 100]
     expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visudet/line-height-201.html.ini
+++ b/tests/wpt/meta/css/CSS2/visudet/line-height-201.html.ini
@@ -1,0 +1,2 @@
+[line-height-201.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visudet/line-height-205.html.ini
+++ b/tests/wpt/meta/css/CSS2/visudet/line-height-205.html.ini
@@ -1,2 +1,0 @@
-[line-height-205.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-001.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-001.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-003.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-003.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-004.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-004.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-005.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-005.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-007.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-007.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-size-adjust-014.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-size-adjust-014.html.ini
@@ -1,2 +1,0 @@
-[font-size-adjust-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-01.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-01.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-01.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-02.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-02.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-02.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-03.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-03.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-03.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-04.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-04.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-04.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-05.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-05.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-05.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-06.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-06.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-06.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-07.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-07.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-07.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-08.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-08.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-08.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-09.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-09.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-09.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-10.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-10.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-10.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-stretch-11.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-stretch-11.html.ini
@@ -1,2 +1,0 @@
-[font-stretch-11.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/at-font-face-font-matching.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/at-font-face-font-matching.html.ini
@@ -8,25 +8,10 @@
   [Descriptor matching priority: Style has higher priority than weight]
     expected: FAIL
 
-  [Matching font-weight: '400' should prefer '450 460' over '500']
-    expected: FAIL
-
   [Matching font-weight: '400' should prefer '350 399' over '351 398']
     expected: FAIL
 
   [Matching font-weight: '500' should prefer '351 398' over '501 550']
-    expected: FAIL
-
-  [Matching font-weight: '500' should prefer '501 550' over '502 560']
-    expected: FAIL
-
-  [Matching font-weight: '501' should prefer '390 410' over '300 350']
-    expected: FAIL
-
-  [Matching font-weight: '399' should prefer '340 360' over '200 300']
-    expected: FAIL
-
-  [Matching font-weight: '399' should prefer '450 460' over '500 501']
     expected: FAIL
 
   [Matching font-style: 'normal' should prefer 'oblique 0deg' over 'oblique 10deg 40deg']
@@ -45,12 +30,6 @@
     expected: FAIL
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 21deg' over 'oblique 30deg 60deg']
-    expected: FAIL
-
-  [Matching font-weight: '400' should prefer '400' over '450 460']
-    expected: FAIL
-
-  [Matching font-weight: '399' should prefer '500 501' over '502 510']
     expected: FAIL
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
@@ -74,9 +53,6 @@
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 0deg' over 'oblique -50deg -20deg']
     expected: FAIL
 
-  [Matching font-weight: '399' should prefer '350 399' over '340 360']
-    expected: FAIL
-
   [Matching font-stretch: '110%' should prefer '100%' over '50% 80%']
     expected: FAIL
 
@@ -93,9 +69,6 @@
     expected: FAIL
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 40deg 50deg' over 'italic']
-    expected: FAIL
-
-  [Matching font-weight: '400' should prefer '501 550' over '502 560']
     expected: FAIL
 
   [Matching font-style: 'normal' should prefer 'normal' over 'oblique 0deg']
@@ -123,9 +96,6 @@
     expected: FAIL
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -60deg -40deg' over 'oblique -10deg']
-    expected: FAIL
-
-  [Matching font-weight: '501' should prefer '450 460' over '390 410']
     expected: FAIL
 
   [Matching font-stretch: '110%' should prefer '110% 120%' over '115% 116%']
@@ -185,16 +155,7 @@
   [Matching font-style: 'oblique -10deg' should prefer 'oblique 0deg 10deg' over 'oblique 40deg 50deg']
     expected: FAIL
 
-  [Matching font-weight: '430' should prefer '400 425' over '350 399']
-    expected: FAIL
-
-  [Matching font-weight: '501' should prefer '501' over '502 510']
-    expected: FAIL
-
   [Matching font-weight: '501' should prefer '503 520' over '500']
-    expected: FAIL
-
-  [Matching font-weight: '501' should prefer '500' over '450 460']
     expected: FAIL
 
   [Matching font-stretch: '110%' should prefer '115% 116%' over '105%']
@@ -221,9 +182,6 @@
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -10deg' over 'italic']
     expected: FAIL
 
-  [Matching font-weight: '430' should prefer '350 399' over '340 398']
-    expected: FAIL
-
   [Matching font-stretch: '90%' should prefer '60% 70%' over '110% 140%']
     expected: FAIL
 
@@ -248,9 +206,6 @@
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -20deg' over 'oblique -60deg -40deg']
     expected: FAIL
 
-  [Matching font-weight: '430' should prefer '420 440' over '450 460']
-    expected: FAIL
-
   [Matching font-stretch: '100%' should prefer '110% 120%' over '115% 116%']
     expected: FAIL
 
@@ -263,9 +218,6 @@
   [Matching font-weight: '430' should prefer '340 398' over '501 550']
     expected: FAIL
 
-  [Matching font-weight: '501' should prefer '502 510' over '503 520']
-    expected: FAIL
-
   [Matching font-style: 'oblique 20deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
     expected: FAIL
 
@@ -273,21 +225,6 @@
     expected: FAIL
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique 0deg' over 'oblique 30deg 60deg']
-    expected: FAIL
-
-  [Matching font-weight: '400' should prefer '351 398' over '501 550']
-    expected: FAIL
-
-  [Matching font-weight: '430' should prefer '501 550' over '502 560']
-    expected: FAIL
-
-  [Matching font-weight: '500' should prefer '500' over '450 460']
-    expected: FAIL
-
-  [Matching font-weight: '500' should prefer '450 460' over '400']
-    expected: FAIL
-
-  [Matching font-weight: '500' should prefer '400' over '350 399']
     expected: FAIL
 
   [Matching font-stretch: '100%' should prefer '100%' over '110% 120%']
@@ -312,12 +249,6 @@
     expected: FAIL
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -50deg -40deg' over 'italic']
-    expected: FAIL
-
-  [Matching font-weight: '430' should prefer '450 460' over '500']
-    expected: FAIL
-
-  [Matching font-weight: '399' should prefer '400' over '450 460']
     expected: FAIL
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 10deg' over 'oblique 5deg']

--- a/tests/wpt/meta/css/css-fonts/variations/font-weight-matching.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/font-weight-matching.html.ini
@@ -14,13 +14,7 @@
   [Test @font-face matching for weight 900]
     expected: FAIL
 
-  [Test @font-face matching for weight 100]
-    expected: FAIL
-
   [Test @font-face matching for weight 400]
-    expected: FAIL
-
-  [Test @font-face matching for weight 249]
     expected: FAIL
 
   [Test @font-face matching for weight 750]

--- a/tests/wpt/meta/css/css-values/ex-unit-001.html.ini
+++ b/tests/wpt/meta/css/css-values/ex-unit-001.html.ini
@@ -1,2 +1,0 @@
-[ex-unit-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/ex-unit-004.html.ini
+++ b/tests/wpt/meta/css/css-values/ex-unit-004.html.ini
@@ -1,2 +1,0 @@
-[ex-unit-004.html]
-  expected: FAIL


### PR DESCRIPTION
There are a couple major changes here:

1. Support is added for the `weight`, `style`, `stretch` and
   `unicode-range` declarations in `@font-face`.
2. Font matching in the font cache can return templates and
   `FontGroupFamily` can own mulitple templates. This is due to needing
   support for "composite fonts". These are `@font-face` declarations
   that only differ in their `unicode-range` definition.

This fixes a lot of non-determinism in font selection especially when
dealing with pages that define "composite faces." A notable example of
such a page is servo.org, which now consistently displays the correct
web font.

One test starts to fail due to an uncovered bug, but this will be fixed
in a followup change.

Fixes #20686.
Fixes #20684.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
