### PR TITLE
fix: remove unused items in gfx

### DIFF
--- a/components/gfx/font_context.rs
+++ b/components/gfx/font_context.rs
@@ -35,8 +35,6 @@ use crate::font_cache_thread::{
 };
 use crate::font_store::{CrossThreadFontStore, CrossThreadWebRenderFontStore};
 use crate::font_template::{FontTemplate, FontTemplateRef, FontTemplateRefMethods};
-#[cfg(target_os = "macos")]
-use crate::platform::core_text_font_cache::CoreTextFontCache;
 
 static SMALL_CAPS_SCALE_FACTOR: f32 = 0.8; // Matches FireFox (see gfxFont.h)
 

--- a/components/gfx/platform/macos/core_text_font_cache.rs
+++ b/components/gfx/platform/macos/core_text_font_cache.rs
@@ -98,9 +98,4 @@ impl CoreTextFontCache {
         identifier_cache.insert(au_size, core_text_font.clone());
         Some(core_text_font)
     }
-
-    pub(crate) fn clear_core_text_font_cache() {
-        let cache = CACHE.0.get_or_init(Default::default);
-        cache.write().clear();
-    }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
There are some build warnings about unused items on macOS. I suppose these are leftovers from font cache refactoring.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [x] These changes do not require tests because they are unused items.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
