### PR TITLE
CI: Cache cargo-deny

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           crate: taplo-cli
           locked: true
+      - name: Install cargo-deny
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deny
+          locked: true
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip virtualenv
       - name: Bootstrap dependencies

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,6 +96,11 @@ jobs:
         with:
           crate: taplo-cli
           locked: true
+      - name: Install cargo-deny
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deny
+          locked: true
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip
       - name: Bootstrap dependencies

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -84,6 +84,11 @@ jobs:
         with:
           crate: taplo-cli
           locked: true
+      - name: Install cargo-deny
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deny
+          locked: true
       - name: Bootstrap
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           crate: taplo-cli
           locked: true
+      - name: Install cargo-deny
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deny
+          locked: true
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip virtualenv
       - name: Bootstrap dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           crate: taplo-cli
           locked: true
+      - name: Install cargo-deny
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-deny
+          locked: true
       - name: Install wixtoolset
         run: |
           choco install wixtoolset


### PR DESCRIPTION
Use the `cargo-install` action to cache the cargo-deny output. `cargo-deny` is currently unconditionally installed during bootstrap, and takes around 2 minutes to install, so caching should give a significant speedup

