### PR TITLE
clippy: Convert more uses of `clone()` + assignement to `clone_from()`

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -348,7 +348,7 @@ impl BrowsingContextActor {
         }
         *self.url.borrow_mut() = url.as_str().to_owned();
         if let Some(ref t) = title {
-            *self.title.borrow_mut() = t.clone();
+            self.title.borrow_mut().clone_from(t);
         }
 
         let msg = TabNavigated {

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -359,7 +359,7 @@ impl NetworkEventActor {
     }
 
     pub fn add_response(&mut self, response: DevtoolsHttpResponse) {
-        self.response.headers = response.headers.clone();
+        self.response.headers.clone_from(&response.headers);
         self.response.status = response.status.as_ref().map(|&(s, ref st)| {
             let status_text = String::from_utf8_lossy(st).into_owned();
             (StatusCode::from_u16(s).unwrap(), status_text)

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -823,10 +823,9 @@ fn perform_border_collapse_for_row(
 
     // Compute block-start borders.
     let block_start_borders = &mut child_table_row.final_collapsed_borders.block_start;
-    *block_start_borders = child_table_row
-        .preliminary_collapsed_borders
-        .block_start
-        .clone();
+
+    block_start_borders.clone_from(&child_table_row.preliminary_collapsed_borders.block_start);
+
     for (i, this_border) in block_start_borders.iter_mut().enumerate() {
         match previous_block_borders {
             PreviousBlockCollapsedBorders::FromPreviousRow(ref previous_block_borders) => {

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -944,7 +944,9 @@ pub fn propagate_column_inline_sizes_to_child(
                 column_computed_inline_sizes.to_vec();
             child_table_row_flow.spacing = *border_spacing;
             child_table_row_flow.table_writing_mode = table_writing_mode;
-            child_table_row_flow.incoming_rowspan = incoming_rowspan.clone();
+            child_table_row_flow
+                .incoming_rowspan
+                .clone_from(incoming_rowspan);
 
             // Update the incoming rowspan for the next row.
             let mut col = 0;

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -360,7 +360,8 @@ impl Flow for TableWrapperFlow {
             debug_assert!(kid.is_table_caption() || kid.is_table());
             if kid.is_table() {
                 let table = kid.as_table();
-                self.column_intrinsic_inline_sizes = table.column_intrinsic_inline_sizes.clone();
+                self.column_intrinsic_inline_sizes
+                    .clone_from(&table.column_intrinsic_inline_sizes)
             }
         }
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -86,7 +86,10 @@ impl<'a> AutoWorkerReset<'a> {
 
 impl<'a> Drop for AutoWorkerReset<'a> {
     fn drop(&mut self) {
-        *self.workerscope.worker.borrow_mut() = self.old_worker.clone();
+        self.workerscope
+            .worker
+            .borrow_mut()
+            .clone_from(&self.old_worker)
     }
 }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -954,7 +954,9 @@ impl HTMLImageElement {
         };
 
         // Step 5
-        *self.last_selected_source.borrow_mut() = selected_source.clone();
+        self.last_selected_source
+            .borrow_mut()
+            .clone_from(&selected_source);
 
         // Step 6, check the list of available images
         if let Some(src) = selected_source {

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -324,7 +324,10 @@ impl MutationObserverMethods for MutationObserver {
                 registered.options.character_data_old_value = character_data_old_value;
                 registered.options.child_list = child_list;
                 registered.options.subtree = subtree;
-                registered.options.attribute_filter = attribute_filter.clone();
+                registered
+                    .options
+                    .attribute_filter
+                    .clone_from(&attribute_filter);
                 replaced = true;
             }
             !replaced

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -336,9 +336,15 @@ impl ResponseMethods for Response {
         // only store the relevant fields, and only clone them here
         *new_response.response_type.borrow_mut() = *self.response_type.borrow();
         *new_response.status.borrow_mut() = *self.status.borrow();
-        *new_response.raw_status.borrow_mut() = self.raw_status.borrow().clone();
-        *new_response.url.borrow_mut() = self.url.borrow().clone();
-        *new_response.url_list.borrow_mut() = self.url_list.borrow().clone();
+        new_response
+            .raw_status
+            .borrow_mut()
+            .clone_from(&self.raw_status.borrow());
+        new_response.url.borrow_mut().clone_from(&self.url.borrow());
+        new_response
+            .url_list
+            .borrow_mut()
+            .clone_from(&self.url_list.borrow());
 
         if let Some(stream) = self.body_stream.get().clone() {
             new_response.body_stream.set(Some(&*stream));

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -961,7 +961,7 @@ impl WebGLFramebuffer {
             return Err(WebGLError::InvalidOperation);
         }
 
-        *self.color_draw_buffers.borrow_mut() = buffers.clone();
+        self.color_draw_buffers.borrow_mut().clone_from(&buffers);
         context.send_command(WebGLCommand::DrawBuffers(buffers));
         Ok(())
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -161,7 +161,7 @@ pub fn Fetch(
     let timing_type = request.timing_type();
 
     let mut request_init = request_init_from_request(request);
-    request_init.csp_list = global.get_csp_list().clone();
+    request_init.csp_list.clone_from(&global.get_csp_list());
 
     // Step 3
     if global.downcast::<ServiceWorkerGlobalScope>().is_some() {

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -304,11 +304,11 @@ impl Response {
                     .map(|v| v.into())
                     .as_ref(),
             );
-            metadata.location_url = response.location_url.clone();
+            metadata.location_url.clone_from(&response.location_url);
             metadata.headers = Some(Serde(response.headers.clone()));
-            metadata.status = response.raw_status.clone();
+            metadata.status.clone_from(&response.raw_status);
             metadata.https_state = response.https_state;
-            metadata.referrer = response.referrer.clone();
+            metadata.referrer.clone_from(&response.referrer);
             metadata.referrer_policy = response.referrer_policy;
             metadata.redirected = response.actual_response().url_list.len() > 1;
             metadata


### PR DESCRIPTION
Encouraged by the last successful clippy fixes, I checked all other `clone_from` clippy issues.
Namely 17 chunks of current 165 clippy issues. (~ 10%)

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500
