### PR TITLE
config: fix panic in PrefValue to [f64; 4] conversion

### DIFF
--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -158,9 +158,11 @@ impl From<PrefValue> for [f64; 4] {
     fn from(other: PrefValue) -> [f64; 4] {
         match other {
             PrefValue::Array(values) if values.len() == 4 => {
-                let mut f = values.into_iter().map(|v| v.try_into());
-                if f.all(|v| v.is_ok()) {
-                    let f = f.flatten().collect::<Vec<f64>>();
+                let f = values
+                    .into_iter()
+                    .filter_map(|v| v.try_into().ok())
+                    .collect::<Vec<f64>>();
+                if f.len() == 4 {
                     [f[0], f[1], f[2], f[3]]
                 } else {
                     panic!(


### PR DESCRIPTION
The `Iterator::all()` method consumes the input iterator `f` so when we reuse `f` in `f.flatten().collect()` it yields an empty Vector in the case where all the elements are successfully converted using try_into(). This causes out of bounds access when indexing into the resulting Vector to extract the individual components.

Fixes #32570.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32570
- [x] These changes do not have tests but ideally we should add unit tests for all PrefValue  conversion functions