### PR TITLE
Fix RefCell borrows

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3258,8 +3258,7 @@ impl Document {
                 return;
             }
 
-            *self.mouse_move_event_index.borrow_mut() =
-                Some(pending_compositor_events.len());
+            *self.mouse_move_event_index.borrow_mut() = Some(pending_compositor_events.len());
         }
 
         pending_compositor_events.push(event);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3259,10 +3259,10 @@ impl Document {
             }
 
             *self.mouse_move_event_index.borrow_mut() =
-                Some(self.pending_compositor_events.borrow().len());
+                Some(pending_compositor_events.len());
         }
 
-        self.pending_compositor_events.borrow_mut().push(event);
+        pending_compositor_events.push(event);
     }
 
     /// Get pending compositor events, for processing within an `update_the_rendering` task.


### PR DESCRIPTION
I think this should fix https://servo.zulipchat.com/#narrow/stream/263398-general/topic/Panic.20on.20touch.20event.20after.20.2331505, but I wrote it online so it might not work.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
