### PR TITLE
script: Have `Window` own `Layout`

### DIFF
--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -91,8 +91,8 @@ impl DocumentOrShadowRoot {
         };
 
         self.window
-            .with_layout(|layout| layout.query_nodes_from_point(*client_point, query_type))
-            .unwrap_or_default()
+            .layout()
+            .query_nodes_from_point(*client_point, query_type)
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -462,8 +462,8 @@ impl HTMLElementMethods for HTMLElement {
 
         window.layout_reflow(QueryMsg::ElementInnerTextQuery);
         let text = window
-            .with_layout(|layout| layout.query_element_inner_text(node.to_trusted_node_address()))
-            .unwrap_or_default();
+            .layout()
+            .query_element_inner_text(node.to_trusted_node_address());
         DOMString::from(text)
     }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -670,7 +670,8 @@ impl HTMLImageElement {
     ) -> Au {
         let document = document_from_node(self);
         let quirks_mode = document.quirks_mode();
-        document.with_device(move |device| source_size_list.evaluate(device, quirks_mode))
+        let result = source_size_list.evaluate(document.window().layout().device(), quirks_mode);
+        result
     }
 
     /// <https://html.spec.whatwg.org/multipage/#matches-the-environment>
@@ -696,7 +697,8 @@ impl HTMLImageElement {
         let mut parserInput = ParserInput::new(&media_query);
         let mut parser = Parser::new(&mut parserInput);
         let media_list = MediaList::parse(&context, &mut parser);
-        document.with_device(move |device| media_list.evaluate(device, quirks_mode))
+        let result = media_list.evaluate(document.window().layout().device(), quirks_mode);
+        result
     }
 
     /// <https://html.spec.whatwg.org/multipage/#normalise-the-source-densities>

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -73,8 +73,8 @@ impl MediaQueryList {
 
     pub fn evaluate(&self) -> bool {
         let quirks_mode = self.document.quirks_mode();
-        self.document
-            .with_device(move |device| self.media_query_list.evaluate(device, quirks_mode))
+        self.media_query_list
+            .evaluate(self.document.window().layout().device(), quirks_mode)
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -73,9 +73,7 @@ use parking_lot::Mutex;
 use percent_encoding::percent_decode;
 use profile_traits::mem::{self as profile_mem, OpaqueSender, ReportsChan};
 use profile_traits::time::{self as profile_time, profile, ProfilerCategory};
-use script_layout_interface::{
-    Layout, LayoutConfig, LayoutFactory, ReflowGoal, ScriptThreadFactory,
-};
+use script_layout_interface::{LayoutConfig, LayoutFactory, ReflowGoal, ScriptThreadFactory};
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{
     CompositorEvent, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity,
@@ -730,10 +728,6 @@ pub struct ScriptThread {
     // Secure context
     inherited_secure_context: Option<bool>,
 
-    /// The layouts that we control.
-    #[no_trace]
-    layouts: RefCell<HashMap<PipelineId, Box<dyn Layout>>>,
-
     /// A factory for making new layouts. This allows layout to depend on script.
     #[no_trace]
     layout_factory: Arc<dyn LayoutFactory>,
@@ -863,22 +857,6 @@ impl ScriptThreadFactory for ScriptThread {
 }
 
 impl ScriptThread {
-    pub fn with_layout<T>(
-        pipeline_id: PipelineId,
-        call: impl FnOnce(&mut dyn Layout) -> T,
-    ) -> Result<T, ()> {
-        SCRIPT_THREAD_ROOT.with(|root| {
-            let script_thread = unsafe { &*root.get().unwrap() };
-            let mut layouts = script_thread.layouts.borrow_mut();
-            if let Some(ref mut layout) = layouts.get_mut(&pipeline_id) {
-                Ok(call(&mut ***layout))
-            } else {
-                warn!("No layout found for {}", pipeline_id);
-                Err(())
-            }
-        })
-    }
-
     pub fn runtime_handle() -> ParentRuntime {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
@@ -1203,19 +1181,14 @@ impl ScriptThread {
         properties: Vec<Atom>,
         painter: Box<dyn Painter>,
     ) {
-        let window = self.documents.borrow().find_window(pipeline_id);
-        let window = match window {
-            Some(window) => window,
-            None => {
-                return warn!(
-                    "Paint worklet registered after pipeline {} closed.",
-                    pipeline_id
-                );
-            },
+        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
+            warn!("Paint worklet registered after pipeline {pipeline_id} closed.");
+            return;
         };
 
-        let _ = window
-            .with_layout(|layout| layout.register_paint_worklet_modules(name, properties, painter));
+        window
+            .layout_mut()
+            .register_paint_worklet_modules(name, properties, painter);
     }
 
     pub fn push_new_element_queue() {
@@ -1440,7 +1413,6 @@ impl ScriptThread {
             gpu_id_hub: Arc::new(Mutex::new(Identities::new())),
             webgpu_port: RefCell::new(None),
             inherited_secure_context: state.inherited_secure_context,
-            layouts: Default::default(),
             layout_factory,
         }
     }
@@ -2394,11 +2366,19 @@ impl ScriptThread {
     }
 
     fn handle_layout_message(&self, msg: LayoutControlMsg, pipeline_id: PipelineId) {
-        let _ = Self::with_layout(pipeline_id, |layout| layout.handle_constellation_msg(msg));
+        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
+            warn!("Received layout message pipeline {pipeline_id} closed: {msg:?}.");
+            return;
+        };
+        window.layout_mut().handle_constellation_msg(msg);
     }
 
     fn handle_font_cache(&self, pipeline_id: PipelineId) {
-        let _ = Self::with_layout(pipeline_id, |layout| layout.handle_font_cache_msg());
+        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
+            warn!("Received font cache message pipeline {pipeline_id} closed.");
+            return;
+        };
+        window.layout_mut().handle_font_cache_msg();
     }
 
     fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg) {
@@ -2856,13 +2836,11 @@ impl ScriptThread {
 
         let mut reports = vec![];
         reports.extend(unsafe { get_reports(*self.get_cx(), path_seg) });
-        SCRIPT_THREAD_ROOT.with(|root| {
-            let script_thread = unsafe { &*root.get().unwrap() };
-            let layouts = script_thread.layouts.borrow();
-            for layout in layouts.values() {
-                layout.collect_reports(&mut reports);
-            }
-        });
+
+        for (_, document) in documents.iter() {
+            document.window().layout().collect_reports(&mut reports);
+        }
+
         reports_chan.send(reports);
     }
 
@@ -3222,7 +3200,7 @@ impl ScriptThread {
             }
 
             debug!("{id}: Shutting down layout");
-            let _ = document.window().with_layout(|layout| layout.exit_now());
+            document.window().layout_mut().exit_now();
 
             debug!("{id}: Sending PipelineExited message to constellation");
             self.script_sender
@@ -3562,16 +3540,13 @@ impl ScriptThread {
             paint_time_metrics,
             window_size: incomplete.window_size,
         };
-        self.layouts.borrow_mut().insert(
-            incomplete.pipeline_id,
-            self.layout_factory.create(layout_config),
-        );
 
         // Create the window and document objects.
         let window = Window::new(
             self.js_runtime.clone(),
             MainThreadScriptChan(sender.clone()),
             task_manager,
+            self.layout_factory.create(layout_config),
             self.image_cache_channel.clone(),
             self.image_cache.clone(),
             self.resource_threads.clone(),


### PR DESCRIPTION
Have `Window` own `Layout`. This makes it impossible to have a
`Window` without `Layout`, which was true, but now the compiler checks
it. In addition, `Layout` is now released when the `Window` is,
avoiding leaking the entire `Layout`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just fix a memory leak.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
