### PR TITLE
layout: Allocate inline box start space on segment

### DIFF
--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -771,18 +771,6 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
                 .map(|index| &self.fonts[index].metrics),
         );
 
-        if inline_box.is_first_fragment {
-            self.current_line.inline_position += Length::from(
-                inline_box_state.pbm.padding.inline_start +
-                    inline_box_state.pbm.border.inline_start,
-            ) + inline_box_state
-                .pbm
-                .margin
-                .inline_start
-                .auto_is(Au::zero)
-                .into()
-        }
-
         // If we are starting a `<br>` element prepare to clear after its deferred linebreak has been
         // processed. Note that a `<br>` is composed of the element itself and the inner pseudo-element
         // with the actual linebreak. Both will have this `FragmentFlag`; that's why this code only
@@ -794,6 +782,18 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
             self.deferred_br_clear == Clear::None
         {
             self.deferred_br_clear = inline_box_state.base.style.clone_clear();
+        }
+
+        if inline_box.is_first_fragment {
+            self.current_line_segment.inline_size += Length::from(
+                inline_box_state.pbm.padding.inline_start +
+                    inline_box_state.pbm.border.inline_start,
+            ) + inline_box_state
+                .pbm
+                .margin
+                .inline_start
+                .auto_is(Au::zero)
+                .into()
         }
 
         let line_item = inline_box_state

--- a/tests/wpt/tests/css/CSS2/normal-flow/inline-box-border-line-break-ref.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/inline-box-border-line-break-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <link
+    rel="help"
+    href="https://drafts.csswg.org/css2/#inline-formatting"
+  />
+  <link rel="help" href="https://github.com/servo/servo/pull/32486" />
+  <link rel="author" href="mrobinson@igalia.com" />
+  <link rel="author" href="atbrakhi@igalia.com" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <body>
+
+    <div style="width: 80px; outline: solid 1px black; font: 20px/1 Ahem;">
+      xx
+      <div style="display: inline-block; padding-left: 50px;">x</div>
+       xx
+    </div>
+
+  </body>
+</html>
+
+

--- a/tests/wpt/tests/css/CSS2/normal-flow/inline-box-border-line-break.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/inline-box-border-line-break.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <link
+    rel="help"
+    href="https://drafts.csswg.org/css2/#inline-formatting"
+  />
+  <link rel="help" href="https://github.com/servo/servo/pull/32486" />
+  <link rel="author" href="mrobinson@igalia.com" />
+  <link rel="author" href="atbrakhi@igalia.com" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <meta name="assert" content="Inline borders should cause content that follows to wrap." />
+  <link rel="match" href="inline-box-border-line-break-ref.html" />
+  <body>
+
+    <div style="width: 80px; outline: solid 1px black; font: 20px/1 Ahem;">
+      xx
+      <!- The left border on this span should trigger a line break before the
+          final xx. -->
+      <span style="border-left: 50px solid transparent">x</span>
+      xx
+    </div>
+
+  </body>
+</html>
+
+

--- a/tests/wpt/tests/css/CSS2/normal-flow/inline-box-padding-line-break.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/inline-box-padding-line-break.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <link
+    rel="help"
+    href="https://drafts.csswg.org/css2/#inline-formatting"
+  />
+  <link rel="help" href="https://github.com/servo/servo/pull/32486" />
+  <link rel="author" href="mrobinson@igalia.com" />
+  <link rel="author" href="atbrakhi@igalia.com" />
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <meta name="assert" content="Inline padding should cause content that follows to wrap." />
+  <link rel="match" href="inline-box-border-line-break-ref.html" />
+  <body>
+
+    <div style="width: 80px; outline: solid 1px black; font: 20px/1 Ahem;">
+      xx
+      <!- The left padding on this span should trigger a line break before the
+          final xx. -->
+      <span style="padding-left: 50px;">x</span>
+      xx
+    </div>
+
+  </body>
+</html>
+
+


### PR DESCRIPTION
Instead of allocating the inline padding and border space on the line,
allocate it on the segment -- which where the inline box start goes.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
