### PR TITLE
mach: fix crash when sending notifications on Windows Server 2019

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -256,12 +256,15 @@ class MachCommands(CommandBase):
                 print("[Warning] Could not generate notification: "
                       f"Could not run '{notify_command}'.", file=sys.stderr)
         else:
-            notifier = LinuxNotifier if sys.platform.startswith("linux") else None
-            notification = notifypy.Notify(use_custom_notifier=notifier)
-            notification.title = title
-            notification.message = message
-            notification.icon = path.join(self.get_top_dir(), "resources", "servo_64.png")
-            notification.send(block=False)
+            try:
+                notifier = LinuxNotifier if sys.platform.startswith("linux") else None
+                notification = notifypy.Notify(use_custom_notifier=notifier)
+                notification.title = title
+                notification.message = message
+                notification.icon = path.join(self.get_top_dir(), "resources", "servo_64.png")
+                notification.send(block=False)
+            except notifypy.exceptions.UnsupportedPlatform as e:
+                print(f"[Warning] Could not generate notification: {e}", file=sys.stderr)
 
 
 def otool(s):


### PR DESCRIPTION
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32351
- [x] These changes do not require tests because they affect an untested part of mach