### PR TITLE
layout: Make `geom.rs` logical geoemetry types more ergonomic

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -617,7 +617,7 @@ impl<'a> BuilderForBoxFragment<'a> {
 
         let radii = inner_radii(
             self.border_radius,
-            (&self.fragment.border + &self.fragment.padding)
+            (self.fragment.border + self.fragment.padding)
                 .to_physical(self.fragment.style.writing_mode)
                 .to_webrender(),
         );

--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -266,6 +266,6 @@ where
         inline: flow_relative_base_rect_size.inline - flow_relative_offsets.inline_end,
         block: flow_relative_base_rect_size.block - flow_relative_offsets.block_end,
     };
-    let size = &end_corner_position - &start_corner;
+    let size = end_corner_position - start_corner;
     LogicalRect { start_corner, size }
 }

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -428,7 +428,7 @@ impl FlexContainer {
                     },
                 };
                 for (fragment, _) in &mut line.item_fragments {
-                    fragment.content_rect.start_corner += &flow_relative_line_position
+                    fragment.content_rect.start_corner += flow_relative_line_position
                 }
                 line.item_fragments
             });

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -897,7 +897,7 @@ impl FloatBox {
                 // or non-replaced.
                 let pbm = style.padding_border_margin(containing_block);
                 let margin = pbm.margin.auto_is(Au::zero);
-                let pbm_sums = &(&pbm.padding + &pbm.border) + &margin.clone();
+                let pbm_sums = pbm.padding + pbm.border + margin;
 
                 let (content_size, children);
                 match self.contents {
@@ -1208,10 +1208,10 @@ impl SequentialLayoutState {
             block_start_of_containing_block_in_bfc + block_offset_from_containing_block_top,
         );
 
-        let pbm_sums = &(&box_fragment.padding + &box_fragment.border) + &box_fragment.margin;
-        let content_rect = box_fragment.content_rect.clone();
+        let pbm_sums = box_fragment.padding + box_fragment.border + box_fragment.margin;
+        let content_rect = &box_fragment.content_rect;
         let margin_box_start_corner = self.floats.add_float(&PlacementInfo {
-            size: &content_rect.size + &pbm_sums.sum(),
+            size: content_rect.size + pbm_sums.sum(),
             side: FloatSide::from_style(&box_fragment.style).expect("Float box wasn't floated!"),
             clear: box_fragment.style.get_box().clear,
         });
@@ -1219,7 +1219,7 @@ impl SequentialLayoutState {
         // This is the position of the float in the float-containing block formatting context. We add the
         // existing start corner here because we may have already gotten some relative positioning offset.
         let new_position_in_bfc =
-            &(&margin_box_start_corner + &pbm_sums.start_offset()) + &content_rect.start_corner;
+            margin_box_start_corner + pbm_sums.start_offset() + content_rect.start_corner;
 
         // This is the position of the float relative to the containing block start.
         let new_position_in_containing_block = LogicalVec2 {

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1206,7 +1206,7 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
         );
 
         let mut placement_rect = placement.place();
-        placement_rect.start_corner = &placement_rect.start_corner - &ifc_offset_in_float_container;
+        placement_rect.start_corner -= ifc_offset_in_float_container;
         placement_rect.into()
     }
 
@@ -2026,7 +2026,7 @@ impl IndependentFormattingContext {
         let style = self.style();
         let pbm = style.padding_border_margin(ifc.containing_block);
         let margin = pbm.margin.auto_is(Au::zero);
-        let pbm_sums = &(&pbm.padding + &pbm.border) + &margin.clone();
+        let pbm_sums = pbm.padding + pbm.border + margin;
         let mut child_positioning_context = None;
 
         // We need to know the inline size of the atomic before deciding whether to do the line break.
@@ -2156,7 +2156,7 @@ impl IndependentFormattingContext {
             ifc.process_soft_wrap_opportunity();
         }
 
-        let size = &pbm_sums.sum() + &fragment.content_rect.size;
+        let size = pbm_sums.sum() + fragment.content_rect.size;
         let baseline_offset = self
             .pick_baseline(&fragment.baselines)
             .map(|baseline| pbm_sums.block_start + baseline)
@@ -2171,7 +2171,7 @@ impl IndependentFormattingContext {
         );
         ifc.push_line_item_to_unbreakable_segment(LineItem::Atomic(AtomicLineItem {
             fragment,
-            size: size.into(),
+            size,
             positioning_context: child_positioning_context,
             baseline_offset_in_parent,
             baseline_offset_in_item: baseline_offset,
@@ -2402,7 +2402,7 @@ impl<'a> ContentSizesComputation<'a> {
                     .percentages_relative_to(zero)
                     .auto_is(Length::zero);
 
-                let pbm = &(&margin + &padding) + &border;
+                let pbm = margin + padding + border;
                 if inline_box.is_first_fragment {
                     self.add_length(pbm.inline_start);
                 }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1086,7 +1086,7 @@ impl NonReplacedFormattingContext {
                 &collapsed_margin_block_start,
                 containing_block,
                 &pbm,
-                &content_size + &pbm.padding_border_sums.into(),
+                content_size + pbm.padding_border_sums.into(),
                 &self.style,
             );
         } else {
@@ -1102,12 +1102,10 @@ impl NonReplacedFormattingContext {
             });
 
             // Create a PlacementAmongFloats using the minimum size in all dimensions as the object size.
-            let minimum_size_of_block = &LogicalVec2 {
-                inline: min_box_size.inline,
-                block: block_size.auto_is(|| min_box_size.block),
-            }
-            .into() +
-                &pbm.padding_border_sums;
+            let minimum_size_of_block = LogicalVec2 {
+                inline: min_box_size.inline.into(),
+                block: block_size.auto_is(|| min_box_size.block).into(),
+            } + pbm.padding_border_sums;
             let mut placement = PlacementAmongFloats::new(
                 &sequential_layout_state.floats,
                 ceiling,
@@ -1291,7 +1289,7 @@ fn layout_in_flow_replaced_block_level(
         //  than defined by section 10.3.3. CSS 2 does not define when a UA may put said
         //  element next to the float or by how much said element may become narrower."
         let collapsed_margin_block_start = CollapsedMargin::new(margin_block_start);
-        let size = &content_size + &pbm.padding_border_sums.clone();
+        let size = content_size + pbm.padding_border_sums;
         (
             clearance,
             (margin_inline_start, margin_inline_end),

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -4,7 +4,7 @@
 
 use std::convert::From;
 use std::fmt;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 use app_units::Au;
 use serde::Serialize;
@@ -32,13 +32,13 @@ pub struct LogicalVec2<T> {
     pub block: T,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Copy, Serialize)]
 pub struct LogicalRect<T> {
     pub start_corner: LogicalVec2<T>,
     pub size: LogicalVec2<T>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Copy, Debug, Serialize)]
 pub struct LogicalSides<T> {
     pub inline_start: T,
     pub inline_end: T,
@@ -79,13 +79,9 @@ impl<T: Clone> LogicalVec2<T> {
     }
 }
 
-impl<T> Add<&'_ LogicalVec2<T>> for &'_ LogicalVec2<T>
-where
-    T: Add<Output = T> + Copy,
-{
+impl<T: Add<Output = T> + Copy> Add<LogicalVec2<T>> for LogicalVec2<T> {
     type Output = LogicalVec2<T>;
-
-    fn add(self, other: &'_ LogicalVec2<T>) -> Self::Output {
+    fn add(self, other: Self) -> Self::Output {
         LogicalVec2 {
             inline: self.inline + other.inline,
             block: self.block + other.block,
@@ -93,13 +89,9 @@ where
     }
 }
 
-impl<T> Sub<&'_ LogicalVec2<T>> for &'_ LogicalVec2<T>
-where
-    T: Sub<Output = T> + Copy,
-{
+impl<T: Sub<Output = T> + Copy> Sub<LogicalVec2<T>> for LogicalVec2<T> {
     type Output = LogicalVec2<T>;
-
-    fn sub(self, other: &'_ LogicalVec2<T>) -> Self::Output {
+    fn sub(self, other: Self) -> Self::Output {
         LogicalVec2 {
             inline: self.inline - other.inline,
             block: self.block - other.block,
@@ -107,41 +99,27 @@ where
     }
 }
 
-impl<T> AddAssign<&'_ LogicalVec2<T>> for LogicalVec2<T>
-where
-    T: AddAssign<T> + Copy,
-{
-    fn add_assign(&mut self, other: &'_ LogicalVec2<T>) {
+impl<T: AddAssign<T> + Copy> AddAssign<LogicalVec2<T>> for LogicalVec2<T> {
+    fn add_assign(&mut self, other: LogicalVec2<T>) {
         self.inline += other.inline;
         self.block += other.block;
     }
 }
 
-impl<T> AddAssign<LogicalVec2<T>> for LogicalVec2<T>
-where
-    T: AddAssign<T> + Copy,
-{
-    fn add_assign(&mut self, other: LogicalVec2<T>) {
-        self.add_assign(&other);
-    }
-}
-
-impl<T> SubAssign<&'_ LogicalVec2<T>> for LogicalVec2<T>
-where
-    T: SubAssign<T> + Copy,
-{
-    fn sub_assign(&mut self, other: &'_ LogicalVec2<T>) {
+impl<T: SubAssign<T> + Copy> SubAssign<LogicalVec2<T>> for LogicalVec2<T> {
+    fn sub_assign(&mut self, other: LogicalVec2<T>) {
         self.inline -= other.inline;
         self.block -= other.block;
     }
 }
 
-impl<T> SubAssign<LogicalVec2<T>> for LogicalVec2<T>
-where
-    T: SubAssign<T> + Copy,
-{
-    fn sub_assign(&mut self, other: LogicalVec2<T>) {
-        self.sub_assign(&other);
+impl<T: Neg<Output = T> + Copy> Neg for LogicalVec2<T> {
+    type Output = LogicalVec2<T>;
+    fn neg(self) -> Self::Output {
+        Self {
+            inline: -self.inline,
+            block: -self.block,
+        }
     }
 }
 
@@ -352,10 +330,7 @@ impl<T> LogicalSides<T> {
     }
 }
 
-impl<T> LogicalSides<T>
-where
-    T: Copy,
-{
+impl<T: Copy> LogicalSides<T> {
     pub fn start_offset(&self) -> LogicalVec2<T> {
         LogicalVec2 {
             inline: self.inline_start,
@@ -382,18 +357,27 @@ impl<T: Clone> LogicalSides<AutoOr<T>> {
     }
 }
 
-impl<T> Add<&'_ LogicalSides<T>> for &'_ LogicalSides<T>
-where
-    T: Add<Output = T> + Copy,
-{
+impl<T: Add<Output = T> + Copy> Add<LogicalSides<T>> for LogicalSides<T> {
     type Output = LogicalSides<T>;
 
-    fn add(self, other: &'_ LogicalSides<T>) -> Self::Output {
+    fn add(self, other: Self) -> Self::Output {
         LogicalSides {
             inline_start: self.inline_start + other.inline_start,
             inline_end: self.inline_end + other.inline_end,
             block_start: self.block_start + other.block_start,
             block_end: self.block_end + other.block_end,
+        }
+    }
+}
+
+impl<T: Neg<Output = T> + Copy> Neg for LogicalSides<T> {
+    type Output = LogicalSides<T>;
+    fn neg(self) -> Self::Output {
+        Self {
+            inline_start: -self.inline_start,
+            inline_end: -self.inline_end,
+            block_start: -self.block_start,
+            block_end: -self.block_end,
         }
     }
 }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -240,8 +240,7 @@ impl PositioningContext {
         self.append(new_context);
 
         if style.clone_position() == Position::Relative {
-            new_fragment.content_rect.start_corner +=
-                &relative_adjustement(style, containing_block);
+            new_fragment.content_rect.start_corner += relative_adjustement(style, containing_block);
         }
 
         new_fragment
@@ -690,7 +689,7 @@ impl HoistedAbsolutelyPositionedBox {
                 block_end: block_axis.margin_end,
             };
 
-            let pb = &pbm.padding + &pbm.border;
+            let pb = pbm.padding + pbm.border;
             let inline_start = match inline_axis.anchor {
                 Anchor::Start(start) => start + pb.inline_start + margin.inline_start,
                 Anchor::End(end) => {


### PR DESCRIPTION
Make using the logical geometry types more ergonomic by having them all
implement `Copy` (at most 4 64-bit numbers), similar to what `euclid`
does. In addition add an implementation of `Neg` for `LogicalVec` and
`LogicalSides` as it will be used in upcoming table implementation code.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
