### PR TITLE
android: Remove serde-json build-dependency

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -24,8 +24,6 @@ bench = false
 vergen = { version = "8.3.1", features = ["git", "git2"] }
 # Android and OpenHarmony
 gl_generator = "0.14"
-# Android only
-serde_json = { workspace = true }
 # MacOS only
 cc = "1.0"
 

--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -5,10 +5,9 @@
 use std::error::Error;
 use std::fs::File;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use gl_generator::{Api, Fallbacks, Profile, Registry};
-use serde_json::Value;
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -60,12 +59,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         let mut libgcc = File::create(out.join("libgcc.a")).unwrap();
         libgcc.write_all(b"INPUT(-lunwind)").unwrap();
         println!("cargo:rustc-link-search=native={}", out.display());
-
-        let mut default_prefs = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        default_prefs.push("../../resources/prefs.json");
-        let prefs: Value = serde_json::from_reader(File::open(&default_prefs).unwrap()).unwrap();
-        let file = File::create(out.join("prefs.json")).unwrap();
-        serde_json::to_writer(file, &prefs).unwrap();
     }
 
     if let Err(error) = EmitBuilder::builder()

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -916,7 +916,7 @@ impl ResourceReaderInstance {
 impl ResourceReaderMethods for ResourceReaderInstance {
     fn read(&self, res: Resource) -> Vec<u8> {
         Vec::from(match res {
-            Resource::Preferences => &include_bytes!(concat!(env!("OUT_DIR"), "/prefs.json"))[..],
+            Resource::Preferences => &include_bytes!("../../../../resources/prefs.json")[..],
             Resource::HstsPreloadList => {
                 &include_bytes!("../../../../resources/hsts_preload.json")[..]
             },


### PR DESCRIPTION
There is no need to add `serde-json` as a
build-dependency (which causes serde to be built
twice when cross-compiling - once for host and once for the target)

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix: remove an unneeded build-time dependency when cross-compiling
- [x] There are tests for these changes 
