### PR TITLE
android: use `jemalloc` on Android

### DIFF
--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [features]
 use-system-allocator = ["libc"]
 
-[target.'cfg(not(any(windows, target_os = "android",  target_env = "ohos")))'.dependencies]
+[target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
 jemallocator = { workspace = true }
 jemalloc-sys = { workspace = true }
 libc = { workspace = true, optional = true }
@@ -20,5 +20,5 @@ libc = { workspace = true, optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["heapapi"] }
 
-[target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
+[target.'cfg(target_env = "ohos")'.dependencies]
 libc = { workspace = true }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -9,12 +9,7 @@ static ALLOC: Allocator = Allocator;
 
 pub use crate::platform::*;
 
-#[cfg(not(any(
-    windows,
-    target_os = "android",
-    feature = "use-system-allocator",
-    target_env = "ohos"
-)))]
+#[cfg(not(any(windows, feature = "use-system-allocator", target_env = "ohos")))]
 mod platform {
     use std::os::raw::c_void;
 
@@ -37,11 +32,7 @@ mod platform {
 
 #[cfg(all(
     not(windows),
-    any(
-        target_os = "android",
-        feature = "use-system-allocator",
-        target_env = "ohos"
-    )
+    any(feature = "use-system-allocator", target_env = "ohos")
 ))]
 mod platform {
     pub use std::alloc::System as Allocator;

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -23,7 +23,7 @@ task_info = { path = "../../support/rust-task_info" }
 [target.'cfg(target_os = "linux")'.dependencies]
 regex = { workspace = true }
 
-[target.'cfg(not(any(target_os = "windows", target_os = "android")))'.dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = { workspace = true }
-[target.'cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))'.dependencies]
+[target.'cfg(not(any(target_os = "windows", target_env = "ohos")))'.dependencies]
 jemalloc-sys = { workspace = true }

--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -387,16 +387,16 @@ impl ReportsForest {
 //---------------------------------------------------------------------------
 
 mod system_reporter {
-    #[cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))]
+    #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use std::ffi::CString;
-    #[cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))]
+    #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use std::mem::size_of;
-    #[cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))]
+    #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use std::ptr::null_mut;
 
     #[cfg(target_os = "linux")]
     use libc::c_int;
-    #[cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))]
+    #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use libc::{c_void, size_t};
     use profile_traits::mem::{Report, ReportKind, ReporterRequest};
     use profile_traits::path;
@@ -499,10 +499,10 @@ mod system_reporter {
         None
     }
 
-    #[cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))]
+    #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use jemalloc_sys::mallctl;
 
-    #[cfg(not(any(target_os = "windows", target_os = "android", target_env = "ohos")))]
+    #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     fn jemalloc_stat(value_name: &str) -> Option<usize> {
         // Before we request the measurement of interest, we first send an "epoch"
         // request. Without that jemalloc gives cached statistics(!) which can be
@@ -549,7 +549,7 @@ mod system_reporter {
         Some(value as usize)
     }
 
-    #[cfg(any(target_os = "windows", target_os = "android", target_env = "ohos"))]
+    #[cfg(any(target_os = "windows", target_env = "ohos"))]
     fn jemalloc_stat(_value_name: &str) -> Option<usize> {
         None
     }


### PR DESCRIPTION
This is a fix for the crash issue in 64-bit ARM [#32175][1] and is essentially a revert of [5395c3e][2] from the first Android PR.

When targeting Android 11 and above, 64-bit ARM platforms have the 'Tagged Pointer' feature enabled by default which causes memory allocated using the system allocator to have a non-zero 'tag' set in the highest byte of heap addresses.

This is incompatible with SpiderMonkey which assumes that only the bottom 48 bits are set and asserts this at various points.

Both Servo and Gecko have a similar architecture where the pointer to a heap allocated DOM struct is encoded as a JS::Value and stored in the DOM_OBJECT_SLOT (reserved slot) of the JSObject which reflects the native DOM struct.

As observed in #32175, even Gecko crashes with `jemalloc` disabled which suggests that support for using the native system allocator with tagged pointers enabled by default is not present at the moment.

[1]: https://github.com/servo/servo/issues/32175
[2]: https://github.com/servo/servo/pull/31086/commits/5395c3e421ba2faa558d4db6012a23689efc98ce

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32175 
- [x] These changes do not require tests because they fix a crash in android build and `./mach test-android-startup` is currently broken.