### PR TITLE
Add suppression comments + Suppress lazy_static

### DIFF
--- a/support/suppressed_leaks_for_asan.txt
+++ b/support/suppressed_leaks_for_asan.txt
@@ -1,1 +1,5 @@
+# intentional Box::leak, introduced here: https://github.com/servo/stylo/blob/f4cde5d89d03db92d111eaa4b4b34e622b6eecac/style/sharing/mod.rs#L481
 leak:style::sharing::SHARING_CACHE_KEY::__init
+
+# lazy_static never frees memory because it never runs destructors, see https://docs.rs/lazy_static/1.4.0/lazy_static/index.html#semantics
+leak:lazy_static::lazy::Lazy*::get


### PR DESCRIPTION
We investigated some more memory leaks. Found a couple of `lazy_static` leaks that can be safely ignored because `lazy_static` never run destructors -> always leaks in the end. But as it's only allocated once and used for the whole program duration, this is not an issue.

We added some comments to make the suppression reason/intention of the leak clear.

Btw, currently looking at another leak in `Window::new`, which seems to potentially be an actual leak.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes partially fix #32223 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because leak suppression, no function code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
