### PR TITLE
bootstrap: Add a `--skip-platform` option

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -198,7 +198,9 @@ def bootstrap_command_only(topdir):
     import servo.util
 
     try:
-        servo.platform.get().bootstrap('-f' in sys.argv or '--force' in sys.argv)
+        force = '-f' in sys.argv or '--force' in sys.argv
+        skip_platform = '--skip-platform' in sys.argv
+        servo.platform.get().bootstrap(force, skip_platform)
     except NotImplementedError as exception:
         print(exception)
         return 1

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -40,12 +40,15 @@ class MachCommands(CommandBase):
     @CommandArgument('--force', '-f',
                      action='store_true',
                      help='Boostrap without confirmation')
-    def bootstrap(self, force=False):
+    @CommandArgument('--skip-platform',
+                     action='store_true',
+                     help='Skip platform bootstrapping.')
+    def bootstrap(self, force=False, skip_platform=False):
         # Note: This entry point isn't actually invoked by ./mach bootstrap.
         # ./mach bootstrap calls mach_bootstrap.bootstrap_command_only so that
         # it can install dependencies without needing mach's dependencies
         try:
-            servo.platform.get().bootstrap(force)
+            servo.platform.get().bootstrap(force, skip_platform)
         except NotImplementedError as exception:
             print(exception)
             return 1

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -54,10 +54,12 @@ class Base:
         except FileNotFoundError:
             return False
 
-    def bootstrap(self, force: bool):
-        installed_something = self._platform_bootstrap(force)
+    def bootstrap(self, force: bool, skip_platform: bool):
+        if not skip_platform:
+            installed_something = self._platform_bootstrap(force)
         installed_something |= self.install_taplo(force)
         installed_something |= self.install_crown(force)
+
         if not installed_something:
             print("Dependencies were already installed!")
 


### PR DESCRIPTION
This allows installign `taplo` and `crown` when you are installing
dependencies manually.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just add a new bootstrap option.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
