### PR TITLE
mach: fix test-tidy to handle missing merge commit

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -159,6 +159,8 @@ class FileList(object):
 
     def _git_changed_files(self):
         file_list = git_changes_since_last_merge(self.directory)
+        if not file_list:
+            return
         for f in file_list:
             if not any(os.path.join('.', os.path.dirname(f)).startswith(path) for path in self.excluded):
                 yield os.path.join('.', f)


### PR DESCRIPTION
This restores the behavior prior to #32540 where the case where no merge commit being found (which happens on CI in forks because we do a shallow clone) is handled as if no changes were found.

Fixes #32550.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32550
