### PR TITLE
mach: Use `cargo rustc` instead of `cargo build`

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -99,7 +99,7 @@ class MachCommands(CommandBase):
                 print((key, env[key]))
 
         status = self.run_cargo_build_like_command(
-            "build", opts, env=env, verbose=verbose, **kwargs)
+            "rustc", opts, env=env, verbose=verbose, **kwargs)
 
         if status == 0:
             built_binary = self.get_binary_path(


### PR DESCRIPTION
This allows passing `--crate-type` and rustflags which only apply to the top-level-crate.
The former is useful to merge the android and ohos apps into servoshell, while the later may be useful in the future.

`cargo rustc` should be a superset of `cargo build` and I don't expect anything to break by switching to it - but servo is a large project with a complex build system, so I'd like to keep this as a seperate PR so we can be sure this doesn't break anything.
