### PR TITLE
Fix missing alpha value when using CompositeTarget::Fbo

### DIFF
--- a/components/compositing/gl.rs
+++ b/components/compositing/gl.rs
@@ -31,11 +31,11 @@ impl RenderTargetInfo {
         gl.tex_image_2d(
             gl::TEXTURE_2D,
             0,
-            gl::RGB as gl::GLint,
+            gl::RGBA as gl::GLint,
             width.get() as gl::GLsizei,
             height.get() as gl::GLsizei,
             0,
-            gl::RGB,
+            gl::RGBA,
             gl::UNSIGNED_BYTE,
             None,
         );


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When using `CompositeTarget::Fbo`, I noticed it could not be transparent, although the background color alpha is 0.
It turns out the texture we created is not in `RGBA` format.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no new features.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
