### PR TITLE
minibrowser: Disables urlbar when in fullscreen

### DIFF
--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -171,7 +171,7 @@ impl Minibrowser {
         } = self;
         let widget_fbo = *widget_surface_fbo;
         let _duration = context.run(window, |ctx| {
-            // TODO: While in fullscreen add some way to mitigate the increased phishing risk when not dispalying the URL bar:
+            // TODO: While in fullscreen add some way to mitigate the increased phishing risk when not displaying the URL bar:
             // https://github.com/servo/servo/issues/32443
             // disables drawing the toolbar in fullscreen
             if !window.fullscreen().is_some() {

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -171,58 +171,63 @@ impl Minibrowser {
         } = self;
         let widget_fbo = *widget_surface_fbo;
         let _duration = context.run(window, |ctx| {
-            TopBottomPanel::top("toolbar").show(ctx, |ui| {
-                ui.allocate_ui_with_layout(
-                    ui.available_size(),
-                    egui::Layout::left_to_right(egui::Align::Center),
-                    |ui| {
-                        if ui.button("back").clicked() {
-                            event_queue.borrow_mut().push(MinibrowserEvent::Back);
-                        }
-                        if ui.button("forward").clicked() {
-                            event_queue.borrow_mut().push(MinibrowserEvent::Forward);
-                        }
-                        ui.allocate_ui_with_layout(
-                            ui.available_size(),
-                            egui::Layout::right_to_left(egui::Align::Center),
-                            |ui| {
-                                if ui.button("go").clicked() {
-                                    event_queue.borrow_mut().push(MinibrowserEvent::Go);
-                                    location_dirty.set(false);
-                                }
+            // disables drawing the toolbar in fullscreen
+            if !window.fullscreen().is_some() {
+                TopBottomPanel::top("toolbar").show(ctx, |ui| {
+                    ui.allocate_ui_with_layout(
+                        ui.available_size(),
+                        egui::Layout::left_to_right(egui::Align::Center),
+                        |ui| {
+                            if ui.button("back").clicked() {
+                                event_queue.borrow_mut().push(MinibrowserEvent::Back);
+                            }
+                            if ui.button("forward").clicked() {
+                                event_queue.borrow_mut().push(MinibrowserEvent::Forward);
+                            }
+                            ui.allocate_ui_with_layout(
+                                ui.available_size(),
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if ui.button("go").clicked() {
+                                        event_queue.borrow_mut().push(MinibrowserEvent::Go);
+                                        location_dirty.set(false);
+                                    }
 
-                                match self.load_status {
-                                    LoadStatus::LoadStart => {
-                                        ui.add(Spinner::new().color(Color32::GRAY));
-                                    },
-                                    LoadStatus::HeadParsed => {
-                                        ui.add(Spinner::new().color(Color32::WHITE));
-                                    },
-                                    LoadStatus::LoadComplete => { /* No Spinner */ },
-                                }
+                                    match self.load_status {
+                                        LoadStatus::LoadStart => {
+                                            ui.add(Spinner::new().color(Color32::GRAY));
+                                        },
+                                        LoadStatus::HeadParsed => {
+                                            ui.add(Spinner::new().color(Color32::WHITE));
+                                        },
+                                        LoadStatus::LoadComplete => { /* No Spinner */ },
+                                    }
 
-                                let location_field = ui.add_sized(
-                                    ui.available_size(),
-                                    egui::TextEdit::singleline(&mut *location.borrow_mut()),
-                                );
+                                    let location_field = ui.add_sized(
+                                        ui.available_size(),
+                                        egui::TextEdit::singleline(&mut *location.borrow_mut()),
+                                    );
 
-                                if location_field.changed() {
-                                    location_dirty.set(true);
-                                }
-                                if ui.input(|i| i.clone().consume_key(Modifiers::COMMAND, Key::L)) {
-                                    location_field.request_focus();
-                                }
-                                if location_field.lost_focus() &&
-                                    ui.input(|i| i.clone().key_pressed(Key::Enter))
-                                {
-                                    event_queue.borrow_mut().push(MinibrowserEvent::Go);
-                                    location_dirty.set(false);
-                                }
-                            },
-                        );
-                    },
-                );
-            });
+                                    if location_field.changed() {
+                                        location_dirty.set(true);
+                                    }
+                                    if ui.input(|i| {
+                                        i.clone().consume_key(Modifiers::COMMAND, Key::L)
+                                    }) {
+                                        location_field.request_focus();
+                                    }
+                                    if location_field.lost_focus() &&
+                                        ui.input(|i| i.clone().key_pressed(Key::Enter))
+                                    {
+                                        event_queue.borrow_mut().push(MinibrowserEvent::Go);
+                                        location_dirty.set(false);
+                                    }
+                                },
+                            );
+                        },
+                    );
+                });
+            };
 
             // The toolbar height is where the Context’s available rect starts.
             // For reasons that are unclear, the TopBottomPanel’s ui cursor exceeds this by one egui

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -171,9 +171,8 @@ impl Minibrowser {
         } = self;
         let widget_fbo = *widget_surface_fbo;
         let _duration = context.run(window, |ctx| {
-            // TODO: While in fullscreen add some way to mitigate the increased phishing risk when not displaying the URL bar:
-            // https://github.com/servo/servo/issues/32443
-            // disables drawing the toolbar in fullscreen
+            // TODO: While in fullscreen add some way to mitigate the increased phishing risk
+            // when not displaying the URL bar: https://github.com/servo/servo/issues/32443
             if !window.fullscreen().is_some() {
                 TopBottomPanel::top("toolbar").show(ctx, |ui| {
                     ui.allocate_ui_with_layout(

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -129,8 +129,8 @@ impl Minibrowser {
                 self.event_queue.borrow_mut().push(MinibrowserEvent::Back);
                 true
             },
-            winit::event::WindowEvent::MouseWheel { .. } |
-            winit::event::WindowEvent::MouseInput { .. } => self
+            winit::event::WindowEvent::MouseWheel { .. }
+            | winit::event::WindowEvent::MouseInput { .. } => self
                 .last_mouse_position
                 .map_or(false, |p| self.is_in_browser_rect(p)),
             _ => true,
@@ -171,6 +171,8 @@ impl Minibrowser {
         } = self;
         let widget_fbo = *widget_surface_fbo;
         let _duration = context.run(window, |ctx| {
+            // TODO: While in fullscreen add some way to mitigate the increased phishing risk when not dispalying the URL bar:
+            // https://github.com/servo/servo/issues/32443
             // disables drawing the toolbar in fullscreen
             if !window.fullscreen().is_some() {
                 TopBottomPanel::top("toolbar").show(ctx, |ui| {
@@ -216,8 +218,8 @@ impl Minibrowser {
                                     }) {
                                         location_field.request_focus();
                                     }
-                                    if location_field.lost_focus() &&
-                                        ui.input(|i| i.clone().key_pressed(Key::Enter))
+                                    if location_field.lost_focus()
+                                        && ui.input(|i| i.clone().key_pressed(Key::Enter))
                                     {
                                         event_queue.borrow_mut().push(MinibrowserEvent::Go);
                                         location_dirty.set(false);
@@ -264,10 +266,9 @@ impl Minibrowser {
                         x: width,
                         y: height,
                     } = ui.available_size();
-                    let rect = Box2D::from_origin_and_size(
-                        Point2D::new(x, y),
-                        Size2D::new(width, height),
-                    ) * scale;
+                    let rect =
+                        Box2D::from_origin_and_size(Point2D::new(x, y), Size2D::new(width, height))
+                            * scale;
                     if rect != webview.rect {
                         webview.rect = rect;
                         embedder_events
@@ -429,8 +430,8 @@ impl Minibrowser {
         //       because logical OR would short-circuit if any of the functions return true.
         //       We want to ensure that all functions are called. The "bitwise OR" operator
         //       does not short-circuit.
-        self.update_location_in_toolbar(browser) |
-            self.update_spinner_in_toolbar(browser) |
-            self.update_status_text(browser)
+        self.update_location_in_toolbar(browser)
+            | self.update_spinner_in_toolbar(browser)
+            | self.update_status_text(browser)
     }
 }

--- a/ports/servoshell/minibrowser.rs
+++ b/ports/servoshell/minibrowser.rs
@@ -129,8 +129,8 @@ impl Minibrowser {
                 self.event_queue.borrow_mut().push(MinibrowserEvent::Back);
                 true
             },
-            winit::event::WindowEvent::MouseWheel { .. }
-            | winit::event::WindowEvent::MouseInput { .. } => self
+            winit::event::WindowEvent::MouseWheel { .. } |
+            winit::event::WindowEvent::MouseInput { .. } => self
                 .last_mouse_position
                 .map_or(false, |p| self.is_in_browser_rect(p)),
             _ => true,
@@ -218,8 +218,8 @@ impl Minibrowser {
                                     }) {
                                         location_field.request_focus();
                                     }
-                                    if location_field.lost_focus()
-                                        && ui.input(|i| i.clone().key_pressed(Key::Enter))
+                                    if location_field.lost_focus() &&
+                                        ui.input(|i| i.clone().key_pressed(Key::Enter))
                                     {
                                         event_queue.borrow_mut().push(MinibrowserEvent::Go);
                                         location_dirty.set(false);
@@ -266,9 +266,10 @@ impl Minibrowser {
                         x: width,
                         y: height,
                     } = ui.available_size();
-                    let rect =
-                        Box2D::from_origin_and_size(Point2D::new(x, y), Size2D::new(width, height))
-                            * scale;
+                    let rect = Box2D::from_origin_and_size(
+                        Point2D::new(x, y),
+                        Size2D::new(width, height),
+                    ) * scale;
                     if rect != webview.rect {
                         webview.rect = rect;
                         embedder_events
@@ -430,8 +431,8 @@ impl Minibrowser {
         //       because logical OR would short-circuit if any of the functions return true.
         //       We want to ensure that all functions are called. The "bitwise OR" operator
         //       does not short-circuit.
-        self.update_location_in_toolbar(browser)
-            | self.update_spinner_in_toolbar(browser)
-            | self.update_status_text(browser)
+        self.update_location_in_toolbar(browser) |
+            self.update_spinner_in_toolbar(browser) |
+            self.update_status_text(browser)
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Disables the top url/toolbar when entering fullscreen via: `document.documentElement.requestFullscreen();`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #30347 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
[Asking](https://servo.zulipchat.com/#narrow/stream/263398-general/topic/Adding.20a.20test.20for.20small.20pr/near/441936183) about tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
