### PR TITLE
Fix cross-compiling servoshell on Mac hosts

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -20,12 +20,10 @@ bench = false
 
 [build-dependencies]
 vergen = { version = "8.3.1", features = ["git", "git2"] }
+cc = "1.0"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
-
-[target.'cfg(target_os = "macos")'.build-dependencies]
-cc = "1.0"
 
 [package.metadata.winres]
 FileDescription = "Servo"


### PR DESCRIPTION
`#[cfg(target_os = "xxx")]` when used in build scripts checks which platform the **build script** is compiled for - i.e. the Host OS. Since we are interested in the actual target os, we need to read `CARGO_CFG_TARGET_OS`, a value that is set at **runtime of the build script**.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix cross-compiling servoshell on Mac

