### PR TITLE
build: Fix build warnings on Windows

### DIFF
--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -43,13 +43,17 @@ pub struct Registers {
     pub frame_ptr: Address,
 }
 
+#[allow(dead_code)]
 pub struct NativeStack {
     instruction_ptrs: [*mut std::ffi::c_void; MAX_NATIVE_FRAMES],
+    #[allow(dead_code)]
     stack_ptrs: [*mut std::ffi::c_void; MAX_NATIVE_FRAMES],
+    #[allow(dead_code)]
     count: usize,
 }
 
 impl NativeStack {
+    #[allow(dead_code)]
     pub fn new() -> Self {
         NativeStack {
             instruction_ptrs: [ptr::null_mut(); MAX_NATIVE_FRAMES],
@@ -58,6 +62,7 @@ impl NativeStack {
         }
     }
 
+    #[allow(dead_code)]
     pub fn process_register(
         &mut self,
         instruction_ptr: *mut std::ffi::c_void,

--- a/components/constellation/sandboxing.rs
+++ b/components/constellation/sandboxing.rs
@@ -243,6 +243,7 @@ fn setup_common<C: CommandMethods>(command: &mut C, token: String) {
 }
 
 /// A trait to unify commands launched as multiprocess with or without a sandbox.
+#[allow(dead_code)]
 trait CommandMethods {
     /// A command line argument.
     fn arg<T>(&mut self, arg: T)

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -831,6 +831,7 @@ impl FontFamilyDescriptor {
 /// ];
 /// let mapped_weight = apply_font_config_to_style_mapping(&mapping, weight as f64);
 /// ```
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value: f64) -> f64 {
     if value < mapping[0].0 {
         return mapping[0].1;

--- a/components/gfx/platform/mod.rs
+++ b/components/gfx/platform/mod.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use unicode_script::Script;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -11,6 +13,7 @@ pub use crate::platform::freetype::{font, font_list, library_handle};
 pub use crate::platform::macos::{core_text_font_cache, font, font_list};
 #[cfg(target_os = "windows")]
 pub use crate::platform::windows::{font, font_list};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::text::FallbackFontSelectionOptions;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
Disable some code for Windows, which is causing build warnings. When it
cannot be easily disabled (mainly for the incomplete BHM and sandbox
feature), allow dead code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
