### PR TITLE
webgpu: Move errorscopes to WGPU thread

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2081,7 +2081,7 @@ where
                         options,
                         ids,
                     };
-                    if webgpu_chan.0.send((None, adapter_request)).is_err() {
+                    if webgpu_chan.0.send(adapter_request).is_err() {
                         warn!("Failed to send request adapter message on WebGPU channel");
                     }
                 },

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -232,7 +232,7 @@ class Descriptor(DescriptorProvider):
         self.register = desc.get('register', True)
         self.path = desc.get('path', pathDefault)
         self.inRealmMethods = [name for name in desc.get('inRealms', [])]
-        self.bindingPath = f"crate::dom::bindings::codegen::Bindings::{ifaceName}Binding::{ifaceName}_Binding"
+        self.bindingPath = f"{getModuleFromObject(self.interface)}::{ifaceName}_Binding"
         self.outerObjectHook = desc.get('outerObjectHook', 'None')
         self.proxy = False
         self.weakReferenceable = desc.get('weakReferenceable', False)

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -56,7 +56,7 @@ use script_traits::{
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use uuid::Uuid;
-use webgpu::{ErrorScopeId, WebGPUDevice, WebGPUOpResult};
+use webgpu::WebGPUDevice;
 
 use super::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::cell::{DomRefCell, RefMut};
@@ -3097,17 +3097,12 @@ impl GlobalScope {
         let _ = self.gpu_devices.borrow_mut().remove(&device);
     }
 
-    pub fn handle_wgpu_msg(
-        &self,
-        device: WebGPUDevice,
-        scope: Option<ErrorScopeId>,
-        result: WebGPUOpResult,
-    ) {
+    pub fn handle_uncaptured_gpu_error(&self, device: WebGPUDevice, error: webgpu::Error) {
         self.gpu_devices
             .borrow()
             .get(&device)
             .expect("GPUDevice not found")
-            .handle_server_msg(scope, result);
+            .fire_uncaptured_error(error);
     }
 
     pub fn handle_gamepad_event(&self, gamepad_event: GamepadEvent) {

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -91,7 +91,7 @@ impl Drop for GPUAdapter {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropAdapter(self.adapter.0)))
+            .send(WebGPURequest::DropAdapter(self.adapter.0))
         {
             warn!(
                 "Failed to send WebGPURequest::DropAdapter({:?}) ({})",
@@ -217,16 +217,13 @@ impl GPUAdapterMethods for GPUAdapter {
         if self
             .channel
             .0
-            .send((
-                None,
-                WebGPURequest::RequestDevice {
-                    sender,
-                    adapter_id: self.adapter,
-                    descriptor: desc,
-                    device_id: id,
-                    pipeline_id,
-                },
-            ))
+            .send(WebGPURequest::RequestDevice {
+                sender,
+                adapter_id: self.adapter,
+                descriptor: desc,
+                device_id: id,
+                pipeline_id,
+            })
             .is_err()
         {
             promise.reject_error(Error::Operation);

--- a/components/script/dom/gpubindgroup.rs
+++ b/components/script/dom/gpubindgroup.rs
@@ -73,7 +73,7 @@ impl Drop for GPUBindGroup {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropBindGroup(self.bind_group.0)))
+            .send(WebGPURequest::DropBindGroup(self.bind_group.0))
         {
             warn!(
                 "Failed to send WebGPURequest::DropBindGroup({:?}) ({})",

--- a/components/script/dom/gpubindgrouplayout.rs
+++ b/components/script/dom/gpubindgrouplayout.rs
@@ -62,10 +62,11 @@ impl GPUBindGroupLayout {
 
 impl Drop for GPUBindGroupLayout {
     fn drop(&mut self) {
-        if let Err(e) = self.channel.0.send((
-            None,
-            WebGPURequest::DropBindGroupLayout(self.bind_group_layout.0),
-        )) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropBindGroupLayout(self.bind_group_layout.0))
+        {
             warn!(
                 "Failed to send WebGPURequest::DropBindGroupLayout({:?}) ({})",
                 self.bind_group_layout.0, e

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -12,9 +12,7 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
 use js::typedarray::{ArrayBuffer, ArrayBufferU8};
 use webgpu::wgc::device::HostMap;
-use webgpu::{
-    WebGPU, WebGPUBuffer, WebGPUOpResult, WebGPURequest, WebGPUResponse, WebGPUResponseResult,
-};
+use webgpu::{WebGPU, WebGPUBuffer, WebGPURequest, WebGPUResponse, WebGPUResponseResult};
 
 use super::bindings::buffer_source::{create_new_external_array_buffer, HeapBufferSource};
 use crate::dom::bindings::cell::DomRefCell;
@@ -234,12 +232,11 @@ impl GPUBufferMethods for GPUBuffer {
         } else {
             self.size - offset
         };
-        let scope_id = self.device.use_current_scope();
         if self.state.get() != GPUBufferState::Unmapped {
-            self.device.handle_server_msg(
-                scope_id,
-                WebGPUOpResult::ValidationError(String::from("Buffer is not Unmapped")),
-            );
+            self.device
+                .dispatch_error(webgpu::Error::Validation(String::from(
+                    "Buffer is not Unmapped",
+                )));
             promise.reject_error(Error::Abort);
             return promise;
         }
@@ -247,10 +244,10 @@ impl GPUBufferMethods for GPUBuffer {
             GPUMapModeConstants::READ => HostMap::Read,
             GPUMapModeConstants::WRITE => HostMap::Write,
             _ => {
-                self.device.handle_server_msg(
-                    scope_id,
-                    WebGPUOpResult::ValidationError(String::from("Invalid MapModeFlags")),
-                );
+                self.device
+                    .dispatch_error(webgpu::Error::Validation(String::from(
+                        "Invalid MapModeFlags",
+                    )));
                 promise.reject_error(Error::Abort);
                 return promise;
             },

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -72,10 +72,11 @@ impl GPUCommandBuffer {
 
 impl Drop for GPUCommandBuffer {
     fn drop(&mut self) {
-        if let Err(e) = self.channel.0.send((
-            None,
-            WebGPURequest::DropCommandBuffer(self.command_buffer.0),
-        )) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropCommandBuffer(self.command_buffer.0))
+        {
             warn!(
                 "Failed to send DropCommandBuffer({:?}) ({})",
                 self.command_buffer.0, e

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -270,17 +270,14 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .insert(DomRoot::from_ref(destination));
         self.channel
             .0
-            .send((
-                None,
-                WebGPURequest::CopyBufferToBuffer {
-                    command_encoder_id: self.encoder.0,
-                    source_id: source.id().0,
-                    source_offset,
-                    destination_id: destination.id().0,
-                    destination_offset,
-                    size,
-                },
-            ))
+            .send(WebGPURequest::CopyBufferToBuffer {
+                command_encoder_id: self.encoder.0,
+                source_id: source.id().0,
+                source_offset,
+                destination_id: destination.id().0,
+                destination_offset,
+                size,
+            })
             .expect("Failed to send CopyBufferToBuffer");
     }
 
@@ -302,17 +299,12 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
 
         self.channel
             .0
-            .send((
-                None,
-                WebGPURequest::CopyBufferToTexture {
-                    command_encoder_id: self.encoder.0,
-                    source: convert_ic_buffer(source),
-                    destination: convert_ic_texture(destination),
-                    copy_size: convert_texture_size_to_wgt(&convert_texture_size_to_dict(
-                        &copy_size,
-                    )),
-                },
-            ))
+            .send(WebGPURequest::CopyBufferToTexture {
+                command_encoder_id: self.encoder.0,
+                source: convert_ic_buffer(source),
+                destination: convert_ic_texture(destination),
+                copy_size: convert_texture_size_to_wgt(&convert_texture_size_to_dict(&copy_size)),
+            })
             .expect("Failed to send CopyBufferToTexture");
     }
 
@@ -334,17 +326,12 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
 
         self.channel
             .0
-            .send((
-                None,
-                WebGPURequest::CopyTextureToBuffer {
-                    command_encoder_id: self.encoder.0,
-                    source: convert_ic_texture(source),
-                    destination: convert_ic_buffer(destination),
-                    copy_size: convert_texture_size_to_wgt(&convert_texture_size_to_dict(
-                        &copy_size,
-                    )),
-                },
-            ))
+            .send(WebGPURequest::CopyTextureToBuffer {
+                command_encoder_id: self.encoder.0,
+                source: convert_ic_texture(source),
+                destination: convert_ic_buffer(destination),
+                copy_size: convert_texture_size_to_wgt(&convert_texture_size_to_dict(&copy_size)),
+            })
             .expect("Failed to send CopyTextureToBuffer");
     }
 
@@ -362,17 +349,12 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
 
         self.channel
             .0
-            .send((
-                None,
-                WebGPURequest::CopyTextureToTexture {
-                    command_encoder_id: self.encoder.0,
-                    source: convert_ic_texture(source),
-                    destination: convert_ic_texture(destination),
-                    copy_size: convert_texture_size_to_wgt(&convert_texture_size_to_dict(
-                        &copy_size,
-                    )),
-                },
-            ))
+            .send(WebGPURequest::CopyTextureToTexture {
+                command_encoder_id: self.encoder.0,
+                source: convert_ic_texture(source),
+                destination: convert_ic_texture(destination),
+                copy_size: convert_texture_size_to_wgt(&convert_texture_size_to_dict(&copy_size)),
+            })
             .expect("Failed to send CopyTextureToTexture");
     }
 
@@ -380,16 +362,13 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
     fn Finish(&self, descriptor: &GPUCommandBufferDescriptor) -> DomRoot<GPUCommandBuffer> {
         self.channel
             .0
-            .send((
-                self.device.use_current_scope(),
-                WebGPURequest::CommandEncoderFinish {
-                    command_encoder_id: self.encoder.0,
-                    device_id: self.device.id().0,
-                    is_error: !self.valid.get(),
-                    // TODO(zakorgy): We should use `_descriptor` here after it's not empty
-                    // and the underlying wgpu-core struct is serializable
-                },
-            ))
+            .send(WebGPURequest::CommandEncoderFinish {
+                command_encoder_id: self.encoder.0,
+                device_id: self.device.id().0,
+                is_error: !self.valid.get(),
+                // TODO(zakorgy): We should use `_descriptor` here after it's not empty
+                // and the underlying wgpu-core struct is serializable
+            })
             .expect("Failed to send Finish");
 
         *self.state.borrow_mut() = GPUCommandEncoderState::Closed;

--- a/components/script/dom/gpucomputepassencoder.rs
+++ b/components/script/dom/gpucomputepassencoder.rs
@@ -100,13 +100,10 @@ impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
         let compute_pass = self.compute_pass.borrow_mut().take();
         self.channel
             .0
-            .send((
-                None,
-                WebGPURequest::RunComputePass {
-                    command_encoder_id: self.command_encoder.id().0,
-                    compute_pass,
-                },
-            ))
+            .send(WebGPURequest::RunComputePass {
+                command_encoder_id: self.command_encoder.id().0,
+                compute_pass,
+            })
             .expect("Failed to send RunComputePass"); //TODO: handle error
 
         self.command_encoder.set_state(

--- a/components/script/dom/gpucomputepipeline.rs
+++ b/components/script/dom/gpucomputepipeline.rs
@@ -103,10 +103,11 @@ impl GPUComputePipelineMethods for GPUComputePipeline {
 
 impl Drop for GPUComputePipeline {
     fn drop(&mut self) {
-        if let Err(e) = self.channel.0.send((
-            None,
-            WebGPURequest::DropComputePipeline(self.compute_pipeline.0),
-        )) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropComputePipeline(self.compute_pipeline.0))
+        {
             warn!(
                 "Failed to send WebGPURequest::DropComputePipeline({:?}) ({})",
                 self.compute_pipeline.0, e

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -17,19 +17,21 @@ use webgpu::wgc::id::{BindGroupLayoutId, PipelineLayoutId};
 use webgpu::wgc::{
     binding_model as wgpu_bind, command as wgpu_com, pipeline as wgpu_pipe, resource as wgpu_res,
 };
-use webgpu::{self, wgt, ErrorScopeId, WebGPU, WebGPUOpResult, WebGPURequest};
+use webgpu::{self, wgt, PopError, WebGPU, WebGPURequest, WebGPUResponse, WebGPUResponseResult};
 
 use super::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use super::bindings::error::Fallible;
+use super::gpu::AsyncWGPUListener;
 use super::gpudevicelostinfo::GPUDeviceLostInfo;
 use super::gpusupportedlimits::GPUSupportedLimits;
+use super::types::GPUError;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBindingResource, GPUBufferBindingType,
     GPUBufferDescriptor, GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor,
-    GPUDeviceLostReason, GPUDeviceMethods, GPUError, GPUErrorFilter, GPUPipelineLayoutDescriptor,
+    GPUDeviceLostReason, GPUDeviceMethods, GPUErrorFilter, GPUPipelineLayoutDescriptor,
     GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor, GPUSamplerBindingType,
     GPUSamplerDescriptor, GPUShaderModuleDescriptor, GPUStorageTextureAccess,
     GPUSupportedLimitsMethods, GPUTextureDescriptor, GPUTextureDimension, GPUTextureSampleType,
@@ -42,6 +44,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpu::response_async;
 use crate::dom::gpuadapter::GPUAdapter;
 use crate::dom::gpubindgroup::GPUBindGroup;
 use crate::dom::gpubindgrouplayout::GPUBindGroupLayout;
@@ -54,7 +57,6 @@ use crate::dom::gpuconvert::{
     convert_texture_size_to_dict, convert_texture_size_to_wgt, convert_vertex_format,
     convert_view_dimension,
 };
-use crate::dom::gpuoutofmemoryerror::GPUOutOfMemoryError;
 use crate::dom::gpupipelinelayout::GPUPipelineLayout;
 use crate::dom::gpuqueue::GPUQueue;
 use crate::dom::gpurenderbundleencoder::GPURenderBundleEncoder;
@@ -64,32 +66,8 @@ use crate::dom::gpushadermodule::GPUShaderModule;
 use crate::dom::gpusupportedfeatures::GPUSupportedFeatures;
 use crate::dom::gputexture::GPUTexture;
 use crate::dom::gpuuncapturederrorevent::GPUUncapturedErrorEvent;
-use crate::dom::gpuvalidationerror::GPUValidationError;
 use crate::dom::promise::Promise;
 use crate::realms::InRealm;
-
-#[derive(JSTraceable, MallocSizeOf)]
-struct ErrorScopeInfo {
-    op_count: u64,
-    #[ignore_malloc_size_of = "Because it is non-owning"]
-    error: Option<GPUError>,
-    #[ignore_malloc_size_of = "promises are hard"]
-    promise: Option<Rc<Promise>>,
-}
-
-#[derive(JSTraceable, MallocSizeOf)]
-struct ErrorScopeMetadata {
-    id: ErrorScopeId,
-    filter: GPUErrorFilter,
-    popped: Cell<bool>,
-}
-
-#[derive(JSTraceable, MallocSizeOf)]
-struct ScopeContext {
-    error_scopes: HashMap<ErrorScopeId, ErrorScopeInfo>,
-    scope_stack: Vec<ErrorScopeMetadata>,
-    next_scope_id: ErrorScopeId,
-}
 
 #[dom_struct]
 pub struct GPUDevice {
@@ -106,7 +84,6 @@ pub struct GPUDevice {
     #[no_trace]
     device: webgpu::WebGPUDevice,
     default_queue: Dom<GPUQueue>,
-    scope_context: DomRefCell<ScopeContext>,
     #[ignore_malloc_size_of = "promises are hard"]
     lost_promise: DomRefCell<Option<Rc<Promise>>>,
     valid: Cell<bool>,
@@ -134,11 +111,6 @@ impl GPUDevice {
             label: DomRefCell::new(USVString::from(label)),
             device,
             default_queue: Dom::from_ref(queue),
-            scope_context: DomRefCell::new(ScopeContext {
-                error_scopes: HashMap::new(),
-                scope_stack: Vec::new(),
-                next_scope_id: ErrorScopeId::new(1).unwrap(),
-            }),
             lost_promise: DomRefCell::new(None),
             valid: Cell::new(true),
         }
@@ -179,108 +151,26 @@ impl GPUDevice {
         self.channel.clone()
     }
 
-    pub fn handle_server_msg(&self, scope: Option<ErrorScopeId>, result: WebGPUOpResult) {
-        let result = match result {
-            WebGPUOpResult::Success => Ok(()),
-            WebGPUOpResult::ValidationError(m) => {
-                let val_err = GPUValidationError::new(&self.global(), DOMString::from_string(m));
-                Err((
-                    GPUError::GPUValidationError(val_err),
-                    GPUErrorFilter::Validation,
-                ))
-            },
-            WebGPUOpResult::OutOfMemoryError => {
-                let oom_err = GPUOutOfMemoryError::new(&self.global());
-                Err((
-                    GPUError::GPUOutOfMemoryError(oom_err),
-                    GPUErrorFilter::Out_of_memory,
-                ))
-            },
-        };
-
-        if let Some(s_id) = scope {
-            if let Err((err, filter)) = result {
-                let scop = self
-                    .scope_context
-                    .borrow()
-                    .scope_stack
-                    .iter()
-                    .rev()
-                    .find(|meta| meta.id <= s_id && meta.filter == filter)
-                    .map(|meta| meta.id);
-                if let Some(s) = scop {
-                    self.handle_error(s, err);
-                } else {
-                    self.fire_uncaptured_error(err);
-                }
-            }
-            self.try_remove_scope(s_id);
-        } else if let Err((err, _)) = result {
-            self.fire_uncaptured_error(err);
+    pub fn dispatch_error(&self, error: webgpu::Error) {
+        if let Err(e) = self.channel.0.send(WebGPURequest::DispatchError {
+            device_id: self.device.0,
+            error,
+        }) {
+            warn!("Failed to send WebGPURequest::DispatchError due to {e:?}");
         }
     }
 
-    fn handle_error(&self, scope: ErrorScopeId, error: GPUError) {
-        let mut context = self.scope_context.borrow_mut();
-        if let Some(err_scope) = context.error_scopes.get_mut(&scope) {
-            if err_scope.error.is_none() {
-                err_scope.error = Some(error);
-            }
-        } else {
-            warn!("Could not find ErrorScope with Id({})", scope);
-        }
-    }
-
-    fn try_remove_scope(&self, scope: ErrorScopeId) {
-        let mut context = self.scope_context.borrow_mut();
-        let remove = if let Some(err_scope) = context.error_scopes.get_mut(&scope) {
-            err_scope.op_count -= 1;
-            if let Some(ref promise) = err_scope.promise {
-                if !promise.is_fulfilled() {
-                    if let Some(ref e) = err_scope.error {
-                        promise.resolve_native(e);
-                    } else if err_scope.op_count == 0 {
-                        promise.resolve_native(&None::<GPUError>);
-                    }
-                }
-            }
-            err_scope.op_count == 0 && err_scope.promise.is_some()
-        } else {
-            warn!("Could not find ErrorScope with Id({})", scope);
-            false
-        };
-        if remove {
-            let _ = context.error_scopes.remove(&scope);
-            context.scope_stack.retain(|meta| meta.id != scope);
-        }
-    }
-
-    fn fire_uncaptured_error(&self, err: GPUError) {
+    pub fn fire_uncaptured_error(&self, error: webgpu::Error) {
+        let error = GPUError::from_error(&self.global(), error);
         let ev = GPUUncapturedErrorEvent::new(
             &self.global(),
             DOMString::from("uncapturederror"),
             &GPUUncapturedErrorEventInit {
-                error: err,
+                error,
                 parent: EventInit::empty(),
             },
         );
         let _ = self.eventtarget.DispatchEvent(ev.event());
-    }
-
-    pub fn use_current_scope(&self) -> Option<ErrorScopeId> {
-        let mut context = self.scope_context.borrow_mut();
-        let scope_id = context
-            .scope_stack
-            .iter()
-            .rev()
-            .find(|meta| !meta.popped.get())
-            .map(|meta| meta.id);
-        scope_id.and_then(|s_id| {
-            context.error_scopes.get_mut(&s_id).map(|scope| {
-                scope.op_count += 1;
-                s_id
-            })
-        })
     }
 
     fn get_pipeline_layout_data(
@@ -379,12 +269,10 @@ impl GPUDeviceMethods for GPUDevice {
             .lock()
             .create_buffer_id(self.device.0.backend());
 
-        let scope_id = self.use_current_scope();
         if desc.is_none() {
-            self.handle_server_msg(
-                scope_id,
-                WebGPUOpResult::ValidationError(String::from("Invalid GPUBufferUsage")),
-            );
+            self.dispatch_error(webgpu::Error::Validation(String::from(
+                "Invalid GPUBufferUsage",
+            )));
         }
 
         self.channel
@@ -506,18 +394,15 @@ impl GPUDeviceMethods for GPUDevice {
             })
             .collect::<Vec<_>>();
 
-        let scope_id = self.use_current_scope();
-
         let desc = if valid {
             Some(wgpu_bind::BindGroupLayoutDescriptor {
                 label: convert_label(&descriptor.parent),
                 entries: Cow::Owned(entries),
             })
         } else {
-            self.handle_server_msg(
-                scope_id,
-                WebGPUOpResult::ValidationError(String::from("Invalid GPUShaderStage")),
-            );
+            self.dispatch_error(webgpu::Error::Validation(String::from(
+                "Invalid GPUShaderStage",
+            )));
             None
         };
 
@@ -561,8 +446,6 @@ impl GPUDeviceMethods for GPUDevice {
             ),
             push_constant_ranges: Cow::Owned(vec![]),
         };
-
-        let scope_id = self.use_current_scope();
 
         let pipeline_layout_id = self
             .global()
@@ -624,8 +507,6 @@ impl GPUDeviceMethods for GPUDevice {
             entries: Cow::Owned(entries),
         };
 
-        let scope_id = self.use_current_scope();
-
         let bind_group_id = self
             .global()
             .wgpu_id_hub()
@@ -663,7 +544,6 @@ impl GPUDeviceMethods for GPUDevice {
             .lock()
             .create_shader_module_id(self.device.0.backend());
 
-        let scope_id = self.use_current_scope();
         self.channel
             .0
             .send(WebGPURequest::CreateShaderModule {
@@ -694,7 +574,6 @@ impl GPUDeviceMethods for GPUDevice {
             .lock()
             .create_compute_pipeline_id(self.device.0.backend());
 
-        let scope_id = self.use_current_scope();
         let (layout, implicit_ids, bgls) = self.get_pipeline_layout_data(&descriptor.parent.layout);
 
         let desc = wgpu_pipe::ComputePipelineDescriptor {
@@ -750,7 +629,6 @@ impl GPUDeviceMethods for GPUDevice {
             .wgpu_id_hub()
             .lock()
             .create_command_encoder_id(self.device.0.backend());
-        let scope_id = self.use_current_scope();
         self.channel
             .0
             .send(WebGPURequest::CreateCommandEncoder {
@@ -801,7 +679,6 @@ impl GPUDeviceMethods for GPUDevice {
             .lock()
             .create_texture_id(self.device.0.backend());
 
-        let scope_id = self.use_current_scope();
         if desc.is_none() {
             return Err(Error::Type(String::from("Invalid GPUTextureUsage")));
         }
@@ -856,7 +733,6 @@ impl GPUDeviceMethods for GPUDevice {
             border_color: None,
         };
 
-        let scope_id = self.use_current_scope();
         self.channel
             .0
             .send(WebGPURequest::CreateSampler {
@@ -883,7 +759,6 @@ impl GPUDeviceMethods for GPUDevice {
         &self,
         descriptor: &GPURenderPipelineDescriptor,
     ) -> DomRoot<GPURenderPipeline> {
-        let scope_id = self.use_current_scope();
         let mut valid = true;
 
         let (layout, implicit_ids, bgls) = self.get_pipeline_layout_data(&descriptor.parent.layout);
@@ -1001,10 +876,9 @@ impl GPUDeviceMethods for GPUDevice {
                 multiview: None,
             })
         } else {
-            self.handle_server_msg(
-                scope_id,
-                WebGPUOpResult::ValidationError(String::from("Invalid GPUColorWriteFlags")),
-            );
+            self.dispatch_error(webgpu::Error::Validation(String::from(
+                "Invalid GPUColorWriteFlags",
+            )));
             None
         };
 
@@ -1087,50 +961,33 @@ impl GPUDeviceMethods for GPUDevice {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope>
     fn PushErrorScope(&self, filter: GPUErrorFilter) {
-        let mut context = self.scope_context.borrow_mut();
-        let scope_id = context.next_scope_id;
-        context.next_scope_id = ErrorScopeId::new(scope_id.get() + 1).unwrap();
-        let err_scope = ErrorScopeInfo {
-            op_count: 0,
-            error: None,
-            promise: None,
-        };
-        let res = context.error_scopes.insert(scope_id, err_scope);
-        context.scope_stack.push(ErrorScopeMetadata {
-            id: scope_id,
-            filter,
-            popped: Cell::new(false),
-        });
-        assert!(res.is_none());
+        if self
+            .channel
+            .0
+            .send(WebGPURequest::PushErrorScope {
+                device_id: self.device.0,
+                filter: filter.to_webgpu(),
+            })
+            .is_err()
+        {
+            warn!("Failed sending WebGPURequest::PushErrorScope");
+        }
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope>
     fn PopErrorScope(&self, comp: InRealm) -> Rc<Promise> {
-        let mut context = self.scope_context.borrow_mut();
         let promise = Promise::new_in_current_realm(comp);
-        let scope_id =
-            if let Some(meta) = context.scope_stack.iter().rev().find(|m| !m.popped.get()) {
-                meta.popped.set(true);
-                meta.id
-            } else {
-                promise.reject_error(Error::Operation);
-                return promise;
-            };
-        let remove = if let Some(err_scope) = context.error_scopes.get_mut(&scope_id) {
-            if let Some(ref e) = err_scope.error {
-                promise.resolve_native(e);
-            } else if err_scope.op_count == 0 {
-                promise.resolve_native(&None::<GPUError>);
-            }
-            err_scope.promise = Some(promise.clone());
-            err_scope.op_count == 0
-        } else {
-            error!("Could not find ErrorScope with Id({})", scope_id);
-            false
-        };
-        if remove {
-            let _ = context.error_scopes.remove(&scope_id);
-            context.scope_stack.retain(|meta| meta.id != scope_id);
+        let sender = response_async(&promise, self);
+        if self
+            .channel
+            .0
+            .send(WebGPURequest::PopErrorScope {
+                device_id: self.device.0,
+                sender,
+            })
+            .is_err()
+        {
+            warn!("Error when sending WebGPURequest::PopErrorScope");
         }
         promise
     }
@@ -1152,6 +1009,22 @@ impl GPUDeviceMethods for GPUDevice {
             {
                 warn!("Failed to send DestroyDevice ({:?}) ({})", self.device.0, e);
             }
+        }
+    }
+}
+
+impl AsyncWGPUListener for GPUDevice {
+    fn handle_response(&self, response: Option<WebGPUResponseResult>, promise: &Rc<Promise>) {
+        match response {
+            Some(Ok(WebGPUResponse::PoppedErrorScope(result))) => match result {
+                Ok(None) | Err(PopError::Lost) => promise.resolve_native(&()),
+                Err(PopError::Empty) => promise.reject_native(&()),
+                Ok(Some(error)) => {
+                    let error = GPUError::from_error(&self.global(), error);
+                    promise.resolve_native(&error);
+                },
+            },
+            _ => unreachable!("Wrong response recived on AsyncWGPUListener for GPUDevice"),
         }
     }
 }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -1017,8 +1017,8 @@ impl AsyncWGPUListener for GPUDevice {
     fn handle_response(&self, response: Option<WebGPUResponseResult>, promise: &Rc<Promise>) {
         match response {
             Some(Ok(WebGPUResponse::PoppedErrorScope(result))) => match result {
-                Ok(None) | Err(PopError::Lost) => promise.resolve_native(&()),
-                Err(PopError::Empty) => promise.reject_native(&()),
+                Ok(None) | Err(PopError::Lost) => promise.resolve_native(&None::<Option<GPUError>>),
+                Err(PopError::Empty) => promise.reject_error(Error::Operation),
                 Ok(Some(error)) => {
                     let error = GPUError::from_error(&self.global(), error);
                     promise.resolve_native(&error);

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -389,14 +389,11 @@ impl GPUDeviceMethods for GPUDevice {
 
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateBuffer {
-                    device_id: self.device.0,
-                    buffer_id: id,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreateBuffer {
+                device_id: self.device.0,
+                buffer_id: id,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU buffer");
 
         let buffer = webgpu::WebGPUBuffer(id);
@@ -531,14 +528,11 @@ impl GPUDeviceMethods for GPUDevice {
             .create_bind_group_layout_id(self.device.0.backend());
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateBindGroupLayout {
-                    device_id: self.device.0,
-                    bind_group_layout_id,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreateBindGroupLayout {
+                device_id: self.device.0,
+                bind_group_layout_id,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU BindGroupLayout");
 
         let bgl = webgpu::WebGPUBindGroupLayout(bind_group_layout_id);
@@ -577,14 +571,11 @@ impl GPUDeviceMethods for GPUDevice {
             .create_pipeline_layout_id(self.device.0.backend());
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreatePipelineLayout {
-                    device_id: self.device.0,
-                    pipeline_layout_id,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreatePipelineLayout {
+                device_id: self.device.0,
+                pipeline_layout_id,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU PipelineLayout");
 
         let bgls = descriptor
@@ -642,14 +633,11 @@ impl GPUDeviceMethods for GPUDevice {
             .create_bind_group_id(self.device.0.backend());
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateBindGroup {
-                    device_id: self.device.0,
-                    bind_group_id,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreateBindGroup {
+                device_id: self.device.0,
+                bind_group_id,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU BindGroup");
 
         let bind_group = webgpu::WebGPUBindGroup(bind_group_id);
@@ -678,15 +666,12 @@ impl GPUDeviceMethods for GPUDevice {
         let scope_id = self.use_current_scope();
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateShaderModule {
-                    device_id: self.device.0,
-                    program_id,
-                    program: descriptor.code.0.clone(),
-                    label: None,
-                },
-            ))
+            .send(WebGPURequest::CreateShaderModule {
+                device_id: self.device.0,
+                program_id,
+                program: descriptor.code.0.clone(),
+                label: None,
+            })
             .expect("Failed to create WebGPU ShaderModule");
 
         let shader_module = webgpu::WebGPUShaderModule(program_id);
@@ -725,15 +710,12 @@ impl GPUDeviceMethods for GPUDevice {
 
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateComputePipeline {
-                    device_id: self.device.0,
-                    compute_pipeline_id,
-                    descriptor: desc,
-                    implicit_ids,
-                },
-            ))
+            .send(WebGPURequest::CreateComputePipeline {
+                device_id: self.device.0,
+                compute_pipeline_id,
+                descriptor: desc,
+                implicit_ids,
+            })
             .expect("Failed to create WebGPU ComputePipeline");
 
         let compute_pipeline = webgpu::WebGPUComputePipeline(compute_pipeline_id);
@@ -771,14 +753,11 @@ impl GPUDeviceMethods for GPUDevice {
         let scope_id = self.use_current_scope();
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateCommandEncoder {
-                    device_id: self.device.0,
-                    command_encoder_id,
-                    label: convert_label(&descriptor.parent),
-                },
-            ))
+            .send(WebGPURequest::CreateCommandEncoder {
+                device_id: self.device.0,
+                command_encoder_id,
+                label: convert_label(&descriptor.parent),
+            })
             .expect("Failed to create WebGPU command encoder");
 
         let encoder = webgpu::WebGPUCommandEncoder(command_encoder_id);
@@ -828,14 +807,11 @@ impl GPUDeviceMethods for GPUDevice {
         }
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateTexture {
-                    device_id: self.device.0,
-                    texture_id,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreateTexture {
+                device_id: self.device.0,
+                texture_id,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU Texture");
 
         let texture = webgpu::WebGPUTexture(texture_id);
@@ -883,14 +859,11 @@ impl GPUDeviceMethods for GPUDevice {
         let scope_id = self.use_current_scope();
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateSampler {
-                    device_id: self.device.0,
-                    sampler_id,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreateSampler {
+                device_id: self.device.0,
+                sampler_id,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU sampler");
 
         let sampler = webgpu::WebGPUSampler(sampler_id);
@@ -1043,15 +1016,12 @@ impl GPUDeviceMethods for GPUDevice {
 
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateRenderPipeline {
-                    device_id: self.device.0,
-                    render_pipeline_id,
-                    descriptor: desc,
-                    implicit_ids,
-                },
-            ))
+            .send(WebGPURequest::CreateRenderPipeline {
+                device_id: self.device.0,
+                render_pipeline_id,
+                descriptor: desc,
+                implicit_ids,
+            })
             .expect("Failed to create WebGPU render pipeline");
 
         let render_pipeline = webgpu::WebGPURenderPipeline(render_pipeline_id);
@@ -1178,7 +1148,7 @@ impl GPUDeviceMethods for GPUDevice {
             if let Err(e) = self
                 .channel
                 .0
-                .send((None, WebGPURequest::DestroyDevice(self.device.0)))
+                .send(WebGPURequest::DestroyDevice(self.device.0))
             {
                 warn!("Failed to send DestroyDevice ({:?}) ({})", self.device.0, e);
             }
@@ -1191,14 +1161,14 @@ impl Drop for GPUDevice {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DestroyDevice(self.device.0)))
+            .send(WebGPURequest::DestroyDevice(self.device.0))
         {
             warn!("Failed to send DestroyDevice ({:?}) ({})", self.device.0, e);
         }
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropDevice(self.device.0)))
+            .send(WebGPURequest::DropDevice(self.device.0))
         {
             warn!("Failed to send DropDevice ({:?}) ({})", self.device.0, e);
         }

--- a/components/script/dom/gpuerror.rs
+++ b/components/script/dom/gpuerror.rs
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::rust::HandleObject;
+use webgpu::{Error, ErrorFilter};
+
+use super::types::{GPUInternalError, GPUOutOfMemoryError, GPUValidationError};
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{GPUErrorFilter, GPUErrorMethods};
+use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::globalscope::GlobalScope;
+
+#[dom_struct]
+pub struct GPUError {
+    reflector_: Reflector,
+    message: DOMString,
+}
+
+impl GPUError {
+    pub fn new_inherited(message: DOMString) -> Self {
+        Self {
+            reflector_: Reflector::new(),
+            message,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new(global: &GlobalScope, message: DOMString) -> DomRoot<Self> {
+        Self::new_with_proto(global, None, message)
+    }
+
+    #[allow(dead_code)]
+    pub fn new_with_proto(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        message: DOMString,
+    ) -> DomRoot<Self> {
+        reflect_dom_object_with_proto(Box::new(GPUError::new_inherited(message)), global, proto)
+    }
+
+    pub fn from_error(global: &GlobalScope, error: Error) -> DomRoot<Self> {
+        match error {
+            Error::Validation(msg) => DomRoot::upcast(GPUValidationError::new_with_proto(
+                global,
+                None,
+                DOMString::from_string(msg),
+            )),
+            Error::OutOfMemory(msg) => DomRoot::upcast(GPUOutOfMemoryError::new_with_proto(
+                global,
+                None,
+                DOMString::from_string(msg),
+            )),
+            Error::Internal(msg) => DomRoot::upcast(GPUInternalError::new_with_proto(
+                global,
+                None,
+                DOMString::from_string(msg),
+            )),
+        }
+    }
+}
+
+impl GPUErrorMethods for GPUError {
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuerror-message>
+    fn Message(&self) -> DOMString {
+        self.message.clone()
+    }
+}
+
+impl From<ErrorFilter> for GPUErrorFilter {
+    fn from(filter: ErrorFilter) -> Self {
+        match filter {
+            ErrorFilter::Validation => GPUErrorFilter::Validation,
+            ErrorFilter::OutOfMemory => GPUErrorFilter::Out_of_memory,
+            ErrorFilter::Internal => GPUErrorFilter::Internal,
+        }
+    }
+}
+
+impl GPUErrorFilter {
+    pub fn to_webgpu(&self) -> ErrorFilter {
+        match self {
+            GPUErrorFilter::Validation => ErrorFilter::Validation,
+            GPUErrorFilter::Out_of_memory => ErrorFilter::OutOfMemory,
+            GPUErrorFilter::Internal => ErrorFilter::Internal,
+        }
+    }
+}

--- a/components/script/dom/gpuinternalerror.rs
+++ b/components/script/dom/gpuinternalerror.rs
@@ -12,11 +12,11 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
-pub struct GPUOutOfMemoryError {
+pub struct GPUInternalError {
     gpu_error: GPUError,
 }
 
-impl GPUOutOfMemoryError {
+impl GPUInternalError {
     fn new_inherited(message: DOMString) -> Self {
         Self {
             gpu_error: GPUError::new_inherited(message),
@@ -31,7 +31,7 @@ impl GPUOutOfMemoryError {
         reflect_dom_object_with_proto(Box::new(Self::new_inherited(message)), global, proto)
     }
 
-    /// <https://gpuweb.github.io/gpuweb/#dom-GPUOutOfMemoryError-GPUOutOfMemoryError>
+    /// <https://gpuweb.github.io/gpuweb/#dom-GPUInternalError-GPUInternalError>
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,

--- a/components/script/dom/gpupipelinelayout.rs
+++ b/components/script/dom/gpupipelinelayout.rs
@@ -84,10 +84,11 @@ impl GPUPipelineLayoutMethods for GPUPipelineLayout {
 
 impl Drop for GPUPipelineLayout {
     fn drop(&mut self) {
-        if let Err(e) = self.channel.0.send((
-            None,
-            WebGPURequest::DropPipelineLayout(self.pipeline_layout.0),
-        )) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropPipelineLayout(self.pipeline_layout.0))
+        {
             warn!(
                 "Failed to send DropPipelineLayout ({:?}) ({})",
                 self.pipeline_layout.0, e

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
-use webgpu::{wgt, WebGPU, WebGPUOpResult, WebGPUQueue, WebGPURequest, WebGPUResponse};
+use webgpu::{wgt, WebGPU, WebGPUQueue, WebGPURequest, WebGPUResponse};
 
 use super::bindings::codegen::Bindings::WebGPUBinding::{GPUImageCopyTexture, GPUImageDataLayout};
 use super::gpu::{response_async, AsyncWGPUListener};
@@ -81,14 +81,14 @@ impl GPUQueueMethods for GPUQueue {
                 .iter()
                 .all(|b| matches!(b.state(), GPUBufferState::Unmapped))
         });
-        let scope_id = self.device.borrow().as_ref().unwrap().use_current_scope();
         if !valid {
-            self.device.borrow().as_ref().unwrap().handle_server_msg(
-                scope_id,
-                WebGPUOpResult::ValidationError(String::from(
+            self.device
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .dispatch_error(webgpu::Error::Validation(String::from(
                     "Referenced GPUBuffer(s) are not Unmapped",
-                )),
-            );
+                )));
             return;
         }
         let command_buffers = command_buffers.iter().map(|cb| cb.id().0).collect();

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -94,13 +94,10 @@ impl GPUQueueMethods for GPUQueue {
         let command_buffers = command_buffers.iter().map(|cb| cb.id().0).collect();
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::Submit {
-                    queue_id: self.queue.0,
-                    command_buffers,
-                },
-            ))
+            .send(WebGPURequest::Submit {
+                queue_id: self.queue.0,
+                command_buffers,
+            })
             .unwrap();
     }
 
@@ -135,15 +132,12 @@ impl GPUQueueMethods for GPUQueue {
         let final_data = IpcSharedMemory::from_bytes(
             &bytes[data_offset as usize..(data_offset + content_size) as usize],
         );
-        if let Err(e) = self.channel.0.send((
-            self.device.borrow().as_ref().unwrap().use_current_scope(),
-            WebGPURequest::WriteBuffer {
-                queue_id: self.queue.0,
-                buffer_id: buffer.id().0,
-                buffer_offset,
-                data: final_data,
-            },
-        )) {
+        if let Err(e) = self.channel.0.send(WebGPURequest::WriteBuffer {
+            queue_id: self.queue.0,
+            buffer_id: buffer.id().0,
+            buffer_offset,
+            data: final_data,
+        }) {
             warn!("Failed to send WriteBuffer({:?}) ({})", buffer.id(), e);
             return Err(Error::Operation);
         }
@@ -174,16 +168,13 @@ impl GPUQueueMethods for GPUQueue {
         let write_size = convert_texture_size_to_wgt(&convert_texture_size_to_dict(&size));
         let final_data = IpcSharedMemory::from_bytes(&bytes);
 
-        if let Err(e) = self.channel.0.send((
-            self.device.borrow().as_ref().unwrap().use_current_scope(),
-            WebGPURequest::WriteTexture {
-                queue_id: self.queue.0,
-                texture_cv,
-                data_layout: texture_layout,
-                size: write_size,
-                data: final_data,
-            },
-        )) {
+        if let Err(e) = self.channel.0.send(WebGPURequest::WriteTexture {
+            queue_id: self.queue.0,
+            texture_cv,
+            data_layout: texture_layout,
+            size: write_size,
+            data: final_data,
+        }) {
             warn!(
                 "Failed to send WriteTexture({:?}) ({})",
                 destination.texture.id().0,
@@ -200,13 +191,14 @@ impl GPUQueueMethods for GPUQueue {
         let global = self.global();
         let promise = Promise::new(&global);
         let sender = response_async(&promise, self);
-        if let Err(e) = self.channel.0.send((
-            self.device.borrow().as_ref().unwrap().use_current_scope(),
-            WebGPURequest::QueueOnSubmittedWorkDone {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::QueueOnSubmittedWorkDone {
                 sender,
                 queue_id: self.queue.0,
-            },
-        )) {
+            })
+        {
             warn!("QueueOnSubmittedWorkDone failed with {e}")
         }
         promise

--- a/components/script/dom/gpurenderbundle.rs
+++ b/components/script/dom/gpurenderbundle.rs
@@ -83,7 +83,7 @@ impl Drop for GPURenderBundle {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropRenderBundle(self.render_bundle.0)))
+            .send(WebGPURequest::DropRenderBundle(self.render_bundle.0))
         {
             warn!(
                 "Failed to send DropRenderBundle ({:?}) ({})",

--- a/components/script/dom/gpurenderbundleencoder.rs
+++ b/components/script/dom/gpurenderbundleencoder.rs
@@ -209,15 +209,12 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
 
         self.channel
             .0
-            .send((
-                self.device.use_current_scope(),
-                WebGPURequest::RenderBundleEncoderFinish {
-                    render_bundle_encoder: encoder,
-                    descriptor: desc,
-                    render_bundle_id,
-                    device_id: self.device.id().0,
-                },
-            ))
+            .send(WebGPURequest::RenderBundleEncoderFinish {
+                render_bundle_encoder: encoder,
+                descriptor: desc,
+                render_bundle_id,
+                device_id: self.device.id().0,
+            })
             .expect("Failed to send RenderBundleEncoderFinish");
 
         let render_bundle = WebGPURenderBundle(render_bundle_id);

--- a/components/script/dom/gpurenderpassencoder.rs
+++ b/components/script/dom/gpurenderpassencoder.rs
@@ -164,13 +164,10 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         let render_pass = self.render_pass.borrow_mut().take();
         self.channel
             .0
-            .send((
-                None,
-                WebGPURequest::RunRenderPass {
-                    command_encoder_id: self.command_encoder.id().0,
-                    render_pass,
-                },
-            ))
+            .send(WebGPURequest::RunRenderPass {
+                command_encoder_id: self.command_encoder.id().0,
+                render_pass,
+            })
             .expect("Failed to send RunRenderPass");
 
         self.command_encoder.set_state(

--- a/components/script/dom/gpurenderpipeline.rs
+++ b/components/script/dom/gpurenderpipeline.rs
@@ -100,10 +100,11 @@ impl GPURenderPipelineMethods for GPURenderPipeline {
 
 impl Drop for GPURenderPipeline {
     fn drop(&mut self) {
-        if let Err(e) = self.channel.0.send((
-            None,
-            WebGPURequest::DropRenderPipeline(self.render_pipeline.0),
-        )) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropRenderPipeline(self.render_pipeline.0))
+        {
             warn!(
                 "Failed to send WebGPURequest::DropRenderPipeline({:?}) ({})",
                 self.render_pipeline.0, e

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -88,7 +88,7 @@ impl Drop for GPUSampler {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropSampler(self.sampler.0)))
+            .send(WebGPURequest::DropSampler(self.sampler.0))
         {
             warn!("Failed to send DropSampler ({:?}) ({})", self.sampler.0, e);
         }

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -82,7 +82,7 @@ impl Drop for GPUShaderModule {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropShaderModule(self.shader_module.0)))
+            .send(WebGPURequest::DropShaderModule(self.shader_module.0))
         {
             warn!(
                 "Failed to send DropShaderModule ({:?}) ({})",

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -7,7 +7,7 @@ use std::string::String;
 
 use dom_struct::dom_struct;
 use webgpu::wgc::resource;
-use webgpu::{wgt, WebGPU, WebGPUOpResult, WebGPURequest, WebGPUTexture, WebGPUTextureView};
+use webgpu::{wgt, WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -143,8 +143,6 @@ impl GPUTextureMethods for GPUTexture {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-createview>
     fn CreateView(&self, descriptor: &GPUTextureViewDescriptor) -> DomRoot<GPUTextureView> {
-        let scope_id = self.device.use_current_scope();
-
         let desc = if !matches!(descriptor.mipLevelCount, Some(0)) &&
             !matches!(descriptor.arrayLayerCount, Some(0))
         {
@@ -165,12 +163,10 @@ impl GPUTextureMethods for GPUTexture {
                 },
             })
         } else {
-            self.device.handle_server_msg(
-                scope_id,
-                WebGPUOpResult::ValidationError(String::from(
+            self.device
+                .dispatch_error(webgpu::Error::Validation(String::from(
                     "arrayLayerCount and mipLevelCount cannot be 0",
-                )),
-            );
+                )));
             None
         };
 

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -114,7 +114,7 @@ impl Drop for GPUTexture {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropTexture(self.texture.0)))
+            .send(WebGPURequest::DropTexture(self.texture.0))
         {
             warn!(
                 "Failed to send WebGPURequest::DropTexture({:?}) ({})",
@@ -182,15 +182,12 @@ impl GPUTextureMethods for GPUTexture {
 
         self.channel
             .0
-            .send((
-                scope_id,
-                WebGPURequest::CreateTextureView {
-                    texture_id: self.texture.0,
-                    texture_view_id,
-                    device_id: self.device.id().0,
-                    descriptor: desc,
-                },
-            ))
+            .send(WebGPURequest::CreateTextureView {
+                texture_id: self.texture.0,
+                texture_view_id,
+                device_id: self.device.id().0,
+                descriptor: desc,
+            })
             .expect("Failed to create WebGPU texture view");
 
         let texture_view = WebGPUTextureView(texture_view_id);
@@ -209,13 +206,10 @@ impl GPUTextureMethods for GPUTexture {
         if self.destroyed.get() {
             return;
         }
-        if let Err(e) = self.channel.0.send((
-            None,
-            WebGPURequest::DestroyTexture {
-                device_id: self.device.id().0,
-                texture_id: self.texture.0,
-            },
-        )) {
+        if let Err(e) = self.channel.0.send(WebGPURequest::DestroyTexture {
+            device_id: self.device.id().0,
+            texture_id: self.texture.0,
+        }) {
             warn!(
                 "Failed to send WebGPURequest::DestroyTexture({:?}) ({})",
                 self.texture.0, e

--- a/components/script/dom/gputextureview.rs
+++ b/components/script/dom/gputextureview.rs
@@ -83,7 +83,7 @@ impl Drop for GPUTextureView {
         if let Err(e) = self
             .channel
             .0
-            .send((None, WebGPURequest::DropTextureView(self.texture_view.0)))
+            .send(WebGPURequest::DropTextureView(self.texture_view.0))
         {
             warn!(
                 "Failed to send DropTextureView ({:?}) ({})",

--- a/components/script/dom/gpuuncapturederrorevent.rs
+++ b/components/script/dom/gpuuncapturederrorevent.rs
@@ -8,25 +8,26 @@ use servo_atoms::Atom;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUError, GPUUncapturedErrorEventInit, GPUUncapturedErrorEventMethods,
+    GPUUncapturedErrorEventInit, GPUUncapturedErrorEventMethods,
 };
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpuerror::GPUError;
 
 #[dom_struct]
 pub struct GPUUncapturedErrorEvent {
     event: Event,
     #[ignore_malloc_size_of = "Because it is non-owning"]
-    gpu_error: GPUError,
+    gpu_error: Dom<GPUError>,
 }
 
 impl GPUUncapturedErrorEvent {
     fn new_inherited(init: &GPUUncapturedErrorEventInit) -> Self {
         Self {
-            gpu_error: clone_gpu_error(&init.error),
+            gpu_error: Dom::from_ref(&init.error),
             event: Event::new_inherited(),
         }
     }
@@ -78,19 +79,12 @@ impl GPUUncapturedErrorEvent {
 
 impl GPUUncapturedErrorEventMethods for GPUUncapturedErrorEvent {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error>
-    fn Error(&self) -> GPUError {
-        clone_gpu_error(&self.gpu_error)
+    fn Error(&self) -> DomRoot<GPUError> {
+        DomRoot::from_ref(&self.gpu_error)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.event.IsTrusted()
-    }
-}
-
-fn clone_gpu_error(error: &GPUError) -> GPUError {
-    match *error {
-        GPUError::GPUValidationError(ref v) => GPUError::GPUValidationError(v.clone()),
-        GPUError::GPUOutOfMemoryError(ref w) => GPUError::GPUOutOfMemoryError(w.clone()),
     }
 }

--- a/components/script/dom/gpuvalidationerror.rs
+++ b/components/script/dom/gpuvalidationerror.rs
@@ -5,41 +5,30 @@
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 
-use super::bindings::error::Fallible;
-use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUValidationErrorMethods;
-use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
+use super::types::GPUError;
+use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
 pub struct GPUValidationError {
-    reflector_: Reflector,
-    message: DOMString,
+    gpu_error: GPUError,
 }
 
 impl GPUValidationError {
     fn new_inherited(message: DOMString) -> Self {
         Self {
-            reflector_: Reflector::new(),
-            message,
+            gpu_error: GPUError::new_inherited(message),
         }
     }
 
-    pub fn new(global: &GlobalScope, message: DOMString) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, message)
-    }
-
-    fn new_with_proto(
+    pub fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
-            Box::new(GPUValidationError::new_inherited(message)),
-            global,
-            proto,
-        )
+        reflect_dom_object_with_proto(Box::new(Self::new_inherited(message)), global, proto)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror>
@@ -48,14 +37,7 @@ impl GPUValidationError {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
-    ) -> Fallible<DomRoot<Self>> {
-        Ok(GPUValidationError::new_with_proto(global, proto, message))
-    }
-}
-
-impl GPUValidationErrorMethods for GPUValidationError {
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-message>
-    fn Message(&self) -> DOMString {
-        self.message.clone()
+    ) -> DomRoot<Self> {
+        Self::new_with_proto(global, proto, message)
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -340,6 +340,8 @@ pub mod gpucomputepipeline;
 pub mod gpuconvert;
 pub mod gpudevice;
 pub mod gpudevicelostinfo;
+pub mod gpuerror;
+pub mod gpuinternalerror;
 pub mod gpumapmode;
 pub mod gpuoutofmemoryerror;
 pub mod gpupipelinelayout;

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -1086,19 +1086,28 @@ partial interface GPUDevice {
     readonly attribute Promise<GPUDeviceLostInfo> lost;
 };
 
-[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
-interface GPUValidationError {
-    [Throws]
-    constructor(DOMString message);
+[Exposed=(Window, Worker), Pref="dom.webgpu.enabled"]
+interface GPUError {
     readonly attribute DOMString message;
 };
 
-[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
-interface GPUOutOfMemoryError {
-    constructor();
+[Exposed=(Window, Worker), Pref="dom.webgpu.enabled"]
+interface GPUValidationError
+        : GPUError {
+    constructor(DOMString message);
 };
 
-typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
+[Exposed=(Window, Worker), Pref="dom.webgpu.enabled"]
+interface GPUOutOfMemoryError
+        : GPUError {
+    constructor(DOMString message);
+};
+
+[Exposed=(Window, Worker), Pref="dom.webgpu.enabled"]
+interface GPUInternalError
+        : GPUError {
+    constructor(DOMString message);
+};
 
 enum GPUErrorFilter {
     "validation",
@@ -1112,7 +1121,7 @@ partial interface GPUDevice {
     Promise<GPUError?> popErrorScope();
 };
 
-[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
+[Exposed=(Window, Worker), Pref="dom.webgpu.enabled"]
 interface GPUUncapturedErrorEvent : Event {
     constructor(
         DOMString type,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2423,22 +2423,21 @@ impl ScriptThread {
             WebGPUMsg::FreeTexture(id) => self.gpu_id_hub.lock().kill_texture_id(id),
             WebGPUMsg::FreeTextureView(id) => self.gpu_id_hub.lock().kill_texture_view_id(id),
             WebGPUMsg::Exit => *self.webgpu_port.borrow_mut() = None,
-            WebGPUMsg::WebGPUOpResult {
-                device,
-                scope_id,
-                pipeline_id,
-                result,
-            } => {
-                let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                let _ac = enter_realm(&*global);
-                global.handle_wgpu_msg(device, scope_id, result);
-            },
             WebGPUMsg::CleanDevice {
                 pipeline_id,
                 device,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
                 global.remove_gpu_device(device);
+            },
+            WebGPUMsg::UncapturedError {
+                device,
+                pipeline_id,
+                error,
+            } => {
+                let global = self.documents.borrow().find_global(pipeline_id).unwrap();
+                let _ac = enter_realm(&*global);
+                global.handle_uncaptured_gpu_error(device, error);
             },
             _ => {},
         }

--- a/components/webgpu/device_scope.rs
+++ b/components/webgpu/device_scope.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::vec::Vec;
 
 use msg::constellation_msg::PipelineId;
@@ -29,7 +33,7 @@ impl DeviceScope {
 }
 
 /// <https://www.w3.org/TR/webgpu/#gpu-error-scope>
-#[derive(Debug, Eq, Hash, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ErrorScope {
     // we only store first error
     pub errors: Option<Error>,
@@ -46,7 +50,7 @@ impl ErrorScope {
 }
 
 /// <https://www.w3.org/TR/webgpu/#enumdef-gpuerrorfilter>
-#[derive(Debug, Deserialize, Serialize, Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum ErrorFilter {
     Validation,
     OutOfMemory,
@@ -54,7 +58,7 @@ pub enum ErrorFilter {
 }
 
 /// <https://www.w3.org/TR/webgpu/#gpuerror>
-#[derive(Debug, Deserialize, Serialize, Eq, Hash, PartialEq, Clone)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum Error {
     Validation(String),
     OutOfMemory(String),
@@ -79,7 +83,7 @@ impl Error {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum PopError {
     Lost,
     Empty,

--- a/components/webgpu/device_scope.rs
+++ b/components/webgpu/device_scope.rs
@@ -1,0 +1,86 @@
+use std::vec::Vec;
+
+use msg::constellation_msg::PipelineId;
+use serde::{Deserialize, Serialize};
+
+use crate::wgc::id::DeviceId;
+
+#[derive(Eq, Hash, PartialEq)]
+pub(crate) struct DeviceScope {
+    pub device_id: DeviceId,
+    pub pipeline_id: PipelineId,
+    /// <https://www.w3.org/TR/webgpu/#dom-gpudevice-errorscopestack-slot>
+    pub error_scope_stack: Vec<ErrorScope>,
+    // TODO:
+    // Queue for this device (to remove transmutes)
+    // queue_id: QueueId,
+    // Poller for this device
+    // poller: Poller,
+}
+
+impl DeviceScope {
+    pub fn new(device_id: DeviceId, pipeline_id: PipelineId) -> Self {
+        Self {
+            device_id,
+            pipeline_id,
+            error_scope_stack: Vec::new(),
+        }
+    }
+}
+
+/// <https://www.w3.org/TR/webgpu/#gpu-error-scope>
+#[derive(Debug, Eq, Hash, PartialEq, Clone)]
+pub(crate) struct ErrorScope {
+    // we only store first error
+    pub errors: Option<Error>,
+    pub filter: ErrorFilter,
+}
+
+impl ErrorScope {
+    pub fn new(filter: ErrorFilter) -> Self {
+        Self {
+            filter,
+            errors: None,
+        }
+    }
+}
+
+/// <https://www.w3.org/TR/webgpu/#enumdef-gpuerrorfilter>
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, Eq, Hash, PartialEq)]
+pub enum ErrorFilter {
+    Validation,
+    OutOfMemory,
+    Internal,
+}
+
+/// <https://www.w3.org/TR/webgpu/#gpuerror>
+#[derive(Debug, Deserialize, Serialize, Eq, Hash, PartialEq, Clone)]
+pub enum Error {
+    Validation(String),
+    OutOfMemory(String),
+    Internal(String),
+}
+
+impl Error {
+    pub fn filter(&self) -> ErrorFilter {
+        match self {
+            Error::Validation(_) => ErrorFilter::Validation,
+            Error::OutOfMemory(_) => ErrorFilter::OutOfMemory,
+            Error::Internal(_) => ErrorFilter::Internal,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        match self {
+            Error::Validation(m) => m,
+            Error::OutOfMemory(m) => m,
+            Error::Internal(m) => m,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy)]
+pub enum PopError {
+    Lost,
+    Empty,
+}

--- a/components/webgpu/dom_messages.rs
+++ b/components/webgpu/dom_messages.rs
@@ -257,6 +257,10 @@ pub enum WebGPURequest {
         device_id: id::DeviceId,
         filter: ErrorFilter,
     },
+    DispatchError {
+        device_id: id::DeviceId,
+        error: Error,
+    },
     PopErrorScope {
         device_id: id::DeviceId,
         sender: IpcSender<Option<WebGPUResponseResult>>,

--- a/components/webgpu/dom_messages.rs
+++ b/components/webgpu/dom_messages.rs
@@ -28,9 +28,8 @@ use wgc::resource::{
 };
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
-use crate::device_scope::{Error, ErrorFilter, PopError};
 use crate::identity::*;
-use crate::{WebGPU, PRESENTATION_BUFFER_COUNT};
+use crate::{Error, ErrorFilter, PopError, WebGPU, PRESENTATION_BUFFER_COUNT};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]

--- a/components/webgpu/dom_messages.rs
+++ b/components/webgpu/dom_messages.rs
@@ -28,6 +28,7 @@ use wgc::resource::{
 };
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
+use crate::device_scope::{Error, ErrorFilter, PopError};
 use crate::identity::*;
 use crate::{WebGPU, PRESENTATION_BUFFER_COUNT};
 
@@ -48,6 +49,7 @@ pub enum WebGPUResponse {
     },
     BufferMapAsync(IpcSharedMemory),
     SubmittedWorkDone,
+    PoppedErrorScope(Result<Option<Error>, PopError>),
 }
 
 pub type WebGPUResponseResult = Result<WebGPUResponse, String>;
@@ -250,5 +252,13 @@ pub enum WebGPURequest {
     QueueOnSubmittedWorkDone {
         sender: IpcSender<Option<WebGPUResponseResult>>,
         queue_id: id::QueueId,
+    },
+    PushErrorScope {
+        device_id: id::DeviceId,
+        filter: ErrorFilter,
+    },
+    PopErrorScope {
+        device_id: id::DeviceId,
+        sender: IpcSender<Option<WebGPUResponseResult>>,
     },
 }

--- a/components/webgpu/gpu_error.rs
+++ b/components/webgpu/gpu_error.rs
@@ -13,8 +13,7 @@ use crate::wgc;
 /// <https://www.w3.org/TR/webgpu/#gpu-error-scope>
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct ErrorScope {
-    // we only store first error
-    pub errors: Option<Error>,
+    pub errors: Vec<Error>,
     pub filter: ErrorFilter,
 }
 
@@ -22,7 +21,7 @@ impl ErrorScope {
     pub fn new(filter: ErrorFilter) -> Self {
         Self {
             filter,
-            errors: None,
+            errors: Vec::new(),
         }
     }
 }

--- a/components/webgpu/gpu_error.rs
+++ b/components/webgpu/gpu_error.rs
@@ -2,35 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::vec::Vec;
+//! Error scopes and GPUError types
 
-use msg::constellation_msg::PipelineId;
 use serde::{Deserialize, Serialize};
-
-use crate::wgc::id::DeviceId;
-
-#[derive(Eq, Hash, PartialEq)]
-pub(crate) struct DeviceScope {
-    pub device_id: DeviceId,
-    pub pipeline_id: PipelineId,
-    /// <https://www.w3.org/TR/webgpu/#dom-gpudevice-errorscopestack-slot>
-    pub error_scope_stack: Vec<ErrorScope>,
-    // TODO:
-    // Queue for this device (to remove transmutes)
-    // queue_id: QueueId,
-    // Poller for this device
-    // poller: Poller,
-}
-
-impl DeviceScope {
-    pub fn new(device_id: DeviceId, pipeline_id: PipelineId) -> Self {
-        Self {
-            device_id,
-            pipeline_id,
-            error_scope_stack: Vec::new(),
-        }
-    }
-}
 
 /// <https://www.w3.org/TR/webgpu/#gpu-error-scope>
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -16,8 +16,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use arrayvec::ArrayVec;
-pub use device_scope::{Error, ErrorFilter, PopError};
 use euclid::default::Size2D;
+pub use gpu_error::{Error, ErrorFilter, PopError};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use serde::{Deserialize, Serialize};
 use servo_config::pref;
@@ -27,8 +27,8 @@ use webrender_traits::{
 };
 use wgc::id;
 
-mod device_scope;
 mod dom_messages;
+mod gpu_error;
 mod script_messages;
 pub use dom_messages::*;
 pub use identity::*;

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -38,7 +38,7 @@ pub type ErrorScopeId = NonZeroU64;
 pub use wgpu_thread::PRESENTATION_BUFFER_COUNT;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct WebGPU(pub IpcSender<(Option<ErrorScopeId>, WebGPURequest)>);
+pub struct WebGPU(pub IpcSender<WebGPURequest>);
 
 impl WebGPU {
     pub fn new(
@@ -96,7 +96,7 @@ impl WebGPU {
 
     pub fn exit(&self, sender: IpcSender<()>) -> Result<(), &'static str> {
         self.0
-            .send((None, WebGPURequest::Exit(sender)))
+            .send(WebGPURequest::Exit(sender))
             .map_err(|_| "Failed to send Exit message")
     }
 }

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -27,6 +27,7 @@ use webrender_traits::{
 };
 use wgc::id;
 
+mod device_scope;
 mod dom_messages;
 mod script_messages;
 pub use dom_messages::*;

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -13,10 +13,10 @@ mod wgpu_thread;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
 
 use arrayvec::ArrayVec;
+pub use device_scope::{Error, ErrorFilter, PopError};
 use euclid::default::Size2D;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use serde::{Deserialize, Serialize};
@@ -33,8 +33,6 @@ mod script_messages;
 pub use dom_messages::*;
 pub use identity::*;
 pub use script_messages::*;
-
-pub type ErrorScopeId = NonZeroU64;
 pub use wgpu_thread::PRESENTATION_BUFFER_COUNT;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/webgpu/script_messages.rs
+++ b/components/webgpu/script_messages.rs
@@ -7,7 +7,7 @@
 use msg::constellation_msg::PipelineId;
 use serde::{Deserialize, Serialize};
 
-use crate::device_scope::Error;
+use crate::gpu_error::Error;
 use crate::identity::WebGPUDevice;
 use crate::wgc::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, ComputePipelineId,

--- a/components/webgpu/script_messages.rs
+++ b/components/webgpu/script_messages.rs
@@ -7,6 +7,7 @@
 use msg::constellation_msg::PipelineId;
 use serde::{Deserialize, Serialize};
 
+use crate::device_scope::Error;
 use crate::identity::WebGPUDevice;
 use crate::wgc::id::{
     AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, ComputePipelineId,
@@ -50,6 +51,11 @@ pub enum WebGPUMsg {
     CleanDevice {
         device: WebGPUDevice,
         pipeline_id: PipelineId,
+    },
+    UncapturedError {
+        device: WebGPUDevice,
+        pipeline_id: PipelineId,
+        error: Error,
     },
     Exit,
 }

--- a/components/webgpu/script_messages.rs
+++ b/components/webgpu/script_messages.rs
@@ -14,14 +14,6 @@ use crate::wgc::id::{
     DeviceId, PipelineLayoutId, QuerySetId, RenderBundleId, RenderPipelineId, SamplerId,
     ShaderModuleId, StagingBufferId, SurfaceId, TextureId, TextureViewId,
 };
-use crate::ErrorScopeId;
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum WebGPUOpResult {
-    ValidationError(String),
-    OutOfMemoryError,
-    Success,
-}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum WebGPUMsg {
@@ -42,12 +34,6 @@ pub enum WebGPUMsg {
     FreeRenderBundle(RenderBundleId),
     FreeStagingBuffer(StagingBufferId),
     FreeQuerySet(QuerySetId),
-    WebGPUOpResult {
-        device: WebGPUDevice,
-        scope_id: Option<ErrorScopeId>,
-        pipeline_id: PipelineId,
-        result: WebGPUOpResult,
-    },
     CleanDevice {
         device: WebGPUDevice,
         pipeline_id: PipelineId,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -1074,7 +1074,8 @@ impl WGPU {
                             if let Some(error_scope) = device_scope.error_scope_stack.pop() {
                                 if let Err(e) =
                                     sender.send(Some(Ok(WebGPUResponse::PoppedErrorScope(Ok(
-                                        error_scope.errors.clone(),
+                                        // TODO: Do actual selection instead of selecting first error
+                                        error_scope.errors.first().cloned(),
                                     )))))
                                 {
                                     warn!(
@@ -1130,7 +1131,7 @@ impl WGPU {
                 .rev()
                 .find(|error_scope| error_scope.filter == error.filter())
             {
-                error_scope.errors.get_or_insert(error);
+                error_scope.errors.push(error);
             } else {
                 if self
                     .script_sender

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -68142,12 +68142,8 @@
 
 [cts.https.html?q=webgpu:idl,constructable:gpu_errors:*]
   [:errorType="GPUInternalError"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:errorType="GPUOutOfMemoryError"]
-    expected:
-      if os == "linux" and not debug: FAIL
 
   [:errorType="GPUValidationError"]
 

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -2116,17 +2116,29 @@
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:large_dispatch:*]
+  expected:
+    if os == "linux" and not debug: [OK, TIMEOUT]
   [:dispatchSize="maximum"]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:dispatchSize=2048]
+    expected:
+      if os == "linux" and not debug: [PASS, TIMEOUT]
 
   [:dispatchSize=2179]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:dispatchSize=256]
 
   [:dispatchSize=315]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:dispatchSize=628]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
 
 [cts.https.html?q=webgpu:api,operation,compute,basic:memcpy:*]
@@ -9120,6 +9132,8 @@
 
 
 [cts.https.html?q=webgpu:api,validation,buffer,mapping:mapAsync,state,destroyed:*]
+  expected:
+    if os == "linux" and not debug: [OK, ERROR]
   [:]
     expected:
       if os == "linux" and not debug: FAIL
@@ -9142,7 +9156,7 @@
     if os == "linux" and not debug: ERROR
   [:]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,buffer,mapping:mapAsync,usage:*]
@@ -18424,14 +18438,20 @@
   [:limitTest="atDefault";testValueName="atLimit"]
 
   [:limitTest="atDefault";testValueName="underLimit"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="atMinimum";testValueName="atLimit"]
 
   [:limitTest="atMinimum";testValueName="underLimit"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="betweenDefaultAndMinimum";testValueName="atLimit"]
 
   [:limitTest="betweenDefaultAndMinimum";testValueName="underLimit"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:limitTest="overDefault";testValueName="atLimit"]
     expected:
@@ -18710,16 +18730,24 @@
 
 [cts.https.html?q=webgpu:api,validation,compute_pipeline:overrides,uninitialized:*]
   [:isAsync=false;constants={"c0":0,"c2":0,"c5":0,"c8":0,"c1":0}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;constants={"c0":0,"c2":0,"c5":0,"c8":0}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;constants={"c0":0,"c2":0,"c8":0}]
 
   [:isAsync=false;constants={}]
 
   [:isAsync=true;constants={"c0":0,"c2":0,"c5":0,"c8":0,"c1":0}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;constants={"c0":0,"c2":0,"c5":0,"c8":0}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;constants={"c0":0,"c2":0,"c8":0}]
     expected:
@@ -18918,8 +18946,12 @@
       if os == "linux" and not debug: FAIL
 
   [:isAsync=false;type="i32";constants={"x":16,"y":1,"z":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;type="i32";constants={}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;type="u32";constants={"x":0,"y":0,"z":0}]
     expected:
@@ -18934,8 +18966,12 @@
       if os == "linux" and not debug: FAIL
 
   [:isAsync=false;type="u32";constants={"x":16,"y":1,"z":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;type="u32";constants={}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;type="i32";constants={"x":0,"y":0,"z":0}]
     expected:
@@ -18950,8 +18986,12 @@
       if os == "linux" and not debug: FAIL
 
   [:isAsync=true;type="i32";constants={"x":16,"y":1,"z":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;type="i32";constants={}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;type="u32";constants={"x":0,"y":0,"z":0}]
     expected:
@@ -18966,8 +19006,12 @@
       if os == "linux" and not debug: FAIL
 
   [:isAsync=true;type="u32";constants={"x":16,"y":1,"z":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;type="u32";constants={}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,compute_pipeline:pipeline_layout,device_mismatch:*]
@@ -19408,6 +19452,8 @@
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:buffer,resource_state:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,createBindGroup:buffer,usage:*]
@@ -26214,10 +26260,16 @@
       if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="r32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="r32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="r32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="r8sint"]
     expected:
@@ -26250,10 +26302,16 @@
       if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rg32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rg32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rg32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rg8sint"]
     expected:
@@ -26282,24 +26340,42 @@
       if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba8snorm"]
 
   [:dimension="3d";format="rgba8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";format="rgba8unorm-srgb"]
     expected:
@@ -27396,6 +27472,8 @@
 
 [cts.https.html?q=webgpu:api,validation,createView:texture_state:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,debugMarker:push_pop_call_count_unbalance,command_encoder:*]
@@ -27448,6 +27526,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,beginRenderPass:color_attachments,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,beginRenderPass:depth_stencil_attachment,device_mismatch:*]
@@ -27540,6 +27620,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,compute_pass:indirect_dispatch_buffer,usage:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,compute_pass:indirect_dispatch_buffer_state:*]
@@ -27556,54 +27638,86 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,compute_pass:set_pipeline:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer_state:*]
   [:srcBufferState="destroyed";dstBufferState="destroyed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="destroyed";dstBufferState="invalid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="destroyed";dstBufferState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="invalid";dstBufferState="destroyed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="invalid";dstBufferState="invalid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="invalid";dstBufferState="valid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="valid";dstBufferState="destroyed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="valid";dstBufferState="invalid"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcBufferState="valid";dstBufferState="valid"]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:buffer_usage:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:copy_offset_alignment:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:copy_out_of_bounds:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:copy_overflow:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:copy_size_alignment:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyBufferToBuffer:copy_within_same_buffer:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:copy_aspects:*]
@@ -27612,16 +27726,24 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="stencil8"]
     expected:
@@ -27668,58 +27790,112 @@
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=3]
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=0;dstCopyLevel=0]
 
@@ -27794,22 +27970,40 @@
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=3;dstCopyLevel=3]
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d";copyBoxOffsets={"x":0,"y":1,"z":0,"width":0,"height":-1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
 
@@ -27904,92 +28098,178 @@
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=0]
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":0,"depthOrArrayLayers":1};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":0,"width":1,"height":0,"depthOrArrayLayers":-2};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=0;dstCopyLevel=0]
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":0,"depthOrArrayLayers":-1};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":1,"width":0,"height":1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
     expected:
@@ -28062,22 +28342,40 @@
       if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=0;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=1;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":0,"z":2,"width":0,"height":1,"depthOrArrayLayers":0};srcCopyLevel=3;dstCopyLevel=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d";copyBoxOffsets={"x":0,"y":1,"z":0,"width":0,"height":-1,"depthOrArrayLayers":-2};srcCopyLevel=0;dstCopyLevel=0]
 
@@ -28210,32 +28508,60 @@
   [:format="astc-8x8-unorm-srgb";dimension="2d"]
 
   [:format="bc1-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc1-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc2-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc2-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc3-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc3-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc4-r-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc4-r-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc5-rg-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc5-rg-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc6h-rgb-float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc6h-rgb-ufloat";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc7-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bc7-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="eac-r11snorm";dimension="2d"]
 
@@ -28276,10 +28602,16 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8"]
     expected:
@@ -28292,10 +28624,16 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:mipmap_level:*]
   [:dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:multisampled_copy_restrictions:*]
@@ -28312,6 +28650,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_format_compatibility:*]
@@ -28368,6 +28708,8 @@
   [:srcFormatFeature="texture-compression-bc";dstFormatFeature="texture-compression-astc"]
 
   [:srcFormatFeature="texture-compression-bc";dstFormatFeature="texture-compression-bc"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:srcFormatFeature="texture-compression-bc";dstFormatFeature="texture-compression-etc2"]
 
@@ -28384,6 +28726,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,copyTextureToTexture:texture_usage:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,debug:debug_group:*]
@@ -28446,32 +28790,56 @@
   [:indexCount=0;firstIndex=6;instanceCount=10000]
 
   [:indexCount=0;firstIndex=7;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=0;firstIndex=7;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=10000;firstIndex=0;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=10000;firstIndex=0;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=1;firstIndex=5;instanceCount=1]
 
   [:indexCount=1;firstIndex=5;instanceCount=10000]
 
   [:indexCount=1;firstIndex=6;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=1;firstIndex=6;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=2;firstIndex=4294967295;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=2;firstIndex=4294967295;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=2;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=2;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=4294967295;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=4294967295;firstIndex=4294967295;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=5;firstIndex=1;instanceCount=1]
 
@@ -28482,16 +28850,28 @@
   [:indexCount=6;firstIndex=0;instanceCount=10000]
 
   [:indexCount=6;firstIndex=10000;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=6;firstIndex=10000;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=6;firstIndex=1;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=6;firstIndex=1;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=7;firstIndex=0;instanceCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:indexCount=7;firstIndex=0;instanceCount=10000]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,index_access:out_of_bounds_zero_sized_index_buffer:*]
@@ -28552,6 +28932,8 @@
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexedIndirect"]
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bufferSizeInElements=100;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexedIndirect"]
 
@@ -28560,6 +28942,8 @@
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=10;drawType="drawIndexedIndirect"]
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bufferSizeInElements=10;bindingSizeInElements=10;drawIndexCount=11;drawType="drawIndexedIndirect"]
 
@@ -28904,6 +29288,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,dynamic_state:setScissorRect,xy_rect_contained_in_attachment:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,dynamic_state:setStencilReference:*]
@@ -28942,6 +29328,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_buffer_usage:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,indirect_draw:indirect_offset_alignment:*]
@@ -28958,6 +29346,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setIndexBuffer:index_buffer,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setIndexBuffer:index_buffer_state:*]
@@ -28968,6 +29358,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setIndexBuffer:index_buffer_usage:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setIndexBuffer:offset_alignment:*]
@@ -28984,10 +29376,14 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setPipeline:invalid_pipeline:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setPipeline:pipeline,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:offset_alignment:*]
@@ -29004,10 +29400,14 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:slot:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:vertex_buffer,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:vertex_buffer_state:*]
@@ -29018,6 +29418,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,setVertexBuffer:vertex_buffer_usage:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,state_tracking:all_needed_index_buffer_should_be_bound:*]
@@ -29030,10 +29432,14 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,state_tracking:vertex_buffers_do_not_inherit_between_render_passes:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,render,state_tracking:vertex_buffers_inherit_from_previous_pipeline:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:bind_group,device_mismatch:*]
@@ -29042,74 +29448,136 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:buffer_dynamic_offsets:*]
   [:type="read-only-storage";encoderType="compute%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="read-only-storage";encoderType="render%20bundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="read-only-storage";encoderType="render%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="storage";encoderType="compute%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="storage";encoderType="render%20bundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="storage";encoderType="render%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="uniform";encoderType="compute%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="uniform";encoderType="render%20bundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="uniform";encoderType="render%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:*]
   [:encoderType="compute%20pass";dynamicOffsets=[0,1024\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[0,1024\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[0,4294967295\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[0,4294967295\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[0,512\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[0,512\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[1,2\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[1,2\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[1024,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[1024,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[256,0,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[256,0,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[256,0\];useU32array=false]
 
   [:encoderType="compute%20pass";dynamicOffsets=[256,0\];useU32array=true]
 
   [:encoderType="compute%20pass";dynamicOffsets=[256\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[256\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[4294967295,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[4294967295,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[512,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[512,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";dynamicOffsets=[\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[0,1024\];useU32array=false]
     expected:
@@ -29120,8 +29588,12 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[0,4294967295\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[0,4294967295\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[0,512\];useU32array=false]
     expected:
@@ -29132,8 +29604,12 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[1,2\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[1,2\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[1024,0\];useU32array=false]
     expected:
@@ -29144,20 +29620,32 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[256,0,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[256,0,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[256,0\];useU32array=false]
 
   [:encoderType="render%20bundle";dynamicOffsets=[256,0\];useU32array=true]
 
   [:encoderType="render%20bundle";dynamicOffsets=[256\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[256\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[4294967295,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[4294967295,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[512,0\];useU32array=false]
     expected:
@@ -29168,60 +29656,110 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";dynamicOffsets=[\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[0,1024\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[0,1024\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[0,4294967295\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[0,4294967295\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[0,512\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[0,512\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[1,2\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[1,2\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[1024,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[1024,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[256,0,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[256,0,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[256,0\];useU32array=false]
 
   [:encoderType="render%20pass";dynamicOffsets=[256,0\];useU32array=true]
 
   [:encoderType="render%20pass";dynamicOffsets=[256\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[256\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[4294967295,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[4294967295,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[512,0\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[512,0\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[\];useU32array=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";dynamicOffsets=[\];useU32array=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:dynamic_offsets_passed_but_not_expected:*]
   [:encoderType="compute%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:state_and_binding_index:*]
@@ -29230,42 +29768,72 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="destroyed";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="invalid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="invalid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="valid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";state="valid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";state="destroyed";resourceType="buffer"]
     expected:
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20bundle";state="destroyed";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";state="invalid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";state="invalid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";state="valid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";state="valid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";state="destroyed";resourceType="buffer"]
     expected:
       if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:encoderType="render%20pass";state="destroyed";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";state="invalid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";state="invalid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";state="valid";resourceType="buffer"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";state="valid";resourceType="texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,cmds,setBindGroup:u32array_start_and_length:*]
@@ -29874,12 +30442,20 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_binding_mismatch:*]
   [:encoderType="compute%20pass";call="dispatch";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatch";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatchIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatchIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";call="draw";callWithZero=false]
     expected:
@@ -29914,20 +30490,36 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="draw";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="draw";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexed";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexed";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_resource_type_mismatch:*]
@@ -30014,12 +30606,20 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_visibility_mismatch:*]
   [:encoderType="compute%20pass";call="dispatch";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatch";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatchIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatchIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";call="draw";callWithZero=false]
     expected:
@@ -30054,30 +30654,54 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="draw";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="draw";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexed";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexed";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_groups_and_pipeline_layout_mismatch:*]
   [:encoderType="compute%20pass";call="dispatch";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatch";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatchIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="compute%20pass";call="dispatchIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";call="draw";callWithZero=false]
     expected:
@@ -30112,34 +30736,58 @@
       if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="draw";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="draw";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexed";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexed";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndexedIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndirect";callWithZero=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";call="drawIndirect";callWithZero=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*]
   [:type="read-only-storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type="uniform"]
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_requires_empty_bind_groups,compute_pass:*]
   [:bindGroupLayoutEntryCount=3;computeCommand="dispatch"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindGroupLayoutEntryCount=3;computeCommand="dispatchIndirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindGroupLayoutEntryCount=4;computeCommand="dispatch"]
 
@@ -30148,12 +30796,20 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_requires_empty_bind_groups,render_pass:*]
   [:bindGroupLayoutEntryCount=3;renderCommand="draw"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindGroupLayoutEntryCount=3;renderCommand="drawIndexed"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindGroupLayoutEntryCount=3;renderCommand="drawIndexedIndirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindGroupLayoutEntryCount=3;renderCommand="drawIndirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindGroupLayoutEntryCount=4;renderCommand="draw"]
 
@@ -30168,18 +30824,30 @@
   [:bglType="comparison";bgType="comparison"]
 
   [:bglType="comparison";bgType="filtering"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bglType="comparison";bgType="non-filtering"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bglType="filtering";bgType="comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bglType="filtering";bgType="filtering"]
 
   [:bglType="filtering";bgType="non-filtering"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bglType="non-filtering";bgType="comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bglType="non-filtering";bgType="filtering"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bglType="non-filtering";bgType="non-filtering"]
 
@@ -30324,14 +30992,22 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,render_bundle:color_formats_mismatch:*]
   [:bundleFormats=["bgra8unorm","rg8unorm","rgba8unorm"\];passFormats=["rg8unorm","bgra8unorm"\]]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bundleFormats=["bgra8unorm","rg8unorm"\];passFormats=["bgra8unorm","bgra8unorm"\]]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bundleFormats=["bgra8unorm","rg8unorm"\];passFormats=["bgra8unorm","rg8unorm"\]]
 
   [:bundleFormats=["bgra8unorm","rg8unorm"\];passFormats=["rg8unorm","bgra8unorm","rgba8unorm"\]]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bundleFormats=["bgra8unorm","rg8unorm"\];passFormats=["rg8unorm","bgra8unorm"\]]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,render_bundle:depth_stencil_formats_mismatch:*]
@@ -30342,6 +31018,8 @@
   [:bundleFormat="depth24plus";passFormat="depth24plus"]
 
   [:bundleFormat="depth24plus";passFormat="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bundleFormat="stencil8";passFormat="depth24plus-stencil8"]
     expected:
@@ -30376,6 +31054,8 @@
 
 [cts.https.html?q=webgpu:api,validation,encoding,render_bundle:device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,encoding,render_bundle:empty_bundle_list:*]
@@ -30445,8 +31125,6 @@
 
 
 [cts.https.html?q=webgpu:api,validation,error_scope:current_scope:*]
-  expected:
-    if os == "linux" and not debug: [OK, CRASH]
   [:errorFilter="out-of-memory";stackDepth=1]
 
   [:errorFilter="out-of-memory";stackDepth=10]
@@ -31302,6 +31980,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="depth32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="eac-r11snorm";dimension="2d"]
 
@@ -32124,12 +32804,18 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";aspect="stencil-only";copyType="WriteTexture"]
 
   [:format="depth32float";aspect="depth-only";copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";aspect="depth-only";copyType="CopyT2B"]
     expected:
@@ -32174,12 +32860,18 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyB2T"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";aspect="stencil-only";copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8";aspect="stencil-only";copyType="WriteTexture"]
 
   [:format="depth32float";aspect="depth-only";copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8";aspect="depth-only";copyType="CopyT2B"]
     expected:
@@ -32216,10 +32908,16 @@
       if os == "linux" and not debug: FAIL
 
   [:format="depth24plus"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="depth32float-stencil8"]
     expected:
@@ -32232,8 +32930,12 @@
 
 [cts.https.html?q=webgpu:api,validation,image_copy,buffer_texture_copies:device_mismatch:*]
   [:copyType="CopyB2T"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,image_copy,buffer_texture_copies:sample_count:*]
@@ -32242,12 +32944,18 @@
       if os == "linux" and not debug: FAIL
 
   [:copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,image_copy,buffer_texture_copies:texture_buffer_usages:*]
   [:copyType="CopyB2T"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:copyType="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,image_copy,layout_related:bound_on_bytes_per_row:*]
@@ -32308,44 +33016,84 @@
   [:method="CopyB2T";format="astc-8x8-unorm-srgb";dimension="2d"]
 
   [:method="CopyB2T";format="bc1-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc1-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc2-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc2-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc3-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc3-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc4-r-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc4-r-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc5-rg-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc5-rg-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc6h-rgb-float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc6h-rgb-ufloat";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc7-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc7-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="depth16unorm";dimension="2d"]
     expected:
@@ -32372,64 +33120,124 @@
   [:method="CopyB2T";format="etc2-rgba8unorm-srgb";dimension="2d"]
 
   [:method="CopyB2T";format="r16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg11b10ufloat";dimension="1d"]
     expected:
@@ -32444,64 +33252,124 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2uint";dimension="1d"]
     expected:
@@ -32516,10 +33384,16 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb9e5ufloat";dimension="1d"]
     expected:
@@ -32534,70 +33408,136 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="stencil8";dimension="2d"]
     expected:
@@ -32660,50 +33600,92 @@
   [:method="CopyT2B";format="astc-8x8-unorm-srgb";dimension="2d"]
 
   [:method="CopyT2B";format="bc1-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc1-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc2-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc2-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc3-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc3-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc4-r-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc4-r-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc5-rg-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc5-rg-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc6h-rgb-float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc6h-rgb-ufloat";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc7-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc7-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="depth16unorm";dimension="2d"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="depth32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="eac-r11snorm";dimension="2d"]
 
@@ -32726,64 +33708,124 @@
   [:method="CopyT2B";format="etc2-rgba8unorm-srgb";dimension="2d"]
 
   [:method="CopyT2B";format="r16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg11b10ufloat";dimension="1d"]
     expected:
@@ -32798,64 +33840,124 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2uint";dimension="1d"]
     expected:
@@ -32870,10 +33972,16 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb9e5ufloat";dimension="1d"]
     expected:
@@ -32888,70 +33996,136 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="stencil8";dimension="2d"]
     expected:
@@ -33376,8 +34550,12 @@
 
 [cts.https.html?q=webgpu:api,validation,image_copy,layout_related:copy_end_overflows_u64:*]
   [:method="CopyB2T"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="WriteTexture"]
 
@@ -33440,44 +34618,84 @@
   [:method="CopyB2T";format="astc-8x8-unorm-srgb";dimension="2d"]
 
   [:method="CopyB2T";format="bc1-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc1-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc2-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc2-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc3-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc3-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc4-r-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc4-r-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc5-rg-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc5-rg-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc6h-rgb-float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc6h-rgb-ufloat";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc7-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bc7-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="depth16unorm";dimension="2d"]
     expected:
@@ -33504,40 +34722,76 @@
   [:method="CopyB2T";format="etc2-rgba8unorm-srgb";dimension="2d"]
 
   [:method="CopyB2T";format="r16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8sint";dimension="1d"]
 
@@ -33576,64 +34830,124 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2uint";dimension="1d"]
     expected:
@@ -33648,10 +34962,16 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb9e5ufloat";dimension="1d"]
     expected:
@@ -33666,70 +34986,136 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="stencil8";dimension="2d"]
     expected:
@@ -33792,50 +35178,92 @@
   [:method="CopyT2B";format="astc-8x8-unorm-srgb";dimension="2d"]
 
   [:method="CopyT2B";format="bc1-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc1-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc2-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc2-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc3-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc3-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc4-r-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc4-r-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc5-rg-snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc5-rg-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc6h-rgb-float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc6h-rgb-ufloat";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc7-rgba-unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bc7-rgba-unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="depth16unorm";dimension="2d"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="depth32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="eac-r11snorm";dimension="2d"]
 
@@ -33858,40 +35286,76 @@
   [:method="CopyT2B";format="etc2-rgba8unorm-srgb";dimension="2d"]
 
   [:method="CopyT2B";format="r16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8sint";dimension="1d"]
 
@@ -33930,64 +35394,124 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2uint";dimension="1d"]
     expected:
@@ -34002,10 +35526,16 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb9e5ufloat";dimension="1d"]
     expected:
@@ -34020,70 +35550,136 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="stencil8";dimension="2d"]
     expected:
@@ -34556,6 +36152,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm";dimension="2d"]
     expected:
@@ -34566,6 +36164,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="bgra8unorm-srgb";dimension="2d"]
     expected:
@@ -34600,6 +36200,8 @@
   [:method="CopyB2T";format="etc2-rgba8unorm-srgb";dimension="2d"]
 
   [:method="CopyB2T";format="r16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16float";dimension="2d"]
     expected:
@@ -34610,6 +36212,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16sint";dimension="2d"]
     expected:
@@ -34620,6 +36224,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r16uint";dimension="2d"]
     expected:
@@ -34630,6 +36236,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32float";dimension="2d"]
     expected:
@@ -34640,6 +36248,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32sint";dimension="2d"]
     expected:
@@ -34650,6 +36260,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r32uint";dimension="2d"]
     expected:
@@ -34660,6 +36272,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8sint";dimension="2d"]
     expected:
@@ -34670,6 +36284,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8snorm";dimension="2d"]
     expected:
@@ -34680,6 +36296,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8uint";dimension="2d"]
     expected:
@@ -34690,6 +36308,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="r8unorm";dimension="2d"]
     expected:
@@ -34712,6 +36332,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16float";dimension="2d"]
     expected:
@@ -34722,6 +36344,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16sint";dimension="2d"]
     expected:
@@ -34732,6 +36356,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg16uint";dimension="2d"]
     expected:
@@ -34742,6 +36368,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32float";dimension="2d"]
     expected:
@@ -34752,6 +36380,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32sint";dimension="2d"]
     expected:
@@ -34762,6 +36392,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg32uint";dimension="2d"]
     expected:
@@ -34772,6 +36404,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8sint";dimension="2d"]
     expected:
@@ -34782,6 +36416,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8snorm";dimension="2d"]
     expected:
@@ -34792,6 +36428,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8uint";dimension="2d"]
     expected:
@@ -34802,6 +36440,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rg8unorm";dimension="2d"]
     expected:
@@ -34824,6 +36464,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgb10a2unorm";dimension="2d"]
     expected:
@@ -34846,6 +36488,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16float";dimension="2d"]
     expected:
@@ -34856,6 +36500,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16sint";dimension="2d"]
     expected:
@@ -34866,6 +36512,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba16uint";dimension="2d"]
     expected:
@@ -34876,6 +36524,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32float";dimension="2d"]
     expected:
@@ -34886,6 +36536,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32sint";dimension="2d"]
     expected:
@@ -34896,6 +36548,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba32uint";dimension="2d"]
     expected:
@@ -34906,6 +36560,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8sint";dimension="2d"]
     expected:
@@ -34916,6 +36572,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8snorm";dimension="2d"]
     expected:
@@ -34926,6 +36584,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8uint";dimension="2d"]
     expected:
@@ -34936,6 +36596,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm";dimension="2d"]
     expected:
@@ -34946,6 +36608,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyB2T";format="rgba8unorm-srgb";dimension="2d"]
     expected:
@@ -35072,6 +36736,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm";dimension="2d"]
     expected:
@@ -35082,6 +36748,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="bgra8unorm-srgb";dimension="2d"]
     expected:
@@ -35096,6 +36764,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="depth32float";dimension="2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="eac-r11snorm";dimension="2d"]
 
@@ -35118,6 +36788,8 @@
   [:method="CopyT2B";format="etc2-rgba8unorm-srgb";dimension="2d"]
 
   [:method="CopyT2B";format="r16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16float";dimension="2d"]
     expected:
@@ -35128,6 +36800,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16sint";dimension="2d"]
     expected:
@@ -35138,6 +36812,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r16uint";dimension="2d"]
     expected:
@@ -35148,6 +36824,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32float";dimension="2d"]
     expected:
@@ -35158,6 +36836,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32sint";dimension="2d"]
     expected:
@@ -35168,6 +36848,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r32uint";dimension="2d"]
     expected:
@@ -35178,6 +36860,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8sint";dimension="2d"]
     expected:
@@ -35188,6 +36872,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8snorm";dimension="2d"]
     expected:
@@ -35198,6 +36884,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8uint";dimension="2d"]
     expected:
@@ -35208,6 +36896,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="r8unorm";dimension="2d"]
     expected:
@@ -35230,6 +36920,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16float";dimension="2d"]
     expected:
@@ -35240,6 +36932,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16sint";dimension="2d"]
     expected:
@@ -35250,6 +36944,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg16uint";dimension="2d"]
     expected:
@@ -35260,6 +36956,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32float";dimension="2d"]
     expected:
@@ -35270,6 +36968,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32sint";dimension="2d"]
     expected:
@@ -35280,6 +36980,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg32uint";dimension="2d"]
     expected:
@@ -35290,6 +36992,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8sint";dimension="2d"]
     expected:
@@ -35300,6 +37004,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8snorm";dimension="2d"]
     expected:
@@ -35310,6 +37016,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8uint";dimension="2d"]
     expected:
@@ -35320,6 +37028,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rg8unorm";dimension="2d"]
     expected:
@@ -35342,6 +37052,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgb10a2unorm";dimension="2d"]
     expected:
@@ -35364,6 +37076,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16float";dimension="2d"]
     expected:
@@ -35374,6 +37088,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16sint";dimension="2d"]
     expected:
@@ -35384,6 +37100,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba16uint";dimension="2d"]
     expected:
@@ -35394,6 +37112,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32float";dimension="2d"]
     expected:
@@ -35404,6 +37124,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32sint";dimension="2d"]
     expected:
@@ -35414,6 +37136,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba32uint";dimension="2d"]
     expected:
@@ -35424,6 +37148,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8sint";dimension="2d"]
     expected:
@@ -35434,6 +37160,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8snorm";dimension="2d"]
     expected:
@@ -35444,6 +37172,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8uint";dimension="2d"]
     expected:
@@ -35454,6 +37184,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm";dimension="2d"]
     expected:
@@ -35464,6 +37196,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";format="rgba8unorm-srgb";dimension="2d"]
     expected:
@@ -37810,6 +39544,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";depthOrArrayLayers=1;dimension="2d";format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";depthOrArrayLayers=1;dimension="2d";format="eac-r11snorm"]
 
@@ -38084,6 +39820,8 @@
       if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";depthOrArrayLayers=3;dimension="2d";format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:method="CopyT2B";depthOrArrayLayers=3;dimension="2d";format="eac-r11snorm"]
 
@@ -42694,6 +44432,8 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,destroyed,texture:writeTexture:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,submit:command_buffer,device_mismatch:*]
@@ -42734,6 +44474,8 @@
 
 [cts.https.html?q=webgpu:api,validation,queue,writeTexture:texture,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,queue,writeTexture:texture_state:*]
@@ -42782,10 +44524,14 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_and_bundle,device_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_and_bundle,sample_count:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,color_count:*]
@@ -42899,24 +44645,40 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,attachment_compatibility:render_pass_or_bundle_and_pipeline,sample_count:*]
   [:encoderType="render%20bundle";attachmentType="color"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20bundle";attachmentType="depthstencil"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";attachmentType="color"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:encoderType="render%20pass";attachmentType="depthstencil"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,color_depth_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,layer_count:*]
   [:arrayLayerCount=1;baseArrayLayer=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:arrayLayerCount=1;baseArrayLayer=9]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:arrayLayerCount=5;baseArrayLayer=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,mip_level_count:*]
@@ -42925,6 +44687,8 @@
   [:mipLevelCount=1;baseMipLevel=3]
 
   [:mipLevelCount=2;baseMipLevel=0]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,one_color_attachment:*]
@@ -42937,6 +44701,8 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:attachments,same_size:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,bound_check:*]
@@ -42973,6 +44739,8 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,overlaps,diff_miplevel:*]
   [:sameMipLevel=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:sameMipLevel=true]
     expected:
@@ -42981,6 +44749,8 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,depthSlice,overlaps,same_miplevel:*]
   [:sameDepthSlice=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:sameDepthSlice=true]
     expected:
@@ -43010,16 +44780,24 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,limits,maxColorAttachments:*]
   [:colorAttachmentsCountVariant={"mult":1,"add":0}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentsCountVariant={"mult":1,"add":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,non_multisampled:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:color_attachments,sample_count:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,depth_clear_value:*]
@@ -43106,6 +44884,8 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:depth_stencil_attachment,sample_counts_mismatch:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:occlusionQuerySet,query_set_type:*]
@@ -43120,18 +44900,26 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,array_layer_count:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,different_format:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,different_size:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,error_state:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,format_supports_resolve:*]
@@ -43142,26 +44930,44 @@
   [:format="r16float"]
 
   [:format="r16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r8unorm"]
 
   [:format="rg16float"]
 
   [:format="rg16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg8unorm"]
 
@@ -43174,12 +44980,20 @@
   [:format="rgba16float"]
 
   [:format="rgba16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm"]
 
@@ -43188,10 +45002,14 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,mipmap_level_count:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,sample_count:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,single_sample_count:*]
@@ -43200,12 +45018,18 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:resolveTarget,usage:*]
   [:usage=12]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage=20]
 
   [:usage=3]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage=8]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrite,query_index:*]
@@ -43228,42 +45052,74 @@
   [:]
 
   [:colorAttachmentFormat="bgra8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentFormat="rgba8unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentHeight=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentSamples=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentWidth=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:otherAttachmentFormat="bgra8unorm"]
 
   [:resolveTargetFormat="bgra8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetFormat="rgba8unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetHeight=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetInvalid=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetSamples=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetUsage=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetViewArrayLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetViewBaseArrayLayer=1]
 
   [:resolveTargetViewBaseArrayLayer=1;resolveTargetViewArrayLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetViewBaseMipLevel=1;resolveTargetHeight=4;resolveTargetWidth=4]
 
   [:resolveTargetViewBaseMipLevel=1;resolveTargetViewMipCount=2;resolveTargetHeight=4;resolveTargetWidth=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetViewMipCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:resolveTargetWidth=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:*]
@@ -47172,70 +49028,132 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,fragment_state:limits,maxColorAttachmentBytesPerSample,aligned:*]
   [:format="bgra8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="bgra8unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="r8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rg8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba32sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba32uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8sint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8uint"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba8unorm-srgb"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,fragment_state:limits,maxColorAttachmentBytesPerSample,unaligned:*]
@@ -48298,10 +50216,14 @@
   [:isAsync=false;output="%40interpolate(flat)";input="%40interpolate(flat)"]
 
   [:isAsync=false;output="%40interpolate(linear,%20center)";input="%40interpolate(linear)"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;output="%40interpolate(perspective)";input="%40interpolate(perspective)"]
 
   [:isAsync=false;output="%40interpolate(perspective)";input="%40interpolate(perspective,%20center)"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;output="%40interpolate(perspective)";input="%40interpolate(perspective,%20sample)"]
 
@@ -48314,10 +50236,14 @@
   [:isAsync=true;output="%40interpolate(flat)";input="%40interpolate(flat)"]
 
   [:isAsync=true;output="%40interpolate(linear,%20center)";input="%40interpolate(linear)"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;output="%40interpolate(perspective)";input="%40interpolate(perspective)"]
 
   [:isAsync=true;output="%40interpolate(perspective)";input="%40interpolate(perspective,%20center)"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;output="%40interpolate(perspective)";input="%40interpolate(perspective,%20sample)"]
     expected:
@@ -48342,6 +50268,8 @@
   [:isAsync=false;output="";input="%40interpolate(linear)"]
 
   [:isAsync=false;output="";input="%40interpolate(perspective)"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;output="";input="%40interpolate(perspective,%20center)"]
 
@@ -48354,6 +50282,8 @@
   [:isAsync=false;output="%40interpolate(linear,%20center)";input="%40interpolate(linear,%20center)"]
 
   [:isAsync=false;output="%40interpolate(perspective)";input=""]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;output="%40interpolate(perspective)";input="%40interpolate(perspective)"]
 
@@ -48364,6 +50294,8 @@
       if os == "linux" and not debug: FAIL
 
   [:isAsync=true;output="";input="%40interpolate(perspective)"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;output="";input="%40interpolate(perspective,%20center)"]
 
@@ -48382,6 +50314,8 @@
   [:isAsync=true;output="%40interpolate(linear,%20center)";input="%40interpolate(linear,%20center)"]
 
   [:isAsync=true;output="%40interpolate(perspective)";input=""]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;output="%40interpolate(perspective)";input="%40interpolate(perspective)"]
 
@@ -48422,8 +50356,12 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,inter_stage:location,superset:*]
   [:isAsync=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,inter_stage:max_components_count,input:*]
@@ -48782,16 +50720,24 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,overrides:uninitialized,fragment:*]
   [:isAsync=false;fragmentConstants={"r":1,"b":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;fragmentConstants={"r":1,"g":1,"b":1,"a":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;fragmentConstants={"r":1,"g":1}]
 
   [:isAsync=false;fragmentConstants={}]
 
   [:isAsync=true;fragmentConstants={"r":1,"b":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;fragmentConstants={"r":1,"g":1,"b":1,"a":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;fragmentConstants={"r":1,"g":1}]
     expected:
@@ -48804,20 +50750,28 @@
 
 [cts.https.html?q=webgpu:api,validation,render_pipeline,overrides:uninitialized,vertex:*]
   [:isAsync=false;vertexConstants={"x":1,"y":1,"z":1,"w":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;vertexConstants={"x":1,"y":1}]
 
   [:isAsync=false;vertexConstants={"x":1,"z":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=false;vertexConstants={}]
 
   [:isAsync=true;vertexConstants={"x":1,"y":1,"z":1,"w":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;vertexConstants={"x":1,"y":1}]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:isAsync=true;vertexConstants={"x":1,"z":1}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:isAsync=true;vertexConstants={}]
     expected:
@@ -51194,6 +53148,8 @@
   [:format="float16x4"]
 
   [:format="float32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:format="float32x2"]
 
@@ -51324,6 +53280,8 @@
   [:usage0AccessibleInDispatch=true;usage1AccessibleInDispatch=false;dispatchBeforeUsage1=true]
 
   [:usage0AccessibleInDispatch=true;usage1AccessibleInDispatch=true;dispatchBeforeUsage1=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,resource_usages,buffer,in_pass_encoder:subresources,buffer_usage_in_one_render_pass_with_no_draw:*]
@@ -51332,6 +53290,8 @@
   [:usage0="index";usage1="read-only-storage"]
 
   [:usage0="index";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="index";usage1="uniform"]
 
@@ -51342,26 +53302,38 @@
   [:usage0="read-only-storage";usage1="read-only-storage"]
 
   [:usage0="read-only-storage";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="read-only-storage";usage1="uniform"]
 
   [:usage0="read-only-storage";usage1="vertex"]
 
   [:usage0="storage";usage1="index"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="read-only-storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="storage"]
 
   [:usage0="storage";usage1="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="vertex"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="index"]
 
   [:usage0="uniform";usage1="read-only-storage"]
 
   [:usage0="uniform";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="uniform"]
 
@@ -51372,6 +53344,8 @@
   [:usage0="vertex";usage1="read-only-storage"]
 
   [:usage0="vertex";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="vertex";usage1="uniform"]
 
@@ -51388,6 +53362,8 @@
   [:usage0="index";usage1="read-only-storage"]
 
   [:usage0="index";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="index";usage1="uniform"]
 
@@ -51398,6 +53374,8 @@
   [:usage0="indexedIndirect";usage1="read-only-storage"]
 
   [:usage0="indexedIndirect";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="indexedIndirect";usage1="uniform"]
 
@@ -51408,6 +53386,8 @@
   [:usage0="indirect";usage1="read-only-storage"]
 
   [:usage0="indirect";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="indirect";usage1="uniform"]
 
@@ -51422,22 +53402,36 @@
   [:usage0="read-only-storage";usage1="read-only-storage"]
 
   [:usage0="read-only-storage";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="read-only-storage";usage1="uniform"]
 
   [:usage0="read-only-storage";usage1="vertex"]
 
   [:usage0="storage";usage1="index"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="indexedIndirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="indirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="read-only-storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="vertex"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="index"]
 
@@ -51448,6 +53442,8 @@
   [:usage0="uniform";usage1="read-only-storage"]
 
   [:usage0="uniform";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="uniform"]
 
@@ -51462,6 +53458,8 @@
   [:usage0="vertex";usage1="read-only-storage"]
 
   [:usage0="vertex";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="vertex";usage1="uniform"]
 
@@ -51478,6 +53476,8 @@
   [:usage0="index";usage1="read-only-storage"]
 
   [:usage0="index";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="index";usage1="uniform"]
 
@@ -51492,6 +53492,8 @@
   [:usage0="indexedIndirect";usage1="read-only-storage"]
 
   [:usage0="indexedIndirect";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="indexedIndirect";usage1="uniform"]
 
@@ -51506,6 +53508,8 @@
   [:usage0="indirect";usage1="read-only-storage"]
 
   [:usage0="indirect";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="indirect";usage1="uniform"]
 
@@ -51520,24 +53524,38 @@
   [:usage0="read-only-storage";usage1="read-only-storage"]
 
   [:usage0="read-only-storage";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="read-only-storage";usage1="uniform"]
 
   [:usage0="read-only-storage";usage1="vertex"]
 
   [:usage0="storage";usage1="index"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="indexedIndirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="indirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="read-only-storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="storage"]
 
   [:usage0="storage";usage1="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="vertex"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="index"]
 
@@ -51548,6 +53566,8 @@
   [:usage0="uniform";usage1="read-only-storage"]
 
   [:usage0="uniform";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="uniform"]
 
@@ -51562,6 +53582,8 @@
   [:usage0="vertex";usage1="read-only-storage"]
 
   [:usage0="vertex";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="vertex";usage1="uniform"]
 
@@ -51700,6 +53722,8 @@
   [:usage0="index";usage1="read-only-storage"]
 
   [:usage0="index";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="index";usage1="uniform"]
 
@@ -51714,24 +53738,38 @@
   [:usage0="read-only-storage";usage1="read-only-storage"]
 
   [:usage0="read-only-storage";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="read-only-storage";usage1="uniform"]
 
   [:usage0="read-only-storage";usage1="vertex"]
 
   [:usage0="storage";usage1="index"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="indexedIndirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="indirect"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="read-only-storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="storage"]
 
   [:usage0="storage";usage1="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="storage";usage1="vertex"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="index"]
 
@@ -51742,6 +53780,8 @@
   [:usage0="uniform";usage1="read-only-storage"]
 
   [:usage0="uniform";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="uniform";usage1="uniform"]
 
@@ -51756,6 +53796,8 @@
   [:usage0="vertex";usage1="read-only-storage"]
 
   [:usage0="vertex";usage1="storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:usage0="vertex";usage1="uniform"]
 
@@ -51766,6 +53808,8 @@
   [:type0="multisampled-texture";type1="multisampled-texture"]
 
   [:type0="multisampled-texture";type1="render-target"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="readonly-storage-texture";type1="readonly-storage-texture"]
     expected:
@@ -51808,6 +53852,8 @@
       if os == "linux" and not debug: FAIL
 
   [:type0="render-target";type1="multisampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="render-target";type1="readonly-storage-texture"]
     expected:
@@ -51818,8 +53864,12 @@
       if os == "linux" and not debug: FAIL
 
   [:type0="render-target";type1="sampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="render-target";type1="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="sampled-texture";type1="readonly-storage-texture"]
     expected:
@@ -51830,10 +53880,14 @@
       if os == "linux" and not debug: FAIL
 
   [:type0="sampled-texture";type1="render-target"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="sampled-texture";type1="sampled-texture"]
 
   [:type0="sampled-texture";type1="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="writeonly-storage-texture";type1="readonly-storage-texture"]
     expected:
@@ -51844,8 +53898,12 @@
       if os == "linux" and not debug: FAIL
 
   [:type0="writeonly-storage-texture";type1="render-target"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="writeonly-storage-texture";type1="sampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:type0="writeonly-storage-texture";type1="writeonly-storage-texture"]
 
@@ -51860,6 +53918,8 @@
       if os == "linux" and not debug: FAIL
 
   [:compute=false;callDrawOrDispatch=false;entry={"storageTexture":{"access":"write-only","format":"r32float"}}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;callDrawOrDispatch=false;entry={"texture":{"sampleType":"unfilterable-float"}}]
 
@@ -51872,6 +53932,8 @@
       if os == "linux" and not debug: FAIL
 
   [:compute=false;callDrawOrDispatch=true;entry={"storageTexture":{"access":"write-only","format":"r32float"}}]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;callDrawOrDispatch=true;entry={"texture":{"sampleType":"unfilterable-float"}}]
 
@@ -51920,6 +53982,8 @@
       if os == "linux" and not debug: FAIL
 
   [:dispatch="direct";usage1="sampled-texture";usage2="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dispatch="direct";usage1="writeonly-storage-texture";usage2="readwrite-storage-texture"]
     expected:
@@ -51938,6 +54002,8 @@
       if os == "linux" and not debug: FAIL
 
   [:dispatch="indirect";usage1="sampled-texture";usage2="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dispatch="indirect";usage1="writeonly-storage-texture";usage2="readwrite-storage-texture"]
     expected:
@@ -51996,10 +54062,16 @@
       if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=false;binding1InBundle=false;format="depth24plus"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=false;binding1InBundle=false;format="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=false;binding1InBundle=false;format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=false;binding1InBundle=false;format="depth32float-stencil8"]
     expected:
@@ -52032,10 +54104,16 @@
       if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=true;binding1InBundle=false;format="depth24plus"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=true;binding1InBundle=false;format="depth24plus-stencil8"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=true;binding1InBundle=false;format="depth32float"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;binding0InBundle=true;binding1InBundle=false;format="depth32float-stencil8"]
     expected:
@@ -52120,16 +54198,22 @@
       if os == "linux" and not debug: FAIL
 
   [:compute=false;type0="sampled-texture";type1="render-target"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;type0="sampled-texture";type1="sampled-texture"]
 
   [:compute=false;type0="sampled-texture";type1="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;type0="writeonly-storage-texture";type1="readwrite-storage-texture"]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:compute=false;type0="writeonly-storage-texture";type1="render-target"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;type0="writeonly-storage-texture";type1="writeonly-storage-texture"]
 
@@ -52160,6 +54244,8 @@
   [:compute=true;type0="sampled-texture";type1="sampled-texture"]
 
   [:compute=true;type0="sampled-texture";type1="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;type0="writeonly-storage-texture";type1="readwrite-storage-texture"]
     expected:
@@ -52684,132 +54770,260 @@
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="readwrite-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="before";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="middle";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=false;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="readonly-storage-texture";writableUsage="readwrite-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53338,6 +55552,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53354,6 +55570,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53370,6 +55588,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53386,6 +55606,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=false;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53402,6 +55624,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53418,6 +55642,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=false;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53434,6 +55660,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="common";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="after";callDrawOrDispatch=false]
 
@@ -53450,6 +55678,8 @@
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=false]
 
   [:compute=true;readOnlyUsage="sampled-texture";writableUsage="writeonly-storage-texture";useBindGroup0=true;useBindGroup1=true;setBindGroupsOrder="reversed";setPipeline="none";callDrawOrDispatch=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachment_and_bind_group:*]
@@ -53472,10 +55702,14 @@
   [:colorAttachmentLevel=0;colorAttachmentLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=false]
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="readonly-storage-texture";inSamePass=false]
     expected:
@@ -53652,10 +55886,14 @@
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=false]
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="readonly-storage-texture";inSamePass=false]
     expected:
@@ -53676,10 +55914,14 @@
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="writeonly-storage-texture";inSamePass=false]
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="writeonly-storage-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=0;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="readonly-storage-texture";inSamePass=false]
     expected:
@@ -53856,10 +56098,14 @@
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="readonly-storage-texture";inSamePass=false]
     expected:
@@ -53912,6 +56158,8 @@
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
@@ -54036,10 +56284,14 @@
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1;bgUsage="writeonly-storage-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="readonly-storage-texture";inSamePass=false]
     expected:
@@ -54060,10 +56312,14 @@
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="writeonly-storage-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2;bgUsage="writeonly-storage-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
@@ -54072,10 +56328,14 @@
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=2;bgUsage="sampled-texture";inSamePass=false]
 
   [:colorAttachmentLevel=1;colorAttachmentLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=2;bgUsage="sampled-texture";inSamePass=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,resource_usages,texture,in_render_common:subresources,color_attachments:*]
@@ -54142,22 +56402,40 @@
       if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
     expected:
@@ -54168,46 +56446,80 @@
       if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=0;dsLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=0;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=0;bgLevelCount=1;bgLayer=1;bgLayerCount=2]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=1;bgLevelCount=1;bgLayer=1;bgLayerCount=1]
     expected:
@@ -54218,6 +56530,8 @@
       if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=0;bgLayerCount=1]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:dsLevel=1;dsLayer=1;bgLevel=1;bgLevelCount=2;bgLayer=1;bgLayerCount=1]
     expected:
@@ -55576,6 +57890,8 @@
   [:useDifferentTextureAsTexture2=false;baseLayer2=0;view1Binding="sampled-texture";view2Binding="sampled-texture"]
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=0;view1Binding="sampled-texture";view2Binding="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=0;view1Binding="writeonly-storage-texture";view2Binding="readonly-storage-texture"]
     expected:
@@ -55586,6 +57902,8 @@
       if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=0;view1Binding="writeonly-storage-texture";view2Binding="sampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=0;view1Binding="writeonly-storage-texture";view2Binding="writeonly-storage-texture"]
 
@@ -55632,6 +57950,8 @@
   [:useDifferentTextureAsTexture2=false;baseLayer2=1;view1Binding="sampled-texture";view2Binding="sampled-texture"]
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=1;view1Binding="sampled-texture";view2Binding="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=1;view1Binding="writeonly-storage-texture";view2Binding="readonly-storage-texture"]
     expected:
@@ -55642,6 +57962,8 @@
       if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=1;view1Binding="writeonly-storage-texture";view2Binding="sampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=false;baseLayer2=1;view1Binding="writeonly-storage-texture";view2Binding="writeonly-storage-texture"]
 
@@ -55688,6 +58010,8 @@
   [:useDifferentTextureAsTexture2=true;baseLayer2=0;view1Binding="sampled-texture";view2Binding="sampled-texture"]
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=0;view1Binding="sampled-texture";view2Binding="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=0;view1Binding="writeonly-storage-texture";view2Binding="readonly-storage-texture"]
     expected:
@@ -55698,6 +58022,8 @@
       if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=0;view1Binding="writeonly-storage-texture";view2Binding="sampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=0;view1Binding="writeonly-storage-texture";view2Binding="writeonly-storage-texture"]
 
@@ -55744,6 +58070,8 @@
   [:useDifferentTextureAsTexture2=true;baseLayer2=1;view1Binding="sampled-texture";view2Binding="sampled-texture"]
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=1;view1Binding="sampled-texture";view2Binding="writeonly-storage-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=1;view1Binding="writeonly-storage-texture";view2Binding="readonly-storage-texture"]
     expected:
@@ -55754,18 +58082,28 @@
       if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=1;view1Binding="writeonly-storage-texture";view2Binding="sampled-texture"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:useDifferentTextureAsTexture2=true;baseLayer2=1;view1Binding="writeonly-storage-texture";view2Binding="writeonly-storage-texture"]
 
 
 [cts.https.html?q=webgpu:api,validation,resource_usages,texture,in_render_misc:subresources,set_bind_group_on_same_index_depth_stencil_texture:*]
   [:bindAspect="depth-only";depthStencilReadOnly=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindAspect="depth-only";depthStencilReadOnly=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindAspect="stencil-only";depthStencilReadOnly=false]
+    expected:
+      if os == "linux" and not debug: FAIL
 
   [:bindAspect="stencil-only";depthStencilReadOnly=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,resource_usages,texture,in_render_misc:subresources,set_unused_bind_group:*]
@@ -67084,6 +69422,8 @@
 
 [cts.https.html?q=webgpu:api,validation,texture,destroy:invalid_texture:*]
   [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,validation,texture,destroy:submit_a_destroyed_texture_as_attachment:*]
@@ -68171,6 +70511,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68205,6 +70547,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68239,6 +70583,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:greater_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -68327,6 +70673,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_matrix_addition:matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68409,6 +70757,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68451,12 +70801,16 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68485,6 +70839,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68519,6 +70875,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69577,6 +71935,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -69663,6 +72023,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -69817,6 +72179,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_comparison:less_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -69919,6 +72283,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -69963,6 +72329,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -70015,6 +72383,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -70141,6 +72511,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_addition:matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -70215,6 +72587,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_matrix_multiplication:matrix_matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=2]
 
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=3]
@@ -70507,6 +72881,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -70803,6 +73179,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_subtraction:matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -71025,6 +73403,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_vector_multiplication:vector_matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -71051,6 +73431,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -71061,6 +73443,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -71209,6 +73593,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -71321,6 +73707,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -71391,6 +73779,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -71469,6 +73859,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -71719,6 +74111,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -71941,6 +74335,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -72015,6 +74411,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -72659,6 +75057,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:matrix_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -72935,6 +75335,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73119,6 +75521,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:matrix_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73211,6 +75615,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -73303,6 +75709,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73347,6 +75755,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73453,6 +75863,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73485,6 +75897,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73517,6 +75931,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73635,6 +76051,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73785,6 +76203,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73849,6 +76269,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73923,6 +76345,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74029,6 +76453,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74127,6 +76553,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74293,6 +76721,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74343,6 +76773,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74491,6 +76923,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74655,6 +77089,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75027,6 +77463,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:greater_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75069,6 +77507,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:greater_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75111,6 +77551,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:less_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75195,6 +77637,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:not_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75417,6 +77861,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75549,6 +77995,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75649,6 +78097,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75783,6 +78233,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76111,6 +78563,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:remainder_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76203,6 +78657,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76245,6 +78701,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76277,6 +78735,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76425,6 +78885,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:greater_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76467,6 +78929,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -76873,6 +79337,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acos:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76949,6 +79415,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acosh:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -77725,6 +80193,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asin:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -77793,6 +80263,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asin:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77869,6 +80341,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asinh:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -77903,6 +80377,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asinh:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77979,6 +80455,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan2:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -78055,6 +80533,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -78089,6 +80569,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -83515,6 +85997,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -83557,6 +86041,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83641,6 +86127,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -83675,6 +86163,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -83751,6 +86241,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -84129,6 +86621,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -84261,6 +86755,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,determinant:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -84287,6 +86783,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,determinant:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -84363,6 +86861,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -84373,6 +86873,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f16_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -84405,6 +86907,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -84417,6 +86921,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -84487,6 +86993,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:abstract_int:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -84507,6 +87015,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -84517,6 +87027,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -84563,6 +87075,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -84787,6 +87301,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp2:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -85445,6 +87961,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86009,6 +88527,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86043,6 +88563,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86229,6 +88751,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86263,6 +88787,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -86273,6 +88799,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -86303,6 +88831,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86315,6 +88845,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -86327,6 +88859,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86495,6 +89029,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86623,6 +89159,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86837,6 +89375,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86957,6 +89497,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:u32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87029,12 +89571,16 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_matching:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -87079,6 +89625,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_nonmatching_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87141,6 +89689,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87201,6 +89751,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec3_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87245,6 +89797,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec2_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87255,6 +89809,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec3_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87265,6 +89821,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec3_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87275,6 +89833,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec4_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87295,6 +89855,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87435,6 +89997,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87465,6 +90029,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87811,6 +90377,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,radians:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87931,6 +90499,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87941,6 +90511,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f16_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -88023,6 +90595,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -88053,6 +90627,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88065,6 +90641,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88077,6 +90655,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88191,6 +90771,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89085,6 +91667,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89271,6 +91855,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89339,6 +91925,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -89615,6 +92203,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tanh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -90681,6 +93271,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,transpose:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90719,6 +93311,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,transpose:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -90903,6 +93497,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,trunc:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -91319,6 +93915,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_assignment:abstract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -91947,6 +94545,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_arithmetic:negation:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -92273,6 +94873,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93319,6 +95921,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93353,6 +95957,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL


### PR DESCRIPTION
This should lower amount of messages being set to script (no need to send ErrorScopeId and removed useless WebGPUOps::Success), simplified error scope logic and it aligned us with spec (errors scopes should happen in device timeline = WGPU thread). Also includes GPUError stuff from https://github.com/servo/servo/pull/30504 (see https://github.com/servo/servo/pull/32304/commits/dd78013176c2644b3ffe359270a2c4e2d536d51b).

https://sagudev.github.io/briefcase/WebGPUerrorScopes.html works now as expected.

Some test are now FAIL, because CTS does only check for outstanding errors in error scopes, but error scopes were empty because of bad impl.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://github.com/servo/servo/issues/32297
- [x] There are tests for these changes in CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
