### PR TITLE
Disable `/fetch/api/crashtests/huge-fetch.any.js`

### DIFF
--- a/tests/wpt/meta-legacy-layout/fetch/api/crashtests/huge-fetch.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/fetch/api/crashtests/huge-fetch.any.js.ini
@@ -1,11 +1,11 @@
 [huge-fetch.any.worker.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168
 
 [huge-fetch.any.sharedworker.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168
 
 [huge-fetch.any.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168
 
 [huge-fetch.any.serviceworker.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168

--- a/tests/wpt/meta-legacy-layout/fetch/api/crashtests/huge-fetch.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/fetch/api/crashtests/huge-fetch.any.js.ini
@@ -1,0 +1,11 @@
+[huge-fetch.any.worker.html]
+  disabled: true
+
+[huge-fetch.any.sharedworker.html]
+  disabled: true
+
+[huge-fetch.any.html]
+  disabled: true
+
+[huge-fetch.any.serviceworker.html]
+  disabled: true

--- a/tests/wpt/meta/fetch/api/crashtests/huge-fetch.any.js.ini
+++ b/tests/wpt/meta/fetch/api/crashtests/huge-fetch.any.js.ini
@@ -1,11 +1,11 @@
 [huge-fetch.any.worker.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168
 
 [huge-fetch.any.sharedworker.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168
 
 [huge-fetch.any.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168
 
 [huge-fetch.any.serviceworker.html]
-  disabled: true
+  disabled: https://github.com/servo/servo/issues/32168

--- a/tests/wpt/meta/fetch/api/crashtests/huge-fetch.any.js.ini
+++ b/tests/wpt/meta/fetch/api/crashtests/huge-fetch.any.js.ini
@@ -1,0 +1,11 @@
+[huge-fetch.any.worker.html]
+  disabled: true
+
+[huge-fetch.any.sharedworker.html]
+  disabled: true
+
+[huge-fetch.any.html]
+  disabled: true
+
+[huge-fetch.any.serviceworker.html]
+  disabled: true


### PR DESCRIPTION
This tests was causing the WPT import task to fail, perhaps because Python does not run GC and when we run it for the for the second time, resulting in an OOM error.

Fixes #32168.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they work: https://github.com/servo/servo/actions/runs/8892777516
