### PR TITLE
mach: fix test-tidy to not skip `Cargo.lock`

### DIFF
--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -21,6 +21,7 @@ rand = [
 # Ignored packages with duplicated versions
 packages = [
     "bitflags",
+    "cfg_aliases",
     "cookie",
     "futures",
     "libloading",


### PR DESCRIPTION
PR https://github.com/servo/servo/pull/32465 broke the lint because it initializes FileList with a file name (./Cargo.lock). This causes it to always return an empty list when the `only_changed_files` parameter is `False` since `os.walk` requires a directory and not a file.

Fixes #32530.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32530
- [x] These changes don't have test because  `python/tidy` doesn't support testing git level operations.

