### PR TITLE
url: Only truncate data URLs for `Debug`

### DIFF
--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -23,6 +23,9 @@ pub use url::Host;
 use url::{Position, Url};
 
 pub use crate::origin::{ImmutableOrigin, MutableOrigin, OpaqueOrigin};
+
+const DATA_URL_DISPLAY_LENGTH: usize = 40;
+
 #[derive(Debug)]
 pub enum UrlError {
     SetUsername,
@@ -266,14 +269,23 @@ impl fmt::Display for ServoUrl {
 
 impl fmt::Debug for ServoUrl {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        if self.0.as_str().len() > 40 {
-            let mut hasher = DefaultHasher::new();
-            hasher.write(self.0.as_str().as_bytes());
-            let truncated: String = self.0.as_str().chars().take(40).collect();
-            let result = format!("{}... ({:x})", truncated, hasher.finish());
-            return result.fmt(formatter);
+        let url_string = self.0.as_str();
+        if self.scheme() != "data" || url_string.len() <= DATA_URL_DISPLAY_LENGTH {
+            return url_string.fmt(formatter);
         }
-        self.0.fmt(formatter)
+
+        let mut hasher = DefaultHasher::new();
+        hasher.write(self.0.as_str().as_bytes());
+
+        format!(
+            "{}... ({:x})",
+            url_string
+                .chars()
+                .take(DATA_URL_DISPLAY_LENGTH)
+                .collect::<String>(),
+            hasher.finish()
+        )
+        .fmt(formatter)
     }
 }
 


### PR DESCRIPTION
Other types of URLs aren't so long that they need to be truncated.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change debug output.
