### PR TITLE
android: Enable JIT compilation on 64-bit Android.

### DIFF
--- a/ports/jniapi/src/lib.rs
+++ b/ports/jniapi/src/lib.rs
@@ -867,11 +867,16 @@ fn get_options(
 
     let native_window = unsafe { ANativeWindow_fromSurface(env.get_native_interface(), surface) };
 
-    // FIXME: enable JIT compilation on Android after the startup crash issue (#31134) is fixed.
-    let mut prefs = HashMap::new();
-    prefs.insert("js.baseline_interpreter.enabled".to_string(), false.into());
-    prefs.insert("js.baseline_jit.enabled".to_string(), false.into());
-    prefs.insert("js.ion.enabled".to_string(), false.into());
+    // FIXME: enable JIT compilation on 32-bit Android after the startup crash issue (#31134) is fixed.
+    let prefs = if cfg!(target_pointer_width = "32") {
+        let mut prefs = HashMap::new();
+        prefs.insert("js.baseline_interpreter.enabled".to_string(), false.into());
+        prefs.insert("js.baseline_jit.enabled".to_string(), false.into());
+        prefs.insert("js.ion.enabled".to_string(), false.into());
+        Some(prefs)
+    } else {
+        None
+    };
 
     let opts = InitOptions {
         args: args.unwrap_or(vec![]),
@@ -880,7 +885,8 @@ fn get_options(
         density,
         xr_discovery: None,
         surfman_integration: simpleservo::SurfmanIntegration::Widget(native_window),
-        prefs: Some(prefs),
+        prefs,
     };
+
     Ok((opts, log, log_str, gst_debug_str))
 }


### PR DESCRIPTION
Based on the investigation in [#31134][1], the [bug][2] in
SpiderMonkey JIT affects only 32-bit systems. Therefore, we
can safely enable JIT compilation again on 64-bit systems.

[1]: https://github.com/servo/servo/issues/31134
[2]: https://bugzilla.mozilla.org/show_bug.cgi?id=1892374

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any error
- [X] These changes do not require tests because there shouldn't be any functional changes.
