### PR TITLE
Implement additional logic in DOMString::set_best_representation_of_the_floating_point_number

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2189,7 +2189,13 @@ impl HTMLInputElement {
                     datetime.format("%Y-%m-%dT%H:%M:%S%.3f").to_string(),
                 ))
             },
-            InputType::Number | InputType::Range => Ok(DOMString::from(value.to_string())),
+            InputType::Number | InputType::Range => {
+                let mut value = DOMString::from(value.to_string());
+
+                value.set_best_representation_of_the_floating_point_number();
+
+                Ok(value)
+            },
             // this won't be called from other input types
             _ => unreachable!(),
         }

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLMeterElementBinding::HTMLMeterE
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
@@ -75,8 +76,12 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-value>
     fn SetValue(&self, value: Finite<f64>) {
+        let mut string_value = DOMString::from_string((*value).to_string());
+
+        string_value.set_best_representation_of_the_floating_point_number();
+
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("value"), (*value).to_string().into());
+            .set_string_attribute(&local_name!("value"), string_value);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-minimum>
@@ -91,8 +96,12 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-min>
     fn SetMin(&self, value: Finite<f64>) {
+        let mut string_value = DOMString::from_string((*value).to_string());
+
+        string_value.set_best_representation_of_the_floating_point_number();
+
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("min"), (*value).to_string().into());
+            .set_string_attribute(&local_name!("min"), string_value);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
@@ -108,8 +117,12 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
     fn SetMax(&self, value: Finite<f64>) {
+        let mut string_value = DOMString::from_string((*value).to_string());
+
+        string_value.set_best_representation_of_the_floating_point_number();
+
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("max"), (*value).to_string().into());
+            .set_string_attribute(&local_name!("max"), string_value);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-low>
@@ -129,8 +142,12 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-low>
     fn SetLow(&self, value: Finite<f64>) {
+        let mut string_value = DOMString::from_string((*value).to_string());
+
+        string_value.set_best_representation_of_the_floating_point_number();
+
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("low"), (*value).to_string().into());
+            .set_string_attribute(&local_name!("low"), string_value);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-high>
@@ -154,8 +171,12 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-high>
     fn SetHigh(&self, value: Finite<f64>) {
+        let mut string_value = DOMString::from_string((*value).to_string());
+
+        string_value.set_best_representation_of_the_floating_point_number();
+
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("high"), (*value).to_string().into());
+            .set_string_attribute(&local_name!("high"), string_value);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-optimum>
@@ -175,7 +196,11 @@ impl HTMLMeterElementMethods for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-optimum>
     fn SetOptimum(&self, value: Finite<f64>) {
+        let mut string_value = DOMString::from_string((*value).to_string());
+
+        string_value.set_best_representation_of_the_floating_point_number();
+
         self.upcast::<Element>()
-            .set_string_attribute(&local_name!("optimum"), (*value).to_string().into());
+            .set_string_attribute(&local_name!("optimum"), string_value);
     }
 }

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLProgressElementBinding::HTMLPro
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::htmlelement::HTMLElement;
@@ -75,11 +76,15 @@ impl HTMLProgressElementMethods for HTMLProgressElement {
             })
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-progress-value
+    /// <https://html.spec.whatwg.org/multipage/#dom-progress-value>
     fn SetValue(&self, new_val: Finite<f64>) {
-        if 0.0 <= *new_val {
+        if *new_val >= 0.0 {
+            let mut string_value = DOMString::from_string((*new_val).to_string());
+
+            string_value.set_best_representation_of_the_floating_point_number();
+
             self.upcast::<Element>()
-                .set_string_attribute(&local_name!("value"), (*new_val).to_string().into());
+                .set_string_attribute(&local_name!("value"), string_value);
         }
     }
 
@@ -100,10 +105,16 @@ impl HTMLProgressElementMethods for HTMLProgressElement {
             })
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-progress-max
+    /// <https://html.spec.whatwg.org/multipage/#dom-progress-max>
     fn SetMax(&self, new_val: Finite<f64>) {
-        self.upcast::<Element>()
-            .set_string_attribute(&local_name!("max"), (*new_val).to_string().into());
+        if *new_val > 0.0 {
+            let mut string_value = DOMString::from_string((*new_val).to_string());
+
+            string_value.set_best_representation_of_the_floating_point_number();
+
+            self.upcast::<Element>()
+                .set_string_attribute(&local_name!("max"), string_value);
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-progress-position

--- a/tests/wpt/meta-legacy-layout/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/reflection-forms.html.ini
@@ -20181,37 +20181,19 @@
   [meter.value: IDL get with DOM attribute unset]
     expected: FAIL
 
-  [meter.value: IDL set to -0]
-    expected: FAIL
-
   [meter.min: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [meter.min: IDL set to -0]
     expected: FAIL
 
   [meter.max: IDL get with DOM attribute unset]
     expected: FAIL
 
-  [meter.max: IDL set to -0]
-    expected: FAIL
-
   [meter.low: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [meter.low: IDL set to -0]
     expected: FAIL
 
   [meter.high: IDL get with DOM attribute unset]
     expected: FAIL
 
-  [meter.high: IDL set to -0]
-    expected: FAIL
-
   [meter.optimum: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [meter.optimum: IDL set to -0]
     expected: FAIL
 
   [optgroup.accessKey: setAttribute() to "5%"]
@@ -20800,18 +20782,6 @@
     expected: FAIL
 
   [progress.max: setAttribute() to "+100"]
-    expected: FAIL
-
-  [progress.max: IDL set to -10000000000]
-    expected: FAIL
-
-  [progress.max: IDL set to -1]
-    expected: FAIL
-
-  [progress.max: IDL set to -0]
-    expected: FAIL
-
-  [progress.max: IDL set to 0]
     expected: FAIL
 
   [progress.max: IDL set to 1e-10]

--- a/tests/wpt/meta/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-forms.html.ini
@@ -3380,24 +3380,6 @@
   [meter.tabIndex: IDL set to -2147483648]
     expected: FAIL
 
-  [meter.value: IDL set to -0]
-    expected: FAIL
-
-  [meter.min: IDL set to -0]
-    expected: FAIL
-
-  [meter.max: IDL set to -0]
-    expected: FAIL
-
-  [meter.low: IDL set to -0]
-    expected: FAIL
-
-  [meter.high: IDL set to -0]
-    expected: FAIL
-
-  [meter.optimum: IDL set to -0]
-    expected: FAIL
-
   [form.tabIndex: setAttribute() to "7\\v"]
     expected: FAIL
 
@@ -3549,18 +3531,6 @@
     expected: FAIL
 
   [progress.max: setAttribute() to "+100"]
-    expected: FAIL
-
-  [progress.max: IDL set to -10000000000]
-    expected: FAIL
-
-  [progress.max: IDL set to -1]
-    expected: FAIL
-
-  [progress.max: IDL set to -0]
-    expected: FAIL
-
-  [progress.max: IDL set to 0]
     expected: FAIL
 
   [progress.max: IDL set to 1e-10]


### PR DESCRIPTION
This corrects some failing tests related to "-0.0" values for the `meter` element, as well as updates input number and range elements - these were not failing similar tests, it appears that the default fallback was accounting for -0.0 values.

There are also some fixes to the `progress` element where it was mishandling negative values for `max`.

See https://github.com/servo/servo/issues/32269 for additional context.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32269

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
