### PR TITLE
Add unit test to EmbedderCoordinates

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -290,7 +290,7 @@ mod test {
         assert_eq!(coordinates.get_viewport(), viewport);
         assert_eq!(coordinates.get_flipped_viewport(), viewport);
 
-        // Cehck rects with different y positions inside the viewport.
+        // Check rects with different y positions inside the viewport.
         let rect1 = DeviceIntRect::new(Point2D::new(0, 0), Point2D::new(800, 400));
         let rect2 = DeviceIntRect::new(Point2D::new(0, 100), Point2D::new(800, 600));
         let rect3 = DeviceIntRect::new(Point2D::new(0, 200), Point2D::new(800, 500));
@@ -307,7 +307,7 @@ mod test {
             DeviceIntRect::new(Point2D::new(0, 100), Point2D::new(800, 400))
         );
 
-        // Check rects with different x positions
+        // Check rects with different x positions.
         let rect1 = DeviceIntRect::new(Point2D::new(0, 0), Point2D::new(700, 400));
         let rect2 = DeviceIntRect::new(Point2D::new(100, 100), Point2D::new(800, 600));
         let rect3 = DeviceIntRect::new(Point2D::new(300, 200), Point2D::new(600, 500));

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -263,3 +263,65 @@ impl EmbedderCoordinates {
         self.flip_rect(&self.get_viewport())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use euclid::{Point2D, Scale, Size2D};
+    use webrender_api::units::DeviceIntRect;
+
+    use super::EmbedderCoordinates;
+
+    #[test]
+    fn test() {
+        let pos = Point2D::new(0, 0);
+        let viewport = Size2D::new(800, 600);
+        let screen = Size2D::new(1080, 720);
+        let coordinates = EmbedderCoordinates {
+            hidpi_factor: Scale::new(1.),
+            screen,
+            screen_avail: screen,
+            window: (viewport, pos),
+            framebuffer: viewport,
+            viewport: DeviceIntRect::from_origin_and_size(pos, viewport),
+        };
+
+        // Check if viewport conversion is correct.
+        let viewport = DeviceIntRect::new(Point2D::new(0, 0), Point2D::new(800, 600));
+        assert_eq!(coordinates.get_viewport(), viewport);
+        assert_eq!(coordinates.get_flipped_viewport(), viewport);
+
+        // Cehck rects with different y positions inside the viewport.
+        let rect1 = DeviceIntRect::new(Point2D::new(0, 0), Point2D::new(800, 400));
+        let rect2 = DeviceIntRect::new(Point2D::new(0, 100), Point2D::new(800, 600));
+        let rect3 = DeviceIntRect::new(Point2D::new(0, 200), Point2D::new(800, 500));
+        assert_eq!(
+            coordinates.flip_rect(&rect1),
+            DeviceIntRect::new(Point2D::new(0, 200), Point2D::new(800, 600))
+        );
+        assert_eq!(
+            coordinates.flip_rect(&rect2),
+            DeviceIntRect::new(Point2D::new(0, 0), Point2D::new(800, 500))
+        );
+        assert_eq!(
+            coordinates.flip_rect(&rect3),
+            DeviceIntRect::new(Point2D::new(0, 100), Point2D::new(800, 400))
+        );
+
+        // Check rects with different x positions
+        let rect1 = DeviceIntRect::new(Point2D::new(0, 0), Point2D::new(700, 400));
+        let rect2 = DeviceIntRect::new(Point2D::new(100, 100), Point2D::new(800, 600));
+        let rect3 = DeviceIntRect::new(Point2D::new(300, 200), Point2D::new(600, 500));
+        assert_eq!(
+            coordinates.flip_rect(&rect1),
+            DeviceIntRect::new(Point2D::new(0, 200), Point2D::new(700, 600))
+        );
+        assert_eq!(
+            coordinates.flip_rect(&rect2),
+            DeviceIntRect::new(Point2D::new(100, 0), Point2D::new(800, 500))
+        );
+        assert_eq!(
+            coordinates.flip_rect(&rect3),
+            DeviceIntRect::new(Point2D::new(300, 100), Point2D::new(600, 400))
+        );
+    }
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Adding unit test to `EmbedderCoordinates`. Mainly to ensure the webview sizes we pass to `flip_rect` will get the correct result.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
