### PR TITLE
ci: enable sccache for Rust compilation.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,6 +18,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,6 +60,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -53,6 +53,7 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 


### PR DESCRIPTION
This was previously disabled in #30508 due to sccache not working well with crown. The sccache issue (mozilla/sccache#861) linked in that PR is now closed and [testing][1] on my fork also seems to indicated we should be able to turn on sccache again.

[1]: https://github.com/mukilan/servo/actions/runs/9154196647

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only modify CI build configuration.
