### PR TITLE
layout: Flatten inline box storage in InlineFormattingContexts

### DIFF
--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -22,7 +22,7 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::WhichPseudoElement;
 use crate::flexbox::FlexLevelBox;
-use crate::flow::inline::InlineLevelBox;
+use crate::flow::inline::{InlineBox, InlineItem};
 use crate::flow::BlockLevelBox;
 use crate::geom::PhysicalSize;
 use crate::replaced::{CanvasInfo, CanvasSource};
@@ -39,7 +39,9 @@ pub struct InnerDOMLayoutData {
 pub(super) enum LayoutBox {
     DisplayContents,
     BlockLevel(ArcRefCell<BlockLevelBox>),
-    InlineLevel(ArcRefCell<InlineLevelBox>),
+    #[allow(dead_code)]
+    InlineBox(ArcRefCell<InlineBox>),
+    InlineLevel(ArcRefCell<InlineItem>),
     FlexLevel(ArcRefCell<FlexLevelBox>),
 }
 

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -21,7 +21,7 @@ use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::{iter_child_nodes, Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexLevelBox;
 use crate::flow::float::FloatBox;
-use crate::flow::inline::InlineLevelBox;
+use crate::flow::inline::InlineItem;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::FragmentTree;
@@ -122,7 +122,7 @@ impl BoxTree {
         #[allow(clippy::enum_variant_names)]
         enum UpdatePoint {
             AbsolutelyPositionedBlockLevelBox(ArcRefCell<BlockLevelBox>),
-            AbsolutelyPositionedInlineLevelBox(ArcRefCell<InlineLevelBox>),
+            AbsolutelyPositionedInlineLevelBox(ArcRefCell<InlineItem>),
             AbsolutelyPositionedFlexLevelBox(ArcRefCell<FlexLevelBox>),
         }
 
@@ -180,8 +180,9 @@ impl BoxTree {
                         },
                         _ => return None,
                     },
+                    LayoutBox::InlineBox(_) => return None,
                     LayoutBox::InlineLevel(inline_level_box) => match &*inline_level_box.borrow() {
-                        InlineLevelBox::OutOfFlowAbsolutelyPositionedBox(_)
+                        InlineItem::OutOfFlowAbsolutelyPositionedBox(_)
                             if box_style.position.is_absolutely_positioned() =>
                         {
                             UpdatePoint::AbsolutelyPositionedInlineLevelBox(
@@ -219,7 +220,7 @@ impl BoxTree {
                     },
                     UpdatePoint::AbsolutelyPositionedInlineLevelBox(inline_level_box) => {
                         *inline_level_box.borrow_mut() =
-                            InlineLevelBox::OutOfFlowAbsolutelyPositionedBox(
+                            InlineItem::OutOfFlowAbsolutelyPositionedBox(
                                 out_of_flow_absolutely_positioned_box,
                             );
                     },


### PR DESCRIPTION
This accomplishes two things:

1. Makes it easier to iterate through all inline formatting context
   items.
2. Will make it possible to easily move back and forth through the tree
   of inline boxes, in order to enable reordering and splitting inline
   boxes on lines -- necessary for BiDi.

Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
