### PR TITLE
Don't shrink table columns when handling cells with greater spanning

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -433,8 +433,8 @@ impl<'a> TableLayout<'a> {
 
         for column_index in 0..self.table.size.width {
             let old_column_measure = &old_column_measures[column_index];
-            let mut new_column_content_sizes = ContentSizes::zero();
-            let mut new_column_intrinsic_percentage_width = Percentage(0.);
+            let mut new_column_content_sizes = old_column_measure.content_sizes;
+            let mut new_column_intrinsic_percentage_width = old_column_measure.percentage;
 
             for row_index in 0..self.table.size.height {
                 let coords = TableSlotCoordinates::new(column_index, row_index);

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-121.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-121.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-121.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-122.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-122.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-122.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-123.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-123.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-123.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-125.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-125.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-125.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-158.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/margin-collapse-158.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-158.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-color/hsl-clamp-negative-saturation.html.ini
+++ b/tests/wpt/meta/css/css-color/hsl-clamp-negative-saturation.html.ini
@@ -1,2 +1,0 @@
-[hsl-clamp-negative-saturation.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-color/hsla-clamp-negative-saturation.html.ini
+++ b/tests/wpt/meta/css/css-color/hsla-clamp-negative-saturation.html.ini
@@ -1,2 +1,0 @@
-[hsla-clamp-negative-saturation.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-color/t421-rgb-clip-outside-gamut-b.xht.ini
+++ b/tests/wpt/meta/css/css-color/t421-rgb-clip-outside-gamut-b.xht.ini
@@ -1,2 +1,0 @@
-[t421-rgb-clip-outside-gamut-b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-color/t422-rgba-clip-outside-device-gamut-b.xht.ini
+++ b/tests/wpt/meta/css/css-color/t422-rgba-clip-outside-device-gamut-b.xht.ini
@@ -1,2 +1,0 @@
-[t422-rgba-clip-outside-device-gamut-b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/colspan-004.html.ini
+++ b/tests/wpt/meta/css/css-tables/colspan-004.html.ini
@@ -1,2 +1,0 @@
-[colspan-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/column-track-merging.html.ini
+++ b/tests/wpt/meta/css/css-tables/column-track-merging.html.ini
@@ -22,6 +22,3 @@
 
   [main table 3]
     expected: FAIL
-
-  [main table 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/dynamic-rowspan-change.html.ini
+++ b/tests/wpt/meta/css/css-tables/dynamic-rowspan-change.html.ini
@@ -1,3 +1,0 @@
-[dynamic-rowspan-change.html]
-  [main table 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/height-distribution/computing-row-measure-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/height-distribution/computing-row-measure-1.html.ini
@@ -4,6 +4,3 @@
 
   [Checking intermediate min-content width for span 2 (1)]
     expected: FAIL
-
-  [Checking intermediate min-content width for span 2 (2)]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/colspan-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/colspan-redistribution.html.ini
@@ -79,6 +79,3 @@
 
   [table 8]
     expected: FAIL
-
-  [table 7]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/paint/background-image-column.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/paint/background-image-column.html.ini
@@ -1,2 +1,0 @@
-[background-image-column.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/paint/background-image-row.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/paint/background-image-row.html.ini
@@ -1,2 +1,0 @@
-[background-image-row.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/visibility-collapse-rowcol-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/visibility-collapse-rowcol-001.html.ini
@@ -1,3 +1,0 @@
-[visibility-collapse-rowcol-001.html]
-  [spanning col visibility:collapse changes table width]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/css/table_colspan_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/table_colspan_simple_a.html.ini
@@ -1,2 +1,0 @@
-[table_colspan_simple_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/table_colspan_spacing_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/table_colspan_spacing_a.html.ini
@@ -1,2 +1,0 @@
-[table_colspan_spacing_a.html]
-  expected: FAIL


### PR DESCRIPTION
For example:
```html
<table border="1">
  <tr>  <td></td>  <td></td>  </tr>
  <tr>  <td colspan="2"></td>  </tr>
</table>
```
We should initially size the columns according to the cells in the first row since they have a span of 1. Then we handle the cell in the second row with a span of 2, this should be able to increase the size of the columns, but never decrease them.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
