### PR TITLE
webgpu: Update to wgpu 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,8 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.19.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
  "bitflags 2.5.0",
  "libloading 0.8.3",
@@ -1324,6 +1325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading 0.8.3",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2202,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.5.0",
  "gpu-descriptor-types",
@@ -2213,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3386,7 +3396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3496,6 +3506,12 @@ name = "litemap"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d642685b028806386b2b6e75685faadd3eb65a85fff7df711ce18446a422da"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -3674,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
  "bitflags 2.5.0",
  "block",
@@ -3845,8 +3861,9 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "naga"
-version = "0.19.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -7084,14 +7101,16 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6a86eaa5e763e59c73cf9e97d55fffd4dfda69fd8bda19589fcf851ddfef1f"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.5.0",
  "cfg_aliases",
  "codespan-reporting",
+ "document-features",
  "indexmap 2.2.6",
  "log",
  "naga",
@@ -7110,8 +7129,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d71c8ae05170583049b65ee562fd839fdc0b3e9ddb84f4e40c9d5f8ea0d4c8c"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7129,7 +7149,7 @@ dependencies = [
  "libc",
  "libloading 0.8.3",
  "log",
- "metal 0.27.0",
+ "metal 0.28.0",
  "naga",
  "objc",
  "once_cell",
@@ -7148,8 +7168,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=32e70bc1635905c508d408eb1cf22b2aa062ffe1#32e70bc1635905c508d408eb1cf22b2aa062ffe1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
  "bitflags 2.5.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,8 +126,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.64", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
 webrender_traits = { path = "components/shared/webrender" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "32e70bc1635905c508d408eb1cf22b2aa062ffe1" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "32e70bc1635905c508d408eb1cf22b2aa062ffe1" }
+wgpu-core = "0.20"
+wgpu-types = "0.20"
 winapi = "0.3"
 xi-unicode = "0.1.0"
 xml5ever = "0.18"

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -268,7 +268,8 @@ impl GPUBufferMethods for GPUBuffer {
                 buffer_id: self.buffer.0,
                 device_id: self.device.id().0,
                 host_map,
-                map_range: map_range.clone(),
+                offset,
+                size: Some(range_size),
             },
         )) {
             warn!(

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -208,14 +208,19 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure>
-    fn Configure(&self, descriptor: &GPUCanvasConfiguration) {
+    fn Configure(&self, descriptor: &GPUCanvasConfiguration) -> Fallible<()> {
         // Step 1 is let
         // Step 2
         // TODO: device features
         let format = match descriptor.format {
             GPUTextureFormat::Rgba8unorm | GPUTextureFormat::Rgba8unorm_srgb => ImageFormat::RGBA8,
             GPUTextureFormat::Bgra8unorm | GPUTextureFormat::Bgra8unorm_srgb => ImageFormat::BGRA8,
-            _ => panic!("SwapChain format({:?}) not supported", descriptor.format), // TODO: Better handling
+            _ => {
+                return Err(Error::Type(format!(
+                    "SwapChain format({:?}) not supported",
+                    descriptor.format
+                )))
+            },
         };
 
         // Step 3
@@ -287,6 +292,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
             .set(Some(&descriptor.device.CreateTexture(&text_desc).unwrap()));
 
         self.webrender_image.set(Some(receiver.recv().unwrap()));
+        Ok(())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-unconfigure>

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 use dom_struct::dom_struct;
 use webgpu::wgpu::command as wgpu_com;
-use webgpu::{self, wgt, Transmute, WebGPU, WebGPURequest};
+use webgpu::{self, wgt, WebGPU, WebGPURequest};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -393,7 +393,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .expect("Failed to send Finish");
 
         *self.state.borrow_mut() = GPUCommandEncoderState::Closed;
-        let buffer = webgpu::WebGPUCommandBuffer(self.encoder.0.transmute());
+        let buffer = webgpu::WebGPUCommandBuffer(self.encoder.0.into_command_buffer_id());
         GPUCommandBuffer::new(
             &self.global(),
             self.channel.clone(),

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 use dom_struct::dom_struct;
 use webgpu::wgpu::command as wgpu_com;
-use webgpu::{self, wgt, WebGPU, WebGPURequest};
+use webgpu::{self, wgt, Transmute, WebGPU, WebGPURequest};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{

--- a/components/script/dom/gpucomputepassencoder.rs
+++ b/components/script/dom/gpucomputepassencoder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use webgpu::wgpu::command::{compute_ffi as wgpu_comp, ComputePass};
+use webgpu::wgpu::command::{compute_commands as wgpu_comp, ComputePass};
 use webgpu::{WebGPU, WebGPURequest};
 
 use super::bindings::error::Fallible;
@@ -120,15 +120,12 @@ impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
     #[allow(unsafe_code)]
     fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
         if let Some(compute_pass) = self.compute_pass.borrow_mut().as_mut() {
-            unsafe {
-                wgpu_comp::wgpu_compute_pass_set_bind_group(
-                    compute_pass,
-                    index,
-                    bind_group.id().0,
-                    dynamic_offsets.as_ptr(),
-                    dynamic_offsets.len(),
-                )
-            };
+            wgpu_comp::wgpu_compute_pass_set_bind_group(
+                compute_pass,
+                index,
+                bind_group.id().0,
+                &dynamic_offsets,
+            )
         }
     }
 

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -718,7 +718,9 @@ impl GPUDeviceMethods for GPUDevice {
             layout,
             stage: wgpu_pipe::ProgrammableStageDescriptor {
                 module: descriptor.compute.module.id().0,
-                entry_point: Cow::Owned(descriptor.compute.entryPoint.to_string()),
+                entry_point: Some(Cow::Owned(descriptor.compute.entryPoint.to_string())),
+                constants: Cow::Owned(HashMap::new()),
+                zero_initialize_workgroup_memory: true,
             },
         };
 
@@ -921,7 +923,11 @@ impl GPUDeviceMethods for GPUDevice {
                 vertex: wgpu_pipe::VertexState {
                     stage: wgpu_pipe::ProgrammableStageDescriptor {
                         module: descriptor.vertex.parent.module.id().0,
-                        entry_point: Cow::Owned(descriptor.vertex.parent.entryPoint.to_string()),
+                        entry_point: Some(Cow::Owned(
+                            descriptor.vertex.parent.entryPoint.to_string(),
+                        )),
+                        constants: Cow::Owned(HashMap::new()),
+                        zero_initialize_workgroup_memory: true,
                     },
                     buffers: Cow::Owned(
                         descriptor
@@ -955,7 +961,9 @@ impl GPUDeviceMethods for GPUDevice {
                     .map(|stage| wgpu_pipe::FragmentState {
                         stage: wgpu_pipe::ProgrammableStageDescriptor {
                             module: stage.parent.module.id().0,
-                            entry_point: Cow::Owned(stage.parent.entryPoint.to_string()),
+                            entry_point: Some(Cow::Owned(stage.parent.entryPoint.to_string())),
+                            constants: Cow::Owned(HashMap::new()),
+                            zero_initialize_workgroup_memory: true,
                         },
                         targets: Cow::Owned(
                             stage

--- a/components/script/dom/gpurenderpassencoder.rs
+++ b/components/script/dom/gpurenderpassencoder.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use webgpu::wgpu::command::{render_ffi as wgpu_render, RenderPass};
+use webgpu::wgpu::command::{render_commands as wgpu_render, RenderPass};
 use webgpu::{wgt, WebGPU, WebGPURequest};
 
 use super::bindings::codegen::Bindings::WebGPUBinding::GPUIndexFormat;
@@ -86,15 +86,12 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
     #[allow(unsafe_code)]
     fn SetBindGroup(&self, index: u32, bind_group: &GPUBindGroup, dynamic_offsets: Vec<u32>) {
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
-            unsafe {
-                wgpu_render::wgpu_render_pass_set_bind_group(
-                    render_pass,
-                    index,
-                    bind_group.id().0,
-                    dynamic_offsets.as_ptr(),
-                    dynamic_offsets.len(),
-                )
-            };
+            wgpu_render::wgpu_render_pass_set_bind_group(
+                render_pass,
+                index,
+                bind_group.id().0,
+                &dynamic_offsets,
+            )
         }
     }
 
@@ -286,13 +283,7 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
     fn ExecuteBundles(&self, bundles: Vec<DomRoot<GPURenderBundle>>) {
         let bundle_ids = bundles.iter().map(|b| b.id().0).collect::<Vec<_>>();
         if let Some(render_pass) = self.render_pass.borrow_mut().as_mut() {
-            unsafe {
-                wgpu_render::wgpu_render_pass_execute_bundles(
-                    render_pass,
-                    bundle_ids.as_ptr(),
-                    bundle_ids.len(),
-                )
-            };
+            wgpu_render::wgpu_render_pass_execute_bundles(render_pass, &bundle_ids)
         }
     }
 }

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -1048,6 +1048,7 @@ interface GPUCanvasContext {
 
     // Calling configure() a second time invalidates the previous one,
     // and all of the textures it's produced.
+    [Throws]
     undefined configure(GPUCanvasConfiguration descriptor);
     undefined unconfigure();
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -96,7 +96,6 @@ use style::thread_state::{self, ThreadState};
 use time::precise_time_ns;
 use url::Position;
 use webgpu::identity::WebGPUMsg;
-use webgpu::Transmute;
 use webrender_api::units::LayoutPixel;
 use webrender_api::DocumentId;
 
@@ -2126,7 +2125,7 @@ impl ScriptThread {
             WebGPUMsg::FreeCommandBuffer(id) => self
                 .gpu_id_hub
                 .lock()
-                .kill_command_buffer_id(id.transmute()),
+                .kill_command_buffer_id(id.into_command_encoder_id()),
             WebGPUMsg::FreeSampler(id) => self.gpu_id_hub.lock().kill_sampler_id(id),
             WebGPUMsg::FreeShaderModule(id) => self.gpu_id_hub.lock().kill_shader_module_id(id),
             WebGPUMsg::FreeRenderBundle(id) => self.gpu_id_hub.lock().kill_render_bundle_id(id),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -96,6 +96,7 @@ use style::thread_state::{self, ThreadState};
 use time::precise_time_ns;
 use url::Position;
 use webgpu::identity::WebGPUMsg;
+use webgpu::Transmute;
 use webrender_api::units::LayoutPixel;
 use webrender_api::DocumentId;
 

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -81,7 +81,8 @@ pub enum WebGPURequest {
         buffer_id: id::BufferId,
         device_id: id::DeviceId,
         host_map: HostMap,
-        map_range: std::ops::Range<u64>,
+        offset: u64,
+        size: Option<u64>,
     },
     CommandEncoderFinish {
         command_encoder_id: id::CommandEncoderId,
@@ -407,7 +408,8 @@ impl WGPU {
                         buffer_id,
                         device_id,
                         host_map,
-                        map_range,
+                        offset,
+                        size,
                     } => {
                         let glob = Arc::clone(&self.global);
                         let resp_sender = sender.clone();
@@ -447,7 +449,12 @@ impl WGPU {
                             callback: Some(callback),
                         };
                         let global = &self.global;
-                        let result = gfx_select!(buffer_id => global.buffer_map_async(buffer_id, map_range, operation));
+                        let result = gfx_select!(buffer_id => global.buffer_map_async(
+                            buffer_id,
+                            offset,
+                            size,
+                            operation
+                        ));
                         if let Err(ref e) = result {
                             if let Err(w) = sender.send(Some(Err(format!("{:?}", e)))) {
                                 warn!("Failed to send BufferMapAsync Response ({:?})", w);
@@ -1161,7 +1168,8 @@ impl WGPU {
                             host: HostMap::Read,
                             callback: Some(callback),
                         };
-                        let _ = gfx_select!(buffer_id => global.buffer_map_async(buffer_id, 0..buffer_size, map_op));
+                        let _ = gfx_select!(buffer_id
+                            => global.buffer_map_async(buffer_id, 0, Some(buffer_size), map_op));
                     },
                     WebGPURequest::UnmapBuffer {
                         buffer_id,
@@ -1457,4 +1465,34 @@ pub struct PresentationData {
     image_key: ImageKey,
     image_desc: ImageDescriptor,
     image_data: ImageData,
+}
+
+pub trait Transmute<U: id::Marker> {
+    fn transmute(self) -> id::Id<U>;
+}
+
+impl Transmute<id::markers::Queue> for id::Id<id::markers::Device> {
+    fn transmute(self) -> id::Id<id::markers::Queue> {
+        // if this is removed next one should be removed too.
+        self.into_queue_id()
+    }
+}
+
+impl Transmute<id::markers::Device> for id::Id<id::markers::Queue> {
+    fn transmute(self) -> id::Id<id::markers::Device> {
+        // SAFETY: This is safe because queue_id = device_id in wgpu
+        unsafe { id::Id::from_raw(self.into_raw()) }
+    }
+}
+
+impl Transmute<id::markers::CommandBuffer> for id::Id<id::markers::CommandEncoder> {
+    fn transmute(self) -> id::Id<id::markers::CommandBuffer> {
+        self.into_command_buffer_id()
+    }
+}
+
+impl Transmute<id::markers::CommandEncoder> for id::Id<id::markers::CommandBuffer> {
+    fn transmute(self) -> id::Id<id::markers::CommandEncoder> {
+        self.into_command_encoder_id()
+    }
 }

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -2116,31 +2116,17 @@
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:large_dispatch:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:dispatchSize="maximum"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=2048]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=2179]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=256]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:dispatchSize=315]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:dispatchSize=628]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:memcpy:*]
@@ -2455,12 +2441,8 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -2569,16 +2551,10 @@
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -2665,8 +2641,6 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2679,8 +2653,6 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2693,12 +2665,8 @@
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -2759,8 +2727,6 @@
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -2801,16 +2767,10 @@
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -2901,8 +2861,6 @@
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
     expected:
@@ -3029,12 +2987,8 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -3143,16 +3097,10 @@
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -3279,12 +3227,8 @@
   [:boundary="command-buffer";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="command-buffer";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -3303,12 +3247,8 @@
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -3349,8 +3289,6 @@
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -3391,16 +3329,10 @@
   [:boundary="queue-op";readOp="constant-uniform";readContext="render-pass-encoder";writeOp="write-buffer";writeContext="queue"]
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-bundle-encoder";writeOp="write-buffer";writeContext="queue"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:boundary="queue-op";readOp="input-index";readContext="render-pass-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
 
@@ -3491,24 +3423,16 @@
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
@@ -7477,8 +7401,6 @@
 
 
 [cts.https.html?q=webgpu:api,operation,sampling,filter_mode:mipmapFilter:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm"]
     expected:
       if os == "linux" and not debug: [FAIL, NOTRUN]
@@ -7492,8 +7414,6 @@
       if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:format="r32float"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm"]
     expected:
@@ -7504,8 +7424,6 @@
       if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm"]
     expected:
@@ -7520,8 +7438,6 @@
       if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm"]
     expected:
@@ -10556,20 +10472,14 @@
   [:limitTest="atDefault";testValueName="atLimit"]
 
   [:limitTest="atDefault";testValueName="overLimit"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="atLimit"]
 
   [:limitTest="atMaximum";testValueName="overLimit"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit"]
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:limitTest="overMaximum";testValueName="atLimit"]
     expected:
@@ -18329,12 +18239,8 @@
   [:isAsync=false;constants={"c0":0,"c2":0,"c5":0,"c8":0}]
 
   [:isAsync=false;constants={"c0":0,"c2":0,"c8":0}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;constants={}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;constants={"c0":0,"c2":0,"c5":0,"c8":0,"c1":0}]
 
@@ -18980,8 +18886,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:binding_resources,device_mismatch:*]
-  expected:
-    if os == "linux" and not debug: CRASH
   [:entry={"buffer":{"type":"storage"}}]
 
   [:entry={"sampler":{"type":"filtering"}}]
@@ -19773,34 +19677,22 @@
 
 [cts.https.html?q=webgpu:api,validation,createBindGroupLayout:maximum_binding_limit:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroupLayout:multisampled_validation:*]
   [:viewDimension="1d"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:viewDimension="2d"]
 
   [:viewDimension="2d-array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:viewDimension="3d"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:viewDimension="_undef_"]
 
   [:viewDimension="cube"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:viewDimension="cube-array"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroupLayout:storage_texture,formats:*]
@@ -27191,8 +27083,6 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer,device_mismatch:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer_state:*]
@@ -27945,8 +27835,6 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_format_compatibility:*]
@@ -28040,8 +27928,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,debug:debug_group_balanced:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="compute%20pass"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -28184,39 +28070,21 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:index_buffer_OOB:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexed"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexedIndirect"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexed"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexedIndirect"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexed"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexedIndirect"]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexed"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexedIndirect"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:last_buffer_setting_take_account:*]
@@ -28290,39 +28158,21 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:unused_buffer_bound:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:smallIndexBuffer=false;smallVertexBuffer=false;smallInstanceBuffer=false]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:smallIndexBuffer=false;smallVertexBuffer=false;smallInstanceBuffer=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:smallIndexBuffer=false;smallVertexBuffer=true;smallInstanceBuffer=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=false;smallVertexBuffer=true;smallInstanceBuffer=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=false;smallInstanceBuffer=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=false;smallInstanceBuffer=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=true;smallInstanceBuffer=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:smallIndexBuffer=true;smallVertexBuffer=true;smallInstanceBuffer=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,draw:vertex_buffer_OOB:*]
@@ -28898,15 +28748,11 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="compute%20pass";state="destroyed";resourceType="buffer"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="destroyed";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="invalid";resourceType="buffer"]
 
@@ -28921,48 +28767,28 @@
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20bundle";state="destroyed";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20bundle";state="invalid";resourceType="buffer"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20bundle";state="invalid";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20bundle";state="valid";resourceType="buffer"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20bundle";state="valid";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20pass";state="destroyed";resourceType="buffer"]
     expected:
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";state="destroyed";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";state="invalid";resourceType="buffer"]
-    expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20pass";state="invalid";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20pass";state="valid";resourceType="buffer"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:encoderType="render%20pass";state="valid";resourceType="texture"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:*]
@@ -30142,8 +29968,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:current_scope:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT, CRASH]
   [:errorFilter="out-of-memory";stackDepth=1]
 
   [:errorFilter="out-of-memory";stackDepth=10]
@@ -30155,24 +29979,14 @@
   [:errorFilter="out-of-memory";stackDepth=100000]
 
   [:errorFilter="validation";stackDepth=1]
-    expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT]
 
   [:errorFilter="validation";stackDepth=10]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:errorFilter="validation";stackDepth=100]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:errorFilter="validation";stackDepth=1000]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:errorFilter="validation";stackDepth=100000]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:empty:*]
@@ -31939,12 +31753,8 @@
 
 [cts.https.html?q=webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*]
   [:copyType="CopyB2T"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:copyType="CopyT2B"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*]
@@ -42347,20 +42157,14 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:setBindGroup:*]
   [:]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:setIndexBuffer:*]
   [:]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:setVertexBuffer:*]
   [:]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,buffer:writeBuffer:*]
@@ -42389,8 +42193,6 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:beginRenderPass:*]
   [:]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:copyBufferToTexture:*]
@@ -42513,8 +42315,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,color_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:encoderType="render%20bundle"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -42531,8 +42331,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:encoderType="render%20bundle";encoderFormatFeature="_undef_";pipelineFormatFeature="_undef_"]
     expected:
       if os == "linux" and not debug: NOTRUN
@@ -42567,11 +42365,7 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="render%20bundle";format="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:encoderType="render%20bundle";format="depth16unorm"]
     expected:
@@ -42598,8 +42392,6 @@
       if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20pass";format="_undef_"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:encoderType="render%20pass";format="depth16unorm"]
     expected:
@@ -42627,23 +42419,13 @@
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,sample_count:*]
-  expected:
-    if os == "linux" and not debug: [OK, TIMEOUT]
   [:encoderType="render%20bundle";attachmentType="color"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20bundle";attachmentType="depthstencil"]
-    expected:
-      if os == "linux" and not debug: [PASS, TIMEOUT, NOTRUN]
 
   [:encoderType="render%20pass";attachmentType="color"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL]
 
   [:encoderType="render%20pass";attachmentType="depthstencil"]
-    expected:
-      if os == "linux" and not debug: [PASS, FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,color_depth_mismatch:*]
@@ -48525,12 +48307,8 @@
   [:isAsync=false;fragmentConstants={"r":1,"g":1,"b":1,"a":1}]
 
   [:isAsync=false;fragmentConstants={"r":1,"g":1}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;fragmentConstants={}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;fragmentConstants={"r":1,"b":1}]
 
@@ -48549,14 +48327,10 @@
   [:isAsync=false;vertexConstants={"x":1,"y":1,"z":1,"w":1}]
 
   [:isAsync=false;vertexConstants={"x":1,"y":1}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;vertexConstants={"x":1,"z":1}]
 
   [:isAsync=false;vertexConstants={}]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;vertexConstants={"x":1,"y":1,"z":1,"w":1}]
 
@@ -55841,8 +55615,6 @@
 
 [cts.https.html?q=webgpu:api,validation,shader_module,overrides:id_conflict:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,shader_module,overrides:name_conflict:*]
@@ -67973,20 +67745,12 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:equals:*]
   [:inputSource="const";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:greater_equals:*]
@@ -68031,20 +67795,12 @@
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:not_equals:*]
   [:inputSource="const";vectorize="_undef_"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="const";vectorize=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_division:scalar:*]
@@ -79164,8 +78920,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_storage_advanced:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
       if os == "linux" and not debug: NOTRUN
@@ -79554,8 +79308,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_advanced:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
       if os == "linux" and not debug: NOTRUN
@@ -80728,8 +80480,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_advanced:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
       if os == "linux" and not debug: NOTRUN
@@ -81118,8 +80868,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_advanced:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
       if os == "linux" and not debug: NOTRUN
@@ -84801,52 +84549,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,extractBits:u32:*]
@@ -84867,52 +84591,28 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,faceForward:abstract_float:*]
@@ -85785,100 +85485,52 @@
       if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=false;width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=false;width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=false;width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=false;width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=true;width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=true;width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=true;width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_r";signed=true;width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=false;width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=false;width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=false;width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=false;width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=true;width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=true;width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=true;width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="storage_rw";signed=true;width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=false;width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=false;width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=false;width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=false;width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=true;width=1]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=true;width=2]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=true;width=3]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:inputSource="uniform";signed=true;width=4]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:abstract_float:*]
@@ -95562,8 +95214,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,shader_io,compute_builtins:inputs:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:method="mixed";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
       if os == "linux" and not debug: NOTRUN

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -2490,7 +2490,7 @@
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="b2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-bundle-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
@@ -2502,7 +2502,7 @@
 
   [:boundary="command-buffer";readOp="storage-read";readContext="render-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="dispatch";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -2641,6 +2641,8 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2653,6 +2655,8 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2t-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -2727,6 +2731,8 @@
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -2861,10 +2867,12 @@
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
 
@@ -3200,7 +3208,7 @@
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="storage";writeContext="render-pass-encoder"]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="b2b-copy";readContext="command-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -3247,6 +3255,8 @@
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-bundle-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
 
@@ -3289,6 +3299,8 @@
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
   [:boundary="pass";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";readOp="storage-read";readContext="compute-pass-encoder";writeOp="storage";writeContext="compute-pass-encoder"]
 
@@ -3423,16 +3435,24 @@
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","b2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","storage"\];contexts=["compute-pass-encoder","compute-pass-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["compute-pass-encoder","command-encoder"\]]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-bundle-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["storage","t2b-copy"\];contexts=["render-pass-encoder","command-encoder"\]]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";writeOps=["t2b-copy","b2b-copy"\];contexts=["command-encoder","command-encoder"\]]
 
@@ -3842,7 +3862,7 @@
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-bundle-encoder"};read={"op":"t2t-copy","in":"command-encoder"}]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";write={"op":"storage","in":"render-pass-encoder"};read={"op":"t2b-copy","in":"command-encoder"}]
     expected:
@@ -3869,8 +3889,12 @@
       if os == "linux" and not debug: FAIL
 
   [:boundary="dispatch";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="pass";write={"op":"storage","in":"compute-pass-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="queue-op";write={"op":"attachment-resolve","in":"command-encoder"};read={"op":"sample","in":"compute-pass-encoder"}]
     expected:
@@ -5196,27 +5220,27 @@
 
   [:interpolated=false;sampleCount=4;rasterizationMask=10]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=11]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=12]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=13]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=14]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=15]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=false;sampleCount=4;rasterizationMask=2]
     expected:
@@ -5248,35 +5272,35 @@
 
   [:interpolated=false;sampleCount=4;rasterizationMask=9]
     expected:
-      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=0]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=1]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=10]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=11]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=12]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=13]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=14]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=15]
     expected:
@@ -5284,35 +5308,35 @@
 
   [:interpolated=true;sampleCount=4;rasterizationMask=2]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=3]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=4]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=5]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=6]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=7]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=8]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:interpolated=true;sampleCount=4;rasterizationMask=9]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
 
 [cts.https.html?q=webgpu:api,operation,render_pipeline,sample_mask:fragment_output_mask:*]
@@ -7411,7 +7435,7 @@
 
   [:format="r16float"]
     expected:
-      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:format="r32float"]
 
@@ -7421,7 +7445,7 @@
 
   [:format="rg16float"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg32float"]
 
@@ -7431,11 +7455,11 @@
 
   [:format="rgb10a2unorm"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba32float"]
 
@@ -9178,8 +9202,459 @@
 
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,features,texture_formats:canvas_configuration:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:format="astc-10x10-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x10-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x10-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x10-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x10-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x10-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x10-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x10-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x5-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x5-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x5-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x5-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x6-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x6-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x6-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x6-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x6-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x6-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x6-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x6-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x8-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x8-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x8-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x8-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-10x8-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-10x8-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-10x8-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-10x8-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-12x10-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-12x10-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-12x10-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-12x10-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-12x10-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-12x10-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-12x10-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-12x10-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-12x12-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-12x12-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-12x12-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-12x12-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-12x12-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-12x12-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-12x12-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-12x12-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-4x4-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-4x4-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-4x4-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-4x4-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-4x4-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-4x4-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-4x4-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-4x4-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-5x4-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-5x4-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-5x4-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-5x4-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-5x4-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-5x4-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-5x4-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-5x4-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-5x5-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-5x5-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-5x5-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-5x5-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-5x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-5x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-5x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-5x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-6x5-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-6x5-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-6x5-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-6x5-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-6x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-6x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-6x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-6x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-6x6-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-6x6-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-6x6-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-6x6-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-6x6-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-6x6-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-6x6-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-6x6-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-8x5-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-8x5-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-8x5-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-8x5-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-8x5-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-8x5-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-8x5-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-8x5-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-8x6-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-8x6-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-8x6-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-8x6-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-8x6-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-8x6-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-8x6-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-8x6-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-8x8-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-8x8-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-8x8-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-8x8-unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="astc-8x8-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="astc-8x8-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="astc-8x8-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="astc-8x8-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="bc1-rgba-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc1-rgba-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc1-rgba-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc1-rgba-unorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc1-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc1-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc1-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc1-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc2-rgba-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc2-rgba-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc2-rgba-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc2-rgba-unorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc2-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc2-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc2-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc2-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc3-rgba-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc3-rgba-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc3-rgba-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc3-rgba-unorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc3-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc3-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc3-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc3-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc4-r-snorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc4-r-snorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc4-r-snorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc4-r-snorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc4-r-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc4-r-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc4-r-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc4-r-unorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc5-rg-snorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc5-rg-snorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc5-rg-snorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc5-rg-snorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc5-rg-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc5-rg-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc5-rg-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc5-rg-unorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc6h-rgb-float";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc6h-rgb-float";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc6h-rgb-float";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc6h-rgb-float";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc6h-rgb-ufloat";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc6h-rgb-ufloat";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc6h-rgb-ufloat";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc6h-rgb-ufloat";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc7-rgba-unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc7-rgba-unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc7-rgba-unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc7-rgba-unorm";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="bc7-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="bc7-rgba-unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="bc7-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="bc7-rgba-unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="depth32float-stencil8";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="depth32float-stencil8";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="depth32float-stencil8";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="depth32float-stencil8";canvasType="onscreen";enable_required_feature=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:format="eac-r11snorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="eac-r11snorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="eac-r11snorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="eac-r11snorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="eac-r11unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="eac-r11unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="eac-r11unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="eac-r11unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="eac-rg11snorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="eac-rg11snorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="eac-rg11snorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="eac-rg11snorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="eac-rg11unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="eac-rg11unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="eac-rg11unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="eac-rg11unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8a1unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8a1unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8a1unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8a1unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8a1unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8a1unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8a1unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8a1unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="etc2-rgb8unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="etc2-rgb8unorm-srgb";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="etc2-rgba8unorm";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="etc2-rgba8unorm";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="etc2-rgba8unorm";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="etc2-rgba8unorm";canvasType="onscreen";enable_required_feature=true]
+
+  [:format="etc2-rgba8unorm-srgb";canvasType="offscreen";enable_required_feature=false]
+
+  [:format="etc2-rgba8unorm-srgb";canvasType="offscreen";enable_required_feature=true]
+
+  [:format="etc2-rgba8unorm-srgb";canvasType="onscreen";enable_required_feature=false]
+
+  [:format="etc2-rgba8unorm-srgb";canvasType="onscreen";enable_required_feature=true]
 
 
 [cts.https.html?q=webgpu:api,validation,capability_checks,features,texture_formats:canvas_configuration_view_formats:*]
@@ -26976,6 +27451,8 @@
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,beginRenderPass:depth_stencil_attachment,device_mismatch:*]
+  expected:
+    if os == "linux" and not debug: CRASH
   [:]
     expected:
       if os == "linux" and not debug: FAIL
@@ -29968,6 +30445,8 @@
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:current_scope:*]
+  expected:
+    if os == "linux" and not debug: [OK, CRASH]
   [:errorFilter="out-of-memory";stackDepth=1]
 
   [:errorFilter="out-of-memory";stackDepth=10]
@@ -42333,19 +42812,19 @@
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_format:*]
   [:encoderType="render%20bundle";encoderFormatFeature="_undef_";pipelineFormatFeature="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";encoderFormatFeature="_undef_";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";encoderFormatFeature="_undef_";pipelineFormatFeature="_undef_"]
     expected:
@@ -42353,15 +42832,15 @@
 
   [:encoderType="render%20pass";encoderFormatFeature="_undef_";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="_undef_"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";encoderFormatFeature="depth32float-stencil8";pipelineFormatFeature="depth32float-stencil8"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state:*]
@@ -78922,23 +79401,23 @@
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_storage_advanced:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
@@ -78946,235 +79425,235 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_storage_basic:*]
@@ -79310,19 +79789,19 @@
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_advanced:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
@@ -79334,7 +79813,7 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
@@ -79342,227 +79821,227 @@
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicExchange:exchange_workgroup_basic:*]
@@ -80482,19 +80961,19 @@
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_advanced:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
@@ -80530,211 +81009,211 @@
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_basic:*]
@@ -80870,19 +81349,19 @@
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_advanced:*]
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
@@ -80894,235 +81373,235 @@
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=1;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=2;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=32;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=16;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=1;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=4;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="passthrough";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="i32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:workgroupSize=64;dispatchSize=8;mapId="remap";scalarType="u32"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_basic:*]
@@ -86182,6 +86661,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:f32:*]
+  expected:
+    if os == "linux" and not debug: CRASH
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -95216,35 +95697,35 @@
 [cts.https.html?q=webgpu:shader,execution,shader_io,compute_builtins:inputs:*]
   [:method="mixed";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="direct";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="direct";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="indirect";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="mixed";dispatch="indirect";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
@@ -95252,63 +95733,63 @@
 
   [:method="param";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="direct";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="direct";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="indirect";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="param";dispatch="indirect";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="direct";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="direct";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="direct";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="indirect";groupSize={"x":1,"y":1,"z":1};numGroups={"x":8,"y":4,"z":2}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="indirect";groupSize={"x":3,"y":7,"z":5};numGroups={"x":13,"y":9,"z":11}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:method="struct";dispatch="indirect";groupSize={"x":8,"y":4,"z":2};numGroups={"x":1,"y":1,"z":1}]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,shader_io,fragment_builtins:inputs,front_facing:*]
@@ -99854,8 +100335,495 @@
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,configure:format:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:canvasType="offscreen";format="astc-10x10-unorm"]
+
+  [:canvasType="offscreen";format="astc-10x10-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-10x5-unorm"]
+
+  [:canvasType="offscreen";format="astc-10x5-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-10x6-unorm"]
+
+  [:canvasType="offscreen";format="astc-10x6-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-10x8-unorm"]
+
+  [:canvasType="offscreen";format="astc-10x8-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-12x10-unorm"]
+
+  [:canvasType="offscreen";format="astc-12x10-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-12x12-unorm"]
+
+  [:canvasType="offscreen";format="astc-12x12-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-4x4-unorm"]
+
+  [:canvasType="offscreen";format="astc-4x4-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-5x4-unorm"]
+
+  [:canvasType="offscreen";format="astc-5x4-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-5x5-unorm"]
+
+  [:canvasType="offscreen";format="astc-5x5-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-6x5-unorm"]
+
+  [:canvasType="offscreen";format="astc-6x5-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-6x6-unorm"]
+
+  [:canvasType="offscreen";format="astc-6x6-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-8x5-unorm"]
+
+  [:canvasType="offscreen";format="astc-8x5-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-8x6-unorm"]
+
+  [:canvasType="offscreen";format="astc-8x6-unorm-srgb"]
+
+  [:canvasType="offscreen";format="astc-8x8-unorm"]
+
+  [:canvasType="offscreen";format="astc-8x8-unorm-srgb"]
+
+  [:canvasType="offscreen";format="bc1-rgba-unorm"]
+
+  [:canvasType="offscreen";format="bc1-rgba-unorm-srgb"]
+
+  [:canvasType="offscreen";format="bc2-rgba-unorm"]
+
+  [:canvasType="offscreen";format="bc2-rgba-unorm-srgb"]
+
+  [:canvasType="offscreen";format="bc3-rgba-unorm"]
+
+  [:canvasType="offscreen";format="bc3-rgba-unorm-srgb"]
+
+  [:canvasType="offscreen";format="bc4-r-snorm"]
+
+  [:canvasType="offscreen";format="bc4-r-unorm"]
+
+  [:canvasType="offscreen";format="bc5-rg-snorm"]
+
+  [:canvasType="offscreen";format="bc5-rg-unorm"]
+
+  [:canvasType="offscreen";format="bc6h-rgb-float"]
+
+  [:canvasType="offscreen";format="bc6h-rgb-ufloat"]
+
+  [:canvasType="offscreen";format="bc7-rgba-unorm"]
+
+  [:canvasType="offscreen";format="bc7-rgba-unorm-srgb"]
+
+  [:canvasType="offscreen";format="bgra8unorm"]
+
+  [:canvasType="offscreen";format="bgra8unorm-srgb"]
+
+  [:canvasType="offscreen";format="depth16unorm"]
+
+  [:canvasType="offscreen";format="depth24plus"]
+
+  [:canvasType="offscreen";format="depth24plus-stencil8"]
+
+  [:canvasType="offscreen";format="depth32float"]
+
+  [:canvasType="offscreen";format="depth32float-stencil8"]
+
+  [:canvasType="offscreen";format="eac-r11snorm"]
+
+  [:canvasType="offscreen";format="eac-r11unorm"]
+
+  [:canvasType="offscreen";format="eac-rg11snorm"]
+
+  [:canvasType="offscreen";format="eac-rg11unorm"]
+
+  [:canvasType="offscreen";format="etc2-rgb8a1unorm"]
+
+  [:canvasType="offscreen";format="etc2-rgb8a1unorm-srgb"]
+
+  [:canvasType="offscreen";format="etc2-rgb8unorm"]
+
+  [:canvasType="offscreen";format="etc2-rgb8unorm-srgb"]
+
+  [:canvasType="offscreen";format="etc2-rgba8unorm"]
+
+  [:canvasType="offscreen";format="etc2-rgba8unorm-srgb"]
+
+  [:canvasType="offscreen";format="r16float"]
+
+  [:canvasType="offscreen";format="r16sint"]
+
+  [:canvasType="offscreen";format="r16uint"]
+
+  [:canvasType="offscreen";format="r32float"]
+
+  [:canvasType="offscreen";format="r32sint"]
+
+  [:canvasType="offscreen";format="r32uint"]
+
+  [:canvasType="offscreen";format="r8sint"]
+
+  [:canvasType="offscreen";format="r8snorm"]
+
+  [:canvasType="offscreen";format="r8uint"]
+
+  [:canvasType="offscreen";format="r8unorm"]
+
+  [:canvasType="offscreen";format="rg11b10ufloat"]
+
+  [:canvasType="offscreen";format="rg16float"]
+
+  [:canvasType="offscreen";format="rg16sint"]
+
+  [:canvasType="offscreen";format="rg16uint"]
+
+  [:canvasType="offscreen";format="rg32float"]
+
+  [:canvasType="offscreen";format="rg32sint"]
+
+  [:canvasType="offscreen";format="rg32uint"]
+
+  [:canvasType="offscreen";format="rg8sint"]
+
+  [:canvasType="offscreen";format="rg8snorm"]
+
+  [:canvasType="offscreen";format="rg8uint"]
+
+  [:canvasType="offscreen";format="rg8unorm"]
+
+  [:canvasType="offscreen";format="rgb10a2uint"]
+
+  [:canvasType="offscreen";format="rgb10a2unorm"]
+
+  [:canvasType="offscreen";format="rgb9e5ufloat"]
+
+  [:canvasType="offscreen";format="rgba16float"]
+
+  [:canvasType="offscreen";format="rgba16sint"]
+
+  [:canvasType="offscreen";format="rgba16uint"]
+
+  [:canvasType="offscreen";format="rgba32float"]
+
+  [:canvasType="offscreen";format="rgba32sint"]
+
+  [:canvasType="offscreen";format="rgba32uint"]
+
+  [:canvasType="offscreen";format="rgba8sint"]
+
+  [:canvasType="offscreen";format="rgba8snorm"]
+
+  [:canvasType="offscreen";format="rgba8uint"]
+
+  [:canvasType="offscreen";format="rgba8unorm"]
+
+  [:canvasType="offscreen";format="rgba8unorm-srgb"]
+
+  [:canvasType="offscreen";format="stencil8"]
+
+  [:canvasType="onscreen";format="astc-10x10-unorm"]
+
+  [:canvasType="onscreen";format="astc-10x10-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-10x5-unorm"]
+
+  [:canvasType="onscreen";format="astc-10x5-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-10x6-unorm"]
+
+  [:canvasType="onscreen";format="astc-10x6-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-10x8-unorm"]
+
+  [:canvasType="onscreen";format="astc-10x8-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-12x10-unorm"]
+
+  [:canvasType="onscreen";format="astc-12x10-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-12x12-unorm"]
+
+  [:canvasType="onscreen";format="astc-12x12-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-4x4-unorm"]
+
+  [:canvasType="onscreen";format="astc-4x4-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-5x4-unorm"]
+
+  [:canvasType="onscreen";format="astc-5x4-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-5x5-unorm"]
+
+  [:canvasType="onscreen";format="astc-5x5-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-6x5-unorm"]
+
+  [:canvasType="onscreen";format="astc-6x5-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-6x6-unorm"]
+
+  [:canvasType="onscreen";format="astc-6x6-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-8x5-unorm"]
+
+  [:canvasType="onscreen";format="astc-8x5-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-8x6-unorm"]
+
+  [:canvasType="onscreen";format="astc-8x6-unorm-srgb"]
+
+  [:canvasType="onscreen";format="astc-8x8-unorm"]
+
+  [:canvasType="onscreen";format="astc-8x8-unorm-srgb"]
+
+  [:canvasType="onscreen";format="bc1-rgba-unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc1-rgba-unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc2-rgba-unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc2-rgba-unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc3-rgba-unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc3-rgba-unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc4-r-snorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc4-r-unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc5-rg-snorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc5-rg-unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc6h-rgb-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc6h-rgb-ufloat"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc7-rgba-unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bc7-rgba-unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bgra8unorm"]
+
+  [:canvasType="onscreen";format="bgra8unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="depth16unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="depth24plus"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="depth32float-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="eac-r11snorm"]
+
+  [:canvasType="onscreen";format="eac-r11unorm"]
+
+  [:canvasType="onscreen";format="eac-rg11snorm"]
+
+  [:canvasType="onscreen";format="eac-rg11unorm"]
+
+  [:canvasType="onscreen";format="etc2-rgb8a1unorm"]
+
+  [:canvasType="onscreen";format="etc2-rgb8a1unorm-srgb"]
+
+  [:canvasType="onscreen";format="etc2-rgb8unorm"]
+
+  [:canvasType="onscreen";format="etc2-rgb8unorm-srgb"]
+
+  [:canvasType="onscreen";format="etc2-rgba8unorm"]
+
+  [:canvasType="onscreen";format="etc2-rgba8unorm-srgb"]
+
+  [:canvasType="onscreen";format="r16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r8snorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="r8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg11b10ufloat"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg8snorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rg8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgb10a2uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgb10a2unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgb9e5ufloat"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8snorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8unorm"]
+
+  [:canvasType="onscreen";format="rgba8unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,configure:size_zero_after_configure:*]
@@ -99877,8 +100845,83 @@
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,configure:viewFormats:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:canvasType="offscreen";format="bgra8unorm";viewFormatFeature="_undef_"]
+
+  [:canvasType="offscreen";format="bgra8unorm";viewFormatFeature="depth32float-stencil8"]
+
+  [:canvasType="offscreen";format="bgra8unorm";viewFormatFeature="texture-compression-astc"]
+
+  [:canvasType="offscreen";format="bgra8unorm";viewFormatFeature="texture-compression-bc"]
+
+  [:canvasType="offscreen";format="bgra8unorm";viewFormatFeature="texture-compression-etc2"]
+
+  [:canvasType="offscreen";format="rgba16float";viewFormatFeature="_undef_"]
+
+  [:canvasType="offscreen";format="rgba16float";viewFormatFeature="depth32float-stencil8"]
+
+  [:canvasType="offscreen";format="rgba16float";viewFormatFeature="texture-compression-astc"]
+
+  [:canvasType="offscreen";format="rgba16float";viewFormatFeature="texture-compression-bc"]
+
+  [:canvasType="offscreen";format="rgba16float";viewFormatFeature="texture-compression-etc2"]
+
+  [:canvasType="offscreen";format="rgba8unorm";viewFormatFeature="_undef_"]
+
+  [:canvasType="offscreen";format="rgba8unorm";viewFormatFeature="depth32float-stencil8"]
+
+  [:canvasType="offscreen";format="rgba8unorm";viewFormatFeature="texture-compression-astc"]
+
+  [:canvasType="offscreen";format="rgba8unorm";viewFormatFeature="texture-compression-bc"]
+
+  [:canvasType="offscreen";format="rgba8unorm";viewFormatFeature="texture-compression-etc2"]
+
+  [:canvasType="onscreen";format="bgra8unorm";viewFormatFeature="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bgra8unorm";viewFormatFeature="depth32float-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bgra8unorm";viewFormatFeature="texture-compression-astc"]
+
+  [:canvasType="onscreen";format="bgra8unorm";viewFormatFeature="texture-compression-bc"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="bgra8unorm";viewFormatFeature="texture-compression-etc2"]
+
+  [:canvasType="onscreen";format="rgba16float";viewFormatFeature="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba16float";viewFormatFeature="depth32float-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba16float";viewFormatFeature="texture-compression-astc"]
+
+  [:canvasType="onscreen";format="rgba16float";viewFormatFeature="texture-compression-bc"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba16float";viewFormatFeature="texture-compression-etc2"]
+
+  [:canvasType="onscreen";format="rgba8unorm";viewFormatFeature="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8unorm";viewFormatFeature="depth32float-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8unorm";viewFormatFeature="texture-compression-astc"]
+
+  [:canvasType="onscreen";format="rgba8unorm";viewFormatFeature="texture-compression-bc"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:canvasType="onscreen";format="rgba8unorm";viewFormatFeature="texture-compression-etc2"]
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,context_creation:return_type:*]
@@ -99905,7 +100948,7 @@
 
   [:canvasType="onscreen";prevFrameCallsite="requestAnimationFrame";getCurrentTextureAgain=true]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:canvasType="onscreen";prevFrameCallsite="runInNewCanvasFrame";getCurrentTextureAgain=false]
 
@@ -99944,199 +100987,133 @@
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:drawTo2DCanvas:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="offscreen";canvas2DType="onscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="offscreen"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";webgpuCanvasType="onscreen";canvas2DType="onscreen"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:offscreenCanvas,snapshot:*]
@@ -100214,27 +101191,25 @@
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:onscreenCanvas,snapshot:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
     expected:
@@ -100242,128 +101217,126 @@
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="display-p3";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";colorSpace="srgb";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="display-p3";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="imageBitmap"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toBlob"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";colorSpace="srgb";snapshotType="toDataURL"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:onscreenCanvas,uploadToWebGL:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -100393,72 +101366,62 @@
       if os == "linux" and not debug: [PASS, FAIL, NOTRUN]
 
   [:format="bgra8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
-    expected:
-      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl";upload="texImage2D"]
     expected:
-      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl";upload="texSubImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl2";upload="texImage2D"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="opaque";webgl="webgl2";upload="texSubImage2D"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl";upload="texImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl";upload="texSubImage2D"]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texImage2D"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";alphaMode="premultiplied";webgl="webgl2";upload="texSubImage2D"]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:web_platform,canvas,readbackFromWebGPUCanvas:transferToImageBitmap_huge_size:*]

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_clear.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_clear.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_clear.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_colorspace_rgba16float.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_complex_rgba16float_copy.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_complex_rgba16float_draw.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_complex_rgba16float_store.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_composite_alpha_rgba16float_opaque_copy.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_composite_alpha_rgba16float_opaque_draw.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_composite_alpha_rgba16float_premultiplied_copy.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html.ini
@@ -1,2 +1,6 @@
 [canvas_composite_alpha_rgba16float_premultiplied_draw.https.html]
-  expected: CRASH
+  expected:
+    if os == "win": CRASH
+    if os == "linux" and debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
+    if os == "mac": CRASH


### PR DESCRIPTION
The only real change is Transmute trait that got removed from wgpu (and left us without queue_id->device_id) transmute so I added it back, others are actually provided by wgpu.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
