### PR TITLE
fonts: Clean up messaging during web fonts loads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "core-text",
+ "crossbeam-channel",
  "cssparser",
  "dwrote",
  "euclid",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -18,6 +18,7 @@ app_units = { workspace = true }
 atomic_refcell = { workspace = true }
 bitflags = { workspace = true }
 cssparser = { workspace = true }
+crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 fnv = { workspace = true }
 fontsan = { git = "https://github.com/servo/fontsan" }

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use base::id::PipelineId;
 use fnv::FnvHashMap;
@@ -11,7 +11,7 @@ use gfx::font_context::FontContext;
 use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, UsePlaceholder,
 };
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use script_layout_interface::{PendingImage, PendingImageState};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::context::SharedStyleContext;
@@ -43,7 +43,7 @@ pub struct LayoutContext<'a> {
 impl<'a> Drop for LayoutContext<'a> {
     fn drop(&mut self) {
         if !std::thread::panicking() {
-            assert!(self.pending_images.lock().unwrap().is_empty());
+            assert!(self.pending_images.lock().is_empty());
         }
     }
 }
@@ -79,7 +79,7 @@ impl<'a> LayoutContext<'a> {
                     id,
                     origin: self.origin.clone(),
                 };
-                self.pending_images.lock().unwrap().push(image);
+                self.pending_images.lock().push(image);
                 None
             },
             // Not yet requested - request image or metadata from the cache
@@ -90,7 +90,7 @@ impl<'a> LayoutContext<'a> {
                     id,
                     origin: self.origin.clone(),
                 };
-                self.pending_images.lock().unwrap().push(image);
+                self.pending_images.lock().push(image);
                 None
             },
             // Image failed to load, so just return nothing

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2124,7 +2124,6 @@ impl ScriptThread {
                 MediaSessionAction(..) => None,
                 SetWebGPUPort(..) => None,
                 ForLayoutFromConstellation(_, id) => Some(id),
-                ForLayoutFromFontCache(id) => Some(id),
             },
             MixedMessage::FromDevtools(_) => None,
             MixedMessage::FromScript(ref inner_msg) => match *inner_msg {
@@ -2358,28 +2357,21 @@ impl ScriptThread {
                 panic!("should have handled {:?} already", msg)
             },
             ConstellationControlMsg::ForLayoutFromConstellation(msg, pipeline_id) => {
-                self.handle_layout_message(msg, pipeline_id)
-            },
-            ConstellationControlMsg::ForLayoutFromFontCache(pipeline_id) => {
-                self.handle_font_cache(pipeline_id)
+                self.handle_layout_message_from_constellation(msg, pipeline_id)
             },
         }
     }
 
-    fn handle_layout_message(&self, msg: LayoutControlMsg, pipeline_id: PipelineId) {
+    fn handle_layout_message_from_constellation(
+        &self,
+        msg: LayoutControlMsg,
+        pipeline_id: PipelineId,
+    ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             warn!("Received layout message pipeline {pipeline_id} closed: {msg:?}.");
             return;
         };
-        window.layout_mut().handle_constellation_msg(msg);
-    }
-
-    fn handle_font_cache(&self, pipeline_id: PipelineId) {
-        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
-            warn!("Received font cache message pipeline {pipeline_id} closed.");
-            return;
-        };
-        window.layout_mut().handle_font_cache_msg();
+        window.layout_mut().handle_constellation_message(msg);
     }
 
     fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg) {

--- a/components/shared/gfx/lib.rs
+++ b/components/shared/gfx/lib.rs
@@ -4,6 +4,8 @@
 
 #![deny(unsafe_code)]
 
+use std::sync::Arc;
+
 use malloc_size_of_derive::MallocSizeOf;
 use range::{int_range_index, RangeIndex};
 use serde::{Deserialize, Serialize};
@@ -14,3 +16,5 @@ int_range_index! {
     /// the middle of a glyph.
     struct ByteIndex(isize)
 }
+
+pub type WebFontLoadFinishedCallback = Arc<dyn Fn(bool) + Send + Sync + 'static>;

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -113,8 +113,6 @@ impl UntrustedNodeAddress {
 /// Messages sent to layout from the constellation and/or compositor.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum LayoutControlMsg {
-    /// Requests that this layout clean up before exit.
-    ExitNow,
     /// Tells layout about the new scrolling offsets of each scrollable stacking context.
     SetScrollStates(Vec<ScrollState>),
     /// Send the paint time for a specific epoch to layout.
@@ -395,8 +393,6 @@ pub enum ConstellationControlMsg {
     SetWebGPUPort(IpcReceiver<WebGPUMsg>),
     /// A mesage for a layout from the constellation.
     ForLayoutFromConstellation(LayoutControlMsg, PipelineId),
-    /// A message for a layout from the font cache.
-    ForLayoutFromFontCache(PipelineId),
 }
 
 impl fmt::Debug for ConstellationControlMsg {
@@ -436,7 +432,6 @@ impl fmt::Debug for ConstellationControlMsg {
             MediaSessionAction(..) => "MediaSessionAction",
             SetWebGPUPort(..) => "SetWebGPUPort",
             ForLayoutFromConstellation(..) => "ForLayoutFromConstellation",
-            ForLayoutFromFontCache(..) => "ForLayoutFromFontCache",
         };
         write!(formatter, "ConstellationControlMsg::{}", variant)
     }

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -179,10 +179,7 @@ pub trait LayoutFactory: Send + Sync {
 
 pub trait Layout {
     /// Handle a single message from the Constellation.
-    fn handle_constellation_msg(&mut self, msg: LayoutControlMsg);
-
-    /// Handle a a single mesasge from the FontCacheThread.
-    fn handle_font_cache_msg(&mut self);
+    fn handle_constellation_message(&mut self, msg: LayoutControlMsg);
 
     /// Get a reference to this Layout's Stylo `Device` used to handle media queries and
     /// resolve font metrics.


### PR DESCRIPTION
Instead of sending a message to the script thread via IPC when a web
font loads and then sending another, just give the `FontContext` a
callback that send a single message to the script thread. This moves all
the cache invalidation internally into `FontContext` as well.

Additionally, the unused LayoutControlMessage::ExitNow enum variant is
removed.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
