### PR TITLE
Implement `showModal` and `show` on the `dialog` element

### DIFF
--- a/components/script/dom/webidls/HTMLDialogElement.webidl
+++ b/components/script/dom/webidls/HTMLDialogElement.webidl
@@ -12,8 +12,8 @@ interface HTMLDialogElement : HTMLElement {
   attribute DOMString returnValue;
   // [CEReactions]
   // void show();
-  // [CEReactions]
-  // void showModal();
+  [CEReactions, Throws]
+  undefined showModal();
   [CEReactions]
   undefined close(optional DOMString returnValue);
 };


### PR DESCRIPTION
This PR intends to add support for [`showModal`](https://html.spec.whatwg.org/multipage/#dom-dialog-showmodal) and [`show`](https://html.spec.whatwg.org/multipage/#dom-dialog-show). 

A simple testcase for this is

```html
<dialog id="dialog">
  <p>Greetings, one and all!</p>
  <form method="dialog">
    <button>OK</button>
  </form>
</dialog>
<button onclick="dialog.showModal()">Click</button>
```

This PR is still very much a Draft. I hope it's okay that I've opened this PR (as a draft) to avoid duplicate work (if someone else wants to work on `dialog` as well), even though this PR is not close to ready yet 😅

General Todos:

- [ ] Implement `showModal`: The "basic" functionality works, but additional steps (such as the close watcher) are missing.
- [ ] Implement `show`
- [ ] Add tests for both

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
