### PR TITLE
script: Include layout when collecting memory reports

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -56,7 +56,7 @@ use metrics::{PaintTimeMetrics, ProfilerMetadataFactory};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image_cache::{ImageCache, UsePlaceholder};
 use parking_lot::RwLock;
-use profile_traits::mem::{Report, ReportKind, ReportsChan};
+use profile_traits::mem::{Report, ReportKind};
 use profile_traits::path;
 use profile_traits::time::{
     self as profile_time, profile, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
@@ -508,8 +508,7 @@ impl Layout for LayoutThread {
         self.registered_painters.0.insert(name, registered_painter);
     }
 
-    fn collect_reports(&self, reports_chan: ReportsChan) {
-        let mut reports = vec![];
+    fn collect_reports(&self, reports: &mut Vec<Report>) {
         // Servo uses vanilla jemalloc, which doesn't have a
         // malloc_enclosing_size_of function.
         let mut ops = MallocSizeOfOps::new(servo_allocator::usable_size, None, None);
@@ -536,8 +535,6 @@ impl Layout for LayoutThread {
             kind: ReportKind::ExplicitJemallocHeapSize,
             size: malloc_size_of_persistent_local_context(&mut ops),
         });
-
-        reports_chan.send(reports);
     }
 
     fn reflow(&mut self, script_reflow: script_layout_interface::ScriptReflow) {

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -42,7 +42,7 @@ use metrics::{PaintTimeMetrics, ProfilerMetadataFactory};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image_cache::{ImageCache, UsePlaceholder};
 use parking_lot::{ReentrantMutex, RwLock};
-use profile_traits::mem::{Report, ReportKind, ReportsChan};
+use profile_traits::mem::{Report, ReportKind};
 use profile_traits::path;
 use profile_traits::time::{
     self as profile_time, profile, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
@@ -417,8 +417,7 @@ impl Layout for LayoutThread {
 
     fn exit_now(&mut self) {}
 
-    fn collect_reports(&self, reports_chan: ReportsChan) {
-        let mut reports = vec![];
+    fn collect_reports(&self, reports: &mut Vec<Report>) {
         // Servo uses vanilla jemalloc, which doesn't have a
         // malloc_enclosing_size_of function.
         let mut ops = MallocSizeOfOps::new(servo_allocator::usable_size, None, None);
@@ -436,8 +435,6 @@ impl Layout for LayoutThread {
             kind: ReportKind::ExplicitJemallocHeapSize,
             size: self.stylist.size_of(&mut ops),
         });
-
-        reports_chan.send(reports);
     }
 
     fn set_quirks_mode(&mut self, quirks_mode: QuirksMode) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2556,6 +2556,13 @@ impl ScriptThread {
 
         let mut reports = vec![];
         reports.extend(unsafe { get_reports(*self.get_cx(), path_seg) });
+        SCRIPT_THREAD_ROOT.with(|root| {
+            let script_thread = unsafe { &*root.get().unwrap() };
+            let layouts = script_thread.layouts.borrow();
+            for layout in layouts.values() {
+                layout.collect_reports(&mut reports);
+            }
+        });
         reports_chan.send(reports);
     }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -29,7 +29,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use metrics::PaintTimeMetrics;
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use net_traits::image_cache::{ImageCache, PendingImageId};
-use profile_traits::mem::ReportsChan;
+use profile_traits::mem::Report;
 use profile_traits::time;
 use script_traits::{
     ConstellationControlMsg, InitialScriptState, LayoutControlMsg, LayoutMsg, LoadData, Painter,
@@ -208,7 +208,7 @@ pub trait Layout {
 
     /// Requests that layout measure its memory usage. The resulting reports are sent back
     /// via the supplied channel.
-    fn collect_reports(&self, reports_chan: ReportsChan);
+    fn collect_reports(&self, reports: &mut Vec<Report>);
 
     /// Sets quirks mode for the document, causing the quirks mode stylesheet to be used.
     fn set_quirks_mode(&mut self, quirks_mode: QuirksMode);


### PR DESCRIPTION
Include memory reports from layout thread when reporting the usage from the script threads. This was not happening after the change to merge layout thread and script thread (#31346).

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because we just add more memory reports