### PR TITLE
Cargo.toml cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ compositing_traits = { path = "components/shared/compositing" }
 content-security-policy = { version = "0.5", features = ["serde"] }
 cookie = "0.12"
 crossbeam-channel = "0.5"
-cssparser = { version = "0.33", features = ["serde"], git = "https://github.com/servo/rust-cssparser/", rev = "aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0" }
+cssparser = { version = "0.33", features = ["serde"], git = "https://github.com/servo/rust-cssparser", rev = "aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0" }
 darling = { version = "0.20", default-features = false }
 data-url = "0.1.0"
 devtools_traits = { path = "components/shared/devtools" }
@@ -43,8 +43,7 @@ glib = "0.19"
 gstreamer = { version = "0.22", features = ["v1_18"] }
 gstreamer-base = "0.22"
 gstreamer-gl = "0.22"
-gstreamer-gl-sys = { version = "0.22" }
-gstreamer-gl-wayland = { version = "0.22" }
+gstreamer-gl-sys = "0.22"
 gstreamer-sys = "0.22"
 gstreamer-video = "0.22"
 headers = "0.3"
@@ -58,8 +57,8 @@ imsz = "0.2"
 indexmap = { version = "2.2.6", features = ["std"] }
 ipc-channel = "0.18"
 itertools = "0.12"
-jemallocator = "0.5.4"
 jemalloc-sys = "0.5.4"
+jemallocator = "0.5.4"
 keyboard-types = "0.6"
 lazy_static = "1.4"
 libc = "0.2"
@@ -71,8 +70,8 @@ mime_guess = "2.0.3"
 mozangle = "0.5.1"
 msg = { path = "components/shared/msg" }
 net_traits = { path = "components/shared/net" }
-num_cpus = "1.1.0"
 num-traits = "0.2"
+num_cpus = "1.1.0"
 parking_lot = "0.12"
 percent-encoding = "2.3"
 proc-macro2 = "1"
@@ -105,7 +104,7 @@ string_cache_codegen = "0.5"
 style = { git = "https://github.com/servo/stylo", branch = "2024-04-16", features = ["servo"] }
 style_config = { git = "https://github.com/servo/stylo", branch = "2024-04-16" }
 style_traits = { git = "https://github.com/servo/stylo", branch = "2024-04-16", features = ["servo"] }
-# NOTE: the sm-angle feature only 2024-03-01rms!
+# NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
 surfman = { version = "0.9", features = ["chains", "sm-angle", "sm-angle-default"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
@@ -122,7 +121,6 @@ unicode-segmentation = "1.1.0"
 url = "2.5"
 uuid = { version = "1.8.0", features = ["v4"] }
 webdriver = "0.49.0"
-webpki = "0.22"
 webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.64", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
@@ -160,13 +158,13 @@ debug-assertions = false
 # servo_atoms = { path = "../stylo/atoms" }
 # size_of_test = { path = "../stylo/size_of_test" }
 # static_prefs = { path = "../stylo/style_static_prefs" }
+# style = { path = "../stylo/style" }
 # style_config = { path = "../stylo/style_config" }
 # style_derive = { path = "../stylo/style_derive" }
-# style = { path = "../stylo/style" }
 # style_traits = { path = "../stylo/style_traits" }
 # to_shmem = { path = "../stylo/to_shmem" }
 #
-# Or for another git dependency:
+# Or for another Git dependency:
 #
 # [patch."https://github.com/servo/<repository>"]
 # <crate> = { path = "/path/to/local/checkout" }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
gstreamer-gl-wayland and webpki are removed as I don't see any other references to them and I assume they were added by accident. The comment change in #32114 was reverted as I assume that was also an accident.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
