### PR TITLE
asan: Add a leak suppression file with known false positives

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -43,6 +43,7 @@ import servo.util as util
 from servo.util import download_file, get_default_cache_dir
 
 NIGHTLY_REPOSITORY_URL = "https://servo-builds2.s3.amazonaws.com/"
+ASAN_LEAK_SUPPRESSION_FILE = "support/suppressed_leaks_for_asan.txt"
 
 
 @dataclass
@@ -511,6 +512,9 @@ class CommandBase(object):
         # Work around https://github.com/servo/servo/issues/24446
         # Argument-less str.split normalizes leading, trailing, and double spaces
         env['RUSTFLAGS'] = " ".join(env['RUSTFLAGS'].split())
+
+        # Suppress known false-positives during memory leak sanitizing.
+        env["LSAN_OPTIONS"] = f"{env.get('LSAN_OPTIONS', '')}:suppressions={ASAN_LEAK_SUPPRESSION_FILE}"
 
         self.build_android_env_if_needed(env)
 


### PR DESCRIPTION
Looking into #32223 and found a false-positive in the second memory leak stack trace (intentional leak with `Box::leak` in `stylo`). Therefore we added file to suppress it and included the file in the `asan` integration (#31429) by passing it as env var [as document for ASAN](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions).

We'll check out further leaks in the next days/weeks. Just wanted to know if the leak suppression is cool with you guys.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
  - We both get python stack traces when running this command but it reports `no errors` at the end
  - My error: `flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "E" due to cannot import name 'missing_whitespace_after_keyword' from 'pycodestyle' (~/servo/python/_venv3.11/lib/python3.11/site-packages/pycodestyle.py)`
- [X] These changes are part of #32223.
- [X] These changes do not require tests because build they just update ASAN tooling.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
