### PR TITLE
Set RUSTUP_WINDOWS_PATH_ADD_BIN in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,6 +43,7 @@ env:
   # so we need to override this behaviour until we update clang-sys
   # https://github.com/KyleMayes/clang-sys/issues/150
   LIBCLANG_PATH: C:\\Program Files\\LLVM\\bin
+  RUSTUP_WINDOWS_PATH_ADD_BIN: 1
 
 jobs:
   build:
@@ -71,7 +72,7 @@ jobs:
           echo "C:\\Program Files (x86)\\WiX Toolset v3.11\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Bootstrap
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Fixes windows CI.

CI run: https://github.com/sagudev/servo/actions/runs/9115378420/job/25061559941


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32300 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
