### PR TITLE
dependabot: Group all GStreamer dependencies together for upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+  groups:
+    gstreamer-related:
+       patterns:
+         - "gstreamer*"
+         - "glib*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: servo_atoms


### PR DESCRIPTION
The GStreamer we use is a bracing 24 crates, which tends to flood our CI
infrastructure. Group them together in order to make things more
manageable.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just modify the dependabot configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
