### PR TITLE
deps: Switch from `winapi` to `windows-sys` in Servo code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ version = "0.20.0"
 source = "git+https://github.com/gfx-rs/wgpu?rev=d0a5e48aa7e84683114c3870051cc414ae92ac03#d0a5e48aa7e84683114c3870051cc414ae92ac03"
 dependencies = [
  "bitflags 2.5.0",
- "libloading 0.7.4",
+ "libloading 0.8.3",
  "winapi",
 ]
 
@@ -1382,7 +1382,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.3",
 ]
 
 [[package]]
@@ -5582,7 +5582,7 @@ dependencies = [
  "jemalloc-sys",
  "jemallocator",
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5704,7 +5704,7 @@ dependencies = [
  "url",
  "vergen",
  "webxr",
- "winapi",
+ "windows-sys 0.52.0",
  "winit",
  "winres",
 ]
@@ -7337,7 +7337,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.3",
  "log",
  "metal 0.28.0",
  "naga",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
 webrender_traits = { path = "components/shared/webrender" }
 wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "d0a5e48aa7e84683114c3870051cc414ae92ac03" }
 wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "d0a5e48aa7e84683114c3870051cc414ae92ac03" }
-winapi = "0.3"
+windows-sys = "0.52"
 xi-unicode = "0.1.0"
 xml5ever = "0.18"
 

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -18,7 +18,7 @@ jemalloc-sys = { workspace = true }
 libc = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["heapapi"] }
+windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
 libc = { workspace = true }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -61,7 +61,8 @@ mod platform {
     pub use std::alloc::System as Allocator;
     use std::os::raw::c_void;
 
-    use winapi::um::heapapi::{GetProcessHeap, HeapSize, HeapValidate};
+    use windows_sys::Win32::Foundation::FALSE;
+    use windows_sys::Win32::System::Memory::{GetProcessHeap, HeapSize, HeapValidate};
 
     /// Get the size of a heap block.
     ///
@@ -71,8 +72,8 @@ mod platform {
     pub unsafe extern "C" fn usable_size(mut ptr: *const c_void) -> usize {
         let heap = GetProcessHeap();
 
-        if HeapValidate(heap, 0, ptr) == 0 {
-            ptr = *(ptr as *const *const c_void).offset(-1);
+        if HeapValidate(heap, 0, ptr) == FALSE {
+            ptr = *(ptr as *const *const c_void).offset(-1)
         }
 
         HeapSize(heap, 0, ptr) as usize

--- a/components/background_hang_monitor/sampler_windows.rs
+++ b/components/background_hang_monitor/sampler_windows.rs
@@ -4,7 +4,7 @@
 
 use crate::sampler::{NativeStack, Sampler};
 
-type MonitoredThreadId = usize; // TODO: use winapi
+type MonitoredThreadId = usize; // TODO: use the `windows` crate to do this.
 
 #[allow(dead_code)]
 pub struct WindowsSampler {
@@ -14,7 +14,7 @@ pub struct WindowsSampler {
 impl WindowsSampler {
     #[allow(unsafe_code, dead_code)]
     pub fn new_boxed() -> Box<dyn Sampler> {
-        let thread_id = 0; // TODO: use winapi::um::processthreadsapi::GetThreadId
+        let thread_id = 0; // TODO: use windows::Win32::System::Threading::GetThreadId
         Box::new(WindowsSampler { thread_id })
     }
 }
@@ -28,11 +28,11 @@ impl Sampler for WindowsSampler {
         // or any other unshareable resource.
 
         // TODO:
-        // 1: use winapi::um::processthreadsapi::SuspendThread
-        // 2: use winapi::um::processthreadsapi::GetThreadContext
+        // 1: use windows::Win32::Threading::SuspendThread
+        // 2: use windows::Win32::Threading::GetThreadContext
         // 3: populate registers using the context, see
         // https://dxr.mozilla.org/mozilla-central/source/tools/profiler/core/platform-win32.cpp#129
-        // 4: use winapi::um::processthreadsapi::ResumeThread
+        // 4: use windows::Win32::Threading::ResumeThread
 
         // NOTE: End of "critical section".
         Err(())

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -92,4 +92,4 @@ image = { workspace = true }
 sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { workspace = true, features = ["wingdi", "winuser", "winnt", "winbase", "processenv", "namedpipeapi", "ntdef", "minwindef", "handleapi", "debugapi"] }
+windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -24,8 +24,6 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_traits::RenderingContext;
 use surfman::{Connection, Context, Device, SurfaceType};
-#[cfg(target_os = "windows")]
-use winapi;
 use winit::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use winit::event::{ElementState, KeyEvent, MouseButton, MouseScrollDelta, TouchPhase};
 use winit::keyboard::{Key as LogicalKey, ModifiersState, NamedKey};
@@ -66,8 +64,9 @@ fn window_creation_scale_factor() -> Scale<f32, DeviceIndependentPixel, DevicePi
 
 #[cfg(target_os = "windows")]
 fn window_creation_scale_factor() -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-    let hdc = unsafe { winapi::um::winuser::GetDC(::std::ptr::null_mut()) };
-    let ppi = unsafe { winapi::um::wingdi::GetDeviceCaps(hdc, winapi::um::wingdi::LOGPIXELSY) };
+    use windows_sys::Win32::Graphics::Gdi::{GetDC, GetDeviceCaps, LOGPIXELSY};
+
+    let ppi = unsafe { GetDeviceCaps(GetDC(0), LOGPIXELSY as i32) };
     Scale::new(ppi as f32 / 96.0)
 }
 


### PR DESCRIPTION
This is part of the switch from `winapi` to `windows-sys`. `windows-sys` is
maintained by Microsoft, so is more "official." More and more crates are
switching to it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
