### PR TITLE
Fix mach bootstrap --skip-platform

### DIFF
--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -55,8 +55,9 @@ class Base:
             return False
 
     def bootstrap(self, force: bool, skip_platform: bool):
+        installed_something = False
         if not skip_platform:
-            installed_something = self._platform_bootstrap(force)
+            installed_something |= self._platform_bootstrap(force)
         installed_something |= self.install_taplo(force)
         installed_something |= self.install_crown(force)
 


### PR DESCRIPTION
This patch fixes mach bootstrap --skip-platform, which is needed for the workaround in #32342.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32340

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect an untested part of mach