### PR TITLE
ci: Disable legacy layout tests when landing PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       unit-tests: true
-      wpt-layout: ${{ github.event_name == 'pull_request' && 'none' || 'all' }}
+      wpt-layout: ${{ github.event_name == 'pull_request' && 'none' || '2020' }}
     secrets: inherit
 
   build-android:


### PR DESCRIPTION
This disables Layout 2013 checks when landing PRs. This means that
results might get out of sync for 2013, but they should be updated
weekly during WPT imports.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change the CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
