### PR TITLE
compositing: Fix `flip_rect` calculation

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -249,7 +249,10 @@ impl EmbedderCoordinates {
     /// This should be used when drawing directly to the framebuffer with OpenGL commands.
     pub fn flip_rect(&self, rect: &DeviceIntRect) -> DeviceIntRect {
         let mut result = *rect;
-        result.min.y = self.framebuffer.height - result.min.y - result.size().height;
+        let min_y = self.framebuffer.height - result.max.y;
+        let max_y = self.framebuffer.height - result.min.y;
+        result.min.y = min_y;
+        result.max.y = max_y;
         result
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix the aftermath of https://github.com/servo/servo/issues/32039. `max.y` didn't flip before. I guess it's because we assume `max.y == framebuffer.y` back then.
- [x] These changes do not require tests, because they fix a bug only present when running servoshell with a GUI.