### PR TITLE
android: Trim whitespace around font filenames.

### DIFF
--- a/components/gfx/platform/freetype/android/font_list.rs
+++ b/components/gfx/platform/freetype/android/font_list.rs
@@ -429,7 +429,7 @@ impl FontList {
 
     fn text_content(nodes: &[Node]) -> Option<String> {
         nodes.get(0).and_then(|child| match child {
-            Node::Text(contents) => Some(contents.clone()),
+            Node::Text(contents) => Some(contents.trim().into()),
             Node::Element { .. } => None,
         })
     }


### PR DESCRIPTION
This is a speculative fix for #32161. A similar failure is
reproducible on the Android x86_64 emulator with API 35
system image. The fix has not been validated on the actual
device, so potentially there might be other issues that need
to be fixed to complete #32161.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32161

