### PR TITLE
clippy: Fix warnings in `components/layout_2020/flow/text_run.rs`

### DIFF
--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -827,7 +827,6 @@ where
         };
 
         self.next_character = self.iterator.next();
-        Some((character, self.next_character));
+        Some((character, self.next_character))
     }
 }
-

--- a/components/layout_2020/flow/text_run.rs
+++ b/components/layout_2020/flow/text_run.rs
@@ -827,6 +827,7 @@ where
         };
 
         self.next_character = self.iterator.next();
-        return Some((character, self.next_character.clone()));
+        Some((character, self.next_character));
     }
 }
+


### PR DESCRIPTION
Fix the following warnings:
```
warning: unneeded `return` statement
   --> components/layout_2020/flow/text_run.rs:830:9
    |
830 |         return Some((character, self.next_character.clone()));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `#[warn(clippy::needless_return)]` on by default
help: remove `return`
    |
830 -         return Some((character, self.next_character.clone()));
830 +         Some((character, self.next_character.clone()))
    |


warning: using `clone` on type `Option<char>` which implements the `Copy` trait
   --> components/layout_2020/flow/text_run.rs:830:33
    |
830 |         return Some((character, self.next_character.clone()));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `self.next_character`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
    = note: `#[warn(clippy::clone_on_copy)]` on by default
```


Addresses #31500 