### PR TITLE
Android: fix url resolution

### DIFF
--- a/ports/jniapi/src/simpleservo.rs
+++ b/ports/jniapi/src/simpleservo.rs
@@ -30,6 +30,7 @@ use servo::embedder_traits::{
 };
 use servo::euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use servo::keyboard_types::{Key, KeyState, KeyboardEvent};
+use servo::net_traits::pub_domains::is_reg_domain;
 pub use servo::script_traits::{MediaSessionActionType, MouseButton};
 use servo::script_traits::{TouchEventType, TouchId, TraversalDirection};
 use servo::servo_config::{opts, pref};
@@ -379,9 +380,17 @@ impl ServoGlue {
     }
 
     /// Load an URL. This needs to be a valid url.
-    pub fn load_uri(&mut self, url: &str) -> Result<(), &'static str> {
-        info!("load_uri: {}", url);
-        ServoUrl::parse(url)
+    pub fn load_uri(&mut self, request: &str) -> Result<(), &'static str> {
+        info!("load_uri: {}", request);
+        ServoUrl::parse(request)
+            .or_else(|_| {
+                if request.contains('/') || is_reg_domain(request) {
+                    ServoUrl::parse(&format!("https://{}", request))
+                } else {
+                    let search_url = pref!(shell.searchpage).replace("%s", request);
+                    ServoUrl::parse(&search_url)
+                }
+            })
             .map_err(|_| "Can't parse URL")
             .and_then(|url| {
                 let browser_id = self.get_browser_id()?;

--- a/ports/jniapi/src/simpleservo.rs
+++ b/ports/jniapi/src/simpleservo.rs
@@ -379,7 +379,8 @@ impl ServoGlue {
         Ok(())
     }
 
-    /// Load an URL. This needs to be a valid url.
+    /// Load an URL. If this is not a valid URL, try to "fix" it by adding a scheme or if all else fails,
+    /// interpret the string as a search term.
     pub fn load_uri(&mut self, request: &str) -> Result<(), &'static str> {
         info!("load_uri: {}", request);
         ServoUrl::parse(request)

--- a/support/android/apk/servoapp/src/main/java/org/mozilla/servo/MainActivity.java
+++ b/support/android/apk/servoapp/src/main/java/org/mozilla/servo/MainActivity.java
@@ -14,11 +14,9 @@ import android.os.Bundle;
 import android.system.ErrnoException;
 import android.system.Os;
 import android.util.Log;
-import android.util.Patterns;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.webkit.URLUtil;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ProgressBar;
@@ -80,7 +78,7 @@ public class MainActivity extends Activity implements Servo.Client {
         mServoView.setServoArgs(args, log);
 
         if (Intent.ACTION_VIEW.equals(intent.getAction())) {
-            mServoView.loadUri(intent.getData());
+            mServoView.loadUri(intent.getData().toString());
         }
         setupUrlField();
     }
@@ -115,17 +113,8 @@ public class MainActivity extends Activity implements Servo.Client {
     private void loadUrlFromField() {
         String text = mUrlField.getText().toString();
         text = text.trim();
-        String url;
 
-        if (Patterns.WEB_URL.matcher(text).matches()) {
-            url = URLUtil.guessUrl(text).replaceFirst("http://", "https://");
-        } else if (text.matches("(http://)?localhost:\\d{1,5}(/.*)?")) {
-            url = text.startsWith("http://") ? text : "http://" + text;
-        } else {
-            url = URLUtil.composeSearchUrl(text, "https://duckduckgo.com/html/?q=%s", "%s");
-        }
-
-        mServoView.loadUri(Uri.parse(url));
+        mServoView.loadUri(text);
     }
 
     // From activity_main.xml:

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
@@ -211,11 +211,11 @@ public class ServoView extends SurfaceView
         mServo.stop();
     }
 
-    public void loadUri(Uri uri) {
+    public void loadUri(String uri) {
         if (mServo != null) {
-            mServo.loadUri(uri.toString());
+            mServo.loadUri(uri);
         } else {
-            mInitialUri = uri.toString();
+            mInitialUri = uri;
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The behavior is a bit different from before, previously any string with a . was considered a url, but I don't think is always a correct assumption.
Regarding localhost urls, only http scheme is accepted for now, should https also be accepted? 

---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21948 (GitHub issue number if applicable)
- [X] These changes do not require tests because no new features.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
