### PR TITLE
webgpu: Use WGPU poller thread for poll_all_devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,11 +1135,10 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "d3d12"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d0a5e48aa7e84683114c3870051cc414ae92ac03#d0a5e48aa7e84683114c3870051cc414ae92ac03"
 dependencies = [
  "bitflags 2.5.0",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -3902,8 +3901,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 [[package]]
 name = "naga"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d0a5e48aa7e84683114c3870051cc414ae92ac03#d0a5e48aa7e84683114c3870051cc414ae92ac03"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -7204,14 +7202,12 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6a86eaa5e763e59c73cf9e97d55fffd4dfda69fd8bda19589fcf851ddfef1f"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d0a5e48aa7e84683114c3870051cc414ae92ac03#d0a5e48aa7e84683114c3870051cc414ae92ac03"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.5.0",
  "cfg_aliases",
- "codespan-reporting",
  "document-features",
  "indexmap 2.2.6",
  "log",
@@ -7232,8 +7228,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d71c8ae05170583049b65ee562fd839fdc0b3e9ddb84f4e40c9d5f8ea0d4c8c"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d0a5e48aa7e84683114c3870051cc414ae92ac03#d0a5e48aa7e84683114c3870051cc414ae92ac03"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7249,7 +7244,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.3",
+ "libloading 0.7.4",
  "log",
  "metal 0.28.0",
  "naga",
@@ -7271,8 +7266,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
+source = "git+https://github.com/gfx-rs/wgpu?rev=d0a5e48aa7e84683114c3870051cc414ae92ac03#d0a5e48aa7e84683114c3870051cc414ae92ac03"
 dependencies = [
  "bitflags 2.5.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.64", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
 webrender_traits = { path = "components/shared/webrender" }
-wgpu-core = "0.20"
-wgpu-types = "0.20"
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "d0a5e48aa7e84683114c3870051cc414ae92ac03" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "d0a5e48aa7e84683114c3870051cc414ae92ac03" }
 winapi = "0.3"
 xi-unicode = "0.1.0"
 xml5ever = "0.18"

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -8,6 +8,7 @@ use wgpu_thread::WGPU;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
 pub mod identity;
+mod poll_thread;
 mod wgpu_thread;
 
 use std::borrow::Cow;
@@ -86,7 +87,7 @@ impl WebGPU {
                 .run();
             })
         {
-            warn!("Failed to spwan WGPU thread ({})", e);
+            warn!("Failed to spawn WGPU thread ({})", e);
             return None;
         }
         Some((WebGPU(sender), script_recv))

--- a/components/webgpu/poll_thread.rs
+++ b/components/webgpu/poll_thread.rs
@@ -76,7 +76,7 @@ impl Poller {
                             std::thread::park(); //TODO: should we use timeout here
                         }
                     })
-                    .unwrap(),
+                    .expect("Spawning thread should not fail"),
             ),
         }
     }
@@ -97,7 +97,7 @@ impl Poller {
     pub(crate) fn wake(&self) {
         self.handle
             .as_ref()
-            .expect("Pollers thread does not exist!")
+            .expect("Poller thread does not exist!")
             .thread()
             .unpark();
     }
@@ -113,7 +113,7 @@ impl Drop for Poller {
     }
 }
 
-/// RAII indicating that there is some work enqueued (closure to bi fired),
+/// RAII indicating that there is some work enqueued (closure to be fired),
 /// while this token is held.
 pub(crate) struct WorkToken {
     work_count: Arc<AtomicUsize>,

--- a/components/webgpu/poll_thread.rs
+++ b/components/webgpu/poll_thread.rs
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Data and main loop of WGPU poll thread.
+//!
+//! This is roughly based on <https://github.com/LucentFlux/wgpu-async/blob/1322c7e3fcdfc1865a472c7bbbf0e2e06dcf4da8/src/wgpu_future.rs>
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use log::warn;
+
+use crate::wgc::global::Global;
+
+/// Polls devices while there is something to poll.
+///
+/// This objects corresponds to a thread that parks itself when there is no work,
+/// waiting on it, and then calls `poll_all_devices` repeatedly to block.
+///
+/// The thread dies when this object is dropped, and all work in submission is done.
+///
+/// ## Example
+/// ```no_run
+/// let token = self.poller.token(); // create a new token
+/// let callback = SubmittedWorkDoneClosure::from_rust(Box::from(move || {
+///    drop(token); // drop token as closure has been fired
+///    // ...
+/// }));
+/// let result = gfx_select!(queue_id => global.queue_on_submitted_work_done(queue_id, callback));
+/// self.poller.wake(); // wake poller thread to actually poll
+/// ```
+#[derive(Debug)]
+pub(crate) struct Poller {
+    /// The number of closures that still needs to be fired.
+    /// When this is 0, the thread can park itself.
+    work_count: Arc<AtomicUsize>,
+    /// True if thread should die after all work in submission is done
+    is_done: Arc<AtomicBool>,
+    /// Handle to the WGPU poller thread (to be used for unparking the thread)
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Poller {
+    pub(crate) fn new(global: Arc<Global>) -> Self {
+        let work_count = Arc::new(AtomicUsize::new(0));
+        let is_done = Arc::new(AtomicBool::new(false));
+        let work = work_count.clone();
+        let done = is_done.clone();
+        Self {
+            work_count,
+            is_done,
+            handle: Some(
+                std::thread::Builder::new()
+                    .name("WGPU poller".into())
+                    .spawn(move || {
+                        while !done.load(Ordering::Acquire) {
+                            let mut more_work = false;
+                            while more_work || work.load(Ordering::Acquire) != 0 {
+                                match global.poll_all_devices(true) {
+                                    Ok(all_queue_empty) => more_work = !all_queue_empty,
+                                    Err(e) => warn!("Poller thread got `{e}` on poll_all_devices."),
+                                }
+                            }
+                            std::thread::park();
+                        }
+                    })
+                    .unwrap(),
+            ),
+        }
+    }
+
+    /// Creates a token of work
+    pub(crate) fn token(&self) -> WorkToken {
+        let prev = self.work_count.fetch_add(1, Ordering::AcqRel);
+        debug_assert!(
+            prev < usize::MAX,
+            "cannot have more than `usize::MAX` outstanding operations on the GPU"
+        );
+        WorkToken {
+            work_count: Arc::clone(&self.work_count),
+        }
+    }
+
+    /// Wakes the poller thread to start polling.
+    pub(crate) fn wake(&self) {
+        self.handle
+            .as_ref()
+            .expect("Pollers thread does not exist!")
+            .thread()
+            .unpark();
+    }
+}
+
+impl Drop for Poller {
+    fn drop(&mut self) {
+        self.is_done.store(true, Ordering::Release);
+
+        let handle = self.handle.take().expect("Poller dropped twice");
+        handle.thread().unpark();
+        handle.join().expect("Poller thread panicked");
+    }
+}
+
+/// RAII indicating that there is some work enqueued (closure to bi fired),
+/// while this token is held.
+pub(crate) struct WorkToken {
+    work_count: Arc<AtomicUsize>,
+}
+
+impl Drop for WorkToken {
+    fn drop(&mut self) {
+        self.work_count.fetch_sub(1, Ordering::AcqRel);
+    }
+}


### PR DESCRIPTION
As discussed https://servo.zulipchat.com/#narrow/stream/263398-general/topic/ipc_channel, firefox will also switch to something similar in the future: https://bugzilla.mozilla.org/show_bug.cgi?id=1870699.

In future we could make thread per device, but that would require hashmap for Pollers.

Fastgame still works: https://sagudev.github.io/briefcase/fastgame.html

try run: https://github.com/sagudev/servo/actions/runs/9051091523/job/24867638272


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
