### PR TITLE
layout: Simplify `Contents` a little

### DIFF
--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use servo_arc::Arc;
@@ -401,7 +401,7 @@ where
             DisplayInside::Flow {
                 is_list_item: false,
             },
-            Contents::OfPseudoElement(contents),
+            NonReplacedContents::OfPseudoElement(contents).into(),
             BoxSlot::dummy(),
         );
     }
@@ -494,8 +494,8 @@ where
         }
 
         let propagated_text_decoration_line = self.text_decoration_line;
-        let kind = match contents.try_into() {
-            Ok(contents) => match display_inside {
+        let kind = match contents {
+            Contents::NonReplaced(contents) => match display_inside {
                 DisplayInside::Flow { is_list_item }
                     if !info.style.establishes_block_formatting_context() =>
                 {
@@ -513,7 +513,7 @@ where
                     propagated_text_decoration_line,
                 },
             },
-            Err(contents) => {
+            Contents::Replaced(contents) => {
                 let contents = Contents::Replaced(contents);
                 BlockLevelCreator::Independent {
                     display_inside,

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -18,7 +18,7 @@ use webrender_traits::display_list::ScrollSensitivity;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
-use crate::dom_traversal::{iter_child_nodes, Contents, NodeAndStyleInfo};
+use crate::dom_traversal::{iter_child_nodes, Contents, NodeAndStyleInfo, NonReplacedContents};
 use crate::flexbox::FlexLevelBox;
 use crate::flow::float::FloatBox;
 use crate::flow::inline::InlineItem;
@@ -206,7 +206,7 @@ impl BoxTree {
         loop {
             if let Some((primary_style, display_inside, update_point)) = update_point(dirty_node) {
                 let contents = ReplacedContent::for_element(dirty_node, context)
-                    .map_or(Contents::OfElement, Contents::Replaced);
+                    .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
                 let info = NodeAndStyleInfo::new(dirty_node, Arc::clone(&primary_style));
                 let out_of_flow_absolutely_positioned_box = ArcRefCell::new(
                     AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),
@@ -264,7 +264,7 @@ fn construct_for_root_element<'dom>(
     };
 
     let contents = ReplacedContent::for_element(root_element, context)
-        .map_or(Contents::OfElement, Contents::Replaced);
+        .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
     let root_box = if box_style.position.is_absolutely_positioned() {
         BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
             AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::convert::TryInto;
-
 use app_units::Au;
 use serde::Serialize;
 use servo_arc::Arc;
@@ -92,8 +90,8 @@ impl IndependentFormattingContext {
         contents: Contents,
         propagated_text_decoration_line: TextDecorationLine,
     ) -> Self {
-        match contents.try_into() {
-            Ok(non_replaced_contents) => {
+        match contents {
+            Contents::NonReplaced(non_replaced_contents) => {
                 let contents = match display_inside {
                     DisplayInside::Flow { is_list_item } |
                     DisplayInside::FlowRoot { is_list_item } => {
@@ -131,7 +129,7 @@ impl IndependentFormattingContext {
                     contents,
                 })
             },
-            Err(contents) => {
+            Contents::Replaced(contents) => {
                 let mut base_fragment_info: BaseFragmentInfo = node_and_style_info.into();
                 base_fragment_info.flags.insert(FragmentFlags::IS_REPLACED);
                 Self::Replaced(ReplacedFormattingContext {


### PR DESCRIPTION
Instead of duplicating some of `NonReplacedContents` in `Contents`,
divide it into either replaced and non-replaced content, since this is
how the layout system processes `Contents` always. In addition, stop
using `TryInto` to match replaced or non-replaced contents, as it is
quite confusing to handle an `Err` as a success case.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
