### PR TITLE
Devtools device description: improve how Servo is advertised in Firefox's about:debugging (fixes #27528)

### DIFF
--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 name = "devtools"
 path = "lib.rs"
 
+[build-dependencies]
+chrono = "0.4"
+
 [dependencies]
 chrono = "0.4"
 crossbeam-channel = { workspace = true }

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -52,7 +52,7 @@ impl Actor for DeviceActor {
                         apptype: "servo".to_string(),
                         version: "1.0".to_string(),
                         appbuildid: BUILD_ID.to_string(),
-                        platformversion: "125.0".to_string(),
+                        platformversion: "124.0".to_string(),
                         brandName: "Servo".to_string(),
                     },
                 };

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -17,12 +17,19 @@ struct GetDescriptionReply {
     value: SystemInfo,
 }
 
+// This is only a minimal subset of the properties exposed/expected by Firefox
+// (see https://searchfox.org/mozilla-central/source/devtools/shared/system.js#45)
 #[derive(Serialize)]
 struct SystemInfo {
     apptype: String,
+    // Display version
     version: String,
+    // Build ID (timestamp with format YYYYMMDDhhmmss), used for compatibility checks
+    // (see https://searchfox.org/mozilla-central/source/devtools/client/shared/remote-debugging/version-checker.js#82)
     appbuildid: String,
+    // Firefox major.minor version number, use for compatibility checks
     platformversion: String,
+    // Display name
     brandName: String,
 }
 

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -20,7 +20,9 @@ struct GetDescriptionReply {
 #[derive(Serialize)]
 struct SystemInfo {
     apptype: String,
+    version: String,
     platformversion: String,
+    brandName: String,
 }
 
 pub struct DeviceActor {
@@ -45,7 +47,9 @@ impl Actor for DeviceActor {
                     from: self.name(),
                     value: SystemInfo {
                         apptype: "servo".to_string(),
+                        version: "71.0".to_string(),
                         platformversion: "71.0".to_string(),
+                        brandName: "Servo".to_string(),
                     },
                 };
                 let _ = stream.write_json_packet(&msg);

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -57,7 +57,7 @@ impl Actor for DeviceActor {
                     from: self.name(),
                     value: SystemInfo {
                         apptype: "servo".to_string(),
-                        version: "1.0".to_string(),
+                        version: env!("CARGO_PKG_VERSION").to_string(),
                         appbuildid: BUILD_ID.to_string(),
                         platformversion: "124.0".to_string(),
                         brandName: "Servo".to_string(),

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -52,7 +52,7 @@ impl Actor for DeviceActor {
                         apptype: "servo".to_string(),
                         version: "1.0".to_string(),
                         appbuildid: BUILD_ID.to_string(),
-                        platformversion: "111.0".to_string(),
+                        platformversion: "125.0".to_string(),
                         brandName: "Servo".to_string(),
                     },
                 };

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -21,9 +21,12 @@ struct GetDescriptionReply {
 struct SystemInfo {
     apptype: String,
     version: String,
+    appbuildid: String,
     platformversion: String,
     brandName: String,
 }
+
+include!(concat!(env!("OUT_DIR"), "/build_id.rs"));
 
 pub struct DeviceActor {
     pub name: String,
@@ -48,6 +51,7 @@ impl Actor for DeviceActor {
                     value: SystemInfo {
                         apptype: "servo".to_string(),
                         version: "1.0".to_string(),
+                        appbuildid: BUILD_ID.to_string(),
                         platformversion: "111.0".to_string(),
                         brandName: "Servo".to_string(),
                     },

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -47,8 +47,8 @@ impl Actor for DeviceActor {
                     from: self.name(),
                     value: SystemInfo {
                         apptype: "servo".to_string(),
-                        version: "71.0".to_string(),
-                        platformversion: "71.0".to_string(),
+                        version: "1.0".to_string(),
+                        platformversion: "111.0".to_string(),
                         brandName: "Servo".to_string(),
                     },
                 };

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -20,7 +20,7 @@ struct GetDescriptionReply {
 #[derive(Serialize)]
 struct SystemInfo {
     apptype: String,
-    platformVersion: String,
+    platformversion: String,
 }
 
 pub struct DeviceActor {
@@ -45,7 +45,7 @@ impl Actor for DeviceActor {
                     from: self.name(),
                     value: SystemInfo {
                         apptype: "servo".to_string(),
-                        platformVersion: "71.0".to_string(),
+                        platformversion: "71.0".to_string(),
                     },
                 };
                 let _ = stream.write_json_packet(&msg);

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
 use std::net::TcpStream;
 
 use serde::Serialize;
@@ -36,7 +37,18 @@ impl Actor for PreferenceActor {
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
-        let key = msg.get("value").unwrap().as_str().unwrap();
+        let mut key = msg.get("value").unwrap().as_str().unwrap();
+
+        // Mapping to translate a Firefox preference name onto the corresponding Servo preference name
+        let pref_name_mapping: HashMap<&str, &str> =
+            [("dom.serviceWorkers.enabled", "dom.serviceworker.enabled")]
+                .iter()
+                .copied()
+                .collect();
+        if pref_name_mapping.contains_key(key) {
+            key = pref_name_mapping.get(key).unwrap();
+        }
+
         let pref_value = pref_map().get(key);
         Ok(handle_preference_value(
             pref_value,

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -32,11 +32,12 @@ impl Actor for PreferenceActor {
         &self,
         _registry: &ActorRegistry,
         msg_type: &str,
-        _msg: &Map<String, Value>,
+        msg: &Map<String, Value>,
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
-        let pref_value = pref_map().get(msg_type);
+        let key = msg.get("value").unwrap().as_str().unwrap();
+        let pref_value = pref_map().get(key);
         Ok(handle_preference_value(
             pref_value,
             self.name(),

--- a/components/devtools/build.rs
+++ b/components/devtools/build.rs
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::path::Path;
+use std::{env, fs};
+
+use chrono::Local;
+
+fn main() {
+    let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("build_id.rs");
+    fs::write(
+        path,
+        format!(
+            "const BUILD_ID: &str = \"{}\";",
+            Local::now().format("%Y%m%d%H%M%S")
+        ),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
This change does several things to improve how Servo is advertised in Firefox's about:debugging page
 * set a display name and a version number (Servo 1.0)
 * advertise a recent platform version and a build ID so that Firefox doesn't complain about version incompatibilities (the platform version will need to be bumped regularly to keep the warning at bay)
 * fix the preference actor that wasn't really querying the servo preferences
 * translate Firefox preferences names onto the corresponding Servo names, in case they don't match
 * enable service workers by default (this gets rid of the corresponding warning, but I am not sure about the practical implications of that change, this might need reverting)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #27528

There are no tests for these changes because the devtools components currently doesn't have any tests, and adding some seems like a project of its own, out of the scope of these fixes (but I might be interested in looking into adding some, if deemed relevant).

This is how the Firefox UI looks like **before** this patch:
![screenshot-servo-devtools-before](https://github.com/servo/servo/assets/11027549/a0c470e4-b075-4045-940d-e686f1d5a722)

And **after** this patch:
![screenshot-servo-devtools-after2](https://github.com/servo/servo/assets/11027549/75b7b779-1486-41ba-8988-d4f315da5a97)

