### PR TITLE
webgpu: Parse and forward backend prefs to wgpu

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -206,6 +206,8 @@ mod gen {
                 webgpu: {
                     /// Enable WebGPU APIs.
                     enabled: bool,
+                    /// List of comma-separated backends to be used by wgpu
+                    wgpu_backend: String,
                 },
                 bluetooth: {
                     enabled: bool,

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -32,6 +32,7 @@
   "dom.testing.htmlinputelement.select_files.enabled": false,
   "dom.webgl2.enabled": false,
   "dom.webgpu.enabled": false,
+  "dom.webgpu.wgpu_backend": "",
   "dom.webrtc.enabled": false,
   "dom.webrtc.transceiver.enabled": false,
   "dom.webvr.enabled": false,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
These changes enable wgpu backend selection by defining a new pref. The new pref `dom.webgpu.wgpu_backend` is parsed using `wgpu-core` and forwarded to the wgpu instance.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32390


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process.

r? @sagudev  -->

