### PR TITLE
Avoid Esc shortcut to close Servo

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Run Servo with the command:
 - `Ctrl`+`=` zooms in (`Cmd`+`=` on Mac)
 - `Alt`+`left arrow` goes backwards in the history (`Cmd`+`left arrow` on Mac)
 - `Alt`+`right arrow` goes forwards in the history (`Cmd`+`right arrow` on Mac)
-- `Esc` or `Ctrl`+`Q` exits Servo (`Cmd`+`Q` on Mac)
+- `Ctrl`+`Q` exits Servo (`Cmd`+`Q` on Mac)
+- `Esc` exits fullscreen
 
 ### Runtime dependencies
 

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -342,8 +342,6 @@ where
                         let event = EmbedderEvent::ExitFullScreen(id);
                         self.event_queue.push(event);
                     }
-                } else {
-                    self.event_queue.push(EmbedderEvent::Quit);
                 }
             })
             .otherwise(|| self.platform_handle_key(key_event));

--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -342,6 +342,8 @@ where
                         let event = EmbedderEvent::ExitFullScreen(id);
                         self.event_queue.push(event);
                     }
+                } else {
+                    self.platform_handle_key(key_event.clone());
                 }
             })
             .otherwise(|| self.platform_handle_key(key_event));


### PR DESCRIPTION
Keep Esc shortcut to leave fullscreen, but avoid to close Servo (as this is not common in other similar apps,
and can be shortcut used in some web apps for other things).

This patch also sends Esc to the page, which was not happening before.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the servoshell frontend is currently considered untestable