### PR TITLE
Minor cleanup of shell.nix

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -60,7 +60,7 @@ let
     GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${buildToolsVersion}/aapt2";
   };
 in
-stdenv.mkDerivation (androidEnvironment // rec {
+stdenv.mkDerivation (androidEnvironment // {
   name = "servo-env";
 
   buildInputs = [
@@ -111,7 +111,7 @@ stdenv.mkDerivation (androidEnvironment // rec {
         '';
         dontInstall = true;
       });
-    in (rustPlatform.buildRustPackage rec {
+    in (rustPlatform.buildRustPackage {
       name = "crown";
       src = ../support/crown;
       doCheck = false;
@@ -145,7 +145,7 @@ stdenv.mkDerivation (androidEnvironment // rec {
     androidSdk
   ]);
 
-  LIBCLANG_PATH = llvmPackages.clang-unwrapped.lib + "/lib/";
+  LIBCLANG_PATH = lib.makeLibraryPath [ llvmPackages.clang-unwrapped.lib ];
 
   # Allow cargo to download crates
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";


### PR DESCRIPTION
Clean up unused `rec` instances + tidied up `LIBCLANG_PATH` using `makeLibraryPath`.

- Removal of unused `rec`(ursive) instances
- used `makeLibraryPath` function instead of direct string concatenation for the variable
`LIBCLANG_PATH` to be cohesive with the other instances of such variables (line 158 for instance)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no modifications to anything outside shell.nix,  and I have tested that shell.nix works using nix-shell without throwing any errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
