### PR TITLE
Fix and unify 'span' attribute for table columns

### DIFF
--- a/tests/wpt/meta/css/CSS2/backgrounds/background-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[background-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-color-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-color-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[background-color-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-image-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-image-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[background-image-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-position-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-position-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[background-position-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-position-applies-to-006a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-position-applies-to-006a.xht.ini
@@ -1,2 +1,0 @@
-[background-position-applies-to-006a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-repeat-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-repeat-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[background-repeat-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/containing-block-029.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/containing-block-029.xht.ini
@@ -1,2 +1,0 @@
-[containing-block-029.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/display-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/display-013.xht.ini
@@ -1,2 +1,0 @@
-[display-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-000.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c414-flt-fit-000.xht.ini
@@ -1,2 +1,0 @@
-[c414-flt-fit-000.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/vertical-align-baseline-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/vertical-align-baseline-003.xht.ini
@@ -1,2 +1,0 @@
-[vertical-align-baseline-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[width-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-017.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-018.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-018.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-018.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-019.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-019.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-019.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-020.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-020.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-020.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-021.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-021.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-021.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-022.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-022.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-022.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-023.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-023.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-023.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/paint/col-change-span-bg-invalidation-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/paint/col-change-span-bg-invalidation-001.html.ini
@@ -1,2 +1,0 @@
-[col-change-span-bg-invalidation-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/visibility-collapse-col-005.html.ini
+++ b/tests/wpt/meta/css/css-tables/visibility-collapse-col-005.html.ini
@@ -1,3 +1,0 @@
-[visibility-collapse-col-005.html]
-  [col visibility:collapse changes table width]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/visibility-collapse-rowcol-002.html.ini
+++ b/tests/wpt/meta/css/css-tables/visibility-collapse-rowcol-002.html.ini
@@ -1,3 +1,0 @@
-[visibility-collapse-rowcol-002.html]
-  [spanning row visibility:collapse doesn't change table width]
-    expected: FAIL


### PR DESCRIPTION
The attribute was only taken into account on columns that are immediate children of tables, and on column groups. It was ignored on columns within column groups.

This patch moves the logic into a helper function that is then called from the three consumers.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
