### PR TITLE
clippy: fix some leftover warnings in components/net

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -413,7 +413,7 @@ pub async fn main_fetch(
 
         // Step 16.
         if internal_response.url_list.is_empty() {
-            internal_response.url_list = request.url_list.clone();
+            internal_response.url_list.clone_from(&request.url_list)
         }
 
         // Step 17.

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -328,14 +328,19 @@ fn create_cached_response(
             .unwrap()
             .push(done_sender);
     }
-    response.location_url = cached_resource.data.location_url.clone();
-    response.status = cached_resource.data.status.clone();
-    response.raw_status = cached_resource.data.raw_status.clone();
-    response.url_list = cached_resource.data.url_list.clone();
+    response
+        .location_url
+        .clone_from(&cached_resource.data.location_url);
+    response.status.clone_from(&cached_resource.data.status);
+    response
+        .raw_status
+        .clone_from(&cached_resource.data.raw_status);
+    response.url_list.clone_from(&cached_resource.data.url_list);
     response.https_state = cached_resource.data.https_state;
     response.referrer = request.referrer.to_url().cloned();
     response.referrer_policy = request.referrer_policy;
     response.aborted = cached_resource.aborted.clone();
+
     let expires = cached_resource.data.expires;
     let adjusted_expires = get_expiry_adjustment_from_request_headers(request, expires);
     let now = Duration::seconds(time::now().to_timespec().sec);
@@ -781,12 +786,18 @@ impl HttpCache {
                     resource_timing,
                 );
                 constructed_response.body = cached_resource.body.clone();
-                constructed_response.status = cached_resource.data.status.clone();
+                constructed_response
+                    .status
+                    .clone_from(&cached_resource.data.status);
                 constructed_response.https_state = cached_resource.data.https_state;
                 constructed_response.referrer = request.referrer.to_url().cloned();
                 constructed_response.referrer_policy = request.referrer_policy;
-                constructed_response.raw_status = cached_resource.data.raw_status.clone();
-                constructed_response.url_list = cached_resource.data.url_list.clone();
+                constructed_response
+                    .raw_status
+                    .clone_from(&cached_resource.data.raw_status);
+                constructed_response
+                    .url_list
+                    .clone_from(&cached_resource.data.url_list);
                 cached_resource.data.expires = get_response_expiry(&constructed_response);
                 let mut stored_headers = cached_resource.data.metadata.headers.lock().unwrap();
                 stored_headers.extend(response.headers);

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -226,7 +226,7 @@ impl StorageManager {
             .send(
                 data.get(&origin)
                     .and_then(|(_, entry)| entry.get(&name))
-                    .map(String::clone),
+                    .cloned(),
             )
             .unwrap();
     }


### PR DESCRIPTION
I was lurking around when I found some seems-easy-to-fix clippy warnings in `net` component.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
