### PR TITLE
fonts: Depend directly on `freetype-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ dependencies = [
  "euclid",
  "fnv",
  "fontsan",
- "freetype",
+ "freetype-sys",
  "gfx_traits",
  "harfbuzz-sys",
  "ipc-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ encoding_rs = "0.8"
 env_logger = "0.10"
 euclid = "0.22"
 fnv = "1.0"
+freetype-sys = "0.20"
 fxhash = "0.2"
 getopts = "0.2.11"
 gfx_traits = { path = "components/shared/gfx" }

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -55,7 +55,7 @@ core-text = "20.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 harfbuzz-sys = { version = "0.6", features = ["bundled"] }
-freetype = "0.7"
+freetype-sys = { workspace = true }
 servo_allocator = { path = "../allocator" }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]


### PR DESCRIPTION
Instead of depending on `rust-freetype`, depend directly on
`freetype-sys` which is a transitive dependency. This provides almost
everything we need (apart from one function call). This will help us
eliminate one crate in the dependency chain.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
