### PR TITLE
Implement window.HTMLDocument

### DIFF
--- a/components/script/dom/htmldocument.rs
+++ b/components/script/dom/htmldocument.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ptr::NonNull;
+
+use dom_struct::dom_struct;
+use js::jsapi::JSObject;
+
+use crate::dom::bindings::codegen::Bindings::HTMLDocumentBinding::HTMLDocumentMethods;
+use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::reflector::Reflector;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::location::Location;
+use crate::script_runtime::JSContext as SafeJSContext;
+
+// https://html.spec.whatwg.org/multipage/#htmldocument
+#[dom_struct]
+pub struct HTMLDocument {
+    reflector_: Reflector,
+}
+
+impl HTMLDocumentMethods for HTMLDocument {
+    // https://html.spec.whatwg.org/multipage/#htmldocument
+    fn GetLocation(&self) -> Option<DomRoot<Location>> {
+        None
+    }
+
+    // https://html.spec.whatwg.org/multipage/#htmldocument
+    fn SupportedPropertyNames(&self) -> Vec<DOMString> {
+        Vec::new()
+    }
+
+    // https://html.spec.whatwg.org/multipage/#htmldocument
+    fn NamedGetter(
+        &self,
+        _cx: SafeJSContext,
+        _name: DOMString,
+    ) -> Fallible<Option<NonNull<JSObject>>> {
+        Err(Error::NotFound)
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -380,6 +380,7 @@ pub mod htmldialogelement;
 pub mod htmldirectoryelement;
 pub mod htmldivelement;
 pub mod htmldlistelement;
+pub mod htmldocument;
 pub mod htmlelement;
 pub mod htmlembedelement;
 pub mod htmlfieldsetelement;

--- a/components/script/dom/webidls/HTMLDocument.webidl
+++ b/components/script/dom/webidls/HTMLDocument.webidl
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// https://html.spec.whatwg.org/multipage/#htmldocument
+
+[LegacyOverrideBuiltIns,
+ Exposed=Window]
+interface HTMLDocument : Document {
+  // DOM tree accessors
+  [Throws]
+  getter object (DOMString name);
+};


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds the webidl and implementation needed for `window.HTMLDocument` . Behavior is similar to Gecko's one.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32536

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there is no wpt tests covering that field.


