### PR TITLE
Remove more IPC messages between script and layout

### DIFF
--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -50,13 +50,12 @@ use profile_traits::time::{
 };
 use script::layout_dom::{ServoLayoutDocument, ServoLayoutElement, ServoLayoutNode};
 use script_layout_interface::{
-    node_id_from_scroll_id, Layout, LayoutConfig, LayoutFactory, NodesFromPointQueryType,
-    OffsetParentResponse, ReflowComplete, ReflowGoal, ScriptReflow, TrustedNodeAddress,
+    Layout, LayoutConfig, LayoutFactory, NodesFromPointQueryType, OffsetParentResponse,
+    ReflowComplete, ReflowGoal, ScriptReflow, TrustedNodeAddress,
 };
 use script_traits::{
-    ConstellationControlMsg, DrawAPaintImageResult, IFrameSizeMsg, LayoutControlMsg,
-    LayoutMsg as ConstellationMsg, PaintWorkletError, Painter, ScrollState, UntrustedNodeAddress,
-    WindowSizeData, WindowSizeType,
+    ConstellationControlMsg, DrawAPaintImageResult, IFrameSizeMsg, LayoutMsg as ConstellationMsg,
+    PaintWorkletError, Painter, ScrollState, UntrustedNodeAddress, WindowSizeData, WindowSizeType,
 };
 use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
@@ -221,20 +220,6 @@ impl Drop for ScriptReflowResult {
 }
 
 impl Layout for LayoutThread {
-    fn handle_constellation_message(
-        &mut self,
-        constellation_message: script_traits::LayoutControlMsg,
-    ) {
-        match constellation_message {
-            LayoutControlMsg::SetScrollStates(new_scroll_states) => {
-                self.set_scroll_states(new_scroll_states);
-            },
-            LayoutControlMsg::PaintMetric(epoch, paint_time) => {
-                self.paint_time_metrics.maybe_set_metric(epoch, paint_time);
-            },
-        }
-    }
-
     fn device(&self) -> &Device {
         self.stylist.device()
     }
@@ -468,6 +453,17 @@ impl Layout for LayoutThread {
         _properties: Vec<Atom>,
         _painter: Box<dyn Painter>,
     ) {
+    }
+
+    fn set_scroll_states(&mut self, scroll_states: &[ScrollState]) {
+        *self.scroll_offsets.borrow_mut() = scroll_states
+            .iter()
+            .map(|scroll_state| (scroll_state.scroll_id, scroll_state.scroll_offset))
+            .collect();
+    }
+
+    fn set_epoch_paint_time(&mut self, epoch: Epoch, paint_time: u64) {
+        self.paint_time_metrics.maybe_set_metric(epoch, paint_time);
     }
 }
 
@@ -829,28 +825,6 @@ impl LayoutThread {
             units::LayoutPoint::from_untyped(point),
             state.scroll_id,
         );
-    }
-
-    fn set_scroll_states(&mut self, new_scroll_states: Vec<ScrollState>) {
-        let mut script_scroll_states = vec![];
-        let mut layout_scroll_states = HashMap::new();
-        for new_state in &new_scroll_states {
-            let offset = new_state.scroll_offset;
-            layout_scroll_states.insert(new_state.scroll_id, offset);
-
-            if new_state.scroll_id.is_root() {
-                script_scroll_states.push((UntrustedNodeAddress::from_id(0), offset))
-            } else if let Some(node_id) = node_id_from_scroll_id(new_state.scroll_id.0 as usize) {
-                script_scroll_states.push((UntrustedNodeAddress::from_id(node_id), offset))
-            }
-        }
-        let _ = self
-            .script_chan
-            .send(ConstellationControlMsg::SetScrollState(
-                self.id,
-                script_scroll_states,
-            ));
-        self.scroll_offsets = RefCell::new(layout_scroll_states);
     }
 
     fn perform_post_style_recalc_layout_passes(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -26,8 +26,8 @@ use std::rc::Rc;
 use std::result::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use std::{ptr, thread};
 
 use background_hang_monitor_api::{
     BackgroundHangMonitor, BackgroundHangMonitorExitSignal, HangAnnotation, MonitoredComponentId,
@@ -36,6 +36,7 @@ use background_hang_monitor_api::{
 use base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, TopLevelBrowsingContextId,
 };
+use base::Epoch;
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
@@ -46,7 +47,6 @@ use devtools_traits::{
 };
 use embedder_traits::EmbedderMsg;
 use euclid::default::{Point2D, Rect};
-use euclid::Vector2D;
 use gfx::font_cache_thread::FontCacheThread;
 use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader};
 use html5ever::{local_name, namespace_url, ns};
@@ -73,13 +73,15 @@ use parking_lot::Mutex;
 use percent_encoding::percent_decode;
 use profile_traits::mem::{self as profile_mem, OpaqueSender, ReportsChan};
 use profile_traits::time::{self as profile_time, profile, ProfilerCategory};
-use script_layout_interface::{LayoutConfig, LayoutFactory, ReflowGoal, ScriptThreadFactory};
+use script_layout_interface::{
+    node_id_from_scroll_id, LayoutConfig, LayoutFactory, ReflowGoal, ScriptThreadFactory,
+};
 use script_traits::webdriver_msg::WebDriverScriptCommand;
 use script_traits::{
     CompositorEvent, ConstellationControlMsg, DiscardBrowsingContext, DocumentActivity,
-    EventResult, HistoryEntryReplacement, InitialScriptState, JsEvalResult, LayoutControlMsg,
-    LayoutMsg, LoadData, LoadOrigin, MediaSessionActionType, MouseButton, MouseEventType,
-    NewLayoutInfo, Painter, ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan,
+    EventResult, HistoryEntryReplacement, InitialScriptState, JsEvalResult, LayoutMsg, LoadData,
+    LoadOrigin, MediaSessionActionType, MouseButton, MouseEventType, NewLayoutInfo, Painter,
+    ProgressiveWebMetricType, ScriptMsg, ScriptToConstellationChan, ScrollState,
     StructuredSerializedData, TimerSchedulerMsg, TouchEventType, TouchId, UntrustedNodeAddress,
     UpdatePipelineIdReason, WheelDelta, WindowSizeData, WindowSizeType,
 };
@@ -91,7 +93,6 @@ use style::thread_state::{self, ThreadState};
 use time::precise_time_ns;
 use url::Position;
 use webgpu::WebGPUMsg;
-use webrender_api::units::LayoutPixel;
 use webrender_api::DocumentId;
 use webrender_traits::WebRenderScriptApi;
 
@@ -1836,11 +1837,6 @@ impl ScriptThread {
                     .profile_event(ScriptThreadEventCategory::SetViewport, Some(id), || {
                         self.handle_viewport(id, rect);
                     }),
-                FromConstellation(ConstellationControlMsg::SetScrollState(id, scroll_state)) => {
-                    self.profile_event(ScriptThreadEventCategory::SetScrollState, Some(id), || {
-                        self.handle_set_scroll_state(id, &scroll_state);
-                    })
-                },
                 FromConstellation(ConstellationControlMsg::TickAllAnimations(
                     pipeline_id,
                     tick_type,
@@ -2097,7 +2093,6 @@ impl ScriptThread {
                 ExitScriptThread => None,
                 SendEvent(id, ..) => Some(id),
                 Viewport(id, ..) => Some(id),
-                SetScrollState(id, ..) => Some(id),
                 GetTitle(id) => Some(id),
                 SetDocumentActivity(id, ..) => Some(id),
                 SetThrottled(id, ..) => Some(id),
@@ -2123,7 +2118,8 @@ impl ScriptThread {
                 ExitFullScreen(id, ..) => Some(id),
                 MediaSessionAction(..) => None,
                 SetWebGPUPort(..) => None,
-                ForLayoutFromConstellation(_, id) => Some(id),
+                SetScrollStates(id, ..) => Some(id),
+                SetEpochPaintTime(id, ..) => Some(id),
             },
             MixedMessage::FromDevtools(_) => None,
             MixedMessage::FromScript(ref inner_msg) => match *inner_msg {
@@ -2348,7 +2344,6 @@ impl ScriptThread {
             },
             msg @ ConstellationControlMsg::AttachLayout(..) |
             msg @ ConstellationControlMsg::Viewport(..) |
-            msg @ ConstellationControlMsg::SetScrollState(..) |
             msg @ ConstellationControlMsg::Resize(..) |
             msg @ ConstellationControlMsg::ExitFullScreen(..) |
             msg @ ConstellationControlMsg::SendEvent(..) |
@@ -2356,22 +2351,53 @@ impl ScriptThread {
             msg @ ConstellationControlMsg::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
-            ConstellationControlMsg::ForLayoutFromConstellation(msg, pipeline_id) => {
-                self.handle_layout_message_from_constellation(msg, pipeline_id)
+            ConstellationControlMsg::SetScrollStates(pipeline_id, scroll_states) => {
+                self.handle_set_scroll_states_msg(pipeline_id, scroll_states)
+            },
+            ConstellationControlMsg::SetEpochPaintTime(pipeline_id, epoch, time) => {
+                self.handle_set_epoch_paint_time(pipeline_id, epoch, time)
             },
         }
     }
 
-    fn handle_layout_message_from_constellation(
+    fn handle_set_scroll_states_msg(
         &self,
-        msg: LayoutControlMsg,
         pipeline_id: PipelineId,
+        scroll_states: Vec<ScrollState>,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
-            warn!("Received layout message pipeline {pipeline_id} closed: {msg:?}.");
+            warn!("Received scroll states for closed pipeline {pipeline_id}");
             return;
         };
-        window.layout_mut().handle_constellation_message(msg);
+
+        self.profile_event(
+            ScriptThreadEventCategory::SetScrollState,
+            Some(pipeline_id),
+            || {
+                window.layout_mut().set_scroll_states(&scroll_states);
+
+                let mut scroll_offsets = HashMap::new();
+                for scroll_state in scroll_states.into_iter() {
+                    let scroll_offset = scroll_state.scroll_offset;
+                    if scroll_state.scroll_id.is_root() {
+                        window.update_viewport_for_scroll(-scroll_offset.x, -scroll_offset.y);
+                    } else if let Some(node_id) =
+                        node_id_from_scroll_id(scroll_state.scroll_id.0 as usize)
+                    {
+                        scroll_offsets.insert(OpaqueNode(node_id), -scroll_offset);
+                    }
+                }
+                window.set_scroll_offsets(scroll_offsets)
+            },
+        )
+    }
+
+    fn handle_set_epoch_paint_time(&self, pipeline_id: PipelineId, epoch: Epoch, time: u64) {
+        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
+            warn!("Received set epoch paint time message for closed pipeline {pipeline_id}.");
+            return;
+        };
+        window.layout_mut().set_epoch_paint_time(epoch, time);
     }
 
     fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg) {
@@ -2761,32 +2787,6 @@ impl ScriptThread {
             return;
         }
         warn!("Page rect message sent to nonexistent pipeline");
-    }
-
-    fn handle_set_scroll_state(
-        &self,
-        id: PipelineId,
-        scroll_states: &[(UntrustedNodeAddress, Vector2D<f32, LayoutPixel>)],
-    ) {
-        let window = match self.documents.borrow().find_window(id) {
-            Some(window) => window,
-            None => {
-                return warn!(
-                    "Set scroll state message sent to nonexistent pipeline: {:?}",
-                    id
-                );
-            },
-        };
-
-        let mut scroll_offsets = HashMap::new();
-        for &(node_address, ref scroll_offset) in scroll_states {
-            if node_address == UntrustedNodeAddress(ptr::null()) {
-                window.update_viewport_for_scroll(-scroll_offset.x, -scroll_offset.y);
-            } else {
-                scroll_offsets.insert(OpaqueNode(node_address.0 as usize), -*scroll_offset);
-            }
-        }
-        window.set_scroll_offsets(scroll_offsets)
     }
 
     fn handle_new_layout(&self, new_layout_info: NewLayoutInfo, origin: MutableOrigin) {

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -33,8 +33,8 @@ use net_traits::ResourceThreads;
 use profile_traits::mem::Report;
 use profile_traits::time;
 use script_traits::{
-    ConstellationControlMsg, InitialScriptState, LayoutControlMsg, LayoutMsg, LoadData, Painter,
-    ScrollState, UntrustedNodeAddress, WindowSizeData,
+    ConstellationControlMsg, InitialScriptState, LayoutMsg, LoadData, Painter, ScrollState,
+    UntrustedNodeAddress, WindowSizeData,
 };
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
@@ -178,9 +178,6 @@ pub trait LayoutFactory: Send + Sync {
 }
 
 pub trait Layout {
-    /// Handle a single message from the Constellation.
-    fn handle_constellation_message(&mut self, msg: LayoutControlMsg);
-
     /// Get a reference to this Layout's Stylo `Device` used to handle media queries and
     /// resolve font metrics.
     fn device(&self) -> &Device;
@@ -227,6 +224,12 @@ pub trait Layout {
         properties: Vec<Atom>,
         painter: Box<dyn Painter>,
     );
+
+    /// Set the scroll states of this layout after a compositor scroll.
+    fn set_scroll_states(&mut self, scroll_states: &[ScrollState]);
+
+    /// Set the paint time for a specific epoch.
+    fn set_epoch_paint_time(&mut self, epoch: Epoch, paint_time: u64);
 
     fn query_content_box(&self, node: OpaqueNode) -> Option<Rect<Au>>;
     fn query_content_boxes(&self, node: OpaqueNode) -> Vec<Rect<Au>>;


### PR DESCRIPTION
Instead of bouncing messages from the compositor to script and then to
layout, just have script call methods on Layout. Additionally, we do not
need to send any followup messages to script for these messages. Instead
just execute code after calling the method on Layout.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
