### PR TITLE
Replace null-byte terminated string literals with C-string literals

### DIFF
--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -714,7 +714,7 @@ fn redirect_stdout_to_logcat() {
 
         let mut cursor = 0_usize;
 
-        let tag = b"servoshell\0".as_ptr() as _;
+        let tag = c"servoshell".as_ptr() as _;
 
         loop {
             let result = {
@@ -735,7 +735,7 @@ fn redirect_stdout_to_logcat() {
                     __android_log_write(
                         3,
                         tag,
-                        b"error in log thread; closing\0".as_ptr() as *const _,
+                        c"error in log thread; closing".as_ptr() as *const _,
                     );
                 }
                 return;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32628 (GitHub issue number if applicable)


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
