### PR TITLE
DevTools: Implement watcher actor

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -387,6 +387,19 @@ impl BrowsingContextActor {
         *self.title.borrow_mut() = title;
     }
 
+    pub(crate) fn frame_update(&self, stream: &mut TcpStream) {
+        let _ = stream.write_json_packet(&FrameUpdateReply {
+            from: self.name(),
+            type_: "frameUpdate".into(),
+            frames: vec![FrameUpdateMsg {
+                id: self.browsing_context_id.index.0.get(),
+                isTopLevel: true,
+                title: self.title.borrow().clone(),
+                url: self.url.borrow().clone(),
+            }],
+        });
+    }
+
     pub(crate) fn resource_available(&self, resource_type: &str, stream: &mut TcpStream) {
         match resource_type {
             "document-event" => {
@@ -436,6 +449,22 @@ impl BrowsingContextActor {
             _ => {},
         }
     }
+}
+
+#[derive(Serialize)]
+struct FrameUpdateReply {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+    frames: Vec<FrameUpdateMsg>,
+}
+
+#[derive(Serialize)]
+struct FrameUpdateMsg {
+    id: u32,
+    isTopLevel: bool,
+    url: String,
+    title: String,
 }
 
 #[derive(Serialize)]

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -26,6 +26,7 @@ use crate::actors::stylesheets::StyleSheetsActor;
 use crate::actors::tab::TabDescriptorActor;
 use crate::actors::thread::ThreadActor;
 use crate::actors::timeline::TimelineActor;
+use crate::actors::watcher::{SessionContext, SessionContextType, WatcherActor};
 use crate::protocol::JsonPacketStream;
 use crate::StreamId;
 
@@ -128,6 +129,7 @@ pub(crate) struct BrowsingContextActor {
     pub console: String,
     pub _emulation: String,
     pub _inspector: String,
+    pub watcher: String,
     pub _timeline: String,
     pub _profiler: String,
     pub _performance: String,
@@ -268,6 +270,11 @@ impl BrowsingContextActor {
             browsing_context: name.clone(),
         };
 
+        let watcher = WatcherActor::new(
+            actors.new_name("watcher"),
+            SessionContext::new(SessionContextType::BrowserElement),
+        );
+
         let timeline =
             TimelineActor::new(actors.new_name("timeline"), pipeline, script_sender.clone());
 
@@ -291,6 +298,7 @@ impl BrowsingContextActor {
             console,
             _emulation: emulation.name(),
             _inspector: inspector.name(),
+            watcher: watcher.name(),
             _timeline: timeline.name(),
             _profiler: profiler.name(),
             _performance: performance.name(),
@@ -310,6 +318,7 @@ impl BrowsingContextActor {
         actors.register(Box::new(styleSheets));
         actors.register(Box::new(thread));
         actors.register(Box::new(tabdesc));
+        actors.register(Box::new(watcher));
 
         target
     }

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -272,6 +272,7 @@ impl BrowsingContextActor {
 
         let watcher = WatcherActor::new(
             actors.new_name("watcher"),
+            name.clone(),
             SessionContext::new(SessionContextType::BrowserElement),
         );
 

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::actors::configuration::{TargetConfigurationActor, ThreadConfigurationActor};
 use crate::actors::emulation::EmulationActor;
 use crate::actors::inspector::InspectorActor;
 use crate::actors::performance::PerformanceActor;
@@ -195,6 +196,8 @@ pub(crate) struct BrowsingContextActor {
     pub _profiler: String,
     pub _performance: String,
     pub _styleSheets: String,
+    pub target_configuration: String,
+    pub thread_configuration: String,
     pub thread: String,
     pub _tab: String,
     pub streams: RefCell<HashMap<StreamId, TcpStream>>,
@@ -353,6 +356,12 @@ impl BrowsingContextActor {
 
         let tabdesc = TabDescriptorActor::new(actors, name.clone());
 
+        let target_configuration =
+            TargetConfigurationActor::new(actors.new_name("target-configuration"));
+
+        let thread_configuration =
+            ThreadConfigurationActor::new(actors.new_name("thread-configuration"));
+
         let target = BrowsingContextActor {
             name,
             script_chan: script_sender,
@@ -367,6 +376,8 @@ impl BrowsingContextActor {
             _performance: performance.name(),
             _styleSheets: styleSheets.name(),
             _tab: tabdesc.name(),
+            target_configuration: target_configuration.name(),
+            thread_configuration: thread_configuration.name(),
             thread: thread.name(),
             streams: RefCell::new(HashMap::new()),
             browsing_context_id: id,
@@ -382,6 +393,8 @@ impl BrowsingContextActor {
         actors.register(Box::new(thread));
         actors.register(Box::new(tabdesc));
         actors.register(Box::new(watcher));
+        actors.register(Box::new(target_configuration));
+        actors.register(Box::new(thread_configuration));
 
         target
     }

--- a/components/devtools/actors/configuration.rs
+++ b/components/devtools/actors/configuration.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Liberally derived from <https://searchfox.org/mozilla-central/source/devtools/server/actors/target-configuration.js>
+//! and <https://searchfox.org/mozilla-central/source/devtools/server/actors/thread-configuration.js>
+//! These actors manage the configuration flags that the devtools host can apply to the targets and threads.
+
 use std::collections::HashMap;
 use std::net::TcpStream;
 
@@ -46,6 +50,9 @@ impl Actor for TargetConfigurationActor {
         self.name.clone()
     }
 
+    /// The target configuration actor can handle the following messages:
+    ///
+    /// - `updateConfiguration`: Receives new configuration flags from the devtools host.
     fn handle_message(
         &self,
         _registry: &ActorRegistry,
@@ -57,7 +64,6 @@ impl Actor for TargetConfigurationActor {
         Ok(match msg_type {
             "updateConfiguration" => {
                 // TODO: Actually update configuration
-
                 let _ = stream.write_json_packet(&EmptyReplyMsg { from: self.name() });
 
                 ActorMessageStatus::Processed
@@ -110,6 +116,9 @@ impl Actor for ThreadConfigurationActor {
         self.name.clone()
     }
 
+    /// The thread configuration actor can handle the following messages:
+    ///
+    /// - `updateConfiguration`: Receives new configuration flags from the devtools host.
     fn handle_message(
         &self,
         _registry: &ActorRegistry,
@@ -121,7 +130,6 @@ impl Actor for ThreadConfigurationActor {
         Ok(match msg_type {
             "updateConfiguration" => {
                 // TODO: Actually update configuration
-
                 let _ = stream.write_json_packet(&EmptyReplyMsg { from: self.name() });
 
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/configuration.rs
+++ b/components/devtools/actors/configuration.rs
@@ -9,8 +9,8 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
-use crate::protocol::{EmptyReply, JsonPacketStream};
-use crate::StreamId;
+use crate::protocol::JsonPacketStream;
+use crate::{EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -58,7 +58,7 @@ impl Actor for TargetConfigurationActor {
             "updateConfiguration" => {
                 // TODO: Actually update configuration
 
-                let _ = stream.write_json_packet(&EmptyReply { from: self.name() });
+                let _ = stream.write_json_packet(&EmptyReplyMsg { from: self.name() });
 
                 ActorMessageStatus::Processed
             },
@@ -122,7 +122,7 @@ impl Actor for ThreadConfigurationActor {
             "updateConfiguration" => {
                 // TODO: Actually update configuration
 
-                let _ = stream.write_json_packet(&EmptyReply { from: self.name() });
+                let _ = stream.write_json_packet(&EmptyReplyMsg { from: self.name() });
 
                 ActorMessageStatus::Processed
             },

--- a/components/devtools/actors/configuration.rs
+++ b/components/devtools/actors/configuration.rs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::net::TcpStream;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::protocol::{EmptyReply, JsonPacketStream};
+use crate::StreamId;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetConfigurationTraits {
+    supported_options: HashMap<&'static str, bool>,
+}
+
+#[derive(Serialize)]
+pub struct TargetConfigurationActorMsg {
+    actor: String,
+    configuration: HashMap<&'static str, bool>,
+    traits: TargetConfigurationTraits,
+}
+
+pub struct TargetConfigurationActor {
+    name: String,
+    configuration: HashMap<&'static str, bool>,
+    supported_options: HashMap<&'static str, bool>,
+}
+
+#[derive(Serialize)]
+pub struct ThreadConfigurationActorMsg {
+    actor: String,
+}
+
+pub struct ThreadConfigurationActor {
+    name: String,
+    _configuration: HashMap<&'static str, bool>,
+}
+
+impl Actor for TargetConfigurationActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        stream: &mut TcpStream,
+        _id: StreamId,
+    ) -> Result<ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            "updateConfiguration" => {
+                // TODO: Actually update configuration
+
+                let _ = stream.write_json_packet(&EmptyReply { from: self.name() });
+
+                ActorMessageStatus::Processed
+            },
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+impl TargetConfigurationActor {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            configuration: HashMap::new(),
+            supported_options: HashMap::from([
+                ("cacheDisabled", false),
+                ("colorSchemeSimulation", false),
+                ("customFormatters", false),
+                ("customUserAgent", false),
+                ("javascriptEnabled", false),
+                ("overrideDPPX", false),
+                ("printSimulationEnabled", false),
+                ("rdmPaneMaxTouchPoints", false),
+                ("rdmPaneOrientation", false),
+                ("recordAllocations", false),
+                ("reloadOnTouchSimulationToggle", false),
+                ("restoreFocus", false),
+                ("serviceWorkersTestingEnabled", false),
+                ("setTabOffline", false),
+                ("touchEventsOverride", false),
+                ("tracerOptions", false),
+                ("useSimpleHighlightersForReducedMotion", false),
+            ]),
+        }
+    }
+
+    pub fn encodable(&self) -> TargetConfigurationActorMsg {
+        TargetConfigurationActorMsg {
+            actor: self.name(),
+            configuration: self.configuration.clone(),
+            traits: TargetConfigurationTraits {
+                supported_options: self.supported_options.clone(),
+            },
+        }
+    }
+}
+
+impl Actor for ThreadConfigurationActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        stream: &mut TcpStream,
+        _id: StreamId,
+    ) -> Result<ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            "updateConfiguration" => {
+                // TODO: Actually update configuration
+
+                let _ = stream.write_json_packet(&EmptyReply { from: self.name() });
+
+                ActorMessageStatus::Processed
+            },
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+impl ThreadConfigurationActor {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            _configuration: HashMap::new(),
+        }
+    }
+
+    pub fn encodable(&self) -> ThreadConfigurationActorMsg {
+        ThreadConfigurationActorMsg { actor: self.name() }
+    }
+}

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -59,7 +59,7 @@ impl Actor for DeviceActor {
                         apptype: "servo".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                         appbuildid: BUILD_ID.to_string(),
-                        platformversion: "124.0".to_string(),
+                        platformversion: "125.0".to_string(),
                         brandName: "Servo".to_string(),
                     },
                 };

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -37,9 +37,6 @@ impl Actor for PreferenceActor {
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
-        // TODO: Here in some cases the field is called name and others value. It throws errors
-        // With the button devtools.debugger.prompt-connection is name
-        // With the other connections is value
         let mut key = msg.get("value").unwrap().as_str().unwrap();
 
         // Mapping to translate a Firefox preference name onto the corresponding Servo preference name

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -37,6 +37,9 @@ impl Actor for PreferenceActor {
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
+        // TODO: Here in some cases the field is called name and others value. It throws errors
+        // With the button devtools.debugger.prompt-connection is name
+        // With the other connections is value
         let mut key = msg.get("value").unwrap().as_str().unwrap();
 
         // Mapping to translate a Firefox preference name onto the corresponding Servo preference name

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -40,6 +40,9 @@ impl Actor for ProcessActor {
         self.name.clone()
     }
 
+    /// The process actor can handle the following messages:
+    ///
+    /// - `listWorkers`: Returns a list of web workers, not supported yet.
     fn handle_message(
         &self,
         _registry: &ActorRegistry,

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Liberally derived from the [Firefox JS implementation]
+//! (https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/process.js)
+
 use std::net::TcpStream;
 
 use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::actors::root::DescriptorTraits;
 use crate::protocol::JsonPacketStream;
 use crate::StreamId;
 
@@ -17,14 +21,18 @@ struct ListWorkersReply {
     workers: Vec<u32>, // TODO: use proper JSON structure.
 }
 
-pub struct ProcessActor {
-    name: String,
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessActorMsg {
+    actor: String,
+    id: u32,
+    is_parent: bool,
+    is_windowless_parent: bool,
+    traits: DescriptorTraits,
 }
 
-impl ProcessActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
-    }
+pub struct ProcessActor {
+    name: String,
 }
 
 impl Actor for ProcessActor {
@@ -52,5 +60,21 @@ impl Actor for ProcessActor {
 
             _ => ActorMessageStatus::Ignored,
         })
+    }
+}
+
+impl ProcessActor {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+
+    pub fn encodable(&self) -> ProcessActorMsg {
+        ProcessActorMsg {
+            actor: self.name(),
+            id: 0,
+            is_parent: true,
+            is_windowless_parent: false,
+            traits: Default::default(),
+        }
     }
 }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -239,7 +239,6 @@ impl Actor for RootActor {
                 ActorMessageStatus::Processed
             },
 
-            // TODO: Unexpected message getWatcher for tab (when inspecting)
             "getTab" => {
                 let Some(serde_json::Value::Number(browser_id)) = msg.get("browserId") else {
                     return Ok(ActorMessageStatus::Ignored);

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -105,6 +105,7 @@ pub struct DescriptorTraits {
     pub(crate) supports_reload_descriptor: bool,
 }
 
+// https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/process.js
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ProcessForm {
@@ -169,6 +170,7 @@ impl Actor for RootActor {
                 ActorMessageStatus::Processed
             },
 
+            // TODO: Unexpected message getTarget for process (when inspecting)
             "getProcess" => {
                 let reply = GetProcessResponse {
                     from: self.name(),
@@ -237,6 +239,7 @@ impl Actor for RootActor {
                 ActorMessageStatus::Processed
             },
 
+            // TODO: Unexpected message getWatcher for tab (when inspecting)
             "getTab" => {
                 let Some(serde_json::Value::Number(browser_id)) = msg.get("browserId") else {
                     return Ok(ActorMessageStatus::Ignored);

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -2,18 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Liberally derived from the [Firefox JS implementation]
+//! (https://searchfox.org/mozilla-central/source/devtools/server/actors/root.js).
+//! Connection point for all new remote devtools interactions, providing lists of know actors
+//! that perform more specific actions (targets, addons, browser chrome, etc.)
+
 use std::net::TcpStream;
 
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-/// Liberally derived from the [Firefox JS implementation]
-/// (http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/root.js).
-/// Connection point for all new remote devtools interactions, providing lists of know actors
-/// that perform more specific actions (targets, addons, browser chrome, etc.)
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::actors::device::DeviceActor;
 use crate::actors::performance::PerformanceActor;
+use crate::actors::process::{ProcessActor, ProcessActorMsg};
 use crate::actors::tab::{TabDescriptorActor, TabDescriptorActorMsg};
 use crate::actors::worker::{WorkerActor, WorkerMsg};
 use crate::protocol::{ActorDescription, JsonPacketStream};
@@ -95,7 +97,7 @@ pub struct Types {
 #[derive(Serialize)]
 struct ListProcessesResponse {
     from: String,
-    processes: Vec<ProcessForm>,
+    processes: Vec<ProcessActorMsg>,
 }
 
 #[derive(Default, Serialize)]
@@ -105,22 +107,11 @@ pub struct DescriptorTraits {
     pub(crate) supports_reload_descriptor: bool,
 }
 
-// https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/process.js
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ProcessForm {
-    actor: String,
-    id: u32,
-    is_parent: bool,
-    is_windowless_parent: bool,
-    traits: DescriptorTraits,
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct GetProcessResponse {
     from: String,
-    process_descriptor: ProcessForm,
+    process_descriptor: ProcessActorMsg,
 }
 
 pub struct RootActor {
@@ -156,15 +147,10 @@ impl Actor for RootActor {
             },
 
             "listProcesses" => {
+                let process = registry.find::<ProcessActor>(&self.process).encodable();
                 let reply = ListProcessesResponse {
                     from: self.name(),
-                    processes: vec![ProcessForm {
-                        actor: self.process.clone(),
-                        id: 0,
-                        is_parent: true,
-                        is_windowless_parent: false,
-                        traits: Default::default(),
-                    }],
+                    processes: vec![process],
                 };
                 let _ = stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed
@@ -172,15 +158,10 @@ impl Actor for RootActor {
 
             // TODO: Unexpected message getTarget for process (when inspecting)
             "getProcess" => {
+                let process = registry.find::<ProcessActor>(&self.process).encodable();
                 let reply = GetProcessResponse {
                     from: self.name(),
-                    process_descriptor: ProcessForm {
-                        actor: self.process.clone(),
-                        id: 0,
-                        is_parent: true,
-                        is_windowless_parent: false,
-                        traits: Default::default(),
-                    },
+                    process_descriptor: process,
                 };
                 let _ = stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed
@@ -198,7 +179,6 @@ impl Actor for RootActor {
                 ActorMessageStatus::Processed
             },
 
-            // https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#listing-browser-tabs
             "listTabs" => {
                 let actor = ListTabsReply {
                     from: "root".to_owned(),

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -93,10 +93,10 @@ impl Actor for TabDescriptorActor {
             "getWatcher" => {
                 // TODO: Propperly implement watcher
                 let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                let browserId = ctx_actor.active_pipeline.get().index.0.get();
+                let browser_id = ctx_actor.active_pipeline.get().index.0.get();
                 let watcher = WatcherActor::new(
                     "test".into(),
-                    SessionContext::new(SessionContextType::BrowserElement(browserId)),
+                    SessionContext::new(SessionContextType::BrowserElement(browser_id)),
                 )
                 .encodable();
                 let _ = stream.write_json_packet(&GetWatcherReply {
@@ -129,20 +129,20 @@ impl TabDescriptorActor {
 
         let title = ctx_actor.title.borrow().clone();
         let url = ctx_actor.url.borrow().clone();
-        let browserId = ctx_actor.active_pipeline.get().index.0.get();
-        let browsingContextId = ctx_actor.browsing_context_id.index.0.get();
+        let browser_id = ctx_actor.active_pipeline.get().index.0.get();
+        let browsing_context_id = ctx_actor.browsing_context_id.index.0.get();
 
         TabDescriptorActorMsg {
             actor: self.name(),
-            browsing_context_id: ctx_actor.browsing_context_id.index.0.get(),
-            browser_id: ctx_actor.active_pipeline.get().index.0.get(),
+            browsing_context_id,
+            browser_id,
             is_zombie_tab: false,
-            outer_window_id: ctx_actor.active_pipeline.get().index.0.get(),
+            outer_window_id: browser_id,
             selected,
             title,
             traits: DescriptorTraits {
                 watcher: true,
-                supports_reload_descriptor: false,
+                supports_reload_descriptor: true,
             },
             url,
         }

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -20,8 +20,10 @@ use crate::StreamId;
 pub struct TabDescriptorActorMsg {
     actor: String,
     browser_id: u32,
+    #[serde(rename = "browsingContextID")]
     browsing_context_id: u32,
     is_zombie_tab: bool,
+    #[serde(rename = "outerWindowID")]
     outer_window_id: u32,
     selected: bool,
     title: String,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -121,11 +121,10 @@ impl TabDescriptorActor {
 
     pub fn encodable(&self, registry: &ActorRegistry, selected: bool) -> TabDescriptorActorMsg {
         let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-
-        let title = ctx_actor.title.borrow().clone();
-        let url = ctx_actor.url.borrow().clone();
         let browser_id = ctx_actor.active_pipeline.get().index.0.get();
         let browsing_context_id = ctx_actor.browsing_context_id.index.0.get();
+        let title = ctx_actor.title.borrow().clone();
+        let url = ctx_actor.url.borrow().clone();
 
         TabDescriptorActorMsg {
             actor: self.name(),

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Liberally derived from the [Firefox JS implementation]
+//! (https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/tab.js)
+//! Descriptor actor that represents a web view. It can link a tab to the corresponding watcher
+//! actor to enable inspection.
+
 use std::net::TcpStream;
 
 use serde::Serialize;
@@ -14,7 +19,6 @@ use crate::actors::watcher::{WatcherActor, WatcherActorMsg};
 use crate::protocol::JsonPacketStream;
 use crate::StreamId;
 
-// https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/tab.js
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TabDescriptorActorMsg {
@@ -66,6 +70,12 @@ impl Actor for TabDescriptorActor {
         self.name.clone()
     }
 
+    /// The tab actor can handle the following messages:
+    ///
+    /// - `getTarget`: Returns the surrounding `BrowsingContextActor`.
+    /// - `getFavicon`: Should return the tab favicon, but it is not yet supported.
+    /// - `getWatcher`: Returns a `WatcherActor` linked to the tab's `BrowsingContext`. It is used
+    /// to describe the debugging capabilities of this tab.
     fn handle_message(
         &self,
         registry: &ActorRegistry,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -73,7 +73,9 @@ impl Actor for TabDescriptorActor {
     /// The tab actor can handle the following messages:
     ///
     /// - `getTarget`: Returns the surrounding `BrowsingContextActor`.
+    ///
     /// - `getFavicon`: Should return the tab favicon, but it is not yet supported.
+    ///
     /// - `getWatcher`: Returns a `WatcherActor` linked to the tab's `BrowsingContext`. It is used
     /// to describe the debugging capabilities of this tab.
     fn handle_message(

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -10,7 +10,7 @@ use serde_json::{Map, Value};
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
 use crate::actors::root::{DescriptorTraits, RootActor};
-use crate::actors::watcher::{WatcherActor, WatcherTraits};
+use crate::actors::watcher::{WatcherActor, WatcherActorMsg};
 use crate::protocol::JsonPacketStream;
 use crate::StreamId;
 
@@ -50,8 +50,8 @@ struct GetFaviconReply {
 #[derive(Serialize)]
 struct GetWatcherReply {
     from: String,
-    actor: String,
-    traits: WatcherTraits,
+    #[serde(flatten)]
+    watcher: WatcherActorMsg,
 }
 
 pub struct TabDescriptorActor {
@@ -92,13 +92,11 @@ impl Actor for TabDescriptorActor {
                 ActorMessageStatus::Processed
             },
             "getWatcher" => {
-                // TODO: Handle watcher message there in encodable
                 let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
                 let watcher = registry.find::<WatcherActor>(&ctx_actor.watcher);
                 let _ = stream.write_json_packet(&GetWatcherReply {
                     from: self.name(),
-                    actor: watcher.name(),
-                    traits: watcher.traits(),
+                    watcher: watcher.encodable(),
                 });
                 ActorMessageStatus::Processed
             },

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -15,117 +15,95 @@ use crate::StreamId;
 
 #[derive(Serialize)]
 pub enum SessionContextType {
-    BrowserElement(u32),
+    BrowserElement,
     ContextProcess,
     WebExtension,
     Worker,
     All,
 }
 
-/*TARGETS {
-  [Targets.TYPES.FRAME]: true,
-  [Targets.TYPES.PROCESS]: true,
-  [Targets.TYPES.WORKER]: true,
-  [Targets.TYPES.SERVICE_WORKER]:
-    type == SESSION_TYPES.BROWSER_ELEMENT || type == SESSION_TYPES.ALL,
-  [Targets.TYPES.SHARED_WORKER]: type == SESSION_TYPES.ALL,
-};*/
-
-/*RESOURCES {
-  [Resources.TYPES.CONSOLE_MESSAGE]: true,
-  [Resources.TYPES.CSS_CHANGE]: isTabOrWebExtensionToolbox,
-  [Resources.TYPES.CSS_MESSAGE]: true,
-  [Resources.TYPES.CSS_REGISTERED_PROPERTIES]: true,
-  [Resources.TYPES.DOCUMENT_EVENT]: true,
-  [Resources.TYPES.CACHE_STORAGE]: true,
-  [Resources.TYPES.COOKIE]: true,
-  [Resources.TYPES.ERROR_MESSAGE]: true,
-  [Resources.TYPES.EXTENSION_STORAGE]: true,
-  [Resources.TYPES.INDEXED_DB]: true,
-  [Resources.TYPES.LOCAL_STORAGE]: true,
-  [Resources.TYPES.SESSION_STORAGE]: true,
-  [Resources.TYPES.PLATFORM_MESSAGE]: true,
-  [Resources.TYPES.NETWORK_EVENT]: true,
-  [Resources.TYPES.NETWORK_EVENT_STACKTRACE]: true,
-  [Resources.TYPES.REFLOW]: true,
-  [Resources.TYPES.STYLESHEET]: true,
-  [Resources.TYPES.SOURCE]: true,
-  [Resources.TYPES.THREAD_STATE]: true,
-  [Resources.TYPES.SERVER_SENT_EVENT]: true,
-  [Resources.TYPES.WEBSOCKET]: true,
-  [Resources.TYPES.JSTRACER_TRACE]: true,
-  [Resources.TYPES.JSTRACER_STATE]: true,
-  [Resources.TYPES.LAST_PRIVATE_CONTEXT_EXIT]: true,
-};*/
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionContext {
-    isServerTargetSwitchingEnabled: bool,
-    supportedTargets: HashMap<&'static str, bool>,
-    supportedResources: HashMap<&'static str, bool>,
+    is_server_target_switching_enabled: bool,
+    supported_targets: HashMap<&'static str, bool>,
+    supported_resources: HashMap<&'static str, bool>,
     r#type: SessionContextType,
 }
 
 impl SessionContext {
     pub fn new(r#type: SessionContextType) -> Self {
         Self {
-            isServerTargetSwitchingEnabled: false,
-            supportedTargets: HashMap::new(), // TODO: Fill this
-            supportedResources: HashMap::from([
-                ("Resources.TYPES.CONSOLE_MESSAGE", true),
-                ("Resources.TYPES.CSS_CHANGE", true),
+            is_server_target_switching_enabled: false,
+            supported_targets: HashMap::new(), // TODO: Fill this
+            supported_resources: HashMap::from([
+                ("console-message", true),
+                ("css-change", true),
+                ("css-message", true),
+                ("css-registered-properties", true),
+                ("document-event", true),
+                ("Cache", true),
+                ("cookies", true),
+                ("error-message", true),
+                ("extension-storage", true),
+                ("indexed-db", true),
+                ("local-storage", true),
+                ("session-storage", true),
+                ("platform-message", true),
+                ("network-event", true),
+                ("network-event-stacktrace", true),
+                ("reflow", true),
+                ("stylesheet", true),
+                ("source", true),
+                ("thread-state", true),
+                ("server-sent-event", true),
+                ("websocket", true),
+                ("jstracer-trace", true),
+                ("jstracer-state", true),
+                ("last-private-context-exit", true),
             ]),
             r#type,
         }
     }
 }
 
-#[derive(Serialize)]
-struct WatcherTraits {
-    resources: HashMap<&'static str, bool>,
-    #[serde(rename = "Targets.TYPES.FRAME")]
-    frame: bool,
-    #[serde(rename = "Targets.TYPES.PROCESS")]
-    process: bool,
-    #[serde(rename = "Targets.TYPES.WORKER")]
-    worker: bool,
-    #[serde(rename = "Targets.TYPES.SERVICE_WORKER")]
-    service_worker: bool,
-    #[serde(rename = "Targets.TYPES.SHARED_WORKER")]
-    shared_worker: bool,
-}
+/*
+{"actor":"server1.conn0.watcher42",
+ "traits":{"frame":true,"process":true,"worker":true,"service_worker":true,"resources":{"console-message":true,"css-change":true,"css-message":true,"css-registered-properties":true,"document-event":true,"Cache":true,"cookies":true,"error-message":true,"extension-storage":true,"indexed-db":true,"local-storage":true,"session-storage":true,"platform-message":true,"network-event":true,"network-event-stacktrace":true,"reflow":true,"stylesheet":true,"source":true,"thread-state":true,"server-sent-event":true,"websocket":true,"jstracer-trace":true,"jstracer-state":true,"last-private-context-exit":true}},
+ "from":"server1.conn0.tabDescriptor11"}
+ */
 
 #[derive(Serialize)]
-pub struct WatcherActorMsg {
-    actor: String,
-    traits: WatcherTraits,
+pub struct WatcherTraits {
+    resources: HashMap<&'static str, bool>,
+    frame: bool,
+    process: bool,
+    worker: bool,
+    service_worker: bool,
+    // shared_worker: bool,
 }
 
 pub struct WatcherActor {
     name: String,
-    sessionContext: SessionContext,
+    session_context: SessionContext,
 }
 
 impl WatcherActor {
-    pub fn new(name: String, sessionContext: SessionContext) -> Self {
+    pub fn new(name: String, session_context: SessionContext) -> Self {
         Self {
             name,
-            sessionContext,
+            session_context,
         }
     }
 
-    pub fn encodable(&self) -> WatcherActorMsg {
-        WatcherActorMsg {
-            actor: self.name(),
-            traits: WatcherTraits {
-                resources: self.sessionContext.supportedResources.clone(),
-                frame: true,
-                process: true,
-                worker: true,
-                service_worker: true,
-                shared_worker: true,
-            },
+    // TODO: Change this for encodable and handle message here
+    pub fn traits(&self) -> WatcherTraits {
+        WatcherTraits {
+            resources: self.session_context.supported_resources.clone(),
+            frame: true,
+            process: true,
+            worker: true,
+            service_worker: true,
         }
     }
 }

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#![allow(dead_code)] // TODO: Remove this
+
+use std::net::TcpStream;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::StreamId;
+
+#[derive(Serialize)]
+pub enum SessionContextType {
+    BrowserElement(u32),
+    ContextProcess,
+    WebExtension,
+    Worker,
+    All,
+}
+
+/*TARGETS {
+  [Targets.TYPES.FRAME]: true,
+  [Targets.TYPES.PROCESS]: true,
+  [Targets.TYPES.WORKER]: true,
+  [Targets.TYPES.SERVICE_WORKER]:
+    type == SESSION_TYPES.BROWSER_ELEMENT || type == SESSION_TYPES.ALL,
+  [Targets.TYPES.SHARED_WORKER]: type == SESSION_TYPES.ALL,
+};*/
+
+/*RESOURCES {
+  [Resources.TYPES.CONSOLE_MESSAGE]: true,
+  [Resources.TYPES.CSS_CHANGE]: isTabOrWebExtensionToolbox,
+  [Resources.TYPES.CSS_MESSAGE]: true,
+  [Resources.TYPES.CSS_REGISTERED_PROPERTIES]: true,
+  [Resources.TYPES.DOCUMENT_EVENT]: true,
+  [Resources.TYPES.CACHE_STORAGE]: true,
+  [Resources.TYPES.COOKIE]: true,
+  [Resources.TYPES.ERROR_MESSAGE]: true,
+  [Resources.TYPES.EXTENSION_STORAGE]: true,
+  [Resources.TYPES.INDEXED_DB]: true,
+  [Resources.TYPES.LOCAL_STORAGE]: true,
+  [Resources.TYPES.SESSION_STORAGE]: true,
+  [Resources.TYPES.PLATFORM_MESSAGE]: true,
+  [Resources.TYPES.NETWORK_EVENT]: true,
+  [Resources.TYPES.NETWORK_EVENT_STACKTRACE]: true,
+  [Resources.TYPES.REFLOW]: true,
+  [Resources.TYPES.STYLESHEET]: true,
+  [Resources.TYPES.SOURCE]: true,
+  [Resources.TYPES.THREAD_STATE]: true,
+  [Resources.TYPES.SERVER_SENT_EVENT]: true,
+  [Resources.TYPES.WEBSOCKET]: true,
+  [Resources.TYPES.JSTRACER_TRACE]: true,
+  [Resources.TYPES.JSTRACER_STATE]: true,
+  [Resources.TYPES.LAST_PRIVATE_CONTEXT_EXIT]: true,
+};*/
+
+#[derive(Serialize)]
+pub struct SessionContext {
+    isServerTargetSwitchingEnabled: bool,
+    supportedTargets: bool, // TODO: These need to be a dictionary of supported types
+    supportedResources: bool,
+    r#type: SessionContextType,
+}
+
+impl SessionContext {
+    pub fn new(r#type: SessionContextType) -> Self {
+        Self {
+            isServerTargetSwitchingEnabled: false,
+            supportedTargets: true,
+            supportedResources: true,
+            r#type,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct WatcherTraits {
+    resources: bool,
+    // TODO: This doesn't go here, instead, all of the targets are destructured into the traits
+    // object and are accessed directly
+    // I am getting this.watcherFront.traits is undefined TypeError
+    targets: bool,
+}
+
+#[derive(Serialize)]
+pub struct WatcherActorMsg {
+    actor: String,
+    traits: WatcherTraits,
+}
+
+pub struct WatcherActor {
+    name: String,
+    sessionContext: SessionContext,
+}
+
+impl WatcherActor {
+    pub fn new(name: String, sessionContext: SessionContext) -> Self {
+        Self {
+            name,
+            sessionContext,
+        }
+    }
+
+    pub fn encodable(&self) -> WatcherActorMsg {
+        WatcherActorMsg {
+            actor: self.name(),
+            traits: WatcherTraits {
+                resources: self.sessionContext.supportedResources,
+                targets: self.sessionContext.supportedTargets,
+            },
+        }
+    }
+}
+
+impl Actor for WatcherActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        _stream: &mut TcpStream,
+        _id: StreamId,
+    ) -> Result<ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -50,14 +50,14 @@ impl SessionContext {
             // Support for them will be enabled gradually once the corresponding actors start
             // working propperly
             supported_resources: HashMap::from([
-                ("console-message", false),
+                ("console-message", true),
                 ("css-change", false),
                 ("css-message", false),
                 ("css-registered-properties", false),
                 ("document-event", true),
                 ("Cache", false),
                 ("cookies", false),
-                ("error-message", false),
+                ("error-message", true),
                 ("extension-storage", false),
                 ("indexed-db", false),
                 ("local-storage", false),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -154,14 +154,25 @@ impl Actor for WatcherActor {
                         continue;
                     };
 
-                    // Let the browsing context reply with the resource availability status
                     let target =
                         registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                    target.resource_available(resource, stream);
+
+                    match resource {
+                        "document-event" => {
+                            target.document_event(stream);
+                        },
+                        _ => {},
+                    }
 
                     // This just responds with and acknowledgement
                     let _ = stream.write_json_packet(&WatchResourcesReply { from: self.name() });
                 }
+
+                ActorMessageStatus::Processed
+            },
+            "getTargetConfigurationActor" => {
+                // TODO: Send propper configuration
+                let _ = stream.write_json_packet(&WatchResourcesReply { from: self.name() });
 
                 ActorMessageStatus::Processed
             },

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -14,8 +14,8 @@ use crate::actors::configuration::{
     TargetConfigurationActor, TargetConfigurationActorMsg, ThreadConfigurationActor,
     ThreadConfigurationActorMsg,
 };
-use crate::protocol::{EmptyReply, JsonPacketStream};
-use crate::StreamId;
+use crate::protocol::JsonPacketStream;
+use crate::{EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 pub enum SessionContextType {
@@ -144,7 +144,7 @@ impl Actor for WatcherActor {
                 target.frame_update(stream);
 
                 // TODO: Document this type of reply after sending event messages
-                let _ = stream.write_json_packet(&EmptyReply { from: self.name() });
+                let _ = stream.write_json_packet(&EmptyReplyMsg { from: self.name() });
 
                 ActorMessageStatus::Processed
             },
@@ -172,7 +172,7 @@ impl Actor for WatcherActor {
                         _ => {},
                     }
 
-                    let _ = stream.write_json_packet(&EmptyReply { from: self.name() });
+                    let _ = stream.write_json_packet(&EmptyReplyMsg { from: self.name() });
                 }
 
                 ActorMessageStatus::Processed
@@ -205,8 +205,6 @@ impl Actor for WatcherActor {
         })
     }
 }
-
-// TODO: Improve the JSON response builder (with from, different forms, etc...)
 
 impl WatcherActor {
     pub fn new(

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -132,6 +132,12 @@ impl Actor for WatcherActor {
                     type_: "target-available-form".into(),
                     target,
                 });
+
+                let target = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
+                target.frame_update(stream);
+
+                let _ = stream.write_json_packet(&WatchResourcesReply { from: self.name() });
+
                 ActorMessageStatus::Processed
             },
             "watchResources" => {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -68,6 +68,7 @@ mod actors {
     pub mod tab;
     pub mod thread;
     pub mod timeline;
+    pub mod watcher;
     pub mod worker;
 }
 mod protocol;
@@ -403,6 +404,7 @@ fn run_server(
         browsing_contexts: &HashMap<BrowsingContextId, String>,
         pipelines: &HashMap<PipelineId, BrowsingContextId>,
     ) -> Option<String> {
+        // TODO: Unwrapping error
         let actors = actors.lock().unwrap();
         if let Some(worker_id) = worker_id {
             let actor_name = actor_workers.get(&worker_id)?;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -48,7 +48,7 @@ use crate::actors::worker::{WorkerActor, WorkerType};
 use crate::protocol::JsonPacketStream;
 
 mod actor;
-/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/>
+/// <https://searchfox.org/mozilla-central/source/devtools/server/actors>
 mod actors {
     pub mod browsing_context;
     pub mod configuration;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -48,7 +48,7 @@ use crate::actors::worker::{WorkerActor, WorkerType};
 use crate::protocol::JsonPacketStream;
 
 mod actor;
-/// <https://firefox-source-docs.mozilla.org/devtools/backend/actor-hierarchy.html>
+/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/>
 mod actors {
     pub mod browsing_context;
     pub mod configuration;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -5,7 +5,7 @@
 //! An actor-based remote devtools server implementation. Only tested with
 //! nightly Firefox versions at time of writing. Largely based on
 //! reverse-engineering of Firefox chrome devtool logs and reading of
-//! [code](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/).
+//! [code](https://searchfox.org/mozilla-central/source/devtools/server).
 
 #![crate_name = "devtools"]
 #![crate_type = "rlib"]
@@ -48,7 +48,7 @@ use crate::actors::worker::{WorkerActor, WorkerType};
 use crate::protocol::JsonPacketStream;
 
 mod actor;
-/// Corresponds to <http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/>
+/// <https://firefox-source-docs.mozilla.org/devtools/backend/actor-hierarchy.html>
 mod actors {
     pub mod browsing_context;
     pub mod configuration;
@@ -113,6 +113,11 @@ struct ResponseStartUpdateMsg {
     type_: String,
     updateType: String,
     response: ResponseStartMsg,
+}
+
+#[derive(Serialize)]
+pub struct EmptyReplyMsg {
+    pub from: String,
 }
 
 /// Spin up a devtools server that listens for connections on the specified port.
@@ -405,7 +410,6 @@ fn run_server(
         browsing_contexts: &HashMap<BrowsingContextId, String>,
         pipelines: &HashMap<PipelineId, BrowsingContextId>,
     ) -> Option<String> {
-        // TODO: Unwrapping error
         let actors = actors.lock().unwrap();
         if let Some(worker_id) = worker_id {
             let actor_name = actor_workers.get(&worker_id)?;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -51,6 +51,7 @@ mod actor;
 /// Corresponds to <http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/>
 mod actors {
     pub mod browsing_context;
+    pub mod configuration;
     pub mod console;
     pub mod device;
     pub mod emulation;

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Low-level wire protocol implementation. Currently only supports
-//! [JSON packets](https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport#JSON_Packets).
+//! [JSON packets](https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#json-packets).
 
 use std::error::Error;
 use std::io::{Read, Write};
@@ -25,11 +25,6 @@ pub struct Method {
     pub name: &'static str,
     pub request: Value,
     pub response: Value,
-}
-
-#[derive(Serialize)]
-pub struct EmptyReply {
-    pub from: String,
 }
 
 pub trait JsonPacketStream {
@@ -68,7 +63,7 @@ impl JsonPacketStream for TcpStream {
     }
 
     fn read_json_packet(&mut self) -> Result<Option<Value>, String> {
-        // https://wiki.mozilla.org/Remote_Debugging_Protocol_Stream_Transport
+        // https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#stream-transport
         // In short, each JSON packet is [ascii length]:[JSON data of given length]
         let mut buffer = vec![];
         loop {

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -27,6 +27,11 @@ pub struct Method {
     pub response: Value,
 }
 
+#[derive(Serialize)]
+pub struct EmptyReply {
+    pub from: String,
+}
+
 pub trait JsonPacketStream {
     fn write_json_packet<T: Serialize>(&mut self, obj: &T) -> Result<(), Box<dyn Error>>;
     fn write_merged_json_packet<T: Serialize, U: Serialize>(


### PR DESCRIPTION
The new DevTools protocol creates the figure of the [Watcher actor](https://firefox-source-docs.mozilla.org/devtools/backend/actor-hierarchy.html). This is a mediator that is assigned to an element (tab/browsing context, process, worker...) and shows DevTools what resources and targets are available to inspect. Having one is the first step into restoring the full tab inspection functionality, which will be very useful since it will allow to see the source code of a website, the console logs, the render timeline, etc...

The new watcher actor is able to register itself and respond with the available targets and resources. This makes it so the DevTools UI on Firefox's side appears again, though it doesn't have full functionality yet.

<details>

<summary><b>Messages sent when clicking Inspect</b></summary>

<- (Servo receives, Firefox Sends) | -> (Servo sends, Firefox receives)

- [x] <- **getWatcher** _request a watcher actor for the tab we want to inspect_
- [x] -> **actor: watcher, traits** _replies with the watcher actor and the resources and targets it supports, for example, it can support debugging the console but not the cookies_
- [x] <- **watchTargets, targetType: frame** _tell the watcher actor that we want to inspect the frame of the tab_
- [x] -> **target-available-form, target: browsing context** _it replies with the browsing context of the tab, and all of the related debugging actors' ids, for example the console actor or the inspector actor_
- [x] -> **frameUpdate, frames**
- [x] -> ACK
- [x] <- **watchResources, resourceTypes: document-event** _the first resource we ask for is the document information itself_
- [x] -> **resource-available-form, resources** _reply with the document information, such as the url and the title_
- [x] -> ACK
- [x] <- **getTargetConfigurationActor** / **getServerConfigurationActor** 
- [x] -> **configuration**

</details>

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #32404
- [x] These changes do not require tests because there are no tests yet for DevTools.

### Manual testing

1. Compile and run Servo with devtools enabled. You can also enable debug logs for the devtools module so that you can see the JSON messages being sent.

```sh
RUST_LOG="error,devtools=debug" ./mach run --devtools=1234
```

2. Open a recent version of Firefox and go to `about:debugging`. In Setup, add `localhost:1234` (or the port you selected before) as a network location.

![image](https://github.com/servo/servo/assets/22449369/91d87705-211e-40c5-9847-1175b8568a30)

3. On the sidebar, click on Connect next to `localhost:1234`. Now go to the terminal where you are running Servo and press "y" to accept the incoming connection.

![image](https://github.com/servo/servo/assets/22449369/79f15570-a261-460f-adf8-d74799f6a28e)

4. Go back to Firefox and click on `localhost:1234` on the sidebar. You should be presented with a screen like this:

![image](https://github.com/servo/servo/assets/22449369/b39930b6-10ca-4a26-90ad-500fd1432c2f)

5. Choose one tab and click Inspect. A new window should open with an inspector for the tab. Right now the only feature that is working to some extent is the console. You can't see any message yet, but you can run some javascript. For example, writing `location.reload()` should reload the page. Or, on the https://servo.org website, use `document.getElementsByClassName("hero-body")[0].style.backgroundColor = "royalblue" ` to change the background color:

![image](https://github.com/servo/servo/assets/22449369/c8febc8a-d99c-40d2-861f-54401b8c29e0)

Refer to [this comment](https://github.com/servo/servo/issues/32404#issuecomment-2168414796) for more information on how to test the protocol.
