### PR TITLE
Add a workaround for actions/runner-images#10001

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/head
           fetch-depth: 2
+      # Workaround for https://github.com/actions/runner-images/issues/10001:
+      - name: Upgrade llvm
+        run: choco upgrade llvm
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
       - name: Install taplo


### PR DESCRIPTION
Until GitHub updates their runner images, this workaround should allow
the bots to work.


See actions/runner-images#10001

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just update the CI infrastructure.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
