### PR TITLE
Update flake8 to work on python 3.12

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,9 +9,9 @@ setuptools == 68.2.2
 toml == 0.9.2
 
 # For Python linting
-flake8 == 3.8.3
+flake8 == 7.0.0
 pep8 == 1.5.7
-pyflakes == 2.2.0
+pyflakes == 3.2.0
 
 # For test-webidl
 ply == 3.8


### PR DESCRIPTION
It should still work on python 3.8.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
