### PR TITLE
clippy: Fix vtable_address_comparisons error

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -274,7 +274,7 @@ impl RootCollection {
     unsafe fn unroot(&self, object: *const dyn JSTraceable) {
         assert_in_script();
         let roots = &mut *self.roots.get();
-        // FIXME: Use std::ptr::addr_of after migrating to newer version of std
+        // FIXME: Use std::ptr::addr_eq after migrating to newer version of std.
         match roots
             .iter()
             .rposition(|r| std::ptr::eq(*r as *const (), object as *const ()))

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -274,7 +274,11 @@ impl RootCollection {
     unsafe fn unroot(&self, object: *const dyn JSTraceable) {
         assert_in_script();
         let roots = &mut *self.roots.get();
-        match roots.iter().rposition(|r| std::ptr::eq(*r, object)) {
+        // FIXME: Use std::ptr::addr_of after migrating to newer version of std
+        match roots
+            .iter()
+            .rposition(|r| std::ptr::eq(*r as *const (), object as *const ()))
+        {
             Some(idx) => {
                 roots.remove(idx);
             },


### PR DESCRIPTION
Running `./mach cargo-clippy` fails because of the following error:
```
error: comparing trait object pointers compares a non-unique vtable address
   --> components/script/dom/bindings/root.rs:277:42
    |
277 |         match roots.iter().rposition(|r| std::ptr::eq(*r, object)) {
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider extracting and comparing data pointers only
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#vtable_address_comparisons
    = note: `#[deny(clippy::vtable_address_comparisons)]` on by default
```

Current change implements comparison while ignoring any metadata in fat pointers. This is same as [std::ptr::addr_eq](https://doc.rust-lang.org/src/core/ptr/mod.rs.html#2014) which is not available in currently used edition of rust - `edition = "2018"`. 

This issue is described in:
https://github.com/rust-lang/rust/issues/46139
https://github.com/rust-lang/rust-clippy/issues/6524

Successfully tested change via:
* `./mach build -d`
* `./mach test-tidy`