### PR TITLE
layout: use `au` in `HoistedSharedFragment`

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1762,9 +1762,8 @@ impl PlacementState {
             },
             Fragment::AbsoluteOrFixedPositioned(fragment) => {
                 let offset = LogicalVec2 {
-                    block: (self.current_margin.solve() + self.current_block_direction_position)
-                        .into(),
-                    inline: Length::new(0.),
+                    block: (self.current_margin.solve() + self.current_block_direction_position),
+                    inline: Au::zero(),
                 };
                 fragment.borrow_mut().adjust_offsets(offset);
             },

--- a/components/layout_2020/fragment_tree/hoisted_shared_fragment.rs
+++ b/components/layout_2020/fragment_tree/hoisted_shared_fragment.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use app_units::Au;
 use serde::Serialize;
-use style::values::computed::{Length, LengthPercentage};
+use style::values::computed::LengthPercentage;
 
 use super::Fragment;
 use crate::cell::ArcRefCell;
@@ -31,7 +32,7 @@ impl HoistedSharedFragment {
     /// In some cases `inset: auto`-positioned elements do not know their precise
     /// position until after they're hoisted. This lets us adjust auto values
     /// after the fact.
-    pub(crate) fn adjust_offsets(&mut self, offsets: LogicalVec2<Length>) {
+    pub(crate) fn adjust_offsets(&mut self, offsets: LogicalVec2<Au>) {
         self.box_offsets.inline.adjust_offset(offsets.inline);
         self.box_offsets.block.adjust_offset(offsets.block);
     }
@@ -40,7 +41,7 @@ impl HoistedSharedFragment {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) enum AbsoluteBoxOffsets {
     StaticStart {
-        start: Length,
+        start: Au,
     },
     Start {
         start: LengthPercentage,
@@ -59,7 +60,7 @@ impl AbsoluteBoxOffsets {
         matches!(self, AbsoluteBoxOffsets::Both { .. })
     }
 
-    pub(crate) fn adjust_offset(&mut self, new_offset: Length) {
+    pub(crate) fn adjust_offset(&mut self, new_offset: Au) {
         if let AbsoluteBoxOffsets::StaticStart { ref mut start } = *self {
             *start = new_offset
         }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -81,7 +81,7 @@ impl AbsolutelyPositionedBox {
         ) -> AbsoluteBoxOffsets {
             match (start.non_auto(), end.non_auto()) {
                 (None, None) => AbsoluteBoxOffsets::StaticStart {
-                    start: initial_static_start,
+                    start: initial_static_start.into(),
                 },
                 (Some(start), Some(end)) => AbsoluteBoxOffsets::Both {
                     start: start.clone(),
@@ -196,10 +196,10 @@ impl PositioningContext {
         let update_fragment_if_needed = |hoisted_fragment: &mut HoistedAbsolutelyPositionedBox| {
             let mut fragment = hoisted_fragment.fragment.borrow_mut();
             if let AbsoluteBoxOffsets::StaticStart { start } = &mut fragment.box_offsets.inline {
-                *start += start_offset.inline;
+                *start += start_offset.inline.into();
             }
             if let AbsoluteBoxOffsets::StaticStart { start } = &mut fragment.box_offsets.block {
-                *start += start_offset.block;
+                *start += start_offset.block.into();
             }
         };
 
@@ -773,7 +773,7 @@ impl<'a> AbsoluteAxisSolver<'a> {
     fn solve_for_size(&self, computed_size: AuOrAuto) -> AxisResult {
         match self.box_offsets {
             AbsoluteBoxOffsets::StaticStart { start } => AxisResult {
-                anchor: Anchor::Start((*start).into()),
+                anchor: Anchor::Start(*start),
                 size: computed_size,
                 margin_start: self.computed_margin_start.auto_is(Au::zero),
                 margin_end: self.computed_margin_end.auto_is(Au::zero),


### PR DESCRIPTION
Use `au` in `HoistedSharedFragment` and `AbsoluteBoxOffsets`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

