### PR TITLE
fonts: Add `MallocSizeOf` implementation for `FontContext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,6 +1971,7 @@ dependencies = [
  "libc",
  "log",
  "malloc_size_of",
+ "malloc_size_of_derive",
  "net_traits",
  "parking_lot",
  "range",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -28,6 +28,7 @@ lazy_static = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 parking_lot = { workspace = true }
 range = { path = "../range" }

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -13,6 +13,7 @@ use app_units::Au;
 use bitflags::bitflags;
 use euclid::default::{Point2D, Rect, Size2D};
 use log::debug;
+use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use servo_atoms::{atom, Atom};
@@ -116,7 +117,7 @@ pub trait FontTableMethods {
     fn buffer(&self) -> &[u8];
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct FontMetrics {
     pub underline_size: Au,
     pub underline_offset: Au,
@@ -161,7 +162,7 @@ impl FontMetrics {
 /// template at a particular size, with a particular font-variant-caps applied, etc. This contrasts
 /// with `FontTemplateDescriptor` in that the latter represents only the parameters inherent in the
 /// font data (weight, stretch, etc.).
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct FontDescriptor {
     pub weight: FontWeight,
     pub stretch: FontStretch,
@@ -191,6 +192,19 @@ struct CachedShapeData {
     shaped_text: HashMap<ShapeCacheEntry, Arc<GlyphStore>>,
 }
 
+impl malloc_size_of::MallocSizeOf for CachedShapeData {
+    fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        // Estimate the size of the shaped text cache. This will be smaller, because
+        // HashMap has some overhead, but we are mainly interested in the actual data.
+        let shaped_text_size = self
+            .shaped_text
+            .iter()
+            .map(|(key, value)| key.size_of(ops) + (*value).size_of(ops))
+            .sum::<usize>();
+        self.glyph_advances.size_of(ops) + self.glyph_indices.size_of(ops) + shaped_text_size
+    }
+}
+
 #[derive(Debug)]
 pub struct Font {
     pub handle: PlatformFont,
@@ -205,6 +219,17 @@ pub struct Font {
     /// the version of the font used to replace lowercase ASCII letters. It's up
     /// to the consumer of this font to properly use this reference.
     pub synthesized_small_caps: Option<FontRef>,
+}
+
+impl malloc_size_of::MallocSizeOf for Font {
+    fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        // TODO: Collect memory usage for platform fonts and for shapers.
+        // This skips the template, because they are already stored in the template cache.
+        self.metrics.size_of(ops) +
+            self.descriptor.size_of(ops) +
+            self.cached_shape_data.read().size_of(ops) +
+            self.font_key.size_of(ops)
+    }
 }
 
 impl Font {
@@ -428,10 +453,11 @@ pub type FontRef = Arc<Font>;
 /// A `FontGroup` is a prioritised list of fonts for a given set of font styles. It is used by
 /// `TextRun` to decide which font to render a character with. If none of the fonts listed in the
 /// styles are suitable, a fallback font may be used.
-#[derive(Debug)]
+#[derive(Debug, MallocSizeOf)]
 pub struct FontGroup {
     descriptor: FontDescriptor,
     families: SmallVec<[FontGroupFamily; 8]>,
+    #[ignore_malloc_size_of = "This measured in the FontContext font cache."]
     last_matching_fallback: Option<FontRef>,
 }
 
@@ -587,9 +613,11 @@ impl FontGroup {
 /// `unicode-range` descriptors. In this case, font selection will select a single member
 /// that contains the necessary unicode character. Unicode ranges are specified by the
 /// [`FontGroupFamilyMember::template`] member.
-#[derive(Debug)]
+#[derive(Debug, MallocSizeOf)]
 struct FontGroupFamilyMember {
+    #[ignore_malloc_size_of = "This measured in the FontContext template cache."]
     template: FontTemplateRef,
+    #[ignore_malloc_size_of = "This measured in the FontContext font cache."]
     font: Option<FontRef>,
     loaded: bool,
 }
@@ -598,7 +626,7 @@ struct FontGroupFamilyMember {
 /// families listed in the `font-family` CSS property. The corresponding font data is lazy-loaded,
 /// only if actually needed. A single `FontGroupFamily` can have multiple fonts, in the case that
 /// individual fonts only cover part of the Unicode range.
-#[derive(Debug)]
+#[derive(Debug, MallocSizeOf)]
 struct FontGroupFamily {
     family_descriptor: FontFamilyDescriptor,
     members: Option<Vec<FontGroupFamilyMember>>,
@@ -703,7 +731,7 @@ pub fn get_and_reset_text_shaping_performance_counter() -> usize {
 }
 
 /// The scope within which we will look for a font.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum FontSearchScope {
     /// All fonts will be searched, including those specified via `@font-face` rules.
     Any,
@@ -713,7 +741,7 @@ pub enum FontSearchScope {
 }
 
 /// A font family name used in font selection.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum FontFamilyName {
     /// A specific name such as `"Arial"`
     Specific(Atom),
@@ -758,7 +786,7 @@ impl<'a> From<&'a str> for FontFamilyName {
 }
 
 /// The font family parameters for font selection.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct FontFamilyDescriptor {
     pub name: FontFamilyName,
     pub scope: FontSearchScope,

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -13,6 +13,7 @@ use atomic_refcell::AtomicRefCell;
 use gfx_traits::WebrenderApi;
 use ipc_channel::ipc::{self, IpcBytesSender, IpcReceiver, IpcSender};
 use log::{debug, trace};
+use malloc_size_of_derive::MallocSizeOf;
 use net_traits::request::{Destination, Referrer, RequestBuilder};
 use net_traits::{fetch_async, CoreResourceThread, FetchResponseMsg};
 use serde::{Deserialize, Serialize};
@@ -46,7 +47,7 @@ pub struct FontTemplates {
     templates: Vec<FontTemplateRef>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum FontIdentifier {
     Local(LocalFontIdentifier),
     Web(ServoUrl),

--- a/components/gfx/platform/freetype/android/font_list.rs
+++ b/components/gfx/platform/freetype/android/font_list.rs
@@ -4,7 +4,7 @@
 
 use std::fs::File;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
@@ -14,7 +14,6 @@ use style::values::computed::{
 };
 use style::Atom;
 use ucd::{Codepoint, UnicodeBlock};
-use webrender_api::NativeFontHandle;
 
 use super::xml::{Attribute, Node};
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};

--- a/components/gfx/platform/freetype/android/font_list.rs
+++ b/components/gfx/platform/freetype/android/font_list.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::values::computed::{
     FontStretch as StyleFontStretch, FontStyle as StyleFontStyle, FontWeight as StyleFontWeight,
@@ -24,7 +25,7 @@ lazy_static::lazy_static! {
 }
 
 /// An identifier for a local font on Android systems.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct LocalFontIdentifier {
     /// The path to the font.
     pub path: Atom,

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -24,6 +24,7 @@ use fontconfig_sys::{
 };
 use libc::{c_char, c_int};
 use log::debug;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::values::computed::{FontStretch, FontStyle, FontWeight};
 use style::Atom;
@@ -34,7 +35,7 @@ use crate::font_template::{FontTemplate, FontTemplateDescriptor};
 use crate::text::util::is_cjk;
 
 /// An identifier for a local font on systems using Freetype.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct LocalFontIdentifier {
     /// The path to the font.
     pub path: Atom,

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 use std::path::Path;
 
 use log::debug;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::Atom;
 use ucd::{Codepoint, UnicodeBlock};
@@ -20,7 +21,7 @@ use crate::text::util::unicode_plane;
 /// An identifier for a local font on a MacOS system. These values comes from the CoreText
 /// CTFontCollection. Note that `path` here is required. We do not load fonts that do not
 /// have paths.
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct LocalFontIdentifier {
     pub postscript_name: Atom,
     pub path: Atom,

--- a/components/gfx/platform/windows/font_list.rs
+++ b/components/gfx/platform/windows/font_list.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use dwrote::{Font, FontCollection, FontDescriptor, FontStretch, FontStyle};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::values::computed::{FontStyle as StyleFontStyle, FontWeight as StyleFontWeight};
 use style::values::specified::font::FontStretchKeyword;
@@ -31,9 +32,10 @@ where
 }
 
 /// An identifier for a local font on a Windows system.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct LocalFontIdentifier {
     /// The FontDescriptor of this font.
+    #[ignore_malloc_size_of = "dwrote does not support MallocSizeOf"]
     pub font_descriptor: Arc<FontDescriptor>,
 }
 

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -10,6 +10,7 @@ use app_units::Au;
 use euclid::default::Point2D;
 pub use gfx_traits::ByteIndex;
 use log::debug;
+use malloc_size_of_derive::MallocSizeOf;
 use range::{self, EachIndex, Range, RangeIndex};
 use serde::{Deserialize, Serialize};
 
@@ -21,7 +22,7 @@ use serde::{Deserialize, Serialize};
 /// In the uncommon case (multiple glyphs per unicode character, large glyph index/advance, or
 /// glyph offsets), we pack the glyph count into GlyphEntry, and store the other glyph information
 /// in DetailedGlyphStore.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct GlyphEntry {
     value: u32,
 }
@@ -145,7 +146,7 @@ impl GlyphEntry {
 
 // Stores data for a detailed glyph, in the case that several glyphs
 // correspond to one character, or the glyph's data couldn't be packed.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
 struct DetailedGlyph {
     id: GlyphId,
     // glyph's advance, in the text's direction (LTR or RTL)
@@ -164,7 +165,7 @@ impl DetailedGlyph {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 struct DetailedGlyphRecord {
     // source string offset/GlyphEntry offset in the TextRun
     entry_offset: ByteIndex,
@@ -188,7 +189,7 @@ impl PartialOrd for DetailedGlyphRecord {
 // until a lookup is actually performed; this matches the expected
 // usage pattern of setting/appending all the detailed glyphs, and
 // then querying without setting.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
 struct DetailedGlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
@@ -416,7 +417,7 @@ impl<'a> GlyphInfo<'a> {
 /// |               +---+---+                     |
 /// +---------------------------------------------+
 /// ~~~
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
 pub struct GlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -530,6 +530,12 @@ impl Layout for LayoutThread {
             kind: ReportKind::ExplicitJemallocHeapSize,
             size: self.stylist.size_of(&mut ops),
         });
+
+        reports.push(Report {
+            path: path![formatted_url, "layout-thread", "font-context"],
+            kind: ReportKind::ExplicitJemallocHeapSize,
+            size: self.font_context.size_of(&mut ops),
+        });
     }
 
     fn reflow(&mut self, script_reflow: script_layout_interface::ScriptReflow) {

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -425,7 +425,7 @@ impl Layout for LayoutThread {
         // malloc_enclosing_size_of function.
         let mut ops = MallocSizeOfOps::new(servo_allocator::usable_size, None, None);
 
-        // FIXME(njn): Just measuring the display tree for now.
+        // TODO: Measure more than just display list, stylist, and font context.
         let formatted_url = &format!("url({})", self.url);
         reports.push(Report {
             path: path![formatted_url, "layout-thread", "display-list"],
@@ -437,6 +437,12 @@ impl Layout for LayoutThread {
             path: path![formatted_url, "layout-thread", "stylist"],
             kind: ReportKind::ExplicitJemallocHeapSize,
             size: self.stylist.size_of(&mut ops),
+        });
+
+        reports.push(Report {
+            path: path![formatted_url, "layout-thread", "font-context"],
+            kind: ReportKind::ExplicitJemallocHeapSize,
+            size: self.font_context.size_of(&mut ops),
         });
     }
 


### PR DESCRIPTION

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because `MallocSizeOf` is untested in Servo.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
