### PR TITLE
compositor: Do not handle embedder events during or after shutdown

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1416,6 +1416,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     pub fn on_mouse_window_event_class(&mut self, mouse_window_event: MouseWindowEvent) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         if self.convert_mouse_to_touch {
             match mouse_window_event {
                 MouseWindowEvent::Click(_, _) => {},
@@ -1513,6 +1517,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     pub fn on_mouse_window_move_event_class(&mut self, cursor: DevicePoint) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         if self.convert_mouse_to_touch {
             self.on_touch_move(TouchId(0), cursor);
             return;
@@ -1571,6 +1579,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         identifier: TouchId,
         location: DevicePoint,
     ) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         match event_type {
             TouchEventType::Down => self.on_touch_down(identifier, location),
             TouchEventType::Move => self.on_touch_move(identifier, location),
@@ -1638,6 +1650,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     pub fn on_wheel_event(&mut self, delta: WheelDelta, p: DevicePoint) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         self.send_wheel_event(delta, p);
     }
 
@@ -1647,6 +1663,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         cursor: DeviceIntPoint,
         phase: TouchEventType,
     ) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         match phase {
             TouchEventType::Move => self.on_scroll_window_event(scroll_location, cursor),
             TouchEventType::Up | TouchEventType::Cancel => {
@@ -1860,11 +1880,19 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     pub fn on_zoom_reset_window_event(&mut self) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         self.page_zoom = Scale::new(1.0);
         self.update_after_zoom_or_hidpi_change();
     }
 
     pub fn on_zoom_window_event(&mut self, magnification: f32) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         self.page_zoom = Scale::new(
             (self.page_zoom.get() * magnification)
                 .max(MIN_ZOOM)
@@ -1887,6 +1915,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
     /// Simulate a pinch zoom
     pub fn on_pinch_zoom_window_event(&mut self, magnification: f32) {
+        if self.shutdown_state != ShutdownState::NotShuttingDown {
+            return;
+        }
+
         // TODO: Scroll to keep the center in view?
         self.pending_scroll_zoom_events
             .push(ScrollZoomEvent::PinchZoom(magnification));


### PR DESCRIPTION
This is a speculative fix for #32202, which I cannot reproduce
consistently. This prevents handling any embedder events while
shutting down or after shutdown is complete. It doesn't make sense to do
this as the compositor can be in a very inconsistent state during this
time and lead to panics.

Fixes #32202.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32202.
- [x] These changes do not require tests because this part of Servo is pretty hard to test and this crash is not something that can be reproduced consistently.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
