### PR TITLE
mach: Upgrade boto3 and remove Python < 3.10 dependencies

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,10 +5,8 @@ blessings == 1.7
 distro == 1.4
 mozinfo == 1.2.3
 mozlog == 8.0.0
-setuptools == 68.2.2; python_version >= "3.8"
-setuptools == 65.5.1; python_version < "3.8"
+setuptools == 68.2.2
 toml == 0.9.2
-dataclasses == 0.8; python_version < "3.7"
 
 # For Python linting
 flake8 == 3.8.3
@@ -22,7 +20,7 @@ ply == 3.8
 colorama == 0.3.7
 
 # For package uploading
-boto3 == 1.28.84
+boto3 == 1.34.95
 pyOpenSSL == 23.0.0
 PyGithub == 1.58.1
 


### PR DESCRIPTION
This change upgrades boto3, which will fix an upcoming urllib3 version
conflict in the WPT and also removes all remaining dependencies for
Python version < 3.10. The requirement for Servo is 3.10 now.

Fixes #32201.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just upgrades build dependencies.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
