### PR TITLE
crown: remove references to workspace manifest

### DIFF
--- a/support/crown/Cargo.toml
+++ b/support/crown/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "crown"
-version.workspace = true
-authors.workspace = true
-license.workspace = true
-edition.workspace = true
-publish.workspace = true
+authors = ["The Servo Project Developers"]
+version = "0.0.1"
+edition = "2021"
+license = "MPL-2.0"
+publish = false
 
 # Do not use workspace dependencies in this package!
 # In etc/shell.nix, we filter Cargo.lock and build this package in isolation,


### PR DESCRIPTION
The way our shell.nix works requires crown's Cargo.toml to be self-contained so that it can be built as a nix derivation in isolation.  I couldn't find any other way to make shell.nix work, so this duplication is something we can't avoid.

Fixes #32552.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32552 
- [x] These changes do not require tests because the changes are limited to shell.nix.