### PR TITLE
fonts: Clean up WebRender web fonts when they are no longer used

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -845,6 +845,23 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
             },
 
+            ForwardedToCompositorMsg::Layout(ScriptToCompositorMsg::RemoveFonts(
+                keys,
+                instance_keys,
+            )) => {
+                let mut transaction = Transaction::new();
+
+                for instance in instance_keys.into_iter() {
+                    transaction.delete_font_instance(instance);
+                }
+                for key in keys.into_iter() {
+                    transaction.delete_font(key);
+                }
+
+                self.webrender_api
+                    .send_transaction(self.webrender_document, transaction);
+            },
+
             ForwardedToCompositorMsg::Net(NetToCompositorMsg::AddImage(key, desc, data)) => {
                 let mut txn = Transaction::new();
                 txn.add_image(key, desc, data, None);

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -242,6 +242,16 @@ impl Drop for ScriptReflowResult {
     }
 }
 
+impl Drop for LayoutThread {
+    fn drop(&mut self) {
+        let (keys, instance_keys) = self
+            .font_context
+            .collect_unused_webrender_resources(true /* all */);
+        self.webrender_api
+            .remove_unused_font_resources(keys, instance_keys)
+    }
+}
+
 impl Layout for LayoutThread {
     fn device(&self) -> &Device {
         self.stylist.device()
@@ -921,6 +931,12 @@ impl LayoutThread {
 
                 self.webrender_api
                     .send_display_list(compositor_info, builder.end().1);
+
+                let (keys, instance_keys) = self
+                    .font_context
+                    .collect_unused_webrender_resources(false /* all */);
+                self.webrender_api
+                    .remove_unused_font_resources(keys, instance_keys)
             },
         );
     }

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -191,16 +191,18 @@ pub trait WebRenderFontApi {
         flags: FontInstanceFlags,
     ) -> FontInstanceKey;
     fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey;
-    /// Forward an already prepared `AddFont` message, sending it on to the compositor. This is used
-    /// to get WebRender [`FontKey`]s for web fonts in the per-layout `FontContext`.
+    fn add_system_font(&self, handle: NativeFontHandle) -> FontKey;
+
+    /// Forward a `AddFont` message, sending it on to the compositor. This is used to get WebRender
+    /// [`FontKey`]s for web fonts in the per-layout `FontContext`.
     fn forward_add_font_message(
         &self,
         bytes_receiver: IpcBytesReceiver,
         font_index: u32,
         result_sender: IpcSender<FontKey>,
     );
-    /// Forward an already prepared `AddFontInstance` message, sending it on to the compositor. This
-    /// is used to get WebRender [`FontInstanceKey`]s for web fonts in the per-layout `FontContext`.
+    /// Forward a `AddFontInstance` message, sending it on to the compositor. This is used to get
+    /// WebRender [`FontInstanceKey`]s for web fonts in the per-layout `FontContext`.
     fn forward_add_font_instance_message(
         &self,
         font_key: FontKey,
@@ -208,7 +210,6 @@ pub trait WebRenderFontApi {
         flags: FontInstanceFlags,
         result_receiver: IpcSender<FontInstanceKey>,
     );
-    fn add_system_font(&self, handle: NativeFontHandle) -> FontKey;
 }
 
 pub enum CanvasToCompositorMsg {
@@ -257,6 +258,8 @@ pub enum ScriptToCompositorMsg {
     GenerateImageKey(IpcSender<ImageKey>),
     /// Perform a resource update operation.
     UpdateImages(Vec<SerializedImageUpdate>),
+    /// Remove the given font resources from our WebRender instance.
+    RemoveFonts(Vec<FontKey>, Vec<FontInstanceKey>),
 }
 
 /// A mechanism to send messages from networking to the WebRender instance.
@@ -419,6 +422,19 @@ impl WebRenderScriptApi {
                 warn!("error sending image data: {}", e);
             }
         });
+    }
+
+    pub fn remove_unused_font_resources(
+        &self,
+        keys: Vec<FontKey>,
+        instance_keys: Vec<FontInstanceKey>,
+    ) {
+        if keys.is_empty() && instance_keys.is_empty() {
+            return;
+        }
+        let _ = self
+            .0
+            .send(ScriptToCompositorMsg::RemoveFonts(keys, instance_keys));
     }
 }
 


### PR DESCRIPTION
This is the first part of cleaning up unused WebRender resources.
Currently this only cleans up web font resources, but a more
full-featured implementation in the future could also clean up unused
system fonts.

Fixes #32345.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change observable behavior (memory leak).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
