### PR TITLE
Skip installing 'clang' if 'clang' binary already exists

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -164,6 +164,11 @@ class Linux(Base):
             command = ['apt-get', 'install', "-m"]
             pkgs = APT_PKGS
 
+            # Skip 'clang' if 'clang' binary already exists.
+            result = subprocess.run(['which', 'clang'], capture_output=True)
+            if result and result.returncode == 0:
+                pkgs.remove('clang')
+
             # Try to filter out unknown packages from the list. This is important for Debian
             # as it does not ship all of the packages we want.
             installable = subprocess.check_output(['apt-cache', '--generate', 'pkgnames'])


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

In Linux, script 'python/servo/platform/linux.py', provisions a set of packages. In the case of 'clang', the package provisioned is named 'clang'. Simply installing 'clang'

When running
Skip installing 'clang' if 'clang' binary already exists. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32233

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a change on package provisioning.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
