### PR TITLE
Rename NavigationType to NavigationTimingType

### DIFF
--- a/components/script/dom/performancenavigationtiming.rs
+++ b/components/script/dom/performancenavigationtiming.rs
@@ -6,7 +6,7 @@ use dom_struct::dom_struct;
 
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
 use crate::dom::bindings::codegen::Bindings::PerformanceNavigationTimingBinding::{
-    NavigationType, PerformanceNavigationTimingMethods,
+    NavigationTimingType, PerformanceNavigationTimingMethods,
 };
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::reflect_dom_object;
@@ -25,7 +25,7 @@ pub struct PerformanceNavigationTiming {
     navigation_start: u64,
     navigation_start_precise: u64,
     document: Dom<Document>,
-    nav_type: NavigationType,
+    nav_type: NavigationTimingType,
 }
 
 impl PerformanceNavigationTiming {
@@ -44,7 +44,7 @@ impl PerformanceNavigationTiming {
             navigation_start: nav_start,
             navigation_start_precise: nav_start_precise,
             document: Dom::from_ref(document),
-            nav_type: NavigationType::Navigate,
+            nav_type: NavigationTimingType::Navigate,
         }
     }
 
@@ -108,7 +108,7 @@ impl PerformanceNavigationTimingMethods for PerformanceNavigationTiming {
     }
 
     // https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-type
-    fn Type(&self) -> NavigationType {
+    fn Type(&self) -> NavigationTimingType {
         self.nav_type
     }
 

--- a/components/script/dom/webidls/PerformanceNavigationTiming.webidl
+++ b/components/script/dom/webidls/PerformanceNavigationTiming.webidl
@@ -6,7 +6,7 @@
  * https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming
  */
 
-enum NavigationType {
+enum NavigationTimingType {
     "navigate",
     "reload",
     "back_forward",
@@ -15,18 +15,18 @@ enum NavigationType {
 
 [Exposed=Window]
 interface PerformanceNavigationTiming : PerformanceResourceTiming {
-    readonly attribute DOMHighResTimeStamp unloadEventStart;
-    readonly attribute DOMHighResTimeStamp unloadEventEnd;
-    readonly attribute DOMHighResTimeStamp domInteractive;
-    readonly attribute DOMHighResTimeStamp domContentLoadedEventStart;
-    readonly attribute DOMHighResTimeStamp domContentLoadedEventEnd;
-    readonly attribute DOMHighResTimeStamp domComplete;
-    readonly attribute DOMHighResTimeStamp loadEventStart;
-    readonly attribute DOMHighResTimeStamp loadEventEnd;
-    readonly attribute NavigationType      type;
-    readonly attribute unsigned short      redirectCount;
+    readonly attribute DOMHighResTimeStamp  unloadEventStart;
+    readonly attribute DOMHighResTimeStamp  unloadEventEnd;
+    readonly attribute DOMHighResTimeStamp  domInteractive;
+    readonly attribute DOMHighResTimeStamp  domContentLoadedEventStart;
+    readonly attribute DOMHighResTimeStamp  domContentLoadedEventEnd;
+    readonly attribute DOMHighResTimeStamp  domComplete;
+    readonly attribute DOMHighResTimeStamp  loadEventStart;
+    readonly attribute DOMHighResTimeStamp  loadEventEnd;
+    readonly attribute NavigationTimingType type;
+    readonly attribute unsigned short       redirectCount;
     [Default] object toJSON();
     /* Servo-only attribute for measuring when the top-level document (not iframes) is complete. */
     [Pref="dom.testperf.enabled"]
-    readonly attribute DOMHighResTimeStamp topLevelDomComplete;
+    readonly attribute DOMHighResTimeStamp  topLevelDomComplete;
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This was renamed in the spec:

https://github.com/w3c/navigation-timing/pull/172

The NavigationType enum name is now part of the navigation history apis:

https://html.spec.whatwg.org/multipage/nav-history-apis.html\#navigationtype

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
