### PR TITLE
ci: Use a servo.org email address for the servo-wpt-sync GitHub bot

### DIFF
--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -42,7 +42,7 @@ jobs:
           python3 ./mach bootstrap
       - name: Add upstream remote
         run: |
-          git config --local user.email "josh+wptsync@joshmatthews.net"
+          git config --local user.email "ghbot+wpt-sync@servo.org"
           git config --local user.name "WPT Sync Bot"
           git remote add upstream https://github.com/servo/servo.git
           git fetch --unshallow upstream

--- a/python/wpt/export.py
+++ b/python/wpt/export.py
@@ -33,7 +33,7 @@ def main() -> int:
         github_api_token=os.environ['WPT_SYNC_TOKEN'],
         github_api_url='https://api.github.com/',
         github_username='servo-wpt-sync',
-        github_email='josh+wptsync@joshmatthews.net',
+        github_email='ghbot+wpt-sync@servo.org',
         github_name='Servo WPT Sync',
     ).run(context["event"])
     return 0 if success else 1

--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -27,7 +27,7 @@ def do_sync(**kwargs) -> int:
 
     # Commits should always be authored by the GitHub Actions bot.
     os.environ["GIT_AUTHOR_NAME"] = "Servo WPT Sync"
-    os.environ["GIT_AUTHOR_EMAIL"] = "josh+wptsync@joshmatthews.net"
+    os.environ["GIT_AUTHOR_EMAIL"] = "ghbot+wpt-sync@servo.org"
     os.environ["GIT_COMMITTER_NAME"] = os.environ['GIT_AUTHOR_NAME']
     os.environ["GIT_COMMITTER_EMAIL"] = os.environ['GIT_AUTHOR_EMAIL']
 


### PR DESCRIPTION
This is the new address of the WPT sync bot.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just changes CI behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
