### PR TITLE
clippy: fix some warnings in desktop and some components

### DIFF
--- a/components/bluetooth/empty.rs
+++ b/components/bluetooth/empty.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
 
-const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported platform!";
+const NOT_SUPPORTED_ERROR: &str = "Error! Not supported platform!";
 
 #[derive(Clone, Debug)]
 pub struct EmptyAdapter {}

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -298,7 +298,8 @@ impl BrowsingContextActor {
         if let Some(p) = pipeline {
             self.active_pipeline.set(p);
         }
-        *self.url.borrow_mut() = url.as_str().to_owned();
+        // *self.url.borrow_mut() = url.as_str().to_owned();
+        url.as_str().clone_into(&mut self.url.borrow_mut());
         if let Some(ref t) = title {
             self.title.borrow_mut().clone_from(t);
         }

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -298,7 +298,6 @@ impl BrowsingContextActor {
         if let Some(p) = pipeline {
             self.active_pipeline.set(p);
         }
-        // *self.url.borrow_mut() = url.as_str().to_owned();
         url.as_str().clone_into(&mut self.url.borrow_mut());
         if let Some(ref t) = title {
             self.title.borrow_mut().clone_from(t);

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -346,7 +346,6 @@ impl NetworkEventActor {
     }
 
     pub fn add_request(&mut self, request: DevtoolsHttpRequest) {
-        // self.request.url = request.url.as_str().to_owned();
         request.url.as_str().clone_into(&mut self.request.url);
 
         self.request.method = request.method.clone();

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -191,7 +191,7 @@ impl Actor for NetworkEventActor {
                 let mut headersSize = 0;
                 for (name, value) in self.request.headers.iter() {
                     let value = &value.to_str().unwrap().to_string();
-                    rawHeadersString = rawHeadersString + name.as_str() + ":" + &value + "\r\n";
+                    rawHeadersString = rawHeadersString + name.as_str() + ":" + value + "\r\n";
                     headersSize += name.as_str().len() + value.len();
                     headers.push(Header {
                         name: name.as_str().to_owned(),
@@ -346,7 +346,8 @@ impl NetworkEventActor {
     }
 
     pub fn add_request(&mut self, request: DevtoolsHttpRequest) {
-        self.request.url = request.url.as_str().to_owned();
+        // self.request.url = request.url.as_str().to_owned();
+        request.url.as_str().clone_into(&mut self.request.url);
 
         self.request.method = request.method.clone();
         self.request.headers = request.headers.clone();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -135,7 +135,7 @@ mod media_platform {
 
             match GStreamerBackend::init_with_plugins(
                 plugin_dir,
-                &gstreamer_plugins::GSTREAMER_PLUGINS,
+                gstreamer_plugins::GSTREAMER_PLUGINS,
             ) {
                 Ok(b) => b,
                 Err(e) => {

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -94,9 +94,9 @@ impl EventsLoop {
         }
     }
 
-    pub fn run_forever<F: 'static>(self, mut callback: F)
+    pub fn run_forever<F>(self, mut callback: F)
     where
-        F: FnMut(
+        F: 'static + FnMut(
             winit::event::Event<WakerEvent>,
             Option<&winit::event_loop::EventLoopWindowTarget<WakerEvent>>,
             &mut ControlFlow,

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -96,11 +96,12 @@ impl EventsLoop {
 
     pub fn run_forever<F>(self, mut callback: F)
     where
-        F: 'static + FnMut(
-            winit::event::Event<WakerEvent>,
-            Option<&winit::event_loop::EventLoopWindowTarget<WakerEvent>>,
-            &mut ControlFlow,
-        ),
+        F: 'static
+            + FnMut(
+                winit::event::Event<WakerEvent>,
+                Option<&winit::event_loop::EventLoopWindowTarget<WakerEvent>>,
+                &mut ControlFlow,
+            ),
     {
         match self.0 {
             EventLoop::Winit(events_loop) => {

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -173,7 +173,7 @@ impl Minibrowser {
         let _duration = context.run(window, |ctx| {
             // TODO: While in fullscreen add some way to mitigate the increased phishing risk
             // when not displaying the URL bar: https://github.com/servo/servo/issues/32443
-            if !window.fullscreen().is_some() {
+            if window.fullscreen().is_none() {
                 TopBottomPanel::top("toolbar").show(ctx, |ui| {
                     ui.allocate_ui_with_layout(
                         ui.available_size(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed: 
* two small warnings in `ports/servoshell/desktop/minibrowser.rs` and `ports/servoshell/desktop/event_loop.rs`
* some other warnings in the `bluetooth`, `devtools` and `servo` components.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500

<!-- Either: -->
- [X] These changes do not require tests because they are minor clippy fixes that does not change the logic of the code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
Signed-off-by: ItsSunnyMonster <100400733+ItsSunnyMonster@users.noreply.github.com>