### PR TITLE
htmlmetaelement: improve parsing of meta http-equiv

### DIFF
--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -85,8 +85,15 @@ impl HTMLMetaElement {
             if name == "referrer" {
                 self.apply_referrer();
             }
+        // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv
         } else if !self.HttpEquiv().is_empty() {
-            self.declarative_refresh();
+            // TODO: Implement additional http-equiv candidates
+            match self.HttpEquiv().to_ascii_lowercase().as_str() {
+                "refresh" => {
+                    self.declarative_refresh();
+                },
+                _ => {},
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When we parse the `http-equiv` attribute on a meta element, we currently always assume that it is the `refresh` directive.

This change adds specificity, so other potential values can be implemented, such as `content-security-policy` which is frequently used in the WPTs related to CSP.

I'm not sure if this will have an impact on WPT, I currently can't run the tests en masse, I suspect it wont.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
