### PR TITLE
Update to Rust 1.78

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,7 +3040,8 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.18.1"
-source = "git+https://github.com/sagudev/ipc-channel?branch=empty-slice-simple#affa99e14ae30ff4788246e4e8b90530a6854445"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d038e61635aad6528b810a652e68efd09fc02551b6d108ae7c5c86285c6b40"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,9 +3039,8 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab3a34c91b7e84a72643bd75d1bac3afd241f78f9859fe0b5e5b2a6a75732c2"
+version = "0.18.1"
+source = "git+https://github.com/sagudev/ipc-channel?branch=empty-slice-simple#affa99e14ae30ff4788246e4e8b90530a6854445"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ inherits = "release"
 debug-assertions = false
 
 [patch.crates-io]
-ipc-channel = { git = "https://github.com/sagudev/ipc-channel", branch = "empty-slice-simple" }
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ inherits = "release"
 debug-assertions = false
 
 [patch.crates-io]
+ipc-channel = { git = "https://github.com/sagudev/ipc-channel", branch = "empty-slice-simple" }
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -274,10 +274,9 @@ impl RootCollection {
     unsafe fn unroot(&self, object: *const dyn JSTraceable) {
         assert_in_script();
         let roots = &mut *self.roots.get();
-        // FIXME: Use std::ptr::addr_eq after migrating to newer version of std.
         match roots
             .iter()
-            .rposition(|r| std::ptr::eq(*r as *const (), object as *const ()))
+            .rposition(|r| std::ptr::addr_eq(*r as *const (), object as *const ()))
         {
             Some(idx) => {
                 roots.remove(idx);

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -10,7 +10,7 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/a0df72e106322b67e9c6e591fe870380bd0da0d5.tar.gz";
+      url = "https://github.com/oxalica/rust-overlay/archive/7f0e3ef7b7fbed78e12e5100851175d28af4b7c6.tar.gz";
     }))
   ];
   config = {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update etc/shell.nix when bumping this!
-channel = "1.74"
+channel = "beta-2024-04-28"
 
 components = [
     # For support/crown

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update etc/shell.nix when bumping this!
-channel = "beta-2024-04-28"
+channel = "1.78.0"
 
 components = [
     # For support/crown

--- a/support/crown/Cargo.toml
+++ b/support/crown/Cargo.toml
@@ -20,3 +20,7 @@ trace_in_no_trace_lint = []
 [package.metadata.rust-analyzer]
 # This crate uses #![feature(rustc_private)]
 rustc_private = true
+
+# You might also need this in .vscode/settings.json
+# "rust-analyzer.check.command": "check",
+# "rust-analyzer.rustc.source": "discover",

--- a/support/crown/Cargo.toml
+++ b/support/crown/Cargo.toml
@@ -21,6 +21,6 @@ trace_in_no_trace_lint = []
 # This crate uses #![feature(rustc_private)]
 rustc_private = true
 
-# You might also need this in .vscode/settings.json
+# If you are working on crown, you might also need this in .vscode/settings.json.
 # "rust-analyzer.check.command": "check",
 # "rust-analyzer.rustc.source": "discover",

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -256,10 +256,7 @@ pub fn get_trait_def_id(cx: &LateContext<'_>, path: &[&str]) -> Option<DefId> {
         })
 }
 
-/*
-These are special variants made from above functions
-*/
-
+// These are special variants made from the above functions.
 /// Resolves a def path like `std::vec::Vec`, but searches only local crate
 ///
 /// Also returns multiple results when there are multiple paths under the same name e.g. `std::vec`

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -70,7 +70,8 @@ macro_rules! symbols {
 Stuff copied from clippy:
 */
 
-// https://github.com/rust-lang/rust-clippy/blob/546408be416f0355a39601c1457b37727bc74395/clippy_utils/src/lib.rs#L517
+// This is adapted from
+// https://github.com/rust-lang/rust-clippy/blob/546408be416f0355a39601c1457b37727bc74395/clippy_utils/src/lib.rs#L517.
 fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<Item = DefId> + 'tcx {
     let ty = match name {
         "bool" => SimplifiedType::Bool,

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -128,7 +128,8 @@ fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol)
     }
 }
 
-// from clippy: https://github.com/rust-lang/rust-clippy/blob/546408be416f0355a39601c1457b37727bc74395/clippy_utils/src/lib.rs#L574
+// This is adapted from clippy:
+// https://github.com/rust-lang/rust-clippy/blob/546408be416f0355a39601c1457b37727bc74395/clippy_utils/src/lib.rs#L574.
 fn local_item_children_by_name(tcx: TyCtxt<'_>, local_id: LocalDefId, name: Symbol) -> Vec<Res> {
     let hir = tcx.hir();
 

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -9,10 +9,11 @@ use rustc_hir::{ImplItemRef, ItemKind, Node, OwnerId, PrimTy, TraitItemRef};
 use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::LateContext;
+use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::{self, GenericArg, ParamEnv, Ty, TyCtxt, TypeVisitableExt};
-use rustc_span::source_map::{ExpnKind, MacroKind, Span};
+use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::symbol::{Ident, Symbol};
-use rustc_span::DUMMY_SP;
+use rustc_span::{Span, DUMMY_SP};
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_type_ir::{FloatTy, IntTy, UintTy};
 
@@ -69,8 +70,8 @@ macro_rules! symbols {
 Stuff copied from clippy:
 */
 
+// https://github.com/rust-lang/rust-clippy/blob/546408be416f0355a39601c1457b37727bc74395/clippy_utils/src/lib.rs#L517
 fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<Item = DefId> + 'tcx {
-    use rustc_middle::ty::fast_reject::SimplifiedType;
     let ty = match name {
         "bool" => SimplifiedType::Bool,
         "char" => SimplifiedType::Char,
@@ -96,10 +97,16 @@ fn find_primitive_impls<'tcx>(tcx: TyCtxt<'tcx>, name: &str) -> impl Iterator<It
         "u128" => SimplifiedType::Uint(UintTy::U128),
         "f32" => SimplifiedType::Float(FloatTy::F32),
         "f64" => SimplifiedType::Float(FloatTy::F64),
-        _ => return [].iter().copied(),
+        #[allow(trivial_casts)]
+        _ => {
+            return Result::<_, rustc_errors::ErrorGuaranteed>::Ok(&[] as &[_])
+                .into_iter()
+                .flatten()
+                .copied();
+        },
     };
 
-    tcx.incoherent_impls(ty).iter().copied()
+    tcx.incoherent_impls(ty).into_iter().flatten().copied()
 }
 
 fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol) -> Vec<Res> {
@@ -121,16 +128,17 @@ fn non_local_item_children_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol)
     }
 }
 
+// from clippy: https://github.com/rust-lang/rust-clippy/blob/546408be416f0355a39601c1457b37727bc74395/clippy_utils/src/lib.rs#L574
 fn local_item_children_by_name(tcx: TyCtxt<'_>, local_id: LocalDefId, name: Symbol) -> Vec<Res> {
     let hir = tcx.hir();
 
     let root_mod;
-    let item_kind = match hir.find_by_def_id(local_id) {
-        Some(Node::Crate(r#mod)) => {
+    let item_kind = match tcx.hir_node_by_def_id(local_id) {
+        Node::Crate(r#mod) => {
             root_mod = ItemKind::Mod(r#mod);
             &root_mod
         },
-        Some(Node::Item(item)) => &item.kind,
+        Node::Item(item) => &item.kind,
         _ => return Vec::new(),
     };
 
@@ -225,7 +233,8 @@ pub fn def_path_res(cx: &LateContext<'_>, path: &[&str]) -> Vec<Res> {
                 // `impl S { ... }`
                 let inherent_impl_children = tcx
                     .inherent_impls(def_id)
-                    .iter()
+                    .into_iter()
+                    .flatten()
                     .flat_map(|&impl_def_id| item_children_by_name(tcx, impl_def_id, segment));
 
                 let direct_children = item_children_by_name(tcx, def_id, segment);
@@ -237,6 +246,19 @@ pub fn def_path_res(cx: &LateContext<'_>, path: &[&str]) -> Vec<Res> {
 
     resolutions
 }
+
+pub fn get_trait_def_id(cx: &LateContext<'_>, path: &[&str]) -> Option<DefId> {
+    def_path_res(cx, path)
+        .into_iter()
+        .find_map(|res| match res {
+            Res::Def(DefKind::Trait | DefKind::TraitAlias, trait_id) => Some(trait_id),
+            _ => None,
+        })
+}
+
+/*
+These are special variants made from above functions
+*/
 
 /// Resolves a def path like `std::vec::Vec`, but searches only local crate
 ///
@@ -259,7 +281,8 @@ pub fn def_local_res(cx: &LateContext<'_>, path: &str) -> Vec<Res> {
             // `impl S { ... }`
             let inherent_impl_children = tcx
                 .inherent_impls(def_id)
-                .iter()
+                .into_iter()
+                .flatten()
                 .flat_map(|&impl_def_id| item_children_by_name(tcx, impl_def_id, segment));
 
             let direct_children = item_children_by_name(tcx, def_id, segment);
@@ -269,15 +292,6 @@ pub fn def_local_res(cx: &LateContext<'_>, path: &str) -> Vec<Res> {
         .collect();
 
     resolutions
-}
-
-pub fn get_trait_def_id(cx: &LateContext<'_>, path: &[&str]) -> Option<DefId> {
-    def_path_res(cx, path)
-        .into_iter()
-        .find_map(|res| match res {
-            Res::Def(DefKind::Trait | DefKind::TraitAlias, trait_id) => Some(trait_id),
-            _ => None,
-        })
 }
 
 pub fn get_local_trait_def_id(cx: &LateContext<'_>, path: &str) -> Option<DefId> {

--- a/support/crown/src/main.rs
+++ b/support/crown/src/main.rs
@@ -10,10 +10,12 @@
 extern crate rustc_ast;
 extern crate rustc_driver;
 extern crate rustc_error_messages;
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_infer;
 extern crate rustc_interface;
 extern crate rustc_lint;
+extern crate rustc_log;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
@@ -60,8 +62,8 @@ impl Callbacks for MyCallbacks {
 
 fn main() -> ExitCode {
     let handler =
-        rustc_session::EarlyErrorHandler::new(rustc_session::config::ErrorOutputType::default());
-    rustc_driver::init_env_logger(&handler, "CROWN_LOG");
+        rustc_session::EarlyDiagCtxt::new(rustc_session::config::ErrorOutputType::default());
+    rustc_driver::init_logger(&handler, rustc_log::LoggerConfig::from_env("CROWN_LOG"));
     let args: Vec<_> = std::env::args().collect();
 
     match rustc_driver::RunCompiler::new(&args, &mut MyCallbacks).run() {

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -86,7 +86,7 @@ fn get_must_not_have_traceable(sym: &Symbols, attrs: &[Attribute]) -> Option<usi
                     TokenKind::Literal(lit) => lit.symbol.as_str().parse().unwrap(),
                     _ => panic!("must_not_have_traceable expected integer literal here"),
                 },
-                TokenTree::Delimited(_, _, _) => {
+                TokenTree::Delimited(..) => {
                     todo!("must_not_have_traceable does not support multiple notraceable positions")
                 },
             },
@@ -134,7 +134,9 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
                         cx.lint(
                             EMPTY_TRACE_IN_NO_TRACE,
                             EMPTY_TRACE_IN_NO_TRACE_MSG,
-                            |lint| lint.set_span(span),
+                            |lint| {
+                                lint.span(span);
+                            },
                         )
                     } else if is_jstraceable(cx, inner) {
                         cx.lint(
@@ -143,7 +145,9 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
                                 "must_not_have_traceable marked wrapper must not have \
 jsmanaged inside on {pos}-th position. Consider removing the wrapper."
                             ),
-                            |lint| lint.set_span(span),
+                            |lint| {
+                                lint.span(span);
+                            },
                         )
                     }
                     false

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -8,7 +8,6 @@ use rustc_lint::{LateContext, LateLintPass, LintContext, LintPass, LintStore};
 use rustc_middle::ty;
 use rustc_session::declare_tool_lint;
 use rustc_span::def_id::LocalDefId;
-use rustc_span::source_map;
 use rustc_span::symbol::{sym, Symbol};
 
 use crate::common::{in_derive_expn, match_def_path};
@@ -192,7 +191,9 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                         UNROOTED_MUST_ROOT,
                         "Type must be rooted, use #[crown::unrooted_must_root_lint::must_root] \
                          on the struct definition to propagate",
-                        |lint| lint.set_span(field.span),
+                        |lint| {
+                            lint.span(field.span);
+                        },
                     )
                 }
             }
@@ -216,7 +217,9 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                                 "Type must be rooted, \
                                 use #[crown::unrooted_must_root_lint::must_root] \
                                 on the enum definition to propagate",
-                                |lint| lint.set_span(field.ty.span),
+                                |lint| {
+                                    lint.span(field.ty.span);
+                                },
                             )
                         }
                     }
@@ -232,7 +235,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
         kind: visit::FnKind<'tcx>,
         decl: &'tcx hir::FnDecl,
         body: &'tcx hir::Body,
-        span: source_map::Span,
+        span: rustc_span::Span,
         def_id: LocalDefId,
     ) {
         let in_new_function = match kind {
@@ -248,7 +251,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
             for (arg, ty) in decl.inputs.iter().zip(sig.inputs().skip_binder().iter()) {
                 if is_unrooted_ty(&self.symbols, cx, *ty, false) {
                     cx.lint(UNROOTED_MUST_ROOT, "Type must be rooted", |lint| {
-                        lint.set_span(arg.span)
+                        lint.span(arg.span);
                     })
                 }
             }
@@ -257,7 +260,7 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                 is_unrooted_ty(&self.symbols, cx, sig.output().skip_binder(), false)
             {
                 cx.lint(UNROOTED_MUST_ROOT, "Type must be rooted", |lint| {
-                    lint.set_span(decl.output.span())
+                    lint.span(decl.output.span());
                 })
             }
         }
@@ -289,7 +292,9 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for FnDefVisitor<'a, 'tcx> {
                 cx.lint(
                     UNROOTED_MUST_ROOT,
                     format!("Expression of type {:?} must be rooted", ty),
-                    |lint| lint.set_span(subexpr.span),
+                    |lint| {
+                        lint.span(subexpr.span);
+                    },
                 )
             }
         };
@@ -331,7 +336,9 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for FnDefVisitor<'a, 'tcx> {
                     cx.lint(
                         UNROOTED_MUST_ROOT,
                         format!("Expression of type {:?} must be rooted", ty),
-                        |lint| lint.set_span(pat.span),
+                        |lint| {
+                            lint.span(pat.span);
+                        },
                     )
                 }
             },


### PR DESCRIPTION
Somebody asked for it.

Everybody will need to rerun `mach bootstrap` to rebuild crown (can we do this automatically?).

Requires new version of ipc-channel.

Fixes #32413 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes (compiler and crown tests)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
