### PR TITLE
ci: Sign off commits by WPT importer

### DIFF
--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -57,7 +57,7 @@ jobs:
           ./mach update-wpt linux-layout-2013/raw/*.log --legacy-layout
           ./mach update-wpt linux-layout-2020/raw/*.log
           git add tests/wpt/meta tests/wpt/meta-legacy-layout
-          git commit -a --amend --no-edit
+          git commit -a --amend -s --no-edit
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
This will be important to enforce signing off commits in the project.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only change CI behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
