### PR TITLE
layout: When line-height is not `normal` use metrics of first font not fallback

### DIFF
--- a/tests/wpt/meta/css/CSS2/visudet/line-height-201.html.ini
+++ b/tests/wpt/meta/css/CSS2/visudet/line-height-201.html.ini
@@ -1,2 +1,0 @@
-[line-height-201.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/first-available-font-006.html.ini
+++ b/tests/wpt/meta/css/css-fonts/first-available-font-006.html.ini
@@ -1,2 +1,0 @@
-[first-available-font-006.html]
-  expected: FAIL


### PR DESCRIPTION
This fixes an issue revealed by more consistent font fallback.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
