### PR TITLE
webgpu: Implement device lost

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -169,7 +169,7 @@ DOMInterfaces = {
 },
 
 'GPUDevice': {
-    'inRealms': ['PopErrorScope', 'GetLost', 'CreateComputePipelineAsync', 'CreateRenderPipelineAsync'],
+    'inRealms': ['PopErrorScope', 'CreateComputePipelineAsync', 'CreateRenderPipelineAsync'],
 }
 
 }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -56,8 +56,10 @@ use script_traits::{
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use uuid::Uuid;
+use webgpu::wgt::DeviceLostReason;
 use webgpu::WebGPUDevice;
 
+use super::bindings::codegen::Bindings::WebGPUBinding::GPUDeviceLostReason;
 use super::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::cell::{DomRefCell, RefMut};
 use crate::dom::bindings::codegen::Bindings::BroadcastChannelBinding::BroadcastChannelMethods;
@@ -3093,16 +3095,43 @@ impl GlobalScope {
             .insert(device.id(), Dom::from_ref(device));
     }
 
-    pub fn remove_gpu_device(&self, device: WebGPUDevice) {
-        let _ = self.gpu_devices.borrow_mut().remove(&device);
+    pub fn gpu_device_lost(&self, device: WebGPUDevice, reason: DeviceLostReason, msg: String) {
+        match reason {
+            DeviceLostReason::Unknown => {
+                let _ac = enter_realm(&*self);
+                self.gpu_devices
+                    .borrow_mut()
+                    .remove(&device)
+                    .expect("GPUDevice should still exists")
+                    .lose(GPUDeviceLostReason::Unknown, msg)
+            },
+            DeviceLostReason::Destroyed => {
+                let _ac = enter_realm(&*self);
+                self.gpu_devices
+                    .borrow_mut()
+                    .remove(&device)
+                    .expect("GPUDevice should still exists")
+                    .lose(GPUDeviceLostReason::Destroyed, msg)
+            },
+            DeviceLostReason::Dropped => {
+                // TODO: Can device even be dropped if we keep it alive in hashmap all the time?
+                let _ = self.gpu_devices.borrow_mut().remove(&device);
+            },
+            DeviceLostReason::ReplacedCallback => {
+                panic!("DeviceLost callback should not be replaced")
+            },
+            DeviceLostReason::DeviceInvalid => {
+                panic!("Device should be valid when setting callback")
+            },
+        }
     }
 
     pub fn handle_uncaptured_gpu_error(&self, device: WebGPUDevice, error: webgpu::Error) {
-        self.gpu_devices
-            .borrow()
-            .get(&device)
-            .expect("GPUDevice not found")
-            .fire_uncaptured_error(error);
+        if let Some(gpu_device) = self.gpu_devices.borrow().get(&device) {
+            gpu_device.fire_uncaptured_error(error);
+        } else {
+            warn!("GPUDevice is not available, but error is still dispatched!")
+        }
     }
 
     pub fn handle_gamepad_event(&self, gamepad_event: GamepadEvent) {

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -84,8 +84,9 @@ pub struct GPUDevice {
     #[no_trace]
     device: webgpu::WebGPUDevice,
     default_queue: Dom<GPUQueue>,
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
     #[ignore_malloc_size_of = "promises are hard"]
-    lost_promise: DomRefCell<Option<Rc<Promise>>>,
+    lost_promise: DomRefCell<Rc<Promise>>,
     valid: Cell<bool>,
 }
 
@@ -100,6 +101,7 @@ impl GPUDevice {
         device: webgpu::WebGPUDevice,
         queue: &GPUQueue,
         label: String,
+        lost_promise: Rc<Promise>,
     ) -> Self {
         Self {
             eventtarget: EventTarget::new_inherited(),
@@ -111,7 +113,7 @@ impl GPUDevice {
             label: DomRefCell::new(USVString::from(label)),
             device,
             default_queue: Dom::from_ref(queue),
-            lost_promise: DomRefCell::new(None),
+            lost_promise: DomRefCell::new(lost_promise),
             valid: Cell::new(true),
         }
     }
@@ -131,9 +133,18 @@ impl GPUDevice {
         let queue = GPUQueue::new(global, channel.clone(), queue);
         let limits = GPUSupportedLimits::new(global, limits);
         let features = GPUSupportedFeatures::Constructor(global, None, features).unwrap();
+        let lost_promise = Promise::new(global);
         let device = reflect_dom_object(
             Box::new(GPUDevice::new_inherited(
-                channel, adapter, extensions, &features, &limits, device, &queue, label,
+                channel,
+                adapter,
+                extensions,
+                &features,
+                &limits,
+                device,
+                &queue,
+                label,
+                lost_promise,
             )),
             global,
         );
@@ -207,17 +218,16 @@ impl GPUDevice {
 
     /// <https://gpuweb.github.io/gpuweb/#lose-the-device>
     pub fn lose(&self, reason: GPUDeviceLostReason) {
-        if let Some(ref lost_promise) = *self.lost_promise.borrow() {
-            let global = &self.global();
-            let msg = match reason {
-                GPUDeviceLostReason::Unknown => "Unknown reason for your device loss.",
-                GPUDeviceLostReason::Destroyed => {
-                    "Device self-destruction sequence activated successfully!"
-                },
-            };
-            let lost = GPUDeviceLostInfo::new(global, msg.into(), reason);
-            lost_promise.resolve_native(&*lost);
-        }
+        let ref lost_promise = *self.lost_promise.borrow();
+        let global = &self.global();
+        let msg = match reason {
+            GPUDeviceLostReason::Unknown => "Unknown reason for your device loss.",
+            GPUDeviceLostReason::Destroyed => {
+                "Device self-destruction sequence activated successfully!"
+            },
+        };
+        let lost = GPUDeviceLostInfo::new(global, msg.into(), reason);
+        lost_promise.resolve_native(&*lost);
     }
 }
 
@@ -248,10 +258,8 @@ impl GPUDeviceMethods for GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
-    fn GetLost(&self, comp: InRealm) -> Fallible<Rc<Promise>> {
-        let promise = Promise::new_in_current_realm(comp);
-        *self.lost_promise.borrow_mut() = Some(promise.clone());
-        Ok(promise)
+    fn Lost(&self) -> Rc<Promise> {
+        self.lost_promise.borrow().clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -217,15 +217,9 @@ impl GPUDevice {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#lose-the-device>
-    pub fn lose(&self, reason: GPUDeviceLostReason) {
+    pub fn lose(&self, reason: GPUDeviceLostReason, msg: String) {
         let ref lost_promise = *self.lost_promise.borrow();
         let global = &self.global();
-        let msg = match reason {
-            GPUDeviceLostReason::Unknown => "Unknown reason for your device loss.",
-            GPUDeviceLostReason::Destroyed => {
-                "Device self-destruction sequence activated successfully!"
-            },
-        };
         let lost = GPUDeviceLostInfo::new(global, msg.into(), reason);
         lost_promise.resolve_native(&*lost);
     }
@@ -1007,8 +1001,6 @@ impl GPUDeviceMethods for GPUDevice {
     fn Destroy(&self) {
         if self.valid.get() {
             self.valid.set(false);
-
-            self.lose(GPUDeviceLostReason::Destroyed);
 
             if let Err(e) = self
                 .channel

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -1075,14 +1075,13 @@ enum GPUDeviceLostReason {
     "destroyed",
 };
 
-[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
+[Exposed=(Window, Worker), Pref="dom.webgpu.enabled"]
 interface GPUDeviceLostInfo {
     readonly attribute GPUDeviceLostReason reason;
     readonly attribute DOMString message;
 };
 
 partial interface GPUDevice {
-    [Throws]
     readonly attribute Promise<GPUDeviceLostInfo> lost;
 };
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2424,12 +2424,14 @@ impl ScriptThread {
             WebGPUMsg::FreeTexture(id) => self.gpu_id_hub.lock().kill_texture_id(id),
             WebGPUMsg::FreeTextureView(id) => self.gpu_id_hub.lock().kill_texture_view_id(id),
             WebGPUMsg::Exit => *self.webgpu_port.borrow_mut() = None,
-            WebGPUMsg::CleanDevice {
+            WebGPUMsg::DeviceLost {
                 pipeline_id,
                 device,
+                reason,
+                msg,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                global.remove_gpu_device(device);
+                global.gpu_device_lost(device, reason.wgt(), msg);
             },
             WebGPUMsg::UncapturedError {
                 device,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2431,7 +2431,7 @@ impl ScriptThread {
                 msg,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                global.gpu_device_lost(device, reason.wgt(), msg);
+                global.gpu_device_lost(device, reason, msg);
             },
             WebGPUMsg::UncapturedError {
                 device,

--- a/components/webgpu/script_messages.rs
+++ b/components/webgpu/script_messages.rs
@@ -14,57 +14,12 @@ use crate::wgc::id::{
     DeviceId, PipelineLayoutId, QuerySetId, RenderBundleId, RenderPipelineId, SamplerId,
     ShaderModuleId, StagingBufferId, SurfaceId, TextureId, TextureViewId,
 };
-use crate::wgt;
 
-// Workaround until https://github.com/gfx-rs/wgpu/pull/5732
+/// <https://gpuweb.github.io/gpuweb/#enumdef-gpudevicelostreason>
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum DeviceLostReason {
-    /// Triggered by driver
-    Unknown = 0,
-    /// After Device::destroy
-    Destroyed = 1,
-    /// After Device::drop
-    ///
-    /// WebGPU does not invoke the device lost callback when the device is
-    /// dropped to prevent garbage collection from being observable. In wgpu,
-    /// we invoke the callback on drop to help with managing memory owned by
-    /// the callback.
-    Dropped = 2,
-    /// After replacing the device_lost_callback
-    ///
-    /// WebGPU does not have a concept of a device lost callback, but wgpu
-    /// does. wgpu guarantees that any supplied callback will be invoked
-    /// exactly once before it is dropped, which helps with managing the
-    /// memory owned by the callback.
-    ReplacedCallback = 3,
-    /// When setting the callback, but the device is already invalid
-    ///
-    /// As above, when the callback is provided, wgpu guarantees that it
-    /// will eventually be called. If the device is already invalid, wgpu
-    /// will call the callback immediately, with this reason.
-    DeviceInvalid = 4,
-}
-
-impl DeviceLostReason {
-    pub fn new(reason: wgt::DeviceLostReason) -> Self {
-        match reason {
-            wgt::DeviceLostReason::Unknown => DeviceLostReason::Unknown,
-            wgt::DeviceLostReason::Destroyed => DeviceLostReason::Destroyed,
-            wgt::DeviceLostReason::Dropped => DeviceLostReason::Dropped,
-            wgt::DeviceLostReason::ReplacedCallback => DeviceLostReason::ReplacedCallback,
-            wgt::DeviceLostReason::DeviceInvalid => DeviceLostReason::DeviceInvalid,
-        }
-    }
-
-    pub fn wgt(&self) -> wgt::DeviceLostReason {
-        match self {
-            DeviceLostReason::Unknown => wgt::DeviceLostReason::Unknown,
-            DeviceLostReason::Destroyed => wgt::DeviceLostReason::Destroyed,
-            DeviceLostReason::Dropped => wgt::DeviceLostReason::Dropped,
-            DeviceLostReason::ReplacedCallback => wgt::DeviceLostReason::ReplacedCallback,
-            DeviceLostReason::DeviceInvalid => wgt::DeviceLostReason::DeviceInvalid,
-        }
-    }
+    Unknown,
+    Destroyed,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/webgpu/script_messages.rs
+++ b/components/webgpu/script_messages.rs
@@ -14,6 +14,58 @@ use crate::wgc::id::{
     DeviceId, PipelineLayoutId, QuerySetId, RenderBundleId, RenderPipelineId, SamplerId,
     ShaderModuleId, StagingBufferId, SurfaceId, TextureId, TextureViewId,
 };
+use crate::wgt;
+
+// Workaround until https://github.com/gfx-rs/wgpu/pull/5732
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum DeviceLostReason {
+    /// Triggered by driver
+    Unknown = 0,
+    /// After Device::destroy
+    Destroyed = 1,
+    /// After Device::drop
+    ///
+    /// WebGPU does not invoke the device lost callback when the device is
+    /// dropped to prevent garbage collection from being observable. In wgpu,
+    /// we invoke the callback on drop to help with managing memory owned by
+    /// the callback.
+    Dropped = 2,
+    /// After replacing the device_lost_callback
+    ///
+    /// WebGPU does not have a concept of a device lost callback, but wgpu
+    /// does. wgpu guarantees that any supplied callback will be invoked
+    /// exactly once before it is dropped, which helps with managing the
+    /// memory owned by the callback.
+    ReplacedCallback = 3,
+    /// When setting the callback, but the device is already invalid
+    ///
+    /// As above, when the callback is provided, wgpu guarantees that it
+    /// will eventually be called. If the device is already invalid, wgpu
+    /// will call the callback immediately, with this reason.
+    DeviceInvalid = 4,
+}
+
+impl DeviceLostReason {
+    pub fn new(reason: wgt::DeviceLostReason) -> Self {
+        match reason {
+            wgt::DeviceLostReason::Unknown => DeviceLostReason::Unknown,
+            wgt::DeviceLostReason::Destroyed => DeviceLostReason::Destroyed,
+            wgt::DeviceLostReason::Dropped => DeviceLostReason::Dropped,
+            wgt::DeviceLostReason::ReplacedCallback => DeviceLostReason::ReplacedCallback,
+            wgt::DeviceLostReason::DeviceInvalid => DeviceLostReason::DeviceInvalid,
+        }
+    }
+
+    pub fn wgt(&self) -> wgt::DeviceLostReason {
+        match self {
+            DeviceLostReason::Unknown => wgt::DeviceLostReason::Unknown,
+            DeviceLostReason::Destroyed => wgt::DeviceLostReason::Destroyed,
+            DeviceLostReason::Dropped => wgt::DeviceLostReason::Dropped,
+            DeviceLostReason::ReplacedCallback => wgt::DeviceLostReason::ReplacedCallback,
+            DeviceLostReason::DeviceInvalid => wgt::DeviceLostReason::DeviceInvalid,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum WebGPUMsg {
@@ -34,14 +86,16 @@ pub enum WebGPUMsg {
     FreeRenderBundle(RenderBundleId),
     FreeStagingBuffer(StagingBufferId),
     FreeQuerySet(QuerySetId),
-    CleanDevice {
-        device: WebGPUDevice,
-        pipeline_id: PipelineId,
-    },
     UncapturedError {
         device: WebGPUDevice,
         pipeline_id: PipelineId,
         error: Error,
+    },
+    DeviceLost {
+        device: WebGPUDevice,
+        pipeline_id: PipelineId,
+        reason: DeviceLostReason,
+        msg: String,
     },
     Exit,
 }

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -758,6 +758,7 @@ impl WGPU {
                                 "Invalid command buffer submitted",
                             )))
                         } else {
+                            let _guard = self.poller.lock();
                             gfx_select!(queue_id => global.queue_submit(queue_id, &command_buffers))
                                 .map_err(Error::from_error)
                         };
@@ -965,6 +966,7 @@ impl WGPU {
                         data,
                     } => {
                         let global = &self.global;
+                        let _guard = self.poller.lock();
                         //TODO: Report result to content process
                         let result = gfx_select!(queue_id => global.queue_write_texture(
                             queue_id,
@@ -973,6 +975,7 @@ impl WGPU {
                             &data_layout,
                             &size
                         ));
+                        drop(_guard);
                         self.maybe_dispatch_wgpu_error(queue_id.transmute(), result.err());
                     },
                     WebGPURequest::QueueOnSubmittedWorkDone { sender, queue_id } => {

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -49,11 +49,9 @@
 
 
 [cts.https.html?q=webgpu:api,operation,adapter,requestDevice:invalid:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:]
     expected:
-      if os == "linux" and not debug: TIMEOUT
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,adapter,requestDevice:limit,better_than_supported:*]
@@ -2351,8 +2349,6 @@
 
 [cts.https.html?q=webgpu:api,operation,device,lost:same_object:*]
   [:]
-    expected:
-      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:api,operation,labels:object_has_descriptor_label:*]
@@ -58457,128 +58453,68 @@
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,computePass,dispatch:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="finish";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="finish";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:stage="submit";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="submit";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,copyBufferToBuffer:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="finish";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="finish";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:stage="submit";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="submit";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,copyBufferToTexture:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="finish";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="finish";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:stage="submit";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="submit";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,copyTextureToBuffer:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="finish";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="finish";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:stage="submit";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="submit";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,copyTextureToTexture:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="finish";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="finish";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:stage="submit";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="submit";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,renderPass,draw:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="finish";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="finish";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:stage="submit";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="submit";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:command,renderPass,renderBundle:*]
   expected:
-    if os == "linux" and not debug: TIMEOUT
+    if os == "linux" and not debug: CRASH
   [:stage="finish";awaitLost=false]
     expected:
       if os == "linux" and not debug: NOTRUN
@@ -58649,783 +58585,421 @@
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createBindGroup:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:resourceType="compareSamp";entry={"sampler":{"type":"comparison"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="compareSamp";entry={"sampler":{"type":"comparison"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="filtSamp";entry={"sampler":{"type":"filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="filtSamp";entry={"sampler":{"type":"filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="nonFiltSamp";entry={"sampler":{"type":"filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="nonFiltSamp";entry={"sampler":{"type":"filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="nonFiltSamp";entry={"sampler":{"type":"non-filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="nonFiltSamp";entry={"sampler":{"type":"non-filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="readonlyStorageTex";entry={"storageTexture":{"access":"read-only","format":"r32float"}};awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:resourceType="readonlyStorageTex";entry={"storageTexture":{"access":"read-only","format":"r32float"}};awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:resourceType="readwriteStorageTex";entry={"storageTexture":{"access":"read-write","format":"r32float"}};awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:resourceType="readwriteStorageTex";entry={"storageTexture":{"access":"read-write","format":"r32float"}};awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:resourceType="sampledTex";entry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="sampledTex";entry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="sampledTexMS";entry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="sampledTexMS";entry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="storageBuf";entry={"buffer":{"type":"read-only-storage"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="storageBuf";entry={"buffer":{"type":"read-only-storage"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="storageBuf";entry={"buffer":{"type":"storage"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="storageBuf";entry={"buffer":{"type":"storage"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="uniformBuf";entry={"buffer":{"type":"uniform"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="uniformBuf";entry={"buffer":{"type":"uniform"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:resourceType="writeonlyStorageTex";entry={"storageTexture":{"access":"write-only","format":"r32float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:resourceType="writeonlyStorageTex";entry={"storageTexture":{"access":"write-only","format":"r32float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createBindGroupLayout:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:entry={"buffer":{"type":"read-only-storage"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"read-only-storage"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"storage"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"storage"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"uniform"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"uniform"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:entry={"sampler":{"type":"comparison"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"comparison"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"non-filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"non-filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"storageTexture":{"access":"read-only","format":"r32float"}};awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"read-only","format":"r32float"}};awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"read-write","format":"r32float"}};awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"read-write","format":"r32float"}};awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"write-only","format":"r32float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"storageTexture":{"access":"write-only","format":"r32float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createBuffer:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:usageType="INDEX";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDEX";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="INDIRECT";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_READ";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:usageType="MAP_WRITE";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="MAP_WRITE";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="QUERY_RESOLVE";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="STORAGE";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="UNIFORM";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_NONE";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_NONE";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC_DST";awaitLost=false;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:usageType="VERTEX";usageCopy="COPY_SRC_DST";awaitLost=true;mappedAtCreation=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createCommandEncoder:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createComputePipeline:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createComputePipelineAsync:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:valid=false;awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:valid=false;awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:valid=true;awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:valid=true;awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createPipelineLayout:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:entry={"buffer":{"type":"read-only-storage"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"read-only-storage"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"storage"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"storage"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"uniform"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"buffer":{"type":"uniform"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:entry={"sampler":{"type":"comparison"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"comparison"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"non-filtering"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"sampler":{"type":"non-filtering"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"storageTexture":{"access":"read-only","format":"r32float"}};awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"read-only","format":"r32float"}};awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"read-write","format":"r32float"}};awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"read-write","format":"r32float"}};awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:entry={"storageTexture":{"access":"write-only","format":"r32float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"storageTexture":{"access":"write-only","format":"r32float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":false,"sampleType":"unfilterable-float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}};awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:entry={"texture":{"multisampled":true,"sampleType":"unfilterable-float"}};awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createQuerySet:*]
@@ -59447,9119 +59021,4697 @@
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createRenderBundleEncoder:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="rg16float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2uint";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createRenderPipeline:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createRenderPipelineAsync:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:valid=false;awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:valid=false;awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:valid=true;awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:valid=true;awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createSampler:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createShaderModule:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:stage="COMPUTE";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="COMPUTE";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="FRAGMENT";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="FRAGMENT";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="VERTEX";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:stage="VERTEX";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createTexture,2d,compressed_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createTexture,2d,uncompressed_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="r8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2uint";usageType="render";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createView,2d,compressed_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:createView,2d,uncompressed_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="r8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";usageType="texture";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2uint";usageType="render";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="render";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="dst";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="dst";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="none";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="none";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src-dest";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";usageType="texture";usageCopy="src-dest";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="storage";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="render";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="dst";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="none";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";usageType="texture";usageCopy="src-dest";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:importExternalTexture:*]
@@ -68633,751 +63785,389 @@
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:queue,writeBuffer:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:numElements=16;awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:numElements=16;awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:numElements=4;awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:numElements=4;awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:numElements=8;awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:numElements=8;awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:queue,writeTexture,2d,compressed_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="astc-10x10-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x10-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x5-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x6-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-10x8-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x10-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-12x12-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-4x4-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x4-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-5x5-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x5-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-6x6-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x5-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x6-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="astc-8x8-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="bc1-rgba-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc1-rgba-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc2-rgba-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc3-rgba-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc4-r-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc5-rg-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc6h-rgb-ufloat";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bc7-rgba-unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-r11unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="eac-rg11unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8a1unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgb8unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="etc2-rgba8unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:queue,writeTexture,2d,uncompressed_format:*]
-  expected:
-    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="bgra8unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r16uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r32uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="r8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: TIMEOUT
 
   [:format="rg11b10ufloat";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg11b10ufloat";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rg16float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg16uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg32uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rg8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2uint";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2uint";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb10a2unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb10a2unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb9e5ufloat";awaitLost=false]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgb9e5ufloat";awaitLost=true]
     expected:
-      if os == "linux" and not debug: NOTRUN
+      if os == "linux" and not debug: FAIL
 
   [:format="rgba16float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32float";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba32uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8sint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8snorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8uint";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";awaitLost=false]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba8unorm-srgb";awaitLost=true]
-    expected:
-      if os == "linux" and not debug: NOTRUN
 
 
 [cts.https.html?q=webgpu:api,validation,texture,bgra8unorm_storage:configure_storage_usage_on_canvas_context_with_bgra8unorm_storage:*]
@@ -70511,8 +65301,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70547,8 +65335,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_addition:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70583,8 +65369,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:greater_than:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -70673,8 +65457,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_matrix_addition:matrix:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70757,8 +65539,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70801,16 +65581,12 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70839,8 +65615,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70875,8 +65649,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -71935,8 +66707,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -72023,8 +66793,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72179,8 +66947,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_comparison:less_equals:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -72283,8 +67049,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -72329,8 +67093,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72383,8 +67145,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -72511,8 +67271,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_addition:matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -72587,8 +67345,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_matrix_multiplication:matrix_matrix:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=2]
 
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=3]
@@ -72881,8 +67637,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -73179,8 +67933,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_subtraction:matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -73403,8 +68155,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_vector_multiplication:vector_matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -73431,8 +68181,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -73443,8 +68191,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -73593,8 +68339,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -73707,8 +68451,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -73779,8 +68521,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -73859,8 +68599,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -74111,8 +68849,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_equals:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74335,8 +69071,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -74411,8 +69145,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75057,8 +69789,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_scalar_multiplication:matrix_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75335,8 +70065,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75521,8 +70249,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:matrix_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75615,8 +70341,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -75709,8 +70433,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75755,8 +70477,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75863,8 +70583,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75897,8 +70615,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -75931,8 +70647,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76051,8 +70765,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76203,8 +70915,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76269,8 +70979,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76345,8 +71053,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76453,8 +71159,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76553,8 +71257,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76721,8 +71423,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76773,8 +71473,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -76923,8 +71621,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77089,8 +71785,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77463,8 +72157,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:greater_equals:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77507,8 +72199,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:greater_than:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77551,8 +72241,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:less_equals:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77637,8 +72325,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:not_equals:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77861,8 +72547,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -77995,8 +72679,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78097,8 +72779,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:division_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78233,8 +72913,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78563,8 +73241,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:remainder_vector_scalar_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78657,8 +73333,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_compound:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78701,8 +73375,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_scalar_vector:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78735,8 +73407,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:subtraction_vector_scalar:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78885,8 +73555,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:greater_than:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -78929,8 +73597,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_equals:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -79337,8 +74003,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acos:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79415,8 +74079,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acosh:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -80193,8 +74855,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asin:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -80263,8 +74923,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asin:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -80341,8 +74999,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asinh:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -80377,8 +75033,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asinh:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -80455,8 +75109,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan2:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -80533,8 +75185,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -80569,8 +75219,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -85997,8 +80645,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -86041,8 +80687,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:i32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86127,8 +80771,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86163,8 +80805,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86241,8 +80881,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -86621,8 +81259,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86755,8 +81391,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,determinant:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -86783,8 +81417,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,determinant:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86861,8 +81493,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f16_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -86873,8 +81503,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f16_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -86907,8 +81535,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -86921,8 +81547,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -86993,8 +81617,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:abstract_int:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87015,8 +81637,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87027,8 +81647,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec4:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87075,8 +81693,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:i32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -87301,8 +81917,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp2:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -87961,8 +82575,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88527,8 +83139,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -88563,8 +83173,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -88751,8 +83359,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -88787,8 +83393,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -88799,8 +83403,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f16_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -88831,8 +83433,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88845,8 +83445,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -88859,8 +83457,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -89029,8 +83625,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89159,8 +83753,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89375,8 +83967,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89497,8 +84087,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:u32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -89571,16 +84159,12 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec4:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_matching:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -89625,8 +84209,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f16_nonmatching_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -89689,8 +84271,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -89751,8 +84331,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec3_whole:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -89797,8 +84375,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec2_whole:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -89809,8 +84385,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec3_fract:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -89821,8 +84395,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec3_whole:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -89833,8 +84405,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec4_fract:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -89855,8 +84425,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_whole:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -89997,8 +84565,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f16_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -90029,8 +84595,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90377,8 +84941,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,radians:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90499,8 +85061,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f16_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -90511,8 +85071,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f16_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -90595,8 +85153,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f16_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -90627,8 +85183,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec2:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90641,8 +85195,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec3:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90655,8 +85207,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec4:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -90771,8 +85321,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -91667,8 +86215,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -91855,8 +86401,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -91925,8 +86469,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sqrt:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -92203,8 +86745,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tanh:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93271,8 +87811,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,transpose:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -93311,8 +87849,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,transpose:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -93497,8 +88033,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,trunc:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -93915,8 +88449,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_assignment:abstract:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94545,8 +89077,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_arithmetic:negation:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -94873,8 +89403,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:i32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -95921,8 +90449,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:f16:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -95957,8 +90483,6 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:f32:*]
-  expected:
-    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL


### PR DESCRIPTION
Due to hitting multiple deadlocks in wgpu I added lock to prevent some functions (queue_write_texture, queue_submit) run in parallel with device_poll in poller thread https://github.com/servo/servo/pull/32354/commits/d9d506c6844dc41e1a43363804e6d0445b224ca0 (and thus avoiding deadlocks).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://github.com/servo/servo/issues/32347
- [x] There are tests for these changes in CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
