### PR TITLE
fonts: Respect emoji variation selector when selecting fonts

### DIFF
--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -89,8 +89,8 @@ impl FontTemplateDescriptor {
         // a mismatch between the desired and actual glyph presentation (emoji vs text)
         // will take precedence over any of the style attributes.
         //
-        // TODO: Take into account Unicode presentation preferences here, in order to properly
-        // choose a font for emoji clusters that start with non-emoji characters.
+        // Also relevant for font selection is the emoji presentation preference, but this
+        // is handled later when filtering fonts based on the glyphs they contain.
         const STRETCH_FACTOR: f32 = 1.0e8;
         const STYLE_FACTOR: f32 = 1.0e4;
         const WEIGHT_FACTOR: f32 = 1.0e0;

--- a/components/gfx/platform/freetype/font_list.rs
+++ b/components/gfx/platform/freetype/font_list.rs
@@ -35,7 +35,7 @@ use super::c_str_to_string;
 use crate::font::map_platform_values_to_style_values;
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};
 use crate::platform::add_noto_fallback_families;
-use crate::text::FallbackFontSelectionOptions;
+use crate::text::{EmojiPresentationPreference, FallbackFontSelectionOptions};
 
 /// An identifier for a local font on systems using Freetype.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
@@ -204,7 +204,7 @@ pub static SANS_SERIF_FONT_FAMILY: &str = "DejaVu Sans";
 // Based on gfxPlatformGtk::GetCommonFallbackFonts() in Gecko
 pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'static str> {
     let mut families = Vec::new();
-    if options.prefer_emoji_presentation {
+    if options.presentation_preference == EmojiPresentationPreference::Emoji {
         families.push("Noto Color Emoji");
     }
 

--- a/components/gfx/platform/macos/font_list.rs
+++ b/components/gfx/platform/macos/font_list.rs
@@ -17,7 +17,7 @@ use webrender_api::NativeFontHandle;
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};
 use crate::platform::add_noto_fallback_families;
 use crate::platform::font::CoreTextFontTraitsMapping;
-use crate::text::FallbackFontSelectionOptions;
+use crate::text::{EmojiPresentationPreference, FallbackFontSelectionOptions};
 
 /// An identifier for a local font on a MacOS system. These values comes from the CoreText
 /// CTFontCollection. Note that `path` here is required. We do not load fonts that do not
@@ -97,7 +97,7 @@ pub fn system_default_family(_generic_name: &str) -> Option<String> {
 /// <https://searchfox.org/mozilla-central/source/gfx/thebes/gfxPlatformMac.cpp>.
 pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'static str> {
     let mut families = Vec::new();
-    if options.prefer_emoji_presentation {
+    if options.presentation_preference == EmojiPresentationPreference::Emoji {
         families.push("Apple Color Emoji");
     }
 

--- a/components/gfx/platform/windows/font_list.rs
+++ b/components/gfx/platform/windows/font_list.rs
@@ -13,7 +13,7 @@ use style::values::computed::{FontStyle as StyleFontStyle, FontWeight as StyleFo
 use style::values::specified::font::FontStretchKeyword;
 
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};
-use crate::text::FallbackFontSelectionOptions;
+use crate::text::{EmojiPresentationPreference, FallbackFontSelectionOptions};
 
 pub static SANS_SERIF_FONT_FAMILY: &str = "Arial";
 
@@ -92,8 +92,7 @@ where
 // Based on gfxWindowsPlatform::GetCommonFallbackFonts() in Gecko
 pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'static str> {
     let mut families = Vec::new();
-
-    if options.prefer_emoji_presentation {
+    if options.presentation_preference == EmojiPresentationPreference::Emoji {
         families.push("Segoe UI Emoji");
     }
 

--- a/components/gfx/text/mod.rs
+++ b/components/gfx/text/mod.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use unicode_properties::{emoji, UnicodeEmoji};
+use unicode_properties::{emoji, EmojiStatus, UnicodeEmoji};
 
 pub use crate::text::shaping::Shaper;
 
@@ -10,31 +10,59 @@ pub mod glyph;
 pub mod shaping;
 pub mod util;
 
+/// Whether or not font fallback selection prefers the emoji or text representation
+/// of a character. If `None` then either presentation is acceptable.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EmojiPresentationPreference {
+    None,
+    Text,
+    Emoji,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct FallbackFontSelectionOptions {
     pub character: char,
-    pub prefer_emoji_presentation: bool,
+    pub presentation_preference: EmojiPresentationPreference,
 }
 
 impl Default for FallbackFontSelectionOptions {
     fn default() -> Self {
         Self {
             character: ' ',
-            prefer_emoji_presentation: false,
+            presentation_preference: EmojiPresentationPreference::None,
         }
     }
 }
 
 impl FallbackFontSelectionOptions {
     pub fn new(character: char, next_character: Option<char>) -> Self {
-        let prefer_emoji_presentation = match next_character {
-            Some(next_character) if emoji::is_emoji_presentation_selector(next_character) => true,
-            Some(next_character) if emoji::is_text_presentation_selector(next_character) => false,
-            _ => character.is_emoji_char(),
+        let presentation_preference = match next_character {
+            Some(next_character) if emoji::is_emoji_presentation_selector(next_character) => {
+                EmojiPresentationPreference::Emoji
+            },
+            Some(next_character) if emoji::is_text_presentation_selector(next_character) => {
+                EmojiPresentationPreference::Text
+            },
+            // We don't want to select emoji prsentation for any possible character that might be an emoji, because
+            // that includes characters such as '0' that are also used outside of emoji clusters. Instead, only
+            // select the emoji font for characters that explicitly have an emoji presentation (in the absence
+            // of the emoji presentation selectors above).
+            _ if matches!(
+                character.emoji_status(),
+                EmojiStatus::EmojiPresentation |
+                    EmojiStatus::EmojiPresentationAndModifierBase |
+                    EmojiStatus::EmojiPresentationAndEmojiComponent |
+                    EmojiStatus::EmojiPresentationAndModifierAndEmojiComponent
+            ) =>
+            {
+                EmojiPresentationPreference::Emoji
+            },
+            _ if character.is_emoji_char() => EmojiPresentationPreference::Text,
+            _ => EmojiPresentationPreference::None,
         };
         Self {
             character,
-            prefer_emoji_presentation,
+            presentation_preference,
         }
     }
 }

--- a/tests/wpt/meta/css/css-fonts/font-variant-emoji-1.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variant-emoji-1.html.ini
@@ -1,2 +1,0 @@
-[font-variant-emoji-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-variant-emoji-2.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variant-emoji-2.html.ini
@@ -1,0 +1,2 @@
+[font-variant-emoji-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-capitalize-026.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-capitalize-026.html.ini
@@ -1,2 +1,0 @@
-[text-transform-capitalize-026.html]
-  expected: FAIL


### PR DESCRIPTION
This uses a pretty simple heuristic to select a font likely to contain
color emoji. In the future Servo should actually check if the font also
contains a color representation of the character in question. For now
the code assumes that when a font supports color glyphs of some kind and
supports the character in question at all, it supports the color
version.

This fixes support for rendering keycap emoji clusters such as 1️⃣ .

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #17267.
- [x] These changes do not require tests because emoji rendering is quite hard to test, but we verified that this improves the "emoji-list.html" manual test.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
