### PR TITLE
script: Remove explicit reflow for web font loads

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -182,7 +182,6 @@ pub enum ReflowReason {
     StylesheetLoaded,
     Timer,
     Viewport,
-    WebFontLoaded,
     WindowResize,
     WorkletLoaded,
 }

--- a/tests/wpt/meta-legacy-layout/css/CSS2/generated-content/before-after-dynamic-attr-001.xht.ini
+++ b/tests/wpt/meta-legacy-layout/css/CSS2/generated-content/before-after-dynamic-attr-001.xht.ini
@@ -1,3 +1,0 @@
-[before-after-dynamic-attr-001.xht]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
Instead of using an explicit reflow when a web font laods, queue a
pending reflow. This should be able to eliminate multiple reflows some
situations. A followup should ensure that only nodes that have pending
fonts loading are reflows, but this change is the first step.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
