### PR TITLE
dependabot: Combine more GStreamer / GLib-related crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,10 @@ updates:
   groups:
     gstreamer-related:
        patterns:
-         - "gstreamer*"
+         - "gio*"
          - "glib*"
+         - "gobject*"
+         - "gstreamer*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: servo_atoms


### PR DESCRIPTION
GLib, GIO, and GObject all release together, so these should be grouped
to prevent having so many dependabot PRs.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change the dependabot configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
