### PR TITLE
android: Use location_bar_input_to_url instead of re-implementing

### DIFF
--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -371,20 +371,11 @@ impl ServoGlue {
         Ok(())
     }
 
-    /// Load an URL. If this is not a valid URL, try to "fix" it by adding a scheme or if all else fails,
-    /// interpret the string as a search term.
-    pub fn load_uri(&mut self, request: &str) -> Result<(), &'static str> {
-        info!("load_uri: {}", request);
-        ServoUrl::parse(request)
-            .or_else(|_| {
-                if request.contains('/') || is_reg_domain(request) {
-                    ServoUrl::parse(&format!("https://{}", request))
-                } else {
-                    let search_url = pref!(shell.searchpage).replace("%s", request);
-                    ServoUrl::parse(&search_url)
-                }
-            })
-            .map_err(|_| "Can't parse URL")
+    /// Load an URL.
+    pub fn load_uri(&mut self, url: &str) -> Result<(), &'static str> {
+        info!("load_uri: {}", url);
+        crate::parser::location_bar_input_to_url(url)
+            .ok_or("Can't parse URL")
             .and_then(|url| {
                 let browser_id = self.get_browser_id()?;
                 let event = EmbedderEvent::LoadUrl(browser_id, url);

--- a/ports/servoshell/parser.rs
+++ b/ports/servoshell/parser.rs
@@ -60,6 +60,10 @@ pub fn get_default_url(
     new_url.or(pref_url).or(blank_url).unwrap()
 }
 
+/// Interpret an input URL.
+///
+/// If this is not a valid URL, try to "fix" it by adding a scheme or if all else fails,
+/// interpret the string as a search term.
 pub fn location_bar_input_to_url(request: &str) -> Option<ServoUrl> {
     let request = request.trim();
     ServoUrl::parse(request)


### PR DESCRIPTION
We can use the same function as the desktop version


---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes ~~fix~~ reduce duplicated code.
