### PR TITLE
clippy: Fix warnings in `components/webgpu/wgpu_thread.rs`

### DIFF
--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -192,7 +192,7 @@ impl WGPU {
                             .get(&command_encoder_id)
                         {
                             Err(Error::Internal(err.clone()))
-                        } else  if let Some(error) =
+                        } else if let Some(error) =
                             gfx_select!(command_encoder_id => global.command_encoder_finish(
                                 command_encoder_id,
                                 &wgt::CommandBufferDescriptor::default()
@@ -203,7 +203,7 @@ impl WGPU {
                         } else {
                             Ok(())
                         };
-                        
+
                         self.encoder_record_error(command_encoder_id, &result);
                         self.maybe_dispatch_error(device_id, result.err());
                     },
@@ -1083,10 +1083,10 @@ impl WGPU {
                                     );
                                 }
                             } else if let Err(e) = sender.send(Some(Ok(
-                                    WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)),
-                                ))) {
-                                    warn!("Unable to send PopError::Empty: {e:?}");
-                                }
+                                WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)),
+                            ))) {
+                                warn!("Unable to send PopError::Empty: {e:?}");
+                            }
                         } else {
                             // device lost
                             if let Err(e) = sender.send(Some(Ok(WebGPUResponse::PoppedErrorScope(
@@ -1140,7 +1140,6 @@ impl WGPU {
             {
                 warn!("Failed to send WebGPUMsg::UncapturedError: {error:?}");
             }
-            
         } // else device is lost
     }
 

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -192,19 +192,18 @@ impl WGPU {
                             .get(&command_encoder_id)
                         {
                             Err(Error::Internal(err.clone()))
+                        } else  if let Some(error) =
+                            gfx_select!(command_encoder_id => global.command_encoder_finish(
+                                command_encoder_id,
+                                &wgt::CommandBufferDescriptor::default()
+                            ))
+                            .1
+                        {
+                            Err(Error::from_error(error))
                         } else {
-                            if let Some(error) =
-                                gfx_select!(command_encoder_id => global.command_encoder_finish(
-                                    command_encoder_id,
-                                    &wgt::CommandBufferDescriptor::default()
-                                ))
-                                .1
-                            {
-                                Err(Error::from_error(error))
-                            } else {
-                                Ok(())
-                            }
+                            Ok(())
                         };
+                        
                         self.encoder_record_error(command_encoder_id, &result);
                         self.maybe_dispatch_error(device_id, result.err());
                     },
@@ -734,7 +733,7 @@ impl WGPU {
                             )))
                         } else {
                             gfx_select!(queue_id => global.queue_submit(queue_id, &command_buffers))
-                                .map_err(|e| Error::from_error(e))
+                                .map_err(Error::from_error)
                         };
                         self.maybe_dispatch_error(queue_id.transmute(), result.err());
                     },
@@ -1083,13 +1082,11 @@ impl WGPU {
                                         error_scope.errors
                                     );
                                 }
-                            } else {
-                                if let Err(e) = sender.send(Some(Ok(
+                            } else if let Err(e) = sender.send(Some(Ok(
                                     WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)),
                                 ))) {
                                     warn!("Unable to send PopError::Empty: {e:?}");
                                 }
-                            }
                         } else {
                             // device lost
                             if let Err(e) = sender.send(Some(Ok(WebGPUResponse::PoppedErrorScope(
@@ -1132,19 +1129,18 @@ impl WGPU {
                 .find(|error_scope| error_scope.filter == error.filter())
             {
                 error_scope.errors.push(error);
-            } else {
-                if self
-                    .script_sender
-                    .send(WebGPUMsg::UncapturedError {
-                        device: WebGPUDevice(device_id),
-                        pipeline_id: device_scope.pipeline_id,
-                        error: error.clone(),
-                    })
-                    .is_err()
-                {
-                    warn!("Failed to send WebGPUMsg::UncapturedError: {error:?}");
-                }
+            } else if self
+                .script_sender
+                .send(WebGPUMsg::UncapturedError {
+                    device: WebGPUDevice(device_id),
+                    pipeline_id: device_scope.pipeline_id,
+                    error: error.clone(),
+                })
+                .is_err()
+            {
+                warn!("Failed to send WebGPUMsg::UncapturedError: {error:?}");
             }
+            
         } // else device is lost
     }
 


### PR DESCRIPTION
Fix the following warnings:
```
warning: this `else { if .. }` block can be collapsed
   --> components/webgpu/wgpu_thread.rs:195:32
    |
195 |                           } else {
    |  ________________________________^
196 | |                             if let Some(error) =
197 | |                                 gfx_select!(command_encoder_id => global.command_encoder_finish(
198 | |                                     command_encoder_id,
...   |
206 | |                             }
207 | |                         };
    | |_________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if
    = note: `#[warn(clippy::collapsible_else_if)]` on by default
help: collapse nested if block
    |
195 ~                         } else if let Some(error) =
196 +                             gfx_select!(command_encoder_id => global.command_encoder_finish(
197 +                                 command_encoder_id,
198 +                                 &wgt::CommandBufferDescriptor::default()
199 +                             ))
200 +                             .1
201 +                         {
202 +                             Err(Error::from_error(error))
203 +                         } else {
204 +                             Ok(())
205 ~                         };
    |

FIXED^

warning: this `else { if .. }` block can be collapsed
    --> components/webgpu/wgpu_thread.rs:1086:36
     |
1086 |   ...                   } else {
     |  ______________________________^
1087 | | ...                       if let Err(e) = sender.send(Some(Ok(
1088 | | ...                           WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)),
1089 | | ...                       ))) {
1090 | | ...                           warn!("Unable to send PopError::Empty: {e:?}");
1091 | | ...                       }
1092 | | ...                   }
     | |_______________________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if
help: collapse nested if block
     |
1086 ~                             } else if let Err(e) = sender.send(Some(Ok(
1087 +                                 WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)),
1088 +                             ))) {
1089 +                                 warn!("Unable to send PopError::Empty: {e:?}");
1090 +                             }
     |
warning: this `else { if .. }` block can be collapsed
    --> components/webgpu/wgpu_thread.rs:1135:20
     |
1135 |               } else {
     |  ____________________^
1136 | |                 if self
1137 | |                     .script_sender
1138 | |                     .send(WebGPUMsg::UncapturedError {
...    |
1146 | |                 }
1147 | |             }
     | |_____________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if
help: collapse nested if block
     |
1135 ~             } else if self
1136 +                 .script_sender
1137 +                 .send(WebGPUMsg::UncapturedError {
1138 +                     device: WebGPUDevice(device_id),
1139 +                     pipeline_id: device_scope.pipeline_id,
1140 +                     error: error.clone(),
1141 +                 })
1142 +                 .is_err()
1143 +             {
1144 +                 warn!("Failed to send WebGPUMsg::UncapturedError: {error:?}");
1145 +             }
     |

warning: redundant closure
   --> components/webgpu/wgpu_thread.rs:737:42
    |
737 | ...                   .map_err(|e| Error::from_error(e))
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `Error::from_error`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
    = note: `#[warn(clippy::redundant_closure)]` on by default

warning: `webgpu` (lib) generated 4 warnings (run `cargo clippy --fix --lib -p webgpu` to apply 4 suggestions)
    Checking script_traits v0.0.1 (/home/jujumba/Projects/servo/components/shared/script)
warning: casting raw pointers to the same type and constness is unnecessary (`*const libc::c_void` -> `*const libc::c_void`)
  --> components/shared/script/lib.rs:82:30
   |
82 |         UntrustedNodeAddress(o.0 as *const c_void)
   |                              ^^^^^^^^^^^^^^^^^^^^ help: try: `o.0`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
   = note: `#[warn(clippy::unnecessary_cast)]` on by default
```

Addresses #31500 