### PR TITLE
ohos: Add fallback font for serif

### DIFF
--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -80,6 +80,8 @@ impl FontList {
         let alternatives = [
             ("HarmonyOS Sans", "HarmonyOS_Sans_SC_Regular.ttf"),
             ("sans-serif", "HarmonyOS_Sans_SC_Regular.ttf"),
+            // Todo: It's unclear what font should be used, but we need to use something
+            ("serif", "HarmonyOS_Sans_SC_Regular.ttf"),
         ];
 
         alternatives


### PR DESCRIPTION
The fallback behavior seems to have changed recently (sometime in the last 2 months). Previously we didn't need to specify any fallback for `serif`, and text requesting serif would still render. Now we need to explicitly add a fallback for `serif` otherwise no font is selected, and the text is not rendered.

Background: 

I don't see any fonts on ohos which a) don't have `Sans` in the name and b) are not some special case font, so I think we don't have much of a choice but to fallback to Harmony OS Sans. Using `Harmony OS Sans`  is probably always the preferred choice on ohos devices, except for the languages which are not supported by it (and maybe Emojis).

I'm not sure if adding an explicit fallback here is the preferred solution, or if servo should instead always try to fallback to some other font family if the requested one is not present.


