### PR TITLE
layout: Linebreak the entire InlineFormattingContext at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "gfx",
  "gfx_traits",
  "html5ever",
+ "icu_segmenter",
  "ipc-channel",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ http = "0.2"
 hyper = "0.14"
 hyper-rustls = { version = "0.24", default-features = false, features = ["acceptor", "http1", "http2", "logging", "tls12", "webpki-tokio"] }
 hyper_serde = { path = "components/hyper_serde" }
+icu_segmenter = "1.5.0"
 image = "0.24"
 imsz = "0.2"
 indexmap = { version = "2.2.6", features = ["std"] }

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [lib]
 name = "layout_2020"
 path = "lib.rs"
-test = false
+test = true
 doctest = false
 
 [dependencies]
@@ -26,6 +26,7 @@ fxhash = { workspace = true }
 gfx = { path = "../gfx" }
 gfx_traits = { workspace = true }
 html5ever = { workspace = true }
+icu_segmenter = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
 net_traits = { workspace = true }

--- a/components/layout_2020/flow/inline/construct.rs
+++ b/components/layout_2020/flow/inline/construct.rs
@@ -131,8 +131,16 @@ impl InlineFormattingContextBuilder {
             ArcRefCell::new(InlineLevelBox::Atomic(independent_formatting_context));
         self.current_inline_level_boxes()
             .push(inline_level_box.clone());
+
+        // Push an object replacement character for this atomic, which will ensure that the line breaker
+        // inserts a line breaking opportunity here.
+        let string_to_push = "\u{fffc}";
+        self.text_segments.push(string_to_push.to_owned());
+        self.current_text_offset += string_to_push.len();
+
         self.last_inline_box_ended_with_collapsible_white_space = false;
         self.on_word_boundary = true;
+
         inline_level_box
     }
 

--- a/components/layout_2020/flow/inline/line_breaker.rs
+++ b/components/layout_2020/flow/inline/line_breaker.rs
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ops::Range;
+
+use icu_segmenter::LineSegmenter;
+
+pub(crate) struct LineBreaker {
+    linebreaks: Vec<usize>,
+    current_offset: usize,
+}
+
+impl LineBreaker {
+    pub(crate) fn new(string: &str) -> Self {
+        let line_segmenter = LineSegmenter::new_auto();
+        Self {
+            // From https://docs.rs/icu_segmenter/1.5.0/icu_segmenter/struct.LineSegmenter.html
+            // > For consistency with the grapheme, word, and sentence segmenters, there is always a
+            // > breakpoint returned at index 0, but this breakpoint is not a meaningful line break
+            // > opportunity.
+            //
+            // Skip this first line break opportunity, as it isn't interesting to us.
+            linebreaks: line_segmenter.segment_str(string).skip(1).collect(),
+            current_offset: 0,
+        }
+    }
+
+    pub(crate) fn advance_to_linebreaks_in_range(&mut self, text_range: Range<usize>) -> &[usize] {
+        let linebreaks_in_range = self.linebreaks_in_range_after_current_offset(text_range);
+        self.current_offset = linebreaks_in_range.end;
+        &self.linebreaks[linebreaks_in_range]
+    }
+
+    fn linebreaks_in_range_after_current_offset(&self, text_range: Range<usize>) -> Range<usize> {
+        assert!(text_range.start <= text_range.end);
+
+        let mut linebreaks_range = self.current_offset..self.linebreaks.len();
+
+        while self.linebreaks[linebreaks_range.start] < text_range.start &&
+            linebreaks_range.len() > 1
+        {
+            linebreaks_range.start += 1;
+        }
+
+        let mut ending_linebreak_index = linebreaks_range.start;
+        while self.linebreaks[ending_linebreak_index] < text_range.end &&
+            ending_linebreak_index < self.linebreaks.len() - 1
+        {
+            ending_linebreak_index += 1;
+        }
+        linebreaks_range.end = ending_linebreak_index;
+        linebreaks_range
+    }
+}
+
+#[test]
+fn test_linebreaker_ranges() {
+    let linebreaker = LineBreaker::new("abc def");
+    assert_eq!(linebreaker.linebreaks, [4, 7]);
+    assert_eq!(
+        linebreaker.linebreaks_in_range_after_current_offset(0..5),
+        0..1
+    );
+    // The last linebreak should not be included for the text range we are interested in.
+    assert_eq!(
+        linebreaker.linebreaks_in_range_after_current_offset(0..7),
+        0..1
+    );
+
+    let linebreaker = LineBreaker::new("abc d def");
+    assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+    assert_eq!(
+        linebreaker.linebreaks_in_range_after_current_offset(0..5),
+        0..1
+    );
+    assert_eq!(
+        linebreaker.linebreaks_in_range_after_current_offset(0..7),
+        0..2
+    );
+    assert_eq!(
+        linebreaker.linebreaks_in_range_after_current_offset(0..9),
+        0..2
+    );
+
+    assert_eq!(
+        linebreaker.linebreaks_in_range_after_current_offset(4..9),
+        0..2
+    );
+
+    std::panic::catch_unwind(|| {
+        let linebreaker = LineBreaker::new("abc def");
+        linebreaker.linebreaks_in_range_after_current_offset(5..2);
+    })
+    .expect_err("Reversed range should cause an assertion failure.");
+}
+
+#[test]
+fn test_linebreaker_stateful_advance() {
+    let mut linebreaker = LineBreaker::new("abc d def");
+    assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+    assert!(linebreaker.advance_to_linebreaks_in_range(0..7) == &[4, 6]);
+    assert!(linebreaker.advance_to_linebreaks_in_range(8..9).is_empty());
+
+    // We've already advanced, so a range from the beginning shouldn't affect things.
+    assert!(linebreaker.advance_to_linebreaks_in_range(0..9).is_empty());
+
+    linebreaker.current_offset = 0;
+
+    // Sending a value out of range shoudn't break things.
+    assert!(linebreaker.advance_to_linebreaks_in_range(0..999) == &[4, 6]);
+
+    linebreaker.current_offset = 0;
+
+    std::panic::catch_unwind(|| {
+        let mut linebreaker = LineBreaker::new("abc d def");
+        linebreaker.advance_to_linebreaks_in_range(2..0);
+    })
+    .expect_err("Reversed range should cause an assertion failure.");
+}

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -70,6 +70,7 @@
 
 pub mod construct;
 pub mod line;
+mod line_breaker;
 pub mod text_run;
 
 use std::cell::OnceCell;
@@ -84,6 +85,7 @@ use line::{
     layout_line_items, AbsolutelyPositionedLineItem, AtomicLineItem, FloatLineItem,
     InlineBoxLineItem, LineItem, LineItemLayoutState, LineMetrics, TextRunLineItem,
 };
+use line_breaker::LineBreaker;
 use serde::Serialize;
 use servo_arc::Arc;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
@@ -1593,13 +1595,13 @@ impl InlineFormattingContext {
         let text_content: String = builder.text_segments.into_iter().collect();
         let mut font_metrics = Vec::new();
 
-        let mut linebreaker = None;
+        let mut new_linebreaker = LineBreaker::new(text_content.as_str());
         inline_formatting_context.foreach(|iter_item| match iter_item {
             InlineFormattingContextIterItem::Item(InlineLevelBox::TextRun(ref mut text_run)) => {
-                text_run.break_and_shape(
-                    &text_content[text_run.text_range.clone()],
+                text_run.segment_and_shape(
+                    &text_content,
                     &layout_context.font_context,
-                    &mut linebreaker,
+                    &mut new_linebreaker,
                     &mut font_metrics,
                 );
             },

--- a/tests/wpt/meta/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-015.html.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-015.html.ini
@@ -1,0 +1,2 @@
+[line-break-anywhere-overrides-uax-behavior-015.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-break/line-break-normal-015b.xht.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-normal-015b.xht.ini
@@ -1,2 +1,0 @@
-[line-break-normal-015b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-break/line-break-strict-015b.xht.ini
+++ b/tests/wpt/meta/css/css-text/line-break/line-break-strict-015b.xht.ini
@@ -1,2 +1,0 @@
-[line-break-strict-015b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-013.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-013.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-014.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-014.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-021.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-021.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-021.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-024.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-024.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-024.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-025.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-025.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-025.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-026.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-026.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-026.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-027.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-027.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-027.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-010.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-010.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-011.html.ini
+++ b/tests/wpt/meta/css/css-text/line-breaking/line-breaking-atomic-011.html.ini
@@ -1,2 +1,0 @@
-[line-breaking-atomic-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-001-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-001-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-001-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-002-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-002-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-002-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-003-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-003-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-003-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-008-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-008-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-008-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-009-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-009-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-009-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-010-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-010-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-010-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-011-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-011-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-011-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-014-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-014-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-014-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-016-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-016-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-016-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-020-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-020-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-020-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-021-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-021-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-021-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/reference/shaping-022-ref.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/reference/shaping-022-ref.html.ini
@@ -1,2 +1,0 @@
-[shaping-022-ref.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-001.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-001.html.ini
@@ -1,0 +1,2 @@
+[shaping-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-002.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-002.html.ini
@@ -1,0 +1,2 @@
+[shaping-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-003.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-003.html.ini
@@ -1,0 +1,2 @@
+[shaping-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-008.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-008.html.ini
@@ -1,0 +1,2 @@
+[shaping-008.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-014.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-014.html.ini
@@ -1,0 +1,2 @@
+[shaping-014.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-016.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-016.html.ini
@@ -1,0 +1,2 @@
+[shaping-016.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-017.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-017.html.ini
@@ -1,0 +1,2 @@
+[shaping-017.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-018.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-018.html.ini
@@ -1,0 +1,2 @@
+[shaping-018.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-020.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-020.html.ini
@@ -1,0 +1,2 @@
+[shaping-020.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-021.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-021.html.ini
@@ -1,0 +1,2 @@
+[shaping-021.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-022.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-022.html.ini
@@ -1,0 +1,2 @@
+[shaping-022.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-023.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-023.html.ini
@@ -1,0 +1,2 @@
+[shaping-023.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-024.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-024.html.ini
@@ -1,0 +1,2 @@
+[shaping-024.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-025.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-025.html.ini
@@ -1,0 +1,2 @@
+[shaping-025.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-manual-001.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-manual-001.html.ini
@@ -1,0 +1,2 @@
+[word-break-manual-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-normal-002.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-normal-002.html.ini
@@ -1,2 +1,0 @@
-[word-break-normal-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-normal-003.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-normal-003.html.ini
@@ -1,2 +1,0 @@
-[word-break-normal-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-normal-th-000.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-normal-th-000.html.ini
@@ -1,2 +1,0 @@
-[word-break-normal-th-000.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/word-break/word-break-normal-th-001.html.ini
+++ b/tests/wpt/meta/css/css-text/word-break/word-break-normal-th-001.html.ini
@@ -1,2 +1,0 @@
-[word-break-normal-th-001.html]
-  expected: FAIL


### PR DESCRIPTION
Instead of linebreaking inside each single-font text segment, linebreak
the entire inline formatting context at once. This has several benefits:

1. It allows us to use `icu_segmenter` (already in use from style),
   which is written against a newer version of the Unicode spec --
   preventing breaking emoji clusters.
2. Opens up the possibility of changing the way that linebreaking and
   shaping work -- eventually allowing shaping across inline box
   boundaries and line breaking *after* shaping.

Some tests start to fail:
 - A large portion of the unexpected results is that the linebreaker no longer seems to be putting a soft line break opportunity after the zero-width joiner. This causes the Arabic ('ع') character to render differently when it's shaped together with a zero-width joiner and no followup character. This happens in tests because the character that it is supposed to join with is in a different inline box and we do not shape across inline box boundaries. So, in summary, changes in the line breaker are causing tests that were passing by accident to start failing, when they should have been failing all along.
 - Some tests fail because we do not support `line-break: anywhere` and `word-break: manual`.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
