### PR TITLE
layout: use `Au` in `AtomicLineItem`

### DIFF
--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -444,7 +444,7 @@ impl InlineBoxLineItem {
 
 pub(super) struct AtomicLineItem {
     pub fragment: BoxFragment,
-    pub size: LogicalVec2<Length>,
+    pub size: LogicalVec2<Au>,
     pub positioning_context: Option<PositioningContext>,
 
     /// The block offset of this items' baseline relative to the baseline of the line.
@@ -474,7 +474,7 @@ impl AtomicLineItem {
                 &relative_adjustement(&self.fragment.style, state.ifc_containing_block);
         }
 
-        state.inline_position += self.size.inline;
+        state.inline_position += self.size.inline.into();
 
         if let Some(mut positioning_context) = self.positioning_context {
             positioning_context.adjust_static_position_of_hoisted_fragments_with_offset(
@@ -493,7 +493,7 @@ impl AtomicLineItem {
         match self.fragment.style.clone_vertical_align() {
             GenericVerticalAlign::Keyword(VerticalAlignKeyword::Top) => Length::zero(),
             GenericVerticalAlign::Keyword(VerticalAlignKeyword::Bottom) => {
-                line_metrics.block_size - self.size.block
+                line_metrics.block_size - self.size.block.into()
             },
 
             // This covers all baseline-relative vertical alignment.


### PR DESCRIPTION
I think we somehow missed the conversion of the `size` member of the `AtomicLineItem` struct. With this change, all members of `AtomicLineItem` use `Au` now.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
