### PR TITLE
fonts: Add color emoji support for FreeType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,7 @@ dependencies = [
  "truetype",
  "ucd",
  "unicode-bidi",
+ "unicode-properties",
  "unicode-script",
  "webrender_api",
  "xi-unicode",
@@ -6632,6 +6633,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
 name = "unicode-script"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ tokio-rustls = "0.24"
 tungstenite = "0.20"
 uluru = "3.0"
 unicode-bidi = "0.3.15"
+unicode-properties = { version = "0.1.1", features = ["emoji"] }
 unicode-script = "0.5"
 unicode-segmentation = "1.1.0"
 url = "2.5"

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -41,6 +41,7 @@ surfman = { workspace = true }
 style = { workspace = true }
 ucd = "0.1.1"
 unicode-bidi = { workspace = true, features = ["with_serde"] }
+unicode-properties = { workspace = true }
 unicode-script = { workspace = true }
 webrender_api = { workspace = true }
 xi-unicode = { workspace = true }

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -28,6 +28,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::values::computed::{FontStretch, FontStyle, FontWeight};
 use style::Atom;
+use unicode_properties::UnicodeEmoji;
 
 use super::c_str_to_string;
 use crate::font::map_platform_values_to_style_values;
@@ -197,7 +198,12 @@ pub static SANS_SERIF_FONT_FAMILY: &str = "DejaVu Sans";
 
 // Based on gfxPlatformGtk::GetCommonFallbackFonts() in Gecko
 pub fn fallback_font_families(codepoint: Option<char>) -> Vec<&'static str> {
-    let mut families = vec!["DejaVu Serif", "FreeSerif", "DejaVu Sans", "FreeSans"];
+    let mut families = Vec::new();
+
+    if codepoint.map_or(false, |codepoint| codepoint.is_emoji_char()) {
+        families.push("Noto Color Emoji");
+    }
+    families.extend(["DejaVu Serif", "FreeSerif", "DejaVu Sans", "FreeSans"]);
 
     if let Some(codepoint) = codepoint {
         if is_cjk(codepoint) {

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/font-size-zero-1.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/font-size-zero-1.html.ini
@@ -1,0 +1,3 @@
+[font-size-zero-1.html]
+  expected: FAIL
+

--- a/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-thickness-from-zero-sized-font.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text-decor/text-decoration-thickness-from-zero-sized-font.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-thickness-from-zero-sized-font.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-capitalize-026.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-capitalize-026.html.ini
@@ -1,0 +1,2 @@
+[text-transform-capitalize-026.html]
+  expected: FAIL


### PR DESCRIPTION
Color emoji support with "Noto Color Emoji" requires two things:

1. Support for bitmap fonts in the FreeType backend. This requires
   specially handling bitmap fonts which have different characteristics
   in the FreeType API (such as requiring metrics scaling). This support
   is generally ported from Gecko's implementation.
2. When a character is an emoji "Noto Color Emoji" needs to be in the
   fallback list. Ensure that this is high on the list -- this will be
   improved in a later PR.

This change causes one test to start failing, but this is actually a
progression. Before none of the glyphs were shown, but now since they do the
failure is visible. In general, it is difficult to test emoji support.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #17267.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
