### PR TITLE
mach: Read .servobuild as utf-8

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -273,7 +273,7 @@ class CommandBase(object):
 
         config_path = path.join(context.topdir, ".servobuild")
         if path.exists(config_path):
-            with open(config_path) as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 self.config = toml.loads(f.read())
         else:
             self.config = {}


### PR DESCRIPTION
Without this on my windows machine  `open` seems to default to the `gbk` codec, and then fails to read the file if it contains Windows style paths (e.g. both `ndk = D:\my_path` or `ndk = D:\\my_path` cause the `f.read()` to fail ).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because: I think its safe to assume that `.servobuild` should be `utf-8` anyway.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
