### PR TITLE
layout: Don't default to fallback fonts for spaces

### DIFF
--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -386,7 +386,7 @@ fn char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character: ch
 /// character are not rendered at all, so it doesn't matter what font we use to render them. They
 /// should just be added to the current segment.
 fn char_does_not_change_font(character: char) -> bool {
-    if character.is_whitespace() || character.is_control() {
+    if character.is_control() {
         return true;
     }
     if character == '\u{00A0}' {

--- a/tests/wpt/meta/css/CSS2/fonts/fonts-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/fonts-012.xht.ini
@@ -1,2 +1,0 @@
-[fonts-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-face-unicode-range-2.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-unicode-range-2.html.ini
@@ -1,2 +1,0 @@
-[font-face-unicode-range-2.html]
-  expected: FAIL


### PR DESCRIPTION
Previously, when deciding the font for a space, preference was given to
the previous used font. This could means that the font chosen was a
fallback font instead of the first font that supporting the space
character in the font preference list.

This caused an issue rendering emojis surrounded by spaces with "Noto
Color Emoji" which has a space character the same size as the emoji,
leading to too much spacing between them.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes.
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
