### PR TITLE
fonts: Store web fonts in the per-Layout `FontContext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "ipc-channel",
  "log",
  "lyon_geom",
+ "net_traits",
  "num-traits",
  "pathfinder_geometry",
  "pixels",
@@ -2051,6 +2052,7 @@ dependencies = [
  "unicode-bidi",
  "unicode-properties",
  "unicode-script",
+ "url",
  "webrender_api",
  "webrender_traits",
  "xi-unicode",
@@ -2062,6 +2064,7 @@ dependencies = [
 name = "gfx_traits"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel",
  "malloc_size_of",
  "malloc_size_of_derive",
  "range",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -29,6 +29,7 @@ half = "2"
 ipc-channel = { workspace = true }
 log = { workspace = true }
 lyon_geom = "1.0.4"
+net_traits = { workspace = true }
 num-traits = { workspace = true }
 pathfinder_geometry = "0.5"
 pixels = { path = "../pixels" }

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -43,6 +43,7 @@ ucd = "0.1.1"
 unicode-bidi = { workspace = true, features = ["with_serde"] }
 unicode-properties = { workspace = true }
 unicode-script = { workspace = true }
+url = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
 xi-unicode = { workspace = true }

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -25,8 +25,8 @@ use style::values::computed::{FontStretch, FontStyle, FontWeight};
 use unicode_script::Script;
 use webrender_api::{FontInstanceFlags, FontInstanceKey};
 
-use crate::font_cache_thread::FontIdentifier;
-use crate::font_context::{FontContext, FontSource};
+use crate::font_cache_thread::{FontIdentifier, FontSource};
+use crate::font_context::FontContext;
 use crate::font_template::{FontTemplateDescriptor, FontTemplateRef, FontTemplateRefMethods};
 use crate::platform::font::{FontTable, PlatformFont};
 pub use crate::platform::font_list::fallback_font_families;

--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -9,112 +9,72 @@ use std::sync::Arc;
 
 use app_units::Au;
 use fnv::FnvHasher;
-use log::debug;
+use ipc_channel::ipc::{self, IpcSender};
+use log::{debug, trace};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
-use parking_lot::{Mutex, RwLock};
+use net_traits::request::{Destination, Referrer, RequestBuilder};
+use net_traits::{fetch_async, CoreResourceThread, FetchResponseMsg, ResourceThreads};
+use parking_lot::{Mutex, ReentrantMutex, RwLock};
 use servo_arc::Arc as ServoArc;
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
+use style::font_face::{FontFaceSourceFormat, FontFaceSourceFormatKeyword, Source, UrlSource};
+use style::media_queries::Device;
 use style::properties::style_structs::Font as FontStyleStruct;
-use webrender_api::{FontInstanceFlags, FontInstanceKey};
+use style::shared_lock::SharedRwLockReadGuard;
+use style::stylesheets::{Stylesheet, StylesheetInDocument};
+use style::Atom;
+use url::Url;
 
-use crate::font::{Font, FontDescriptor, FontFamilyDescriptor, FontGroup, FontRef};
-use crate::font_cache_thread::FontIdentifier;
-use crate::font_template::{FontTemplateRef, FontTemplateRefMethods};
+use crate::font::{
+    Font, FontDescriptor, FontFamilyDescriptor, FontFamilyName, FontGroup, FontRef, FontSearchScope,
+};
+use crate::font_cache_thread::{
+    CSSFontFaceDescriptors, FontIdentifier, FontSource, LowercaseString,
+};
+use crate::font_store::{CrossThreadFontStore, CrossThreadWebRenderFontStore};
+use crate::font_template::{FontTemplate, FontTemplateRef, FontTemplateRefMethods};
 #[cfg(target_os = "macos")]
 use crate::platform::core_text_font_cache::CoreTextFontCache;
 
 static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 
-pub trait FontSource {
-    fn get_font_instance(
-        &mut self,
-        font_identifier: FontIdentifier,
-        size: Au,
-        flags: FontInstanceFlags,
-    ) -> FontInstanceKey;
-    fn find_matching_font_templates(
-        &mut self,
-        descriptor_to_match: &FontDescriptor,
-        family_descriptor: FontFamilyDescriptor,
-    ) -> Vec<FontTemplateRef>;
-}
-
 /// The FontContext represents the per-thread/thread state necessary for
 /// working with fonts. It is the public API used by the layout and
 /// paint code. It talks directly to the font cache thread where
 /// required.
-#[derive(Debug)]
 pub struct FontContext<S: FontSource> {
-    font_source: Mutex<S>,
-
-    // TODO: The font context holds a strong ref to the cached fonts
-    // so they will never be released. Find out a good time to drop them.
-    // See bug https://github.com/servo/servo/issues/3300
-    font_cache: RwLock<HashMap<FontCacheKey, Option<FontRef>>>,
-    font_template_cache: RwLock<HashMap<FontTemplateCacheKey, Vec<FontTemplateRef>>>,
-    font_group_cache:
-        RwLock<HashMap<FontGroupCacheKey, Arc<RwLock<FontGroup>>, BuildHasherDefault<FnvHasher>>>,
+    font_source: ReentrantMutex<S>,
+    resource_threads: ReentrantMutex<CoreResourceThread>,
+    cache: CachingFontSource<S>,
+    web_fonts: CrossThreadFontStore,
+    webrender_font_store: CrossThreadWebRenderFontStore,
 }
 
 impl<S: FontSource> MallocSizeOf for FontContext<S> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        let font_cache_size = self
-            .font_cache
-            .read()
-            .iter()
-            .map(|(key, font)| {
-                key.size_of(ops) + font.as_ref().map_or(0, |font| (*font).size_of(ops))
-            })
-            .sum::<usize>();
-        let font_template_cache_size = self
-            .font_template_cache
-            .read()
-            .iter()
-            .map(|(key, templates)| {
-                let templates_size = templates
-                    .iter()
-                    .map(|template| template.borrow().size_of(ops))
-                    .sum::<usize>();
-                key.size_of(ops) + templates_size
-            })
-            .sum::<usize>();
-        let font_group_cache_size = self
-            .font_group_cache
-            .read()
-            .iter()
-            .map(|(key, font_group)| key.size_of(ops) + (*font_group.read()).size_of(ops))
-            .sum::<usize>();
-
-        font_cache_size + font_template_cache_size + font_group_cache_size
+        self.cache.size_of(ops)
     }
 }
 
 impl<S: FontSource> FontContext<S> {
-    pub fn new(font_source: S) -> FontContext<S> {
+    pub fn new(font_source: S, resource_threads: ResourceThreads) -> FontContext<S> {
         #[allow(clippy::default_constructed_unit_structs)]
         FontContext {
-            font_source: Mutex::new(font_source),
-            font_cache: RwLock::default(),
-            font_template_cache: RwLock::default(),
-            font_group_cache: RwLock::default(),
+            font_source: ReentrantMutex::new(font_source.clone()),
+            resource_threads: ReentrantMutex::new(resource_threads.core_thread),
+            cache: CachingFontSource::new(font_source),
+            web_fonts: Arc::new(RwLock::default()),
+            webrender_font_store: Arc::new(RwLock::default()),
         }
     }
 
     /// Invalidate all caches that this [`FontContext`] holds and any in-process platform-specific
     /// caches.
-    ///
-    /// # Safety
-    ///
-    /// This should never be called when more than one thread is using the [`FontContext`] or it
-    /// may leave the context in an inconsistent state.
     pub fn invalidate_caches(&self) {
         #[cfg(target_os = "macos")]
         CoreTextFontCache::clear_core_text_font_cache();
-
-        self.font_cache.write().clear();
-        self.font_template_cache.write().clear();
-        self.font_group_cache.write().clear();
+        self.cache.invalidate()
     }
 
     /// Returns a `FontGroup` representing fonts which can be used for layout, given the `style`.
@@ -132,17 +92,7 @@ impl<S: FontSource> FontContext<S> {
         style: ServoArc<FontStyleStruct>,
         size: Au,
     ) -> Arc<RwLock<FontGroup>> {
-        let cache_key = FontGroupCacheKey { size, style };
-
-        if let Some(font_group) = self.font_group_cache.read().get(&cache_key) {
-            return font_group.clone();
-        }
-
-        let font_group = Arc::new(RwLock::new(FontGroup::new(&cache_key.style)));
-        self.font_group_cache
-            .write()
-            .insert(cache_key, font_group.clone());
-        font_group
+        self.cache.font_group_with_size(style, size)
     }
 
     /// Returns a font matching the parameters. Fonts are cached, so repeated calls will return a
@@ -187,7 +137,7 @@ impl<S: FontSource> FontContext<S> {
             font_descriptor: font_descriptor.clone(),
         };
 
-        if let Some(font) = self.font_cache.read().get(&cache_key).cloned() {
+        if let Some(font) = self.cache.fonts.read().get(&cache_key).cloned() {
             return font;
         }
 
@@ -203,7 +153,7 @@ impl<S: FontSource> FontContext<S> {
                 synthesized_small_caps_font,
             )
             .ok();
-        self.font_cache.write().insert(cache_key, font.clone());
+        self.cache.fonts.write().insert(cache_key, font.clone());
         font
     }
 
@@ -212,30 +162,23 @@ impl<S: FontSource> FontContext<S> {
         descriptor_to_match: &FontDescriptor,
         family_descriptor: &FontFamilyDescriptor,
     ) -> Vec<FontTemplateRef> {
-        let cache_key = FontTemplateCacheKey {
-            font_descriptor: descriptor_to_match.clone(),
-            family_descriptor: family_descriptor.clone(),
-        };
-
-        if let Some(templates) = self.font_template_cache.read().get(&cache_key).cloned() {
-            return templates;
+        // First try to find an appropriate web font that matches this descriptor.
+        if family_descriptor.scope == FontSearchScope::Any {
+            let family_name = LowercaseString::from(&family_descriptor.name);
+            if let Some(templates) = self
+                .web_fonts
+                .read()
+                .families
+                .get(&family_name)
+                .map(|templates| templates.find_for_descriptor(Some(descriptor_to_match)))
+            {
+                return templates;
+            }
         }
 
-        debug!(
-            "FontContext::font_template cache miss for template_descriptor={:?} family_descriptor={:?}",
-            descriptor_to_match,
-            family_descriptor
-        );
-
-        let templates = self
-            .font_source
-            .lock()
-            .find_matching_font_templates(descriptor_to_match, family_descriptor.clone());
-
-        self.font_template_cache
-            .write()
-            .insert(cache_key, templates.clone());
-        templates
+        // If not request a matching font from the system font cache.
+        self.cache
+            .matching_templates(descriptor_to_match, family_descriptor)
     }
 
     /// Create a `Font` for use in layout calculations, from a `FontTemplateData` returned by the
@@ -251,13 +194,410 @@ impl<S: FontSource> FontContext<S> {
             font_descriptor.clone(),
             synthesized_small_caps,
         )?;
-        font.font_key = self.font_source.lock().get_font_instance(
-            font_template.identifier(),
-            font_descriptor.pt_size,
-            font.webrender_font_instance_flags(),
-        );
+
+        let font_source = self.font_source.lock();
+        font.font_key = match font_template.identifier() {
+            FontIdentifier::Local(_) => font_source.get_system_font_instance(
+                font_template.identifier(),
+                font_descriptor.pt_size,
+                font.webrender_font_instance_flags(),
+            ),
+            FontIdentifier::Web(_) => self.webrender_font_store.write().get_font_instance(
+                &*font_source,
+                font_template.clone(),
+                font_descriptor.pt_size,
+                font.webrender_font_instance_flags(),
+            ),
+        };
 
         Ok(Arc::new(font))
+    }
+}
+
+#[derive(Clone)]
+pub struct WebFontDownloadState {
+    css_font_face_descriptors: Arc<CSSFontFaceDescriptors>,
+    remaining_sources: Vec<Source>,
+    result_sender: IpcSender<()>,
+    core_resource_thread: CoreResourceThread,
+    local_fonts: Arc<HashMap<Atom, Option<FontTemplateRef>>>,
+}
+
+pub trait FontContextWebFontMethods {
+    fn add_all_web_fonts_from_stylesheet(
+        &self,
+        stylesheet: &Stylesheet,
+        guard: &SharedRwLockReadGuard,
+        device: &Device,
+        font_cache_sender: &IpcSender<()>,
+        synchronous: bool,
+    ) -> usize;
+    fn process_next_web_font_source(&self, web_font_download_state: WebFontDownloadState);
+}
+
+impl<S: FontSource + Send + 'static> FontContextWebFontMethods for Arc<FontContext<S>> {
+    fn add_all_web_fonts_from_stylesheet(
+        &self,
+        stylesheet: &Stylesheet,
+        guard: &SharedRwLockReadGuard,
+        device: &Device,
+        font_cache_sender: &IpcSender<()>,
+        synchronous: bool,
+    ) -> usize {
+        let (result_sender, receiver) = if synchronous {
+            let (sender, receiver) = ipc::channel().unwrap();
+            (Some(sender), Some(receiver))
+        } else {
+            (None, None)
+        };
+
+        let mut number_loading = 0;
+        stylesheet.effective_font_face_rules(device, guard, |rule| {
+            let font_face = match rule.font_face() {
+                Some(font_face) => font_face,
+                None => return,
+            };
+
+            let sources: Vec<Source> = font_face
+                .sources()
+                .0
+                .iter()
+                .rev()
+                .filter(is_supported_web_font_source)
+                .cloned()
+                .collect();
+            if sources.is_empty() {
+                return;
+            }
+
+            // Fetch all local fonts first, beacause if we try to fetch them later on during the process of
+            // loading the list of web font `src`s we may be running in the context of the router thread, which
+            // means we won't be able to seend IPC messages to the FontCacheThread.
+            //
+            // TODO: This is completely wrong. The specification says that `local()` font-family should match
+            // against full PostScript names, but this is matching against font family names. This works...
+            // sometimes.
+            let mut local_fonts = HashMap::new();
+            for source in sources.iter() {
+                if let Source::Local(family_name) = source {
+                    local_fonts
+                        .entry(family_name.name.clone())
+                        .or_insert_with(|| {
+                            let family_name = FontFamilyName::Specific(family_name.name.clone());
+                            self.font_source
+                                .lock()
+                                .find_matching_font_templates(None, &family_name)
+                                .first()
+                                .cloned()
+                        });
+                }
+            }
+
+            let result_sender = result_sender.as_ref().unwrap_or(font_cache_sender).clone();
+            self.process_next_web_font_source(WebFontDownloadState {
+                css_font_face_descriptors: Arc::new(rule.into()),
+                remaining_sources: sources,
+                result_sender,
+                core_resource_thread: self.resource_threads.lock().clone(),
+                local_fonts: Arc::new(local_fonts),
+            });
+
+            // Either increment the count of loading web fonts, or wait for a synchronous load.
+            if let Some(ref receiver) = receiver {
+                receiver.recv().unwrap();
+            }
+            number_loading += 1;
+        });
+
+        number_loading
+    }
+
+    fn process_next_web_font_source(&self, mut state: WebFontDownloadState) {
+        let Some(source) = state.remaining_sources.pop() else {
+            state.result_sender.send(()).unwrap();
+            return;
+        };
+
+        let this = self.clone();
+        let web_font_family_name = state.css_font_face_descriptors.family_name.clone();
+        match source {
+            Source::Url(url_source) => {
+                RemoteWebFontDownloader::download(url_source, this, web_font_family_name, state)
+            },
+            Source::Local(ref local_family_name) => {
+                if let Some(new_template) = state
+                    .local_fonts
+                    .get(&local_family_name.name)
+                    .cloned()
+                    .flatten()
+                    .and_then(|local_template| {
+                        FontTemplate::new_for_local_web_font(
+                            local_template,
+                            &state.css_font_face_descriptors,
+                        )
+                        .ok()
+                    })
+                {
+                    this.web_fonts
+                        .write()
+                        .families
+                        .entry(web_font_family_name.clone())
+                        .or_default()
+                        .add_template(new_template);
+                    drop(state.result_sender.send(()));
+                } else {
+                    this.process_next_web_font_source(state);
+                }
+            },
+        }
+    }
+}
+
+struct RemoteWebFontDownloader<FCT: FontSource> {
+    font_context: Arc<FontContext<FCT>>,
+    url: ServoArc<Url>,
+    web_font_family_name: LowercaseString,
+    response_valid: Mutex<bool>,
+    response_data: Mutex<Vec<u8>>,
+}
+
+enum DownloaderResponseResult {
+    InProcess,
+    Finished,
+    Failure,
+}
+
+impl<FCT: FontSource + Send + 'static> RemoteWebFontDownloader<FCT> {
+    fn download(
+        url_source: UrlSource,
+        font_context: Arc<FontContext<FCT>>,
+        web_font_family_name: LowercaseString,
+        state: WebFontDownloadState,
+    ) {
+        // https://drafts.csswg.org/css-fonts/#font-fetching-requirements
+        let url = match url_source.url.url() {
+            Some(url) => url.clone(),
+            None => return,
+        };
+
+        // FIXME: This shouldn't use NoReferrer, but the current documents url
+        let request = RequestBuilder::new(url.clone().into(), Referrer::NoReferrer)
+            .destination(Destination::Font);
+
+        debug!("Loading @font-face {} from {}", web_font_family_name, url);
+        let downloader = Self {
+            font_context,
+            url,
+            web_font_family_name,
+            response_valid: Mutex::new(false),
+            response_data: Mutex::default(),
+        };
+
+        let core_resource_thread_clone = state.core_resource_thread.clone();
+        fetch_async(
+            request,
+            &core_resource_thread_clone,
+            move |response_message| match downloader.handle_web_font_fetch_message(response_message)
+            {
+                DownloaderResponseResult::InProcess => {},
+                DownloaderResponseResult::Finished => {
+                    if !downloader.process_downloaded_font_and_signal_completion(&state) {
+                        downloader
+                            .font_context
+                            .process_next_web_font_source(state.clone())
+                    }
+                },
+                DownloaderResponseResult::Failure => downloader
+                    .font_context
+                    .process_next_web_font_source(state.clone()),
+            },
+        )
+    }
+
+    /// After a download finishes, try to process the downloaded data, returning true if
+    /// the font is added successfully to the [`FontContext`] or false if it isn't.
+    fn process_downloaded_font_and_signal_completion(&self, state: &WebFontDownloadState) -> bool {
+        let font_data = std::mem::take(&mut *self.response_data.lock());
+        trace!(
+            "@font-face {} data={:?}",
+            self.web_font_family_name,
+            font_data
+        );
+
+        let font_data = match fontsan::process(&font_data) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                debug!(
+                    "Sanitiser rejected web font: family={} url={:?} with {error:?}",
+                    self.web_font_family_name, self.url,
+                );
+                return false;
+            },
+        };
+
+        let Ok(new_template) = FontTemplate::new_for_remote_web_font(
+            self.url.clone().into(),
+            Arc::new(font_data),
+            &state.css_font_face_descriptors,
+        ) else {
+            return false;
+        };
+
+        let family_name = state.css_font_face_descriptors.family_name.clone();
+        self.font_context
+            .web_fonts
+            .write()
+            .families
+            .entry(family_name.clone())
+            .or_default()
+            .add_template(new_template);
+
+        // Signal the Document that we have finished trying to load this web font.
+        drop(state.result_sender.send(()));
+        true
+    }
+
+    fn handle_web_font_fetch_message(
+        &self,
+        response_message: FetchResponseMsg,
+    ) -> DownloaderResponseResult {
+        match response_message {
+            FetchResponseMsg::ProcessRequestBody | FetchResponseMsg::ProcessRequestEOF => {
+                DownloaderResponseResult::InProcess
+            },
+            FetchResponseMsg::ProcessResponse(meta_result) => {
+                trace!(
+                    "@font-face {} metadata ok={:?}",
+                    self.web_font_family_name,
+                    meta_result.is_ok()
+                );
+                *self.response_valid.lock() = meta_result.is_ok();
+                DownloaderResponseResult::InProcess
+            },
+            FetchResponseMsg::ProcessResponseChunk(new_bytes) => {
+                trace!(
+                    "@font-face {} chunk={:?}",
+                    self.web_font_family_name,
+                    new_bytes
+                );
+                if *self.response_valid.lock() {
+                    self.response_data.lock().extend(new_bytes)
+                }
+                DownloaderResponseResult::InProcess
+            },
+            FetchResponseMsg::ProcessResponseEOF(response) => {
+                trace!(
+                    "@font-face {} EOF={:?}",
+                    self.web_font_family_name,
+                    response
+                );
+                if response.is_err() || !*self.response_valid.lock() {
+                    return DownloaderResponseResult::Failure;
+                }
+                DownloaderResponseResult::Finished
+            },
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct CachingFontSource<FCT: FontSource> {
+    font_cache_thread: ReentrantMutex<FCT>,
+    fonts: RwLock<HashMap<FontCacheKey, Option<FontRef>>>,
+    templates: RwLock<HashMap<FontTemplateCacheKey, Vec<FontTemplateRef>>>,
+    resolved_font_groups:
+        RwLock<HashMap<FontGroupCacheKey, Arc<RwLock<FontGroup>>, BuildHasherDefault<FnvHasher>>>,
+}
+
+impl<FCT: FontSource> CachingFontSource<FCT> {
+    fn new(font_cache_thread: FCT) -> Self {
+        Self {
+            font_cache_thread: ReentrantMutex::new(font_cache_thread),
+            fonts: Default::default(),
+            templates: Default::default(),
+            resolved_font_groups: Default::default(),
+        }
+    }
+
+    fn invalidate(&self) {
+        self.fonts.write().clear();
+        self.templates.write().clear();
+        self.resolved_font_groups.write().clear();
+    }
+
+    pub fn matching_templates(
+        &self,
+        descriptor_to_match: &FontDescriptor,
+        family_descriptor: &FontFamilyDescriptor,
+    ) -> Vec<FontTemplateRef> {
+        let cache_key = FontTemplateCacheKey {
+            font_descriptor: descriptor_to_match.clone(),
+            family_descriptor: family_descriptor.clone(),
+        };
+        if let Some(templates) = self.templates.read().get(&cache_key).cloned() {
+            return templates;
+        }
+
+        debug!(
+            "CachingFontSource: cache miss for template_descriptor={:?} family_descriptor={:?}",
+            descriptor_to_match, family_descriptor
+        );
+        let templates = self
+            .font_cache_thread
+            .lock()
+            .find_matching_font_templates(Some(descriptor_to_match), &family_descriptor.name);
+        self.templates.write().insert(cache_key, templates.clone());
+
+        templates
+    }
+
+    pub fn font_group_with_size(
+        &self,
+        style: ServoArc<FontStyleStruct>,
+        size: Au,
+    ) -> Arc<RwLock<FontGroup>> {
+        let cache_key = FontGroupCacheKey { size, style };
+        if let Some(font_group) = self.resolved_font_groups.read().get(&cache_key) {
+            return font_group.clone();
+        }
+        let font_group = Arc::new(RwLock::new(FontGroup::new(&cache_key.style)));
+        self.resolved_font_groups
+            .write()
+            .insert(cache_key, font_group.clone());
+        font_group
+    }
+}
+
+impl<FCT: FontSource> MallocSizeOf for CachingFontSource<FCT> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let font_cache_size = self
+            .fonts
+            .read()
+            .iter()
+            .map(|(key, font)| {
+                key.size_of(ops) + font.as_ref().map_or(0, |font| (*font).size_of(ops))
+            })
+            .sum::<usize>();
+        let font_template_cache_size = self
+            .templates
+            .read()
+            .iter()
+            .map(|(key, templates)| {
+                let templates_size = templates
+                    .iter()
+                    .map(|template| template.borrow().size_of(ops))
+                    .sum::<usize>();
+                key.size_of(ops) + templates_size
+            })
+            .sum::<usize>();
+        let font_group_cache_size = self
+            .resolved_font_groups
+            .read()
+            .iter()
+            .map(|(key, font_group)| key.size_of(ops) + (*font_group.read()).size_of(ops))
+            .sum::<usize>();
+
+        font_cache_size + font_template_cache_size + font_group_cache_size
     }
 }
 
@@ -295,4 +635,36 @@ impl Hash for FontGroupCacheKey {
     {
         self.style.hash.hash(hasher)
     }
+}
+
+fn is_supported_web_font_source(source: &&Source) -> bool {
+    let url_source = match source {
+        Source::Url(ref url_source) => url_source,
+        Source::Local(_) => return true,
+    };
+    let format_hint = match url_source.format_hint {
+        Some(ref format_hint) => format_hint,
+        None => return true,
+    };
+
+    if matches!(
+        format_hint,
+        FontFaceSourceFormat::Keyword(
+            FontFaceSourceFormatKeyword::Truetype |
+                FontFaceSourceFormatKeyword::Opentype |
+                FontFaceSourceFormatKeyword::Woff |
+                FontFaceSourceFormatKeyword::Woff2
+        )
+    ) {
+        return true;
+    }
+
+    if let FontFaceSourceFormat::String(string) = format_hint {
+        return string == "truetype" ||
+            string == "opentype" ||
+            string == "woff" ||
+            string == "woff2";
+    }
+
+    false
 }

--- a/components/gfx/font_store.rs
+++ b/components/gfx/font_store.rs
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use app_units::Au;
+use atomic_refcell::AtomicRefCell;
+use parking_lot::RwLock;
+use webrender_api::{FontInstanceFlags, FontInstanceKey, FontKey};
+
+use crate::font::FontDescriptor;
+use crate::font_cache_thread::{FontIdentifier, FontSource, LowercaseString};
+use crate::font_template::{FontTemplate, FontTemplateRef, FontTemplateRefMethods};
+
+#[derive(Default)]
+pub struct FontStore {
+    pub(crate) families: HashMap<LowercaseString, FontTemplates>,
+}
+pub(crate) type CrossThreadFontStore = Arc<RwLock<FontStore>>;
+
+impl FontStore {
+    pub(crate) fn clear(&mut self) {
+        self.families.clear();
+    }
+}
+
+#[derive(Default)]
+pub struct WebRenderFontStore {
+    pub(crate) webrender_font_key_map: HashMap<FontIdentifier, FontKey>,
+    pub(crate) webrender_font_instance_map: HashMap<(FontKey, Au), FontInstanceKey>,
+}
+pub(crate) type CrossThreadWebRenderFontStore = Arc<RwLock<WebRenderFontStore>>;
+
+impl WebRenderFontStore {
+    pub(crate) fn get_font_instance<FCT: FontSource>(
+        &mut self,
+        font_cache_thread: &FCT,
+        font_template: FontTemplateRef,
+        pt_size: Au,
+        flags: FontInstanceFlags,
+    ) -> FontInstanceKey {
+        let webrender_font_key_map = &mut self.webrender_font_key_map;
+        let identifier = font_template.identifier().clone();
+        let font_key = *webrender_font_key_map
+            .entry(identifier.clone())
+            .or_insert_with(|| {
+                font_cache_thread.get_web_font(font_template.data(), identifier.index())
+            });
+
+        *self
+            .webrender_font_instance_map
+            .entry((font_key, pt_size))
+            .or_insert_with(|| {
+                font_cache_thread.get_web_font_instance(font_key, pt_size.to_f32_px(), flags)
+            })
+    }
+}
+
+/// A list of font templates that make up a given font family.
+#[derive(Clone, Debug, Default)]
+pub struct FontTemplates {
+    pub(crate) templates: Vec<FontTemplateRef>,
+}
+
+impl FontTemplates {
+    /// Find a font in this family that matches a given descriptor.
+    pub fn find_for_descriptor(
+        &self,
+        descriptor_to_match: Option<&FontDescriptor>,
+    ) -> Vec<FontTemplateRef> {
+        let Some(descriptor_to_match) = descriptor_to_match else {
+            return self.templates.clone();
+        };
+
+        // TODO(Issue #189): optimize lookup for
+        // regular/bold/italic/bolditalic with fixed offsets and a
+        // static decision table for fallback between these values.
+        let matching_templates: Vec<FontTemplateRef> = self
+            .templates
+            .iter()
+            .filter(|template| template.matches_font_descriptor(descriptor_to_match))
+            .cloned()
+            .collect();
+        if !matching_templates.is_empty() {
+            return matching_templates;
+        }
+
+        // We didn't find an exact match. Do more expensive fuzzy matching.
+        // TODO(#190): Do a better job.
+        let mut best_templates = Vec::new();
+        let mut best_distance = f32::MAX;
+        for template in self.templates.iter() {
+            let distance = template.descriptor_distance(descriptor_to_match);
+            if distance < best_distance {
+                best_templates = vec![template.clone()];
+                best_distance = distance
+            } else if distance == best_distance {
+                best_templates.push(template.clone());
+            }
+        }
+
+        if !best_templates.is_empty() {
+            return best_templates;
+        }
+
+        // If a request is made for a font family that exists,
+        // pick the first valid font in the family if we failed
+        // to find an exact match for the descriptor.
+        if let Some(template) = self.templates.first() {
+            return vec![template.clone()];
+        }
+
+        Vec::new()
+    }
+
+    pub fn add_template(&mut self, new_template: FontTemplate) {
+        for existing_template in &self.templates {
+            let existing_template = existing_template.borrow();
+            if *existing_template.identifier() == new_template.identifier &&
+                existing_template.descriptor == new_template.descriptor
+            {
+                return;
+            }
+        }
+        self.templates
+            .push(Arc::new(AtomicRefCell::new(new_template)));
+    }
+}

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -7,6 +7,7 @@
 pub mod font;
 pub mod font_cache_thread;
 pub mod font_context;
+pub mod font_store;
 pub mod font_template;
 #[allow(unsafe_code)]
 pub mod platform;

--- a/components/gfx/platform/freetype/android/font_list.rs
+++ b/components/gfx/platform/freetype/android/font_list.rs
@@ -486,7 +486,10 @@ where
             None => StyleFontStyle::NORMAL,
         };
         let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
-        callback(FontTemplate::new_local(local_font_identifier, descriptor));
+        callback(FontTemplate::new_for_local_font(
+            local_font_identifier,
+            descriptor,
+        ));
     };
 
     if let Some(family) = FONT_LIST.find_family(family_name) {

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -152,7 +152,10 @@ where
             };
             let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
 
-            callback(FontTemplate::new_local(local_font_identifier, descriptor))
+            callback(FontTemplate::new_for_local_font(
+                local_font_identifier,
+                descriptor,
+            ))
         }
 
         FcFontSetDestroy(matches);

--- a/components/gfx/platform/freetype/ohos/font_list.rs
+++ b/components/gfx/platform/freetype/ohos/font_list.rs
@@ -158,7 +158,10 @@ where
             stretch,
             style,
         };
-        callback(FontTemplate::new_local(local_font_identifier, descriptor));
+        callback(FontTemplate::new_for_local_font(
+            local_font_identifier,
+            descriptor,
+        ));
     };
 
     if let Some(family) = FONT_LIST.find_family(family_name) {

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -81,7 +81,7 @@ where
                     postscript_name: Atom::from(family_descriptor.font_name()),
                     path: Atom::from(path),
                 };
-                callback(FontTemplate::new_local(identifier, descriptor));
+                callback(FontTemplate::new_for_local_font(identifier, descriptor));
             }
         }
     }

--- a/components/gfx/platform/windows/font_list.rs
+++ b/components/gfx/platform/windows/font_list.rs
@@ -81,7 +81,7 @@ where
             let local_font_identifier = LocalFontIdentifier {
                 font_descriptor: Arc::new(font.to_descriptor()),
             };
-            callback(FontTemplate::new_local(
+            callback(FontTemplate::new_for_local_font(
                 local_font_identifier,
                 template_descriptor,
             ))

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3558,6 +3558,7 @@ impl ScriptThread {
             script_chan: self.control_chan.clone(),
             image_cache: self.image_cache.clone(),
             font_cache_thread: self.font_cache_thread.clone(),
+            resource_threads: self.resource_threads.clone(),
             time_profiler_chan: self.time_profiler_chan.clone(),
             webrender_api_sender: self.webrender_api_sender.clone(),
             paint_time_metrics,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -72,7 +72,6 @@ use ipc_channel::ipc::{self, IpcSender};
 use log::{error, trace, warn, Log, Metadata, Record};
 use media::{GLPlayerThreads, GlApi, NativeDisplay, WindowGLContext};
 use net::resource_thread::new_resource_threads;
-use net_traits::IpcSend;
 use profile::{mem as profile_mem, time as profile_time};
 use profile_traits::{mem, time};
 use script::serviceworker_manager::ServiceWorkerManager;
@@ -996,14 +995,14 @@ fn create_constellation(
         opts.ignore_certificate_errors,
     );
 
-    let font_cache_thread = FontCacheThread::new(
-        public_resource_threads.sender(),
-        Box::new(FontCacheWR(compositor_proxy.clone())),
-    );
+    let font_cache_thread = FontCacheThread::new(Box::new(WebRenderFontApiCompositorProxy(
+        compositor_proxy.clone(),
+    )));
 
     let (canvas_create_sender, canvas_ipc_sender) = CanvasPaintThread::start(
         Box::new(CanvasWebrenderApi(compositor_proxy.clone())),
         font_cache_thread.clone(),
+        public_resource_threads.clone(),
     );
 
     let initial_state = InitialConstellationState {
@@ -1049,9 +1048,9 @@ fn create_constellation(
     )
 }
 
-struct FontCacheWR(CompositorProxy);
+struct WebRenderFontApiCompositorProxy(CompositorProxy);
 
-impl WebRenderFontApi for FontCacheWR {
+impl WebRenderFontApi for WebRenderFontApiCompositorProxy {
     fn add_font_instance(
         &self,
         font_key: FontKey,
@@ -1065,6 +1064,7 @@ impl WebRenderFontApi for FontCacheWR {
             )));
         receiver.recv().unwrap()
     }
+
     fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey {
         let (sender, receiver) = unbounded();
         let (bytes_sender, bytes_receiver) =
@@ -1084,6 +1084,35 @@ impl WebRenderFontApi for FontCacheWR {
                 FontToCompositorMsg::AddSystemFont(sender, handle),
             )));
         receiver.recv().unwrap()
+    }
+
+    fn forward_add_font_message(
+        &self,
+        bytes_receiver: ipc::IpcBytesReceiver,
+        font_index: u32,
+        result_sender: IpcSender<FontKey>,
+    ) {
+        let (sender, receiver) = unbounded();
+        self.0
+            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
+                FontToCompositorMsg::AddFont(sender, font_index, bytes_receiver),
+            )));
+        let _ = result_sender.send(receiver.recv().unwrap());
+    }
+
+    fn forward_add_font_instance_message(
+        &self,
+        font_key: FontKey,
+        size: f32,
+        flags: FontInstanceFlags,
+        result_sender: IpcSender<FontInstanceKey>,
+    ) {
+        let (sender, receiver) = unbounded();
+        self.0
+            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
+                FontToCompositorMsg::AddFontInstance(font_key, size, flags, sender),
+            )));
+        let _ = result_sender.send(receiver.recv().unwrap());
     }
 }
 

--- a/components/shared/gfx/Cargo.toml
+++ b/components/shared/gfx/Cargo.toml
@@ -11,6 +11,7 @@ name = "gfx_traits"
 path = "lib.rs"
 
 [dependencies]
+ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 range = { path = "../../range" }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -341,7 +341,7 @@ where
 // See also: https://github.com/servo/servo/blob/735480/components/script/script_thread.rs#L313
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourceThreads {
-    core_thread: CoreResourceThread,
+    pub core_thread: CoreResourceThread,
     storage_thread: IpcSender<StorageThreadMsg>,
 }
 

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -29,6 +29,7 @@ use libc::c_void;
 use malloc_size_of_derive::MallocSizeOf;
 use metrics::PaintTimeMetrics;
 use net_traits::image_cache::{ImageCache, PendingImageId};
+use net_traits::ResourceThreads;
 use profile_traits::mem::Report;
 use profile_traits::time;
 use script_traits::{
@@ -164,6 +165,7 @@ pub struct LayoutConfig {
     pub constellation_chan: IpcSender<LayoutMsg>,
     pub script_chan: IpcSender<ConstellationControlMsg>,
     pub image_cache: Arc<dyn ImageCache>,
+    pub resource_threads: ResourceThreads,
     pub font_cache_thread: FontCacheThread,
     pub time_profiler_chan: time::ProfilerChan,
     pub webrender_api_sender: WebRenderScriptApi,

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -188,6 +188,23 @@ pub trait WebRenderFontApi {
         flags: FontInstanceFlags,
     ) -> FontInstanceKey;
     fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey;
+    /// Forward an already prepared `AddFont` message, sending it on to the compositor. This is used
+    /// to get WebRender [`FontKey`]s for web fonts in the per-layout `FontContext`.
+    fn forward_add_font_message(
+        &self,
+        bytes_receiver: IpcBytesReceiver,
+        font_index: u32,
+        result_sender: IpcSender<FontKey>,
+    );
+    /// Forward an already prepared `AddFontInstance` message, sending it on to the compositor. This
+    /// is used to get WebRender [`FontInstanceKey`]s for web fonts in the per-layout `FontContext`.
+    fn forward_add_font_instance_message(
+        &self,
+        font_key: FontKey,
+        size: f32,
+        flags: FontInstanceFlags,
+        result_receiver: IpcSender<FontInstanceKey>,
+    );
     fn add_system_font(&self, handle: NativeFontHandle) -> FontKey;
 }
 

--- a/tests/wpt/tests/css/css-fonts/downloadable-font-scoped-to-document-ref.html
+++ b/tests/wpt/tests/css/css-fonts/downloadable-font-scoped-to-document-ref.html
@@ -1,0 +1,17 @@
+ <!DOCTYPE html>
+
+<html>
+    <head>
+        <title>CSS fonts: Web fonts loaded in a document are not available in other documents</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="author" title="Mukilan Thiyagarajan" href="mukilan@igalia.com">
+    </head>
+
+    <body>
+        <p>Test passes if Ahem is only used in the first iframe.</p>
+        <iframe src="support/iframe-using-ahem-as-web-font.html"></iframe>
+        <iframe src="support/iframe-without-web-font.html"></iframe>
+    </body>
+
+</html>
+

--- a/tests/wpt/tests/css/css-fonts/downloadable-font-scoped-to-document.html
+++ b/tests/wpt/tests/css/css-fonts/downloadable-font-scoped-to-document.html
@@ -1,0 +1,28 @@
+ <!DOCTYPE html>
+
+<html class="reftest-wait">
+    <head>
+        <title>CSS fonts: Web fonts loaded in a document are not available in other documents</title>
+        <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+        <link rel="author" title="Mukilan Thiyagarajan" href="mukilan@igalia.com">
+        <link rel="match" href="downloadable-font-scoped-to-document-ref.html">
+        <link rel="help" href="https://drafts.csswg.org/css-fonts/#font-face-rule">
+    </head>
+
+    <body>
+        <p>Test passes if Ahem is only used in the first iframe.</p>
+        <iframe id="iframe1" src="support/iframe-using-ahem-as-web-font.html"></iframe>
+        <iframe id="iframe2" src=""></iframe>
+
+        <script>
+            // Delay the loading of the second iframe to make it more likely that the font
+            // has loaded properly into the first iframe.
+            iframe1.onload = () => {
+                iframe2.src ="support/iframe-missing-font-face-rule.html";
+                document.documentElement.classList.remove('reftest-wait');
+            };
+        </script>
+    </body>
+
+</html>
+

--- a/tests/wpt/tests/css/css-fonts/support/iframe-missing-font-face-rule.html
+++ b/tests/wpt/tests/css/css-fonts/support/iframe-missing-font-face-rule.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="font-size: 30px; font-family: CustomFontFamily">Hello!</div>

--- a/tests/wpt/tests/css/css-fonts/support/iframe-using-ahem-as-web-font.html
+++ b/tests/wpt/tests/css/css-fonts/support/iframe-using-ahem-as-web-font.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: CustomFontFamily;
+    src: url(/fonts/Ahem.ttf);
+}
+</style>
+<div style="font-size: 30px; font-family: CustomFontFamily">Hello!</div>

--- a/tests/wpt/tests/css/css-fonts/support/iframe-without-web-font.html
+++ b/tests/wpt/tests/css/css-fonts/support/iframe-without-web-font.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="font-size: 30px;">Hello!</div>


### PR DESCRIPTION
This moves mangement of web fonts to the per-Layout `FontContext`,
preventing web fonts from being available in different Documents.

Fixes #12920.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12920.
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
