### PR TITLE
webgpu: Implement ShaderCompilationInfo

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -170,7 +170,12 @@ DOMInterfaces = {
 
 'GPUDevice': {
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
-    'inRealms': ['PopErrorScope', 'CreateComputePipelineAsync', 'CreateRenderPipelineAsync'],
+    'inRealms': [
+        'PopErrorScope',
+        'CreateComputePipelineAsync',
+        'CreateRenderPipelineAsync',
+        'CreateShaderModule' # Creates promise for compilation info
+    ],
 }
 
 }

--- a/components/script/dom/gpucompilationmessage.rs
+++ b/components/script/dom/gpucompilationmessage.rs
@@ -5,6 +5,7 @@
 #![allow(dead_code)] // this file is stub as wgpu does not provide info
 
 use dom_struct::dom_struct;
+use webgpu::ShaderCompilationInfo;
 
 use super::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCompilationMessageMethods, GPUCompilationMessageType,
@@ -60,6 +61,18 @@ impl GPUCompilationMessage {
                 message, mtype, line_num, line_pos, offset, length,
             )),
             global,
+        )
+    }
+
+    pub fn from(global: &GlobalScope, info: ShaderCompilationInfo) -> DomRoot<Self> {
+        GPUCompilationMessage::new(
+            global,
+            info.message.into(),
+            GPUCompilationMessageType::Error,
+            info.line_number as u64,
+            info.line_pos as u64,
+            info.offset as u64,
+            info.length as u64,
         )
     }
 }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -1032,7 +1032,7 @@ impl AsyncWGPUListener for GPUDevice {
                     promise.resolve_native(&error);
                 },
             },
-            _ => unreachable!("Wrong response recived on AsyncWGPUListener for GPUDevice"),
+            _ => unreachable!("Wrong response received on AsyncWGPUListener for GPUDevice"),
         }
     }
 }

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use webgpu::{WebGPU, WebGPURequest, WebGPUShaderModule};
 
-use super::bindings::error::Fallible;
 use super::promise::Promise;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUShaderModuleMethods;
@@ -25,15 +24,23 @@ pub struct GPUShaderModule {
     label: DomRefCell<USVString>,
     #[no_trace]
     shader_module: WebGPUShaderModule,
+    #[ignore_malloc_size_of = "promise"]
+    compilation_info_promise: Rc<Promise>,
 }
 
 impl GPUShaderModule {
-    fn new_inherited(channel: WebGPU, shader_module: WebGPUShaderModule, label: USVString) -> Self {
+    fn new_inherited(
+        channel: WebGPU,
+        shader_module: WebGPUShaderModule,
+        label: USVString,
+        promise: Rc<Promise>,
+    ) -> Self {
         Self {
             reflector_: Reflector::new(),
             channel,
             label: DomRefCell::new(label),
             shader_module,
+            compilation_info_promise: promise,
         }
     }
 
@@ -42,12 +49,14 @@ impl GPUShaderModule {
         channel: WebGPU,
         shader_module: WebGPUShaderModule,
         label: USVString,
+        promise: Rc<Promise>,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUShaderModule::new_inherited(
                 channel,
                 shader_module,
                 label,
+                promise,
             )),
             global,
         )
@@ -72,8 +81,8 @@ impl GPUShaderModuleMethods for GPUShaderModule {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo>
-    fn GetCompilationInfo(&self) -> Fallible<Rc<Promise>> {
-        todo!("Missing in wgpu: https://github.com/gfx-rs/wgpu/issues/2170")
+    fn GetCompilationInfo(&self) -> Rc<Promise> {
+        self.compilation_info_promise.clone()
     }
 }
 

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -95,7 +95,7 @@ impl AsyncWGPUListener for GPUShaderModule {
                 let info = GPUCompilationInfo::from(&self.global(), info);
                 promise.resolve_native(&info);
             },
-            _ => unreachable!("Wrong response recived on AsyncWGPUListener for GPUDevice"),
+            _ => unreachable!("Wrong response received on AsyncWGPUListener for GPUShaderModule"),
         }
     }
 }

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -486,7 +486,6 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
 
 [Exposed=(Window, DedicatedWorker), Serializable, Pref="dom.webgpu.enabled"]
 interface GPUShaderModule {
-    [Throws]
     Promise<GPUCompilationInfo> getCompilationInfo();
 };
 GPUShaderModule includes GPUObjectBase;
@@ -515,9 +514,8 @@ interface GPUCompilationMessage {
 
 [Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
 interface GPUCompilationInfo {
-    // codegen hates it
-    //[Cached, Frozen, Pure]
-    readonly attribute /*sequence<GPUCompilationMessage>*/ any messages;
+    //readonly attribute FrozenArray<GPUCompilationMessage> messages;
+    readonly attribute any messages;
 };
 
 enum GPUAutoLayoutMode {

--- a/components/webgpu/dom_messages.rs
+++ b/components/webgpu/dom_messages.rs
@@ -25,10 +25,53 @@ use wgc::pipeline::{ComputePipelineDescriptor, RenderPipelineDescriptor};
 use wgc::resource::{
     BufferDescriptor, SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
+use wgpu_core::pipeline::CreateShaderModuleError;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
 use crate::identity::*;
 use crate::{Error, ErrorFilter, PopError, WebGPU, PRESENTATION_BUFFER_COUNT};
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ShaderCompilationInfo {
+    pub line_number: u64,
+    pub line_pos: u64,
+    pub offset: u64,
+    pub length: u64,
+    pub message: String,
+}
+
+impl ShaderCompilationInfo {
+    pub fn from(error: &CreateShaderModuleError, source: &str) -> Self {
+        let location = match error {
+            CreateShaderModuleError::Parsing(e) => e.inner.location(source),
+            CreateShaderModuleError::Validation(e) => e.inner.location(source),
+            _ => None,
+        };
+
+        if let Some(location) = location {
+            // Naga reports locations in UTF-8 code units, but spec requires location in UTF-16 code units
+            // Based on https://searchfox.org/mozilla-central/rev/5b037d9c6ecdb0729f39ad519f0b867d80a92aad/gfx/wgpu_bindings/src/server.rs#353
+            fn len_utf16(s: &str) -> u64 {
+                s.chars().map(|c| c.len_utf16() as u64).sum()
+            }
+            let start = location.offset as usize;
+            let end = start + location.length as usize;
+            let line_start = source[0..start].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
+            Self {
+                line_number: location.line_number as u64,
+                line_pos: len_utf16(&source[line_start..start]) + 1,
+                offset: len_utf16(&source[0..start]),
+                length: len_utf16(&source[start..end]),
+                message: error.to_string(),
+            }
+        } else {
+            Self {
+                message: error.to_string(),
+                ..Default::default()
+            }
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
@@ -48,6 +91,7 @@ pub enum WebGPUResponse {
     BufferMapAsync(IpcSharedMemory),
     SubmittedWorkDone,
     PoppedErrorScope(Result<Option<Error>, PopError>),
+    CompilationInfo(Option<ShaderCompilationInfo>),
 }
 
 pub type WebGPUResponseResult = Result<WebGPUResponse, String>;
@@ -145,6 +189,7 @@ pub enum WebGPURequest {
         program_id: id::ShaderModuleId,
         program: String,
         label: Option<String>,
+        sender: IpcSender<Option<WebGPUResponseResult>>,
     },
     CreateSwapChain {
         device_id: id::DeviceId,

--- a/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.https.html.ini
@@ -3273,6 +3273,8 @@
       if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="storage";writeContext="render-pass-encoder"]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:boundary="command-buffer";readOp="input-indirect-dispatch";readContext="compute-pass-encoder";writeOp="t2b-copy";writeContext="command-encoder"]
 
@@ -7487,18 +7489,35 @@
 
 
 [cts.https.html?q=webgpu:api,operation,shader_module,compilation_info:getCompilationInfo_returns:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:valid=false;name="ascii"]
+
+  [:valid=false;name="carriage-return"]
+
+  [:valid=false;name="unicode"]
+
+  [:valid=true;name="ascii"]
+
+  [:valid=true;name="unicode"]
 
 
 [cts.https.html?q=webgpu:api,operation,shader_module,compilation_info:line_number_and_position:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:valid=false;name="ascii"]
+
+  [:valid=false;name="carriage-return"]
+
+  [:valid=false;name="unicode"]
 
 
 [cts.https.html?q=webgpu:api,operation,shader_module,compilation_info:offset_and_length:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:valid=false;name="ascii"]
+
+  [:valid=false;name="carriage-return"]
+
+  [:valid=false;name="unicode"]
+
+  [:valid=true;name="ascii"]
+
+  [:valid=true;name="unicode"]
 
 
 [cts.https.html?q=webgpu:api,operation,storage_texture,read_write:basic:*]
@@ -18270,36 +18289,48 @@
   expected:
     if os == "linux" and not debug: [TIMEOUT, CRASH]
   [:limitTest="atDefault";testValueName="atLimit";async=false]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="atDefault";testValueName="atLimit";async=true]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="atDefault";testValueName="overLimit";async=false]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="atDefault";testValueName="overLimit";async=true]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:limitTest="atMaximum";testValueName="atLimit";async=false]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="atMaximum";testValueName="atLimit";async=true]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="atMaximum";testValueName="overLimit";async=false]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="atMaximum";testValueName="overLimit";async=true]
     expected:
       if os == "linux" and not debug: FAIL
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=false]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=false]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=true]
     expected:
@@ -62403,37 +62434,71 @@
 
 
 [cts.https.html?q=webgpu:api,validation,state,device_lost,destroy:queue,writeTexture,2d,uncompressed_format:*]
+  expected:
+    if os == "linux" and not debug: TIMEOUT
   [:format="bgra8unorm";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="bgra8unorm";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="bgra8unorm-srgb";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="bgra8unorm-srgb";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r16float";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r16float";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r16sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r16sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r16uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r16uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r32float";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r32float";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r32sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r32sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r32uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r32uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="r8sint";awaitLost=false]
 
@@ -62453,35 +62518,59 @@
 
   [:format="rg11b10ufloat";awaitLost=false]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [TIMEOUT, NOTRUN]
 
   [:format="rg11b10ufloat";awaitLost=true]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="rg16float";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg16float";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg16sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg16sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg16uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg16uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg32float";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg32float";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg32sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg32sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg32uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg32uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rg8sint";awaitLost=false]
 
@@ -62501,67 +62590,113 @@
 
   [:format="rgb10a2uint";awaitLost=false]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, TIMEOUT, NOTRUN]
 
   [:format="rgb10a2uint";awaitLost=true]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: [FAIL, NOTRUN]
 
   [:format="rgb10a2unorm";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgb10a2unorm";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgb9e5ufloat";awaitLost=false]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgb9e5ufloat";awaitLost=true]
     expected:
-      if os == "linux" and not debug: FAIL
+      if os == "linux" and not debug: NOTRUN
 
   [:format="rgba16float";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba16float";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba16sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba16sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba16uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba16uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba32float";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba32float";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba32sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba32sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba32uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba32uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8sint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8sint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8snorm";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8snorm";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8uint";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8uint";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8unorm";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, FAIL]
 
   [:format="rgba8unorm";awaitLost=true]
 
   [:format="rgba8unorm-srgb";awaitLost=false]
+    expected:
+      if os == "linux" and not debug: [PASS, NOTRUN]
 
   [:format="rgba8unorm-srgb";awaitLost=true]
+    expected:
+      if os == "linux" and not debug: [PASS, TIMEOUT]
 
 
 [cts.https.html?q=webgpu:api,validation,texture,bgra8unorm_storage:configure_storage_usage_on_canvas_context_with_bgra8unorm_storage:*]
@@ -63743,6 +63878,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_comparison:equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -63809,6 +63946,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_division:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -63889,6 +64028,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_matrix_subtraction:matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -63933,6 +64074,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_multiplication:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -63975,6 +64118,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -64009,6 +64154,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_remainder:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -64029,6 +64176,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,af_subtraction:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -65213,6 +65362,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_addition:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -65307,6 +65458,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_comparison:greater_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -65341,6 +65494,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_comparison:less_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -65409,6 +65564,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_comparison:not_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -65513,6 +65670,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -65539,6 +65698,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -65565,6 +65726,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_division:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -66031,6 +66194,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_scalar_multiplication:matrix_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -66253,6 +66418,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_subtraction:matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -66401,6 +66568,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_vector_multiplication:matrix_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -66475,6 +66644,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_matrix_vector_multiplication:vector_matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -66585,6 +66756,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -66645,6 +66818,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_multiplication:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -66767,6 +66942,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -66819,6 +66996,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_remainder:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -66915,6 +67094,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -66967,6 +67148,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f16_subtraction:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
 
   [:inputSource="const";dim=3]
@@ -67019,6 +67202,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67073,6 +67258,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_addition:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67201,6 +67388,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67243,6 +67432,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_comparison:greater_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67453,6 +67644,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67465,6 +67658,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67507,6 +67702,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67539,6 +67736,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67571,6 +67770,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_division:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67727,6 +67928,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_addition:matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -67819,6 +68022,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_matrix_multiplication:matrix_matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";common_dim=2;x_rows=2;y_cols=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68551,6 +68756,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_subtraction:matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68735,6 +68942,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -68827,6 +69036,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_matrix_vector_multiplication:vector_matrix_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68913,6 +69124,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -68945,6 +69158,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_multiplication:vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69159,6 +69374,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_remainder:vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69373,6 +69590,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,f32_subtraction:vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69489,6 +69708,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69521,6 +69742,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:addition_vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69651,6 +69874,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69767,6 +69992,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:division_vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -69867,6 +70094,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69909,6 +70138,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69951,6 +70182,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -69983,6 +70216,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70015,6 +70250,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:multiplication_vector_scalar_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70047,6 +70284,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70113,6 +70352,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_compound:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70229,6 +70470,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:remainder_vector_scalar:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_lhs=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70413,6 +70656,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_arithmetic:subtraction_scalar_vector:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize_rhs=2]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -70677,6 +70922,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,i32_comparison:less_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -70761,6 +71008,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:addition:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -71223,6 +71472,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_arithmetic:multiplication:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -71949,6 +72200,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:greater_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -71991,6 +72244,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_equals:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -72033,6 +72288,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,binary,u32_comparison:less_than:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -72363,6 +72620,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acos:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -72439,6 +72698,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,acosh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -73317,6 +73578,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,asin:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73537,6 +73800,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan2:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -73579,6 +73844,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -73613,6 +73880,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atan:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -73689,6 +73958,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,atanh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -78843,6 +79114,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,ceil:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -79005,6 +79278,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,clamp:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -79233,6 +79508,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cos:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79275,6 +79552,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cosh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -79643,6 +79922,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -79653,6 +79934,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,cross:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79811,6 +80094,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,determinant:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";dim=2]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79887,6 +80172,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -79907,6 +80194,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f16_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -79917,6 +80206,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -79929,6 +80220,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,distance:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -80011,6 +80304,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:abstract_int:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -80031,6 +80326,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:f16_vec3:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -80087,6 +80384,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -80097,6 +80396,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,dot:u32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -80311,6 +80612,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp2:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -80379,6 +80682,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,exp2:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -80927,6 +81232,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,floor:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -80969,6 +81276,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,fma:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -81533,6 +81842,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -81567,6 +81878,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,inversesqrt:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -81839,6 +82152,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,length:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [PASS, FAIL]
@@ -81943,6 +82258,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log2:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82019,6 +82336,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -82053,6 +82372,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,log:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -82095,6 +82416,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82225,6 +82548,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,max:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82309,6 +82634,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82361,6 +82688,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -82439,6 +82768,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,min:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82523,6 +82854,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_matching:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82553,6 +82886,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:abstract_float_nonmatching_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: [FAIL, TIMEOUT]
@@ -82623,6 +82958,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_matching:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82665,6 +83002,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,mix:f32_nonmatching_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82701,6 +83040,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82713,12 +83054,16 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec2_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_vec3_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82743,12 +83088,16 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:abstract_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82759,6 +83108,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec2_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82769,6 +83120,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec2_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82779,6 +83132,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec3_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82799,6 +83154,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec4_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82809,6 +83166,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_vec4_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82819,6 +83178,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f16_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -82829,6 +83190,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_fract:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82901,6 +83264,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,modf:f32_vec4_whole:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -82959,6 +83324,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f16_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -83013,6 +83380,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,normalize:f32_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83025,6 +83394,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pack2x16float:pack:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83179,6 +83550,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,pow:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -83323,6 +83696,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,radians:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83375,6 +83750,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,radians:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83463,6 +83840,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f16_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
   [:inputSource="storage_r"]
@@ -83497,6 +83876,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,reflect:f32_vec4:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83509,6 +83890,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize=2]
 
   [:inputSource="const";vectorize=3]
@@ -83565,6 +83948,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,refract:f32_vec2:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -83703,6 +84088,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,round:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -83779,6 +84166,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,saturate:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -84335,6 +84724,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sign:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -84487,6 +84878,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sin:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -84563,6 +84956,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -84597,6 +84992,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -84631,6 +85028,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,sinh:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -85085,6 +85484,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tan:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -85195,6 +85596,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,tanh:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86231,6 +86634,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,transpose:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";cols=2;rows=2]
 
   [:inputSource="const";cols=2;rows=3]
@@ -86397,6 +86802,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,trunc:abstract_float:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86449,6 +86856,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,trunc:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86491,6 +86900,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,call,builtin,unpack2x16float:unpack:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -86829,6 +87240,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,af_assignment:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const"]
 
 
@@ -87011,6 +87424,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,bool_conversion:u32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87413,6 +87828,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f16_conversion:u32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -87639,6 +88056,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,f32_conversion:f32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -87983,6 +88402,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_conversion:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -88083,6 +88504,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,i32_conversion:i32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -88819,6 +89242,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:f16:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
 
   [:inputSource="const";vectorize=2]
@@ -88961,6 +89386,8 @@
 
 
 [cts.https.html?q=webgpu:shader,execution,expression,unary,u32_conversion:u32:*]
+  expected:
+    if os == "linux" and not debug: OK
   [:inputSource="const";vectorize="_undef_"]
     expected:
       if os == "linux" and not debug: FAIL
@@ -92067,323 +92494,3477 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:constant_expression_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function"]
+
+  [:scope="module"]
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_and_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function"]
+
+  [:scope="module"]
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_and_no_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="module"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_or_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function"]
+
+  [:scope="module"]
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:constant_expression_logical_or_no_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="module"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:constant_expression_no_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="module"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,const_assert,const_assert:evaluation_stage:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="function";stage="constant"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="function";stage="override"]
+
+  [:scope="function";stage="runtime"]
+
+  [:scope="module";stage="constant"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="module";stage="override"]
+
+  [:scope="module";stage="runtime"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,compound_statement:decl_conflict:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="a"]
+
+  [:case="bc"]
+
+  [:case="d"]
+
+  [:case="e"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,compound_statement:decl_use:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="a"]
+
+  [:case="b"]
+
+  [:case="c_no"]
+
+  [:case="c_yes"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="d_no"]
+
+  [:case="d_yes"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="e"]
+
+  [:case="self"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,const:no_direct_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="a"]
+
+  [:target="b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,const:no_indirect_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="a"]
+
+  [:target="b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,const:no_indirect_recursion_via_array_size:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="a"]
+
+  [:target="b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,const:no_indirect_recursion_via_struct_attribute:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="a";attribute="align"]
+
+  [:target="a";attribute="location"]
+
+  [:target="a";attribute="size"]
+
+  [:target="b";attribute="align"]
+
+  [:target="b";attribute="location"]
+
+  [:target="b";attribute="size"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,override:no_direct_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="a"]
+
+  [:target="b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,override:no_indirect_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="a"]
+
+  [:target="b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:let_ptr_explicit_type_matches_var:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";ptrStoreType="u32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";ptrStoreType="u32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:let_ptr_reads:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:let_ptr_writes:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=false;ptrStoreType="i32"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute";inferPtrType=true;ptrStoreType="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:ptr_address_space_never_uses_access_mode:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";accessMode="read"]
+
+  [:addressSpace="function";accessMode="read_write"]
+
+  [:addressSpace="function";accessMode="write"]
+
+  [:addressSpace="handle";accessMode="read"]
+
+  [:addressSpace="handle";accessMode="read_write"]
+
+  [:addressSpace="handle";accessMode="write"]
+
+  [:addressSpace="private";accessMode="read"]
+
+  [:addressSpace="private";accessMode="read_write"]
+
+  [:addressSpace="private";accessMode="write"]
+
+  [:addressSpace="uniform";accessMode="read"]
+
+  [:addressSpace="uniform";accessMode="read_write"]
+
+  [:addressSpace="uniform";accessMode="write"]
+
+  [:addressSpace="workgroup";accessMode="read"]
+
+  [:addressSpace="workgroup";accessMode="read_write"]
+
+  [:addressSpace="workgroup";accessMode="write"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:ptr_bad_store_type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:storeType="1"]
+
+  [:storeType="clamp"]
+
+  [:storeType="undeclared"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:ptr_handle_space_invalid:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,ptr_spelling:ptr_not_instantiable:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="RTArrayNotLast"]
+
+  [:case="functionAtomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="functionRTArray"]
+
+  [:case="nestedRTArray"]
+
+  [:case="privateAtomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="privateRTArray"]
+
+  [:case="ptr"]
+
+  [:case="uniformAtomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniformRTArray"]
+
+  [:case="workgroupRTArray"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:binding_collision_unused_helper:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:binding_collisions:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:a_group=0;b_group=0;a_binding=0;b_binding=0;b_use="different"]
+
+  [:a_group=0;b_group=0;a_binding=0;b_binding=0;b_use="same"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_group=0;b_group=0;a_binding=0;b_binding=1;b_use="different"]
+
+  [:a_group=0;b_group=0;a_binding=0;b_binding=1;b_use="same"]
+
+  [:a_group=0;b_group=0;a_binding=1;b_binding=0;b_use="different"]
+
+  [:a_group=0;b_group=0;a_binding=1;b_binding=0;b_use="same"]
+
+  [:a_group=0;b_group=0;a_binding=1;b_binding=1;b_use="different"]
+
+  [:a_group=0;b_group=0;a_binding=1;b_binding=1;b_use="same"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_group=0;b_group=1;a_binding=0;b_binding=0;b_use="different"]
+
+  [:a_group=0;b_group=1;a_binding=0;b_binding=0;b_use="same"]
+
+  [:a_group=0;b_group=1;a_binding=0;b_binding=1;b_use="different"]
+
+  [:a_group=0;b_group=1;a_binding=0;b_binding=1;b_use="same"]
+
+  [:a_group=0;b_group=1;a_binding=1;b_binding=0;b_use="different"]
+
+  [:a_group=0;b_group=1;a_binding=1;b_binding=0;b_use="same"]
+
+  [:a_group=0;b_group=1;a_binding=1;b_binding=1;b_use="different"]
+
+  [:a_group=0;b_group=1;a_binding=1;b_binding=1;b_use="same"]
+
+  [:a_group=1;b_group=0;a_binding=0;b_binding=0;b_use="different"]
+
+  [:a_group=1;b_group=0;a_binding=0;b_binding=0;b_use="same"]
+
+  [:a_group=1;b_group=0;a_binding=0;b_binding=1;b_use="different"]
+
+  [:a_group=1;b_group=0;a_binding=0;b_binding=1;b_use="same"]
+
+  [:a_group=1;b_group=0;a_binding=1;b_binding=0;b_use="different"]
+
+  [:a_group=1;b_group=0;a_binding=1;b_binding=0;b_use="same"]
+
+  [:a_group=1;b_group=0;a_binding=1;b_binding=1;b_use="different"]
+
+  [:a_group=1;b_group=0;a_binding=1;b_binding=1;b_use="same"]
+
+  [:a_group=1;b_group=1;a_binding=0;b_binding=0;b_use="different"]
+
+  [:a_group=1;b_group=1;a_binding=0;b_binding=0;b_use="same"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_group=1;b_group=1;a_binding=0;b_binding=1;b_use="different"]
+
+  [:a_group=1;b_group=1;a_binding=0;b_binding=1;b_use="same"]
+
+  [:a_group=1;b_group=1;a_binding=1;b_binding=0;b_use="different"]
+
+  [:a_group=1;b_group=1;a_binding=1;b_binding=0;b_use="same"]
+
+  [:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="different"]
+
+  [:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="same"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:binding_point_on_function_var:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:group="";binding=""]
+
+  [:group="";binding="%40binding(0)"]
+
+  [:group="%40group(0)";binding=""]
+
+  [:group="%40group(0)";binding="%40binding(0)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:binding_point_on_non_resources:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addrspace="private";group="";binding=""]
+
+  [:addrspace="private";group="";binding="%40binding(0)"]
+
+  [:addrspace="private";group="%40group(0)";binding=""]
+
+  [:addrspace="private";group="%40group(0)";binding="%40binding(0)"]
+
+  [:addrspace="workgroup";group="";binding=""]
+
+  [:addrspace="workgroup";group="";binding="%40binding(0)"]
+
+  [:addrspace="workgroup";group="%40group(0)";binding=""]
+
+  [:addrspace="workgroup";group="%40group(0)";binding="%40binding(0)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:binding_point_on_resources:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:decl="sampler";group="";binding=""]
+
+  [:decl="sampler";group="";binding="%40binding(0)"]
+
+  [:decl="sampler";group="%40group(0)";binding=""]
+
+  [:decl="sampler";group="%40group(0)";binding="%40binding(0)"]
+
+  [:decl="storage";group="";binding=""]
+
+  [:decl="storage";group="";binding="%40binding(0)"]
+
+  [:decl="storage";group="%40group(0)";binding=""]
+
+  [:decl="storage";group="%40group(0)";binding="%40binding(0)"]
+
+  [:decl="texture";group="";binding=""]
+
+  [:decl="texture";group="";binding="%40binding(0)"]
+
+  [:decl="texture";group="%40group(0)";binding=""]
+
+  [:decl="texture";group="%40group(0)";binding="%40binding(0)"]
+
+  [:decl="uniform";group="";binding=""]
+
+  [:decl="uniform";group="";binding="%40binding(0)"]
+
+  [:decl="uniform";group="%40group(0)";binding=""]
+
+  [:decl="uniform";group="%40group(0)";binding="%40binding(0)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:function_addrspace_at_module_scope:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addrspace="function"]
+
+  [:addrspace="private"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:function_scope_types:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="S_S_bool";kind="comment";via_alias=false]
+
+  [:type="S_S_bool";kind="comment";via_alias=true]
+
+  [:type="S_S_bool";kind="var";via_alias=false]
+
+  [:type="S_S_bool";kind="var";via_alias=true]
+
+  [:type="S_array_bool_4";kind="comment";via_alias=false]
+
+  [:type="S_array_bool_4";kind="comment";via_alias=true]
+
+  [:type="S_array_bool_4";kind="var";via_alias=false]
+
+  [:type="S_array_bool_4";kind="var";via_alias=true]
+
+  [:type="S_array_vec4u";kind="comment";via_alias=false]
+
+  [:type="S_array_vec4u";kind="comment";via_alias=true]
+
+  [:type="S_array_vec4u";kind="var";via_alias=false]
+
+  [:type="S_array_vec4u";kind="var";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="comment";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="comment";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="var";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="var";via_alias=true]
+
+  [:type="S_bool";kind="comment";via_alias=false]
+
+  [:type="S_bool";kind="comment";via_alias=true]
+
+  [:type="S_bool";kind="var";via_alias=false]
+
+  [:type="S_bool";kind="var";via_alias=true]
+
+  [:type="S_u32";kind="comment";via_alias=false]
+
+  [:type="S_u32";kind="comment";via_alias=true]
+
+  [:type="S_u32";kind="var";via_alias=false]
+
+  [:type="S_u32";kind="var";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="var";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="var";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="var";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="var";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="var";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="var";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="var";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="var";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="var";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="var";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="comment";via_alias=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="comment";via_alias=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="var";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="var";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="comment";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="comment";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="var";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="var";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="comment";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="comment";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="var";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="var";via_alias=true]
+
+  [:type="bool";kind="comment";via_alias=false]
+
+  [:type="bool";kind="comment";via_alias=true]
+
+  [:type="bool";kind="var";via_alias=false]
+
+  [:type="bool";kind="var";via_alias=true]
+
+  [:type="f16";kind="comment";via_alias=false]
+
+  [:type="f16";kind="comment";via_alias=true]
+
+  [:type="f16";kind="var";via_alias=false]
+
+  [:type="f16";kind="var";via_alias=true]
+
+  [:type="f32";kind="comment";via_alias=false]
+
+  [:type="f32";kind="comment";via_alias=true]
+
+  [:type="f32";kind="var";via_alias=false]
+
+  [:type="f32";kind="var";via_alias=true]
+
+  [:type="i32";kind="comment";via_alias=false]
+
+  [:type="i32";kind="comment";via_alias=true]
+
+  [:type="i32";kind="var";via_alias=false]
+
+  [:type="i32";kind="var";via_alias=true]
+
+  [:type="mat2x2f";kind="comment";via_alias=false]
+
+  [:type="mat2x2f";kind="comment";via_alias=true]
+
+  [:type="mat2x2f";kind="var";via_alias=false]
+
+  [:type="mat2x2f";kind="var";via_alias=true]
+
+  [:type="mat3x4h";kind="comment";via_alias=false]
+
+  [:type="mat3x4h";kind="comment";via_alias=true]
+
+  [:type="mat3x4h";kind="var";via_alias=false]
+
+  [:type="mat3x4h";kind="var";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="comment";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="comment";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="var";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="var";via_alias=true]
+
+  [:type="sampler";kind="comment";via_alias=false]
+
+  [:type="sampler";kind="comment";via_alias=true]
+
+  [:type="sampler";kind="var";via_alias=false]
+
+  [:type="sampler";kind="var";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="comment";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="comment";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="var";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="var";via_alias=true]
+
+  [:type="u32";kind="comment";via_alias=false]
+
+  [:type="u32";kind="comment";via_alias=true]
+
+  [:type="u32";kind="var";via_alias=false]
+
+  [:type="u32";kind="var";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="comment";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="comment";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="var";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="var";via_alias=true]
+
+  [:type="vec2f";kind="comment";via_alias=false]
+
+  [:type="vec2f";kind="comment";via_alias=true]
+
+  [:type="vec2f";kind="var";via_alias=false]
+
+  [:type="vec2f";kind="var";via_alias=true]
+
+  [:type="vec3h";kind="comment";via_alias=false]
+
+  [:type="vec3h";kind="comment";via_alias=true]
+
+  [:type="vec3h";kind="var";via_alias=false]
+
+  [:type="vec3h";kind="var";via_alias=true]
+
+  [:type="vec3i";kind="comment";via_alias=false]
+
+  [:type="vec3i";kind="comment";via_alias=true]
+
+  [:type="vec3i";kind="var";via_alias=false]
+
+  [:type="vec3i";kind="var";via_alias=true]
+
+  [:type="vec4u";kind="comment";via_alias=false]
+
+  [:type="vec4u";kind="comment";via_alias=true]
+
+  [:type="vec4u";kind="var";via_alias=false]
+
+  [:type="vec4u";kind="var";via_alias=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:handle_initializer:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:initializer=false;type="sampler"]
+
+  [:initializer=false;type="texture_2d%3Cf32%3E"]
+
+  [:initializer=true;type="sampler"]
+
+  [:initializer=true;type="texture_2d%3Cf32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:initializer_kind:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:initializer="42u";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="42u";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="another_private_var";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="another_private_var";addrspace="private"]
+
+  [:initializer="my_const_42u";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="my_const_42u";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="my_override_42u";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="my_override_42u";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="u32()";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="u32()";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="u32(sqrt(42.0))";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="u32(sqrt(42.0))";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="user_func()";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="user_func()";addrspace="private"]
+
+  [:initializer="vec4u(1,%202,%203,%204)[another_private_var%20%2F%2020\]";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="vec4u(1,%202,%203,%204)[another_private_var%20%2F%2020\]";addrspace="private"]
+
+  [:initializer="vec4u(1,%202,%203,%204)[my_const_42u%20%2F%2020\]";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="vec4u(1,%202,%203,%204)[my_const_42u%20%2F%2020\]";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="vec4u(1,%202,%203,%204)[my_override_42u%20%2F%2020\]";addrspace="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:initializer="vec4u(1,%202,%203,%204)[my_override_42u%20%2F%2020\]";addrspace="private"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:module_scope_initializers:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:initializer=false;kind="private"]
+
+  [:initializer=false;kind="storage_ro"]
+
+  [:initializer=false;kind="storage_rw"]
+
+  [:initializer=false;kind="uniform"]
+
+  [:initializer=false;kind="workgroup"]
+
+  [:initializer=true;kind="private"]
+
+  [:initializer=true;kind="storage_ro"]
+
+  [:initializer=true;kind="storage_rw"]
+
+  [:initializer=true;kind="uniform"]
+
+  [:initializer=true;kind="workgroup"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var:module_scope_types:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="S_S_bool";kind="comment";via_alias=false]
+
+  [:type="S_S_bool";kind="comment";via_alias=true]
+
+  [:type="S_S_bool";kind="handle";via_alias=false]
+
+  [:type="S_S_bool";kind="handle";via_alias=true]
+
+  [:type="S_S_bool";kind="private";via_alias=false]
+
+  [:type="S_S_bool";kind="private";via_alias=true]
+
+  [:type="S_S_bool";kind="storage_ro";via_alias=false]
+
+  [:type="S_S_bool";kind="storage_ro";via_alias=true]
+
+  [:type="S_S_bool";kind="storage_rw";via_alias=false]
+
+  [:type="S_S_bool";kind="storage_rw";via_alias=true]
+
+  [:type="S_S_bool";kind="uniform";via_alias=false]
+
+  [:type="S_S_bool";kind="uniform";via_alias=true]
+
+  [:type="S_S_bool";kind="workgroup";via_alias=false]
+
+  [:type="S_S_bool";kind="workgroup";via_alias=true]
+
+  [:type="S_array_bool_4";kind="comment";via_alias=false]
+
+  [:type="S_array_bool_4";kind="comment";via_alias=true]
+
+  [:type="S_array_bool_4";kind="handle";via_alias=false]
+
+  [:type="S_array_bool_4";kind="handle";via_alias=true]
+
+  [:type="S_array_bool_4";kind="private";via_alias=false]
+
+  [:type="S_array_bool_4";kind="private";via_alias=true]
+
+  [:type="S_array_bool_4";kind="storage_ro";via_alias=false]
+
+  [:type="S_array_bool_4";kind="storage_ro";via_alias=true]
+
+  [:type="S_array_bool_4";kind="storage_rw";via_alias=false]
+
+  [:type="S_array_bool_4";kind="storage_rw";via_alias=true]
+
+  [:type="S_array_bool_4";kind="uniform";via_alias=false]
+
+  [:type="S_array_bool_4";kind="uniform";via_alias=true]
+
+  [:type="S_array_bool_4";kind="workgroup";via_alias=false]
+
+  [:type="S_array_bool_4";kind="workgroup";via_alias=true]
+
+  [:type="S_array_vec4u";kind="comment";via_alias=false]
+
+  [:type="S_array_vec4u";kind="comment";via_alias=true]
+
+  [:type="S_array_vec4u";kind="handle";via_alias=false]
+
+  [:type="S_array_vec4u";kind="handle";via_alias=true]
+
+  [:type="S_array_vec4u";kind="private";via_alias=false]
+
+  [:type="S_array_vec4u";kind="private";via_alias=true]
+
+  [:type="S_array_vec4u";kind="storage_ro";via_alias=false]
+
+  [:type="S_array_vec4u";kind="storage_ro";via_alias=true]
+
+  [:type="S_array_vec4u";kind="storage_rw";via_alias=false]
+
+  [:type="S_array_vec4u";kind="storage_rw";via_alias=true]
+
+  [:type="S_array_vec4u";kind="uniform";via_alias=false]
+
+  [:type="S_array_vec4u";kind="uniform";via_alias=true]
+
+  [:type="S_array_vec4u";kind="workgroup";via_alias=false]
+
+  [:type="S_array_vec4u";kind="workgroup";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="comment";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="comment";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="handle";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="handle";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="private";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="private";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="storage_ro";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="storage_ro";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="storage_rw";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="storage_rw";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="uniform";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="uniform";via_alias=true]
+
+  [:type="S_array_vec4u_4";kind="workgroup";via_alias=false]
+
+  [:type="S_array_vec4u_4";kind="workgroup";via_alias=true]
+
+  [:type="S_bool";kind="comment";via_alias=false]
+
+  [:type="S_bool";kind="comment";via_alias=true]
+
+  [:type="S_bool";kind="handle";via_alias=false]
+
+  [:type="S_bool";kind="handle";via_alias=true]
+
+  [:type="S_bool";kind="private";via_alias=false]
+
+  [:type="S_bool";kind="private";via_alias=true]
+
+  [:type="S_bool";kind="storage_ro";via_alias=false]
+
+  [:type="S_bool";kind="storage_ro";via_alias=true]
+
+  [:type="S_bool";kind="storage_rw";via_alias=false]
+
+  [:type="S_bool";kind="storage_rw";via_alias=true]
+
+  [:type="S_bool";kind="uniform";via_alias=false]
+
+  [:type="S_bool";kind="uniform";via_alias=true]
+
+  [:type="S_bool";kind="workgroup";via_alias=false]
+
+  [:type="S_bool";kind="workgroup";via_alias=true]
+
+  [:type="S_u32";kind="comment";via_alias=false]
+
+  [:type="S_u32";kind="comment";via_alias=true]
+
+  [:type="S_u32";kind="handle";via_alias=false]
+
+  [:type="S_u32";kind="handle";via_alias=true]
+
+  [:type="S_u32";kind="private";via_alias=false]
+
+  [:type="S_u32";kind="private";via_alias=true]
+
+  [:type="S_u32";kind="storage_ro";via_alias=false]
+
+  [:type="S_u32";kind="storage_ro";via_alias=true]
+
+  [:type="S_u32";kind="storage_rw";via_alias=false]
+
+  [:type="S_u32";kind="storage_rw";via_alias=true]
+
+  [:type="S_u32";kind="uniform";via_alias=false]
+
+  [:type="S_u32";kind="uniform";via_alias=true]
+
+  [:type="S_u32";kind="workgroup";via_alias=false]
+
+  [:type="S_u32";kind="workgroup";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="handle";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="handle";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="private";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="private";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="storage_ro";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="storage_ro";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="storage_rw";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="storage_rw";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="uniform";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="uniform";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="workgroup";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E%3E";kind="workgroup";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="handle";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="handle";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="private";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="private";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="storage_ro";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="storage_ro";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="storage_rw";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="storage_rw";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="uniform";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="uniform";via_alias=true]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="workgroup";via_alias=false]
+
+  [:type="array%3Cvec4%3Cbool%3E,%204%3E";kind="workgroup";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="handle";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="handle";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="private";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="private";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="storage_ro";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="storage_ro";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="storage_rw";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="storage_rw";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="uniform";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="uniform";via_alias=true]
+
+  [:type="array%3Cvec4u%3E";kind="workgroup";via_alias=false]
+
+  [:type="array%3Cvec4u%3E";kind="workgroup";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="handle";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="handle";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="private";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="private";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="storage_ro";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="storage_ro";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="storage_rw";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="storage_rw";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="uniform";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="uniform";via_alias=true]
+
+  [:type="array%3Cvec4u,%204%3E";kind="workgroup";via_alias=false]
+
+  [:type="array%3Cvec4u,%204%3E";kind="workgroup";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="comment";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="comment";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="handle";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="handle";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="private";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="private";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="storage_ro";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="storage_ro";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="storage_rw";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="storage_rw";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="uniform";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="uniform";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="workgroup";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_const%3E";kind="workgroup";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="comment";via_alias=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="comment";via_alias=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="handle";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="handle";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="private";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="private";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="storage_ro";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="storage_ro";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="storage_rw";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="storage_rw";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="uniform";via_alias=false]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="uniform";via_alias=true]
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="workgroup";via_alias=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="array%3Cvec4u,%20array_size_override%3E";kind="workgroup";via_alias=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Ci32%3E";kind="comment";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="comment";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="handle";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="handle";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="private";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="private";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="storage_ro";via_alias=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Ci32%3E";kind="storage_ro";via_alias=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Ci32%3E";kind="storage_rw";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="storage_rw";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="uniform";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="uniform";via_alias=true]
+
+  [:type="atomic%3Ci32%3E";kind="workgroup";via_alias=false]
+
+  [:type="atomic%3Ci32%3E";kind="workgroup";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="comment";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="comment";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="handle";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="handle";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="private";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="private";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="storage_ro";via_alias=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Cu32%3E";kind="storage_ro";via_alias=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Cu32%3E";kind="storage_rw";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="storage_rw";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="uniform";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="uniform";via_alias=true]
+
+  [:type="atomic%3Cu32%3E";kind="workgroup";via_alias=false]
+
+  [:type="atomic%3Cu32%3E";kind="workgroup";via_alias=true]
+
+  [:type="bool";kind="comment";via_alias=false]
+
+  [:type="bool";kind="comment";via_alias=true]
+
+  [:type="bool";kind="handle";via_alias=false]
+
+  [:type="bool";kind="handle";via_alias=true]
+
+  [:type="bool";kind="private";via_alias=false]
+
+  [:type="bool";kind="private";via_alias=true]
+
+  [:type="bool";kind="storage_ro";via_alias=false]
+
+  [:type="bool";kind="storage_ro";via_alias=true]
+
+  [:type="bool";kind="storage_rw";via_alias=false]
+
+  [:type="bool";kind="storage_rw";via_alias=true]
+
+  [:type="bool";kind="uniform";via_alias=false]
+
+  [:type="bool";kind="uniform";via_alias=true]
+
+  [:type="bool";kind="workgroup";via_alias=false]
+
+  [:type="bool";kind="workgroup";via_alias=true]
+
+  [:type="f16";kind="comment";via_alias=false]
+
+  [:type="f16";kind="comment";via_alias=true]
+
+  [:type="f16";kind="handle";via_alias=false]
+
+  [:type="f16";kind="handle";via_alias=true]
+
+  [:type="f16";kind="private";via_alias=false]
+
+  [:type="f16";kind="private";via_alias=true]
+
+  [:type="f16";kind="storage_ro";via_alias=false]
+
+  [:type="f16";kind="storage_ro";via_alias=true]
+
+  [:type="f16";kind="storage_rw";via_alias=false]
+
+  [:type="f16";kind="storage_rw";via_alias=true]
+
+  [:type="f16";kind="uniform";via_alias=false]
+
+  [:type="f16";kind="uniform";via_alias=true]
+
+  [:type="f16";kind="workgroup";via_alias=false]
+
+  [:type="f16";kind="workgroup";via_alias=true]
+
+  [:type="f32";kind="comment";via_alias=false]
+
+  [:type="f32";kind="comment";via_alias=true]
+
+  [:type="f32";kind="handle";via_alias=false]
+
+  [:type="f32";kind="handle";via_alias=true]
+
+  [:type="f32";kind="private";via_alias=false]
+
+  [:type="f32";kind="private";via_alias=true]
+
+  [:type="f32";kind="storage_ro";via_alias=false]
+
+  [:type="f32";kind="storage_ro";via_alias=true]
+
+  [:type="f32";kind="storage_rw";via_alias=false]
+
+  [:type="f32";kind="storage_rw";via_alias=true]
+
+  [:type="f32";kind="uniform";via_alias=false]
+
+  [:type="f32";kind="uniform";via_alias=true]
+
+  [:type="f32";kind="workgroup";via_alias=false]
+
+  [:type="f32";kind="workgroup";via_alias=true]
+
+  [:type="i32";kind="comment";via_alias=false]
+
+  [:type="i32";kind="comment";via_alias=true]
+
+  [:type="i32";kind="handle";via_alias=false]
+
+  [:type="i32";kind="handle";via_alias=true]
+
+  [:type="i32";kind="private";via_alias=false]
+
+  [:type="i32";kind="private";via_alias=true]
+
+  [:type="i32";kind="storage_ro";via_alias=false]
+
+  [:type="i32";kind="storage_ro";via_alias=true]
+
+  [:type="i32";kind="storage_rw";via_alias=false]
+
+  [:type="i32";kind="storage_rw";via_alias=true]
+
+  [:type="i32";kind="uniform";via_alias=false]
+
+  [:type="i32";kind="uniform";via_alias=true]
+
+  [:type="i32";kind="workgroup";via_alias=false]
+
+  [:type="i32";kind="workgroup";via_alias=true]
+
+  [:type="mat2x2f";kind="comment";via_alias=false]
+
+  [:type="mat2x2f";kind="comment";via_alias=true]
+
+  [:type="mat2x2f";kind="handle";via_alias=false]
+
+  [:type="mat2x2f";kind="handle";via_alias=true]
+
+  [:type="mat2x2f";kind="private";via_alias=false]
+
+  [:type="mat2x2f";kind="private";via_alias=true]
+
+  [:type="mat2x2f";kind="storage_ro";via_alias=false]
+
+  [:type="mat2x2f";kind="storage_ro";via_alias=true]
+
+  [:type="mat2x2f";kind="storage_rw";via_alias=false]
+
+  [:type="mat2x2f";kind="storage_rw";via_alias=true]
+
+  [:type="mat2x2f";kind="uniform";via_alias=false]
+
+  [:type="mat2x2f";kind="uniform";via_alias=true]
+
+  [:type="mat2x2f";kind="workgroup";via_alias=false]
+
+  [:type="mat2x2f";kind="workgroup";via_alias=true]
+
+  [:type="mat3x4h";kind="comment";via_alias=false]
+
+  [:type="mat3x4h";kind="comment";via_alias=true]
+
+  [:type="mat3x4h";kind="handle";via_alias=false]
+
+  [:type="mat3x4h";kind="handle";via_alias=true]
+
+  [:type="mat3x4h";kind="private";via_alias=false]
+
+  [:type="mat3x4h";kind="private";via_alias=true]
+
+  [:type="mat3x4h";kind="storage_ro";via_alias=false]
+
+  [:type="mat3x4h";kind="storage_ro";via_alias=true]
+
+  [:type="mat3x4h";kind="storage_rw";via_alias=false]
+
+  [:type="mat3x4h";kind="storage_rw";via_alias=true]
+
+  [:type="mat3x4h";kind="uniform";via_alias=false]
+
+  [:type="mat3x4h";kind="uniform";via_alias=true]
+
+  [:type="mat3x4h";kind="workgroup";via_alias=false]
+
+  [:type="mat3x4h";kind="workgroup";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="comment";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="comment";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="handle";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="handle";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="private";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="private";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="storage_ro";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="storage_ro";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="storage_rw";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="storage_rw";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="uniform";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="uniform";via_alias=true]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="workgroup";via_alias=false]
+
+  [:type="ptr%3Cfunction,%20u32%3E";kind="workgroup";via_alias=true]
+
+  [:type="sampler";kind="comment";via_alias=false]
+
+  [:type="sampler";kind="comment";via_alias=true]
+
+  [:type="sampler";kind="handle";via_alias=false]
+
+  [:type="sampler";kind="handle";via_alias=true]
+
+  [:type="sampler";kind="private";via_alias=false]
+
+  [:type="sampler";kind="private";via_alias=true]
+
+  [:type="sampler";kind="storage_ro";via_alias=false]
+
+  [:type="sampler";kind="storage_ro";via_alias=true]
+
+  [:type="sampler";kind="storage_rw";via_alias=false]
+
+  [:type="sampler";kind="storage_rw";via_alias=true]
+
+  [:type="sampler";kind="uniform";via_alias=false]
+
+  [:type="sampler";kind="uniform";via_alias=true]
+
+  [:type="sampler";kind="workgroup";via_alias=false]
+
+  [:type="sampler";kind="workgroup";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="comment";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="comment";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="handle";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="handle";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="private";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="private";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="storage_ro";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="storage_ro";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="storage_rw";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="storage_rw";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="uniform";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="uniform";via_alias=true]
+
+  [:type="texture_2d%3Cf32%3E";kind="workgroup";via_alias=false]
+
+  [:type="texture_2d%3Cf32%3E";kind="workgroup";via_alias=true]
+
+  [:type="u32";kind="comment";via_alias=false]
+
+  [:type="u32";kind="comment";via_alias=true]
+
+  [:type="u32";kind="handle";via_alias=false]
+
+  [:type="u32";kind="handle";via_alias=true]
+
+  [:type="u32";kind="private";via_alias=false]
+
+  [:type="u32";kind="private";via_alias=true]
+
+  [:type="u32";kind="storage_ro";via_alias=false]
+
+  [:type="u32";kind="storage_ro";via_alias=true]
+
+  [:type="u32";kind="storage_rw";via_alias=false]
+
+  [:type="u32";kind="storage_rw";via_alias=true]
+
+  [:type="u32";kind="uniform";via_alias=false]
+
+  [:type="u32";kind="uniform";via_alias=true]
+
+  [:type="u32";kind="workgroup";via_alias=false]
+
+  [:type="u32";kind="workgroup";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="comment";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="comment";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="handle";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="handle";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="private";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="private";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="storage_ro";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="storage_ro";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="storage_rw";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="storage_rw";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="uniform";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="uniform";via_alias=true]
+
+  [:type="vec2%3Cbool%3E";kind="workgroup";via_alias=false]
+
+  [:type="vec2%3Cbool%3E";kind="workgroup";via_alias=true]
+
+  [:type="vec2f";kind="comment";via_alias=false]
+
+  [:type="vec2f";kind="comment";via_alias=true]
+
+  [:type="vec2f";kind="handle";via_alias=false]
+
+  [:type="vec2f";kind="handle";via_alias=true]
+
+  [:type="vec2f";kind="private";via_alias=false]
+
+  [:type="vec2f";kind="private";via_alias=true]
+
+  [:type="vec2f";kind="storage_ro";via_alias=false]
+
+  [:type="vec2f";kind="storage_ro";via_alias=true]
+
+  [:type="vec2f";kind="storage_rw";via_alias=false]
+
+  [:type="vec2f";kind="storage_rw";via_alias=true]
+
+  [:type="vec2f";kind="uniform";via_alias=false]
+
+  [:type="vec2f";kind="uniform";via_alias=true]
+
+  [:type="vec2f";kind="workgroup";via_alias=false]
+
+  [:type="vec2f";kind="workgroup";via_alias=true]
+
+  [:type="vec3h";kind="comment";via_alias=false]
+
+  [:type="vec3h";kind="comment";via_alias=true]
+
+  [:type="vec3h";kind="handle";via_alias=false]
+
+  [:type="vec3h";kind="handle";via_alias=true]
+
+  [:type="vec3h";kind="private";via_alias=false]
+
+  [:type="vec3h";kind="private";via_alias=true]
+
+  [:type="vec3h";kind="storage_ro";via_alias=false]
+
+  [:type="vec3h";kind="storage_ro";via_alias=true]
+
+  [:type="vec3h";kind="storage_rw";via_alias=false]
+
+  [:type="vec3h";kind="storage_rw";via_alias=true]
+
+  [:type="vec3h";kind="uniform";via_alias=false]
+
+  [:type="vec3h";kind="uniform";via_alias=true]
+
+  [:type="vec3h";kind="workgroup";via_alias=false]
+
+  [:type="vec3h";kind="workgroup";via_alias=true]
+
+  [:type="vec3i";kind="comment";via_alias=false]
+
+  [:type="vec3i";kind="comment";via_alias=true]
+
+  [:type="vec3i";kind="handle";via_alias=false]
+
+  [:type="vec3i";kind="handle";via_alias=true]
+
+  [:type="vec3i";kind="private";via_alias=false]
+
+  [:type="vec3i";kind="private";via_alias=true]
+
+  [:type="vec3i";kind="storage_ro";via_alias=false]
+
+  [:type="vec3i";kind="storage_ro";via_alias=true]
+
+  [:type="vec3i";kind="storage_rw";via_alias=false]
+
+  [:type="vec3i";kind="storage_rw";via_alias=true]
+
+  [:type="vec3i";kind="uniform";via_alias=false]
+
+  [:type="vec3i";kind="uniform";via_alias=true]
+
+  [:type="vec3i";kind="workgroup";via_alias=false]
+
+  [:type="vec3i";kind="workgroup";via_alias=true]
+
+  [:type="vec4u";kind="comment";via_alias=false]
+
+  [:type="vec4u";kind="comment";via_alias=true]
+
+  [:type="vec4u";kind="handle";via_alias=false]
+
+  [:type="vec4u";kind="handle";via_alias=true]
+
+  [:type="vec4u";kind="private";via_alias=false]
+
+  [:type="vec4u";kind="private";via_alias=true]
+
+  [:type="vec4u";kind="storage_ro";via_alias=false]
+
+  [:type="vec4u";kind="storage_ro";via_alias=true]
+
+  [:type="vec4u";kind="storage_rw";via_alias=false]
+
+  [:type="vec4u";kind="storage_rw";via_alias=true]
+
+  [:type="vec4u";kind="uniform";via_alias=false]
+
+  [:type="vec4u";kind="uniform";via_alias=true]
+
+  [:type="vec4u";kind="workgroup";via_alias=false]
+
+  [:type="vec4u";kind="workgroup";via_alias=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var_access_mode:explicit_access_mode:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="write";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="write";stage="compute"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="write";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="write";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="write";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="write";stage="compute"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var_access_mode:implicit_access_mode:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var_access_mode:read_access:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
 
 
 [cts.https.html?q=webgpu:shader,validation,decl,var_access_mode:write_access:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:addressSpace="function";explicitSpace=false;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=false;explicitAccess=true;accessMode="";stage="compute"]
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="function";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="private";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read";stage="compute"]
+
+  [:addressSpace="storage";explicitSpace=true;explicitAccess=true;accessMode="read_write";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="uniform";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=false;accessMode="";stage="compute"]
+
+  [:addressSpace="workgroup";explicitSpace=true;explicitAccess=true;accessMode="";stage="compute"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,access,vector:vector:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:vector_decl="const";vector_width=2;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=2;element_type="f16"]
+
+  [:vector_decl="const";vector_width=2;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=2;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=2;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=3;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=3;element_type="f16"]
+
+  [:vector_decl="const";vector_width=3;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=3;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=3;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=4;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=4;element_type="f16"]
+
+  [:vector_decl="const";vector_width=4;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=4;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="const";vector_width=4;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=2;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=2;element_type="f16"]
+
+  [:vector_decl="let";vector_width=2;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=2;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=2;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=3;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=3;element_type="f16"]
+
+  [:vector_decl="let";vector_width=3;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=3;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=3;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=4;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=4;element_type="f16"]
+
+  [:vector_decl="let";vector_width=4;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=4;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="let";vector_width=4;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=2;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=2;element_type="f16"]
+
+  [:vector_decl="param";vector_width=2;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=2;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=2;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=3;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=3;element_type="f16"]
+
+  [:vector_decl="param";vector_width=3;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=3;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=3;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=4;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=4;element_type="f16"]
+
+  [:vector_decl="param";vector_width=4;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=4;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="param";vector_width=4;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=2;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=2;element_type="f16"]
+
+  [:vector_decl="var";vector_width=2;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=2;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=2;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=3;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=3;element_type="f16"]
+
+  [:vector_decl="var";vector_width=3;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=3;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=3;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=4;element_type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=4;element_type="f16"]
+
+  [:vector_decl="var";vector_width=4;element_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=4;element_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vector_decl="var";vector_width=4;element_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_concrete:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case={"lhs":"-1073741824i","rhs":"1u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1073741824i","rhs":"1u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1073741824i","rhs":"1u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1073741824i","rhs":"1u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"1u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"1u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"1u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"1u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"31u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"31u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"31u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"-1i","rhs":"31u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize=4]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize=4]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize=2]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize=3]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize=4]
+
+  [:case={"lhs":"1073741824i","rhs":"1u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1073741824i","rhs":"1u","pass":false};vectorize=2]
+
+  [:case={"lhs":"1073741824i","rhs":"1u","pass":false};vectorize=3]
+
+  [:case={"lhs":"1073741824i","rhs":"1u","pass":false};vectorize=4]
+
+  [:case={"lhs":"1073741824u","rhs":"1u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1073741824u","rhs":"1u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1073741824u","rhs":"1u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1073741824u","rhs":"1u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize=2]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize=3]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize=4]
+
+  [:case={"lhs":"1i","rhs":"31u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1i","rhs":"31u","pass":false};vectorize=2]
+
+  [:case={"lhs":"1i","rhs":"31u","pass":false};vectorize=3]
+
+  [:case={"lhs":"1i","rhs":"31u","pass":false};vectorize=4]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize=2]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize=3]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize=4]
+
+  [:case={"lhs":"1u","rhs":"31u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1u","rhs":"31u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1u","rhs":"31u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"1u","rhs":"31u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"2147483647i","rhs":"1u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"2147483647i","rhs":"1u","pass":false};vectorize=2]
+
+  [:case={"lhs":"2147483647i","rhs":"1u","pass":false};vectorize=3]
+
+  [:case={"lhs":"2147483647i","rhs":"1u","pass":false};vectorize=4]
+
+  [:case={"lhs":"2147483647u","rhs":"1u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"2147483647u","rhs":"1u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"2147483647u","rhs":"1u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"2147483647u","rhs":"1u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"3221225472u","rhs":"1u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"3221225472u","rhs":"1u","pass":false};vectorize=2]
+
+  [:case={"lhs":"3221225472u","rhs":"1u","pass":false};vectorize=3]
+
+  [:case={"lhs":"3221225472u","rhs":"1u","pass":false};vectorize=4]
+
+  [:case={"lhs":"4294967295u","rhs":"1u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"4294967295u","rhs":"1u","pass":false};vectorize=2]
+
+  [:case={"lhs":"4294967295u","rhs":"1u","pass":false};vectorize=3]
+
+  [:case={"lhs":"4294967295u","rhs":"1u","pass":false};vectorize=4]
+
+  [:case={"lhs":"4294967295u","rhs":"31u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"4294967295u","rhs":"31u","pass":false};vectorize=2]
+
+  [:case={"lhs":"4294967295u","rhs":"31u","pass":false};vectorize=3]
+
+  [:case={"lhs":"4294967295u","rhs":"31u","pass":false};vectorize=4]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_vec_size_mismatch:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:vectorize_lhs=2;vectorize_rhs=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vectorize_lhs=2;vectorize_rhs=3]
+
+  [:vectorize_lhs=2;vectorize_rhs=4]
+
+  [:vectorize_lhs=3;vectorize_rhs=2]
+
+  [:vectorize_lhs=3;vectorize_rhs=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vectorize_lhs=3;vectorize_rhs=4]
+
+  [:vectorize_lhs=4;vectorize_rhs=2]
+
+  [:vectorize_lhs=4;vectorize_rhs=3]
+
+  [:vectorize_lhs=4;vectorize_rhs=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_concrete:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"0xFFFFFFFFu","pass":false};vectorize=4]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"1000u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"31u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"32u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0i","rhs":"33u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"0xFFFFFFFFu","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"1000u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"31u","pass":true};vectorize=4]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"32u","pass":false};vectorize=4]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize=2]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize=3]
+
+  [:case={"lhs":"0u","rhs":"33u","pass":false};vectorize=4]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize=2]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize=3]
+
+  [:case={"lhs":"1","rhs":"-1","pass":false};vectorize=4]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize=2]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize=3]
+
+  [:case={"lhs":"1i","rhs":"-1","pass":false};vectorize=4]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize="_undef_"]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize=2]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize=3]
+
+  [:case={"lhs":"1u","rhs":"-1","pass":false};vectorize=4]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_vec_size_mismatch:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:vectorize_lhs=2;vectorize_rhs=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vectorize_lhs=2;vectorize_rhs=3]
+
+  [:vectorize_lhs=2;vectorize_rhs=4]
+
+  [:vectorize_lhs=3;vectorize_rhs=2]
+
+  [:vectorize_lhs=3;vectorize_rhs=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:vectorize_lhs=3;vectorize_rhs=4]
+
+  [:vectorize_lhs=4;vectorize_rhs=2]
+
+  [:vectorize_lhs=4;vectorize_rhs=3]
+
+  [:vectorize_lhs=4;vectorize_rhs=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,abs:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="i32"]
+
+  [:stage="constant";type="u32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec2%3Ci32%3E"]
+
+  [:stage="constant";type="vec2%3Cu32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Ci32%3E"]
+
+  [:stage="constant";type="vec3%3Cu32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Ci32%3E"]
+
+  [:stage="constant";type="vec4%3Cu32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,acos:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,acos:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,acosh:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,acosh:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,arrayLength:access_mode:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:mode="read"]
+
+  [:mode="read_write"]
+
+  [:mode="write"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,arrayLength:bool_type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,arrayLength:type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="T"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="array%3Ci32%3E"]
+
+  [:type="array%3Ci32,%202%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="atomic%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="f16"]
+
+  [:type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat2x2%3Cf16%3E"]
+
+  [:type="mat2x2f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat2x3%3Cf16%3E"]
+
+  [:type="mat2x3f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat2x4%3Cf16%3E"]
+
+  [:type="mat2x4f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat3x2%3Cf16%3E"]
+
+  [:type="mat3x2f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat3x3%3Cf16%3E"]
+
+  [:type="mat3x3f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat3x4%3Cf16%3E"]
+
+  [:type="mat3x4f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat4x2%3Cf16%3E"]
+
+  [:type="mat4x2f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat4x3%3Cf16%3E"]
+
+  [:type="mat4x3f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="mat4x4%3Cf16%3E"]
+
+  [:type="mat4x4f"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec2%3Cf16%3E"]
+
+  [:type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec2%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec2%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec3%3Cf16%3E"]
+
+  [:type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec3%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec3%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec4%3Cf16%3E"]
+
+  [:type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec4%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="vec4%3Cu32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,asin:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,asin:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,asinh:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,asinh:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atan2:integer_argument_x:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atan2:integer_argument_y:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atan2:values:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: [OK, TIMEOUT]
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atan:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atan:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atanh:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atanh:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,atomics:stage:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="compute";atomicOp="add"]
+
+  [:stage="compute";atomicOp="and"]
+
+  [:stage="compute";atomicOp="compareexchangeweak"]
+
+  [:stage="compute";atomicOp="exchange"]
+
+  [:stage="compute";atomicOp="load"]
+
+  [:stage="compute";atomicOp="max"]
+
+  [:stage="compute";atomicOp="min"]
+
+  [:stage="compute";atomicOp="or"]
+
+  [:stage="compute";atomicOp="store"]
+
+  [:stage="compute";atomicOp="sub"]
+
+  [:stage="compute";atomicOp="xor"]
+
+  [:stage="fragment";atomicOp="add"]
+
+  [:stage="fragment";atomicOp="and"]
+
+  [:stage="fragment";atomicOp="compareexchangeweak"]
+
+  [:stage="fragment";atomicOp="exchange"]
+
+  [:stage="fragment";atomicOp="load"]
+
+  [:stage="fragment";atomicOp="max"]
+
+  [:stage="fragment";atomicOp="min"]
+
+  [:stage="fragment";atomicOp="or"]
+
+  [:stage="fragment";atomicOp="store"]
+
+  [:stage="fragment";atomicOp="sub"]
+
+  [:stage="fragment";atomicOp="xor"]
+
+  [:stage="vertex";atomicOp="add"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="and"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="compareexchangeweak"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="exchange"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="load"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="max"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="min"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="or"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="store"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="sub"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";atomicOp="xor"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,barriers:no_return_value:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:assign=false;rhs="bar"]
+
+  [:assign=false;rhs="storageBarrier"]
+
+  [:assign=false;rhs="textureBarrier"]
+
+  [:assign=false;rhs="workgroupBarrier"]
+
+  [:assign=true;rhs="bar"]
+
+  [:assign=true;rhs="storageBarrier"]
+
+  [:assign=true;rhs="textureBarrier"]
+
+  [:assign=true;rhs="workgroupBarrier"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,barriers:only_in_compute:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:entry_point="compute";call="bar"]
+
+  [:entry_point="compute";call="storageBarrier"]
+
+  [:entry_point="compute";call="textureBarrier"]
+
+  [:entry_point="compute";call="workgroupBarrier"]
+
+  [:entry_point="compute_and_fragment";call="bar"]
+
+  [:entry_point="compute_and_fragment";call="storageBarrier"]
+
+  [:entry_point="compute_and_fragment";call="textureBarrier"]
+
+  [:entry_point="compute_and_fragment";call="workgroupBarrier"]
+
+  [:entry_point="fragment";call="bar"]
+
+  [:entry_point="fragment";call="storageBarrier"]
+
+  [:entry_point="fragment";call="textureBarrier"]
+
+  [:entry_point="fragment";call="workgroupBarrier"]
+
+  [:entry_point="fragment_without_call";call="bar"]
+
+  [:entry_point="fragment_without_call";call="storageBarrier"]
+
+  [:entry_point="fragment_without_call";call="textureBarrier"]
+
+  [:entry_point="fragment_without_call";call="workgroupBarrier"]
+
+  [:entry_point="none";call="bar"]
+
+  [:entry_point="none";call="storageBarrier"]
+
+  [:entry_point="none";call="textureBarrier"]
+
+  [:entry_point="none";call="workgroupBarrier"]
+
+  [:entry_point="vertex";call="bar"]
+
+  [:entry_point="vertex";call="storageBarrier"]
+
+  [:entry_point="vertex";call="textureBarrier"]
+
+  [:entry_point="vertex";call="workgroupBarrier"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,bitcast:bad_const_to_f16:*]
@@ -92413,8 +95994,85 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,bitcast:bad_const_to_f32:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:fromScalarType="i32";vectorize="v1_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v2_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v2_b1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v3_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v3_b1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v3_b2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v4_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v4_b1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v4_b2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="i32";vectorize="v4_b3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v1_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v2_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v2_b1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v3_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v3_b1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v3_b2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v4_b0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v4_b1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v4_b2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:fromScalarType="u32";vectorize="v4_b3"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,bitcast:bad_to_f16:*]
@@ -92642,13 +96300,119 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,bitcast:bad_type_constructible:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="S";direction="from"]
+
+  [:type="S";direction="to"]
+
+  [:type="array%3Ci32,2%3E";direction="from"]
+
+  [:type="array%3Ci32,2%3E";direction="to"]
+
+  [:type="bool";direction="from"]
+
+  [:type="bool";direction="to"]
+
+  [:type="mat2x2%3Cf16%3E";direction="from"]
+
+  [:type="mat2x2%3Cf16%3E";direction="to"]
+
+  [:type="mat2x2f";direction="from"]
+
+  [:type="mat2x2f";direction="to"]
+
+  [:type="mat2x3%3Cf16%3E";direction="from"]
+
+  [:type="mat2x3%3Cf16%3E";direction="to"]
+
+  [:type="mat2x3f";direction="from"]
+
+  [:type="mat2x3f";direction="to"]
+
+  [:type="mat2x4%3Cf16%3E";direction="from"]
+
+  [:type="mat2x4%3Cf16%3E";direction="to"]
+
+  [:type="mat2x4f";direction="from"]
+
+  [:type="mat2x4f";direction="to"]
+
+  [:type="mat3x2%3Cf16%3E";direction="from"]
+
+  [:type="mat3x2%3Cf16%3E";direction="to"]
+
+  [:type="mat3x2f";direction="from"]
+
+  [:type="mat3x2f";direction="to"]
+
+  [:type="mat3x3%3Cf16%3E";direction="from"]
+
+  [:type="mat3x3%3Cf16%3E";direction="to"]
+
+  [:type="mat3x3f";direction="from"]
+
+  [:type="mat3x3f";direction="to"]
+
+  [:type="mat3x4%3Cf16%3E";direction="from"]
+
+  [:type="mat3x4%3Cf16%3E";direction="to"]
+
+  [:type="mat3x4f";direction="from"]
+
+  [:type="mat3x4f";direction="to"]
+
+  [:type="mat4x2%3Cf16%3E";direction="from"]
+
+  [:type="mat4x2%3Cf16%3E";direction="to"]
+
+  [:type="mat4x2f";direction="from"]
+
+  [:type="mat4x2f";direction="to"]
+
+  [:type="mat4x3%3Cf16%3E";direction="from"]
+
+  [:type="mat4x3%3Cf16%3E";direction="to"]
+
+  [:type="mat4x3f";direction="from"]
+
+  [:type="mat4x3f";direction="to"]
+
+  [:type="mat4x4%3Cf16%3E";direction="from"]
+
+  [:type="mat4x4%3Cf16%3E";direction="to"]
+
+  [:type="mat4x4f";direction="from"]
+
+  [:type="mat4x4f";direction="to"]
+
+  [:type="vec2%3Cbool%3E";direction="from"]
+
+  [:type="vec2%3Cbool%3E";direction="to"]
+
+  [:type="vec3%3Cbool%3E";direction="from"]
+
+  [:type="vec3%3Cbool%3E";direction="to"]
+
+  [:type="vec4%3Cbool%3E";direction="from"]
+
+  [:type="vec4%3Cbool%3E";direction="to"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,bitcast:bad_type_nonconstructible:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:var="b";direction="from"]
+
+  [:var="b";direction="to"]
+
+  [:var="p";direction="from"]
+
+  [:var="p";direction="to"]
+
+  [:var="s";direction="from"]
+
+  [:var="s";direction="to"]
+
+  [:var="t";direction="from"]
+
+  [:var="t";direction="to"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,bitcast:valid_vec2h:*]
@@ -92728,48 +96492,312 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,ceil:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,ceil:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,clamp:values:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,cos:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,cos:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,cosh:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,cosh:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,degrees:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,degrees:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,dot4I8Packed:bad_args:*]
@@ -92807,8 +96835,9 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,dot4I8Packed:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,dot4U8Packed:bad_args:*]
@@ -92846,103 +96875,646 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,dot4U8Packed:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,exp2:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,exp2:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,exp:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,exp:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,floor:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,floor:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,inverseSqrt:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,inverseSqrt:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,length:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,length:scalar:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,length:vec2:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,length:vec3:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,length:vec4:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: TIMEOUT
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,log2:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,log2:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,log:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,log:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,modf:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,modf:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xI8:bad_args:*]
@@ -92978,8 +97550,9 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xI8:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:bad_args:*]
@@ -93015,8 +97588,9 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xI8Clamp:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xU8:bad_args:*]
@@ -93052,8 +97626,9 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xU8:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:bad_args:*]
@@ -93089,88 +97664,641 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,pack4xU8Clamp:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,radians:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,radians:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,round:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,round:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,saturate:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,saturate:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sign:unsigned_integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sign:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="i32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec2%3Ci32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Ci32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Ci32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Ci32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sin:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sin:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sinh:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sinh:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sqrt:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,sqrt:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,tan:integer_argument:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,tan:values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="constant";type="abstract-float"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="f16"]
+
+  [:stage="constant";type="f32"]
+
+  [:stage="constant";type="vec2%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec2%3Cf16%3E"]
+
+  [:stage="constant";type="vec2%3Cf32%3E"]
+
+  [:stage="constant";type="vec3%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec3%3Cf16%3E"]
+
+  [:stage="constant";type="vec3%3Cf32%3E"]
+
+  [:stage="constant";type="vec4%3Cabstract-float%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="constant";type="vec4%3Cf16%3E"]
+
+  [:stage="constant";type="vec4%3Cf32%3E"]
+
+  [:stage="override";type="f16"]
+
+  [:stage="override";type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec2%3Cf16%3E"]
+
+  [:stage="override";type="vec2%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec3%3Cf16%3E"]
+
+  [:stage="override";type="vec3%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="override";type="vec4%3Cf16%3E"]
+
+  [:stage="override";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,unpack4xI8:bad_args:*]
@@ -93202,8 +98330,9 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,unpack4xI8:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,unpack4xU8:bad_args:*]
@@ -93235,28 +98364,93 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,expression,call,builtin,unpack4xU8:unsupported:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:requires=false]
+
+  [:requires=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,extension,pointer_composite_access:deref:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="array_index_access_via_identifier"]
+
+  [:case="array_index_access_via_pointer"]
+
+  [:case="builtin_struct_frexp_via_identifier"]
+
+  [:case="builtin_struct_frexp_via_pointer"]
+
+  [:case="builtin_struct_modf_via_identifier"]
+
+  [:case="builtin_struct_modf_via_pointer"]
+
+  [:case="matrix_index_access_via_identifier"]
+
+  [:case="matrix_index_access_via_pointer"]
+
+  [:case="struct_member_access_via_identifier"]
+
+  [:case="struct_member_access_via_pointer"]
+
+  [:case="vector_index_access_via_identifier"]
+
+  [:case="vector_index_access_via_pointer"]
+
+  [:case="vector_member_access_via_identifier"]
+
+  [:case="vector_member_access_via_pointer"]
 
 
 [cts.https.html?q=webgpu:shader,validation,extension,pointer_composite_access:pointer:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="array_index_access_via_identifier"]
+
+  [:case="array_index_access_via_pointer"]
+
+  [:case="builtin_struct_frexp_via_identifier"]
+
+  [:case="builtin_struct_frexp_via_pointer"]
+
+  [:case="builtin_struct_modf_via_identifier"]
+
+  [:case="builtin_struct_modf_via_pointer"]
+
+  [:case="matrix_index_access_via_identifier"]
+
+  [:case="matrix_index_access_via_pointer"]
+
+  [:case="struct_member_access_via_identifier"]
+
+  [:case="struct_member_access_via_pointer"]
+
+  [:case="vector_index_access_via_identifier"]
+
+  [:case="vector_index_access_via_pointer"]
+
+  [:case="vector_member_access_via_identifier"]
+
+  [:case="vector_member_access_via_pointer"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:aliasing_inside_function:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="private"]
+
+  [:address_space="storage"]
+
+  [:address_space="workgroup"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:member_accessors:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="private";aliased=false]
+
+  [:address_space="private";aliased=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";aliased=false]
+
+  [:address_space="storage";aliased=true]
+
+  [:address_space="workgroup";aliased=false]
+
+  [:address_space="workgroup";aliased=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:one_atomic_pointer_one_module_scope:*]
@@ -93438,18 +98632,45 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:one_pointer_one_module_scope:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="private";aliased=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="private";aliased=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";aliased=false]
+
+  [:address_space="storage";aliased=true]
+
+  [:address_space="workgroup";aliased=false]
+
+  [:address_space="workgroup";aliased=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:same_pointer_read_and_write:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="private"]
+
+  [:address_space="storage"]
+
+  [:address_space="workgroup"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:subcalls:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="private";aliased=false]
+
+  [:address_space="private";aliased=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";aliased=false]
+
+  [:address_space="storage";aliased=true]
+
+  [:address_space="workgroup";aliased=false]
+
+  [:address_space="workgroup";aliased=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:two_atomic_pointers:*]
@@ -94339,8 +99560,29 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:two_pointers:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="function";aliased=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="function";aliased=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="private";aliased=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="private";aliased=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";aliased=false]
+
+  [:address_space="storage";aliased=true]
+
+  [:address_space="workgroup";aliased=false]
+
+  [:address_space="workgroup";aliased=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,alias_analysis:two_pointers_to_array_elements:*]
@@ -94494,178 +99736,2013 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:call_arg_types_match_1_param:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:p1_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32"]
+
+  [:p1_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:call_arg_types_match_2_params:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:p1_type="f32";p2_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="i32"]
+
+  [:p1_type="i32";p2_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:call_arg_types_match_3_params:*]
   expected:
-    if os == "linux" and not debug: CRASH
+    if os == "linux" and not debug: [OK, TIMEOUT]
+  [:p1_type="f32";p2_type="f32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="f32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="f32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="i32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="i32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="i32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="u32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="u32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="f32";p2_type="u32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="f32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="f32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="f32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="i32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="i32";p3_type="i32"]
+
+  [:p1_type="i32";p2_type="i32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="u32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="u32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="i32";p2_type="u32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="f32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="f32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="f32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="i32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="i32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="i32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="u32";p3_type="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="u32";p3_type="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:p1_type="u32";p2_type="u32";p3_type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:entry_point_call_target:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="%40compute%20%40workgroup_size(1,1,1)";entry_point="with"]
+
+  [:stage="%40compute%20%40workgroup_size(1,1,1)";entry_point="without"]
+
+  [:stage="%40fragment";entry_point="with"]
+
+  [:stage="%40fragment";entry_point="without"]
+
+  [:stage="%40vertex";entry_point="with"]
+
+  [:stage="%40vertex";entry_point="without"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:function_parameter_matching:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:decl="array1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="array2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="array3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="array4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="array5"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="f16"]
+
+  [:decl="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="ptr1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="ptr10"]
+
+  [:decl="ptr11"]
+
+  [:decl="ptr12"]
+
+  [:decl="ptr2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="ptr3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="ptr4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="ptr5"]
+
+  [:decl="ptr6"]
+
+  [:decl="ptr7"]
+
+  [:decl="ptr8"]
+
+  [:decl="ptr9"]
+
+  [:decl="ptrWorkgroupAtomic"]
+
+  [:decl="ptrWorkgroupNestedAtomic"]
+
+  [:decl="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="struct1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="struct2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="texture_depth"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="texture_multisampled"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="texture_sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="texture_storage"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:decl="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:function_parameter_types:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="array1"]
+
+  [:case="array2"]
+
+  [:case="array3"]
+
+  [:case="array4"]
+
+  [:case="array5"]
+
+  [:case="atomic_struct"]
+
+  [:case="atomic_u32"]
+
+  [:case="bool"]
+
+  [:case="f16"]
+
+  [:case="f32"]
+
+  [:case="i32"]
+
+  [:case="invalid_ptr1"]
+
+  [:case="invalid_ptr2"]
+
+  [:case="invalid_ptr3"]
+
+  [:case="invalid_ptr4"]
+
+  [:case="invalid_ptr5"]
+
+  [:case="invalid_ptr6"]
+
+  [:case="invalid_ptr7"]
+
+  [:case="mat2x2"]
+
+  [:case="mat2x3"]
+
+  [:case="mat2x4"]
+
+  [:case="mat3x2"]
+
+  [:case="mat3x3"]
+
+  [:case="mat3x4"]
+
+  [:case="mat4x2"]
+
+  [:case="mat4x3"]
+
+  [:case="mat4x4"]
+
+  [:case="override_array"]
+
+  [:case="ptr1"]
+
+  [:case="ptr10"]
+
+  [:case="ptr11"]
+
+  [:case="ptr12"]
+
+  [:case="ptr2"]
+
+  [:case="ptr3"]
+
+  [:case="ptr4"]
+
+  [:case="ptr5"]
+
+  [:case="ptr6"]
+
+  [:case="ptr7"]
+
+  [:case="ptr8"]
+
+  [:case="ptr9"]
+
+  [:case="ptrWorkgroupAtomic"]
+
+  [:case="ptrWorkgroupNestedAtomic"]
+
+  [:case="runtime_array"]
+
+  [:case="runtime_struct"]
+
+  [:case="sampler"]
+
+  [:case="sampler_comparison"]
+
+  [:case="struct1"]
+
+  [:case="struct2"]
+
+  [:case="texture_depth"]
+
+  [:case="texture_multisampled"]
+
+  [:case="texture_sample"]
+
+  [:case="texture_storage"]
+
+  [:case="u32"]
+
+  [:case="vec2"]
+
+  [:case="vec3"]
+
+  [:case="vec4"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:function_return_types:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="array1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="array2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="array3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="array4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="array5"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="atomic_struct"]
+
+  [:case="atomic_u32"]
+
+  [:case="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="f16"]
+
+  [:case="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="override_array"]
+
+  [:case="ptr"]
+
+  [:case="runtime_array"]
+
+  [:case="runtime_struct"]
+
+  [:case="sampler"]
+
+  [:case="sampler_comparison"]
+
+  [:case="struct1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="struct2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="texture_depth"]
+
+  [:case="texture_multisampled"]
+
+  [:case="texture_sample"]
+
+  [:case="texture_storage"]
+
+  [:case="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:no_direct_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:no_indirect_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:param_names_must_differ:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:p1="a";p2="a"]
+
+  [:p1="a";p2="b"]
+
+  [:p1="a";p2="c"]
+
+  [:p1="b";p2="a"]
+
+  [:p1="b";p2="b"]
+
+  [:p1="b";p2="c"]
+
+  [:p1="c";p2="a"]
+
+  [:p1="c";p2="b"]
+
+  [:p1="c";p2="c"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:param_number_matches_call:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:num_args=0;num_params=0]
+
+  [:num_args=0;num_params=1]
+
+  [:num_args=0;num_params=2]
+
+  [:num_args=0;num_params=255]
+
+  [:num_args=0;num_params=3]
+
+  [:num_args=0;num_params=4]
+
+  [:num_args=1;num_params=0]
+
+  [:num_args=1;num_params=1]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:num_args=1;num_params=2]
+
+  [:num_args=1;num_params=255]
+
+  [:num_args=1;num_params=3]
+
+  [:num_args=1;num_params=4]
+
+  [:num_args=255;num_params=0]
+
+  [:num_args=255;num_params=1]
+
+  [:num_args=255;num_params=2]
+
+  [:num_args=255;num_params=255]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:num_args=255;num_params=3]
+
+  [:num_args=255;num_params=4]
+
+  [:num_args=2;num_params=0]
+
+  [:num_args=2;num_params=1]
+
+  [:num_args=2;num_params=2]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:num_args=2;num_params=255]
+
+  [:num_args=2;num_params=3]
+
+  [:num_args=2;num_params=4]
+
+  [:num_args=3;num_params=0]
+
+  [:num_args=3;num_params=1]
+
+  [:num_args=3;num_params=2]
+
+  [:num_args=3;num_params=255]
+
+  [:num_args=3;num_params=3]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:num_args=3;num_params=4]
+
+  [:num_args=4;num_params=0]
+
+  [:num_args=4;num_params=1]
+
+  [:num_args=4;num_params=2]
+
+  [:num_args=4;num_params=255]
+
+  [:num_args=4;num_params=3]
+
+  [:num_args=4;num_params=4]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:param_scope_is_function_body:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:use="body"]
+
+  [:use="const"]
+
+  [:use="function"]
+
+  [:use="override"]
+
+  [:use="var"]
 
 
 [cts.https.html?q=webgpu:shader,validation,functions,restrictions:vertex_returns_position:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="bare_position"]
+
+  [:case="nested_position"]
+
+  [:case="no_bare_position"]
+
+  [:case="no_nested_position"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,align:multi_align:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:multi=false]
+
+  [:multi=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,align:parsing:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:align="blank"]
+
+  [:align="comment"]
+
+  [:align="const_expr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:align="const_f"]
+
+  [:align="const_i"]
+
+  [:align="const_u"]
+
+  [:align="empty"]
+
+  [:align="four_a"]
+
+  [:align="four_f"]
+
+  [:align="four_h"]
+
+  [:align="four_hex"]
+
+  [:align="four_i"]
+
+  [:align="four_u"]
+
+  [:align="large"]
+
+  [:align="large_no_power_two"]
+
+  [:align="larger_than_max_i32"]
+
+  [:align="missing_left_paren"]
+
+  [:align="missing_right_paren"]
+
+  [:align="misspelling"]
+
+  [:align="multiple_values"]
+
+  [:align="negative"]
+
+  [:align="no_params"]
+
+  [:align="non_power_two"]
+
+  [:align="one"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:align="one_f"]
+
+  [:align="tabs"]
+
+  [:align="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:align="zero_a"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,align:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="_undef_";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="fn-decl";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="fn-param";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="fn-return";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="fn-var";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="private-var";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="storage-var";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="struct-member";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="while-stmt";attribute={"private-var":false,"storage-var":false,"struct-member":true,"fn-decl":false,"fn-param":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,align:required_alignment:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:address_space="storage";align="alignment";type={"name":"S","storage":8,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align="alignment";type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="storage";align="alignment";type={"name":"f32","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"i32","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"u32","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align="alignment";type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align="alignment";type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align="alignment";type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=1;type={"name":"S","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="storage";align=1;type={"name":"f32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"i32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=1;type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=1;type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=1;type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"u32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=1;type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=1;type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=1;type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"S","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="storage";align=2;type={"name":"f32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"i32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=2;type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=2;type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=2;type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"u32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=2;type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=2;type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=2;type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="storage";align=32;type={"name":"S","storage":8,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="storage";align=32;type={"name":"f32","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"i32","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"u32","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="storage";align=32;type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+
+  [:address_space="storage";align=32;type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="storage";align=32;type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"S","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="uniform";align="alignment";type={"name":"f32","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"i32","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"u32","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align="alignment";type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align="alignment";type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align="alignment";type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=1;type={"name":"S","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align=1;type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=1;type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="uniform";align=1;type={"name":"f32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"i32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=1;type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=1;type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=1;type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"u32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=1;type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=1;type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=1;type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"S","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align=2;type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=2;type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="uniform";align=2;type={"name":"f32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"i32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=2;type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=2;type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=2;type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"u32","storage":4,"uniform":4}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=2;type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=2;type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=2;type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:address_space="uniform";align=32;type={"name":"S","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"array%3Cvec2%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"array%3Cvec4%3Ci32%3E,%202%3E","storage":8,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"atomic%3Ci32%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"f16","storage":2,"uniform":2}]
+
+  [:address_space="uniform";align=32;type={"name":"f32","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"i32","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"mat2x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"mat2x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat2x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat2x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"mat2x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat2x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"mat3x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"mat3x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat3x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat3x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"mat3x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat3x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"mat4x2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"mat4x2%3Cf32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat4x3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat4x3%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"mat4x4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"mat4x4%3Cf32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"u32","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"vec2%3Cf16%3E","storage":4,"uniform":4}]
+
+  [:address_space="uniform";align=32;type={"name":"vec2%3Ci32%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"vec3%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"vec3%3Cu32%3E","storage":16,"uniform":16}]
+
+  [:address_space="uniform";align=32;type={"name":"vec4%3Cf16%3E","storage":8,"uniform":8}]
+
+  [:address_space="uniform";align=32;type={"name":"vec4%3Cf32%3E","storage":16,"uniform":16}]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,attribute:expressions:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:value="const";attribute="align"]
+
+  [:value="const";attribute="binding"]
+
+  [:value="const";attribute="group"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:value="const";attribute="id"]
+
+  [:value="const";attribute="location"]
+
+  [:value="const";attribute="size"]
+
+  [:value="const";attribute="workgroup_size"]
+
+  [:value="const_func";attribute="align"]
+
+  [:value="const_func";attribute="binding"]
+
+  [:value="const_func";attribute="group"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:value="const_func";attribute="id"]
+
+  [:value="const_func";attribute="location"]
+
+  [:value="const_func";attribute="size"]
+
+  [:value="const_func";attribute="workgroup_size"]
+
+  [:value="expr";attribute="align"]
+
+  [:value="expr";attribute="binding"]
+
+  [:value="expr";attribute="group"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:value="expr";attribute="id"]
+
+  [:value="expr";attribute="location"]
+
+  [:value="expr";attribute="size"]
+
+  [:value="expr";attribute="workgroup_size"]
+
+  [:value="override";attribute="align"]
+
+  [:value="override";attribute="binding"]
+
+  [:value="override";attribute="group"]
+
+  [:value="override";attribute="id"]
+
+  [:value="override";attribute="location"]
+
+  [:value="override";attribute="size"]
+
+  [:value="override";attribute="workgroup_size"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:value="user_func";attribute="align"]
+
+  [:value="user_func";attribute="binding"]
+
+  [:value="user_func";attribute="group"]
+
+  [:value="user_func";attribute="id"]
+
+  [:value="user_func";attribute="location"]
+
+  [:value="user_func";attribute="size"]
+
+  [:value="user_func";attribute="workgroup_size"]
+
+  [:value="val";attribute="align"]
+
+  [:value="val";attribute="binding"]
+
+  [:value="val";attribute="group"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:value="val";attribute="id"]
+
+  [:value="val";attribute="location"]
+
+  [:value="val";attribute="size"]
+
+  [:value="val";attribute="workgroup_size"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,binary_ops:all:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stmt="and_bool_expr_bool_expr"]
+
+  [:stmt="and_bool_expr_bool_literal"]
+
+  [:stmt="and_bool_expr_int_literal"]
+
+  [:stmt="and_bool_literal_bool_expr"]
+
+  [:stmt="and_bool_literal_bool_literal"]
+
+  [:stmt="and_bool_literal_int_literal"]
+
+  [:stmt="and_int_literal_bool_expr"]
+
+  [:stmt="and_int_literal_bool_literal"]
+
+  [:stmt="or_bool_expr_bool_expr"]
+
+  [:stmt="or_bool_expr_bool_literal"]
+
+  [:stmt="or_bool_expr_int_literal"]
+
+  [:stmt="or_bool_literal_bool_expr"]
+
+  [:stmt="or_bool_literal_bool_literal"]
+
+  [:stmt="or_bool_literal_int_literal"]
+
+  [:stmt="or_int_literal_bool_expr"]
+
+  [:stmt="or_int_literal_bool_literal"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,blankspace:blankspace:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:blankspace=["%20","space"\]]
+
+  [:blankspace=["%5Cf","form_feed"\]]
+
+  [:blankspace=["%5Cn","line_feed"\]]
+
+  [:blankspace=["%5Cr","carriage_return"\]]
+
+  [:blankspace=["%5Ct","horizontal_tab"\]]
+
+  [:blankspace=["%5Cu000b","vertical_tab"\]]
+
+  [:blankspace=["%C2%85","next_line"\]]
+
+  [:blankspace=["%E2%80%8E","left_to_right_mark"\]]
+
+  [:blankspace=["%E2%80%8F","right_to_left_mark"\]]
+
+  [:blankspace=["%E2%80%A8","line_separator"\]]
+
+  [:blankspace=["%E2%80%A9","paragraph_separator"\]]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,blankspace:bom:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:include_bom=false]
+
+  [:include_bom=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,blankspace:null_characters:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:contains_null=false;placement="comment"]
+
+  [:contains_null=false;placement="delimiter"]
+
+  [:contains_null=false;placement="eol"]
+
+  [:contains_null=true;placement="comment"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:contains_null=true;placement="delimiter"]
+
+  [:contains_null=true;placement="eol"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,break:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stmt="break"]
+
+  [:stmt="continuing_break"]
+
+  [:stmt="continuing_if_break"]
+
+  [:stmt="for_break"]
+
+  [:stmt="for_if_break"]
+
+  [:stmt="if_break"]
+
+  [:stmt="loop_break"]
+
+  [:stmt="loop_if_break"]
+
+  [:stmt="return_break"]
+
+  [:stmt="switch_break"]
+
+  [:stmt="switch_case_break"]
+
+  [:stmt="switch_case_if_break"]
+
+  [:stmt="while_break"]
+
+  [:stmt="while_if_break"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,break_if:non_bool_param:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="S"]
+
+  [:type="f16"]
+
+  [:type="f32"]
+
+  [:type="i32"]
+
+  [:type="mat2x2%3Cf16%3E"]
+
+  [:type="mat2x2f"]
+
+  [:type="mat2x3%3Cf16%3E"]
+
+  [:type="mat2x3f"]
+
+  [:type="mat2x4%3Cf16%3E"]
+
+  [:type="mat2x4f"]
+
+  [:type="mat3x2%3Cf16%3E"]
+
+  [:type="mat3x2f"]
+
+  [:type="mat3x3%3Cf16%3E"]
+
+  [:type="mat3x3f"]
+
+  [:type="mat3x4%3Cf16%3E"]
+
+  [:type="mat3x4f"]
+
+  [:type="mat4x2%3Cf16%3E"]
+
+  [:type="mat4x2f"]
+
+  [:type="mat4x3%3Cf16%3E"]
+
+  [:type="mat4x3f"]
+
+  [:type="mat4x4%3Cf16%3E"]
+
+  [:type="mat4x4f"]
+
+  [:type="u32"]
+
+  [:type="vec2%3Cf16%3E"]
+
+  [:type="vec2%3Cf32%3E"]
+
+  [:type="vec2%3Ci32%3E"]
+
+  [:type="vec2%3Cu32%3E"]
+
+  [:type="vec3%3Cf16%3E"]
+
+  [:type="vec3%3Cf32%3E"]
+
+  [:type="vec3%3Ci32%3E"]
+
+  [:type="vec3%3Cu32%3E"]
+
+  [:type="vec4%3Cf16%3E"]
+
+  [:type="vec4%3Cf32%3E"]
+
+  [:type="vec4%3Ci32%3E"]
+
+  [:type="vec4%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,break_if:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stmt="break"]
+
+  [:stmt="compound_break"]
+
+  [:stmt="continuing_break_if"]
+
+  [:stmt="continuing_break_if_not_last"]
+
+  [:stmt="continuing_break_if_parens"]
+
+  [:stmt="continuing_if_break"]
+
+  [:stmt="for_break"]
+
+  [:stmt="for_if_break"]
+
+  [:stmt="if_break"]
+
+  [:stmt="loop_break"]
+
+  [:stmt="loop_if_break"]
+
+  [:stmt="return_break"]
+
+  [:stmt="switch_break"]
+
+  [:stmt="switch_case_break"]
+
+  [:stmt="switch_case_if_break"]
+
+  [:stmt="while_break"]
+
+  [:stmt="while_if_break"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,builtin:parse:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:builtin="ident_param"]
+
+  [:builtin="invalid_name"]
+
+  [:builtin="missing_lparen"]
+
+  [:builtin="missing_param"]
+
+  [:builtin="missing_parens"]
+
+  [:builtin="missing_rparen"]
+
+  [:builtin="multiple_params"]
+
+  [:builtin="newline_in_attr"]
+
+  [:builtin="no_params"]
+
+  [:builtin="number_param"]
+
+  [:builtin="pos"]
+
+  [:builtin="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:builtin="whitespace_in_attr"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,builtin:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="_undef_";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="fn-decl";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="fn-var";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="non-ep-param";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="non-ep-ret";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="private-var";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="storage-var";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+
+  [:scope="struct-member";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="while-stmt";attribute={"private-var":false,"storage-var":false,"struct-member":true,"non-ep-param":false,"non-ep-ret":false,"fn-decl":false,"fn-var":false,"fn-return":false,"while-stmt":false}]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,comments:comments:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,comments:line_comment_eof:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,comments:line_comment_terminators:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:blankspace=["%20","space"\]]
+
+  [:blankspace=["%5Cf","form_feed"\]]
+
+  [:blankspace=["%5Cn","line_feed"\]]
+
+  [:blankspace=["%5Cr","carriage_return"\]]
+
+  [:blankspace=["%5Cr%5Cn","carriage_return_line_feed"\]]
+
+  [:blankspace=["%5Ct","tab"\]]
+
+  [:blankspace=["%5Cu000b","vertical_tab"\]]
+
+  [:blankspace=["%C2%85","next_line"\]]
+
+  [:blankspace=["%E2%80%A8","line_separator"\]]
+
+  [:blankspace=["%E2%80%A9","paragraph_separator"\]]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,comments:unterminated_block_comment:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:terminated=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:terminated=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,compound:parse:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stmt="decl"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stmt="empty"]
+
+  [:stmt="missing_end"]
+
+  [:stmt="missing_start"]
+
+  [:stmt="nested"]
+
+  [:stmt="semicolon"]
+
+  [:stmt="semicolons"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,const:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="_undef_"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="fn-decl"]
+
+  [:scope="fn-param"]
+
+  [:scope="fn-return"]
+
+  [:scope="fn-var"]
+
+  [:scope="private-var"]
+
+  [:scope="storage-var"]
+
+  [:scope="struct-member"]
+
+  [:scope="while-stmt"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,const_assert:parse:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="both_parentheses"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="condition_on_newline"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="invalid_expression"]
+
+  [:case="left_parenthesis_only"]
+
+  [:case="multiline_with_parentheses"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="no_condition_no_parentheses"]
+
+  [:case="no_condition_with_parentheses"]
+
+  [:case="no_parentheses"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="not_a_boolean"]
+
+  [:case="right_parenthesis_only"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,continuing:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stmt="continuing"]
+
+  [:stmt="continuing_block"]
+
+  [:stmt="continuing_break"]
+
+  [:stmt="continuing_break_if"]
+
+  [:stmt="continuing_break_if_parens"]
+
+  [:stmt="continuing_const"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stmt="continuing_const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stmt="continuing_continue"]
+
+  [:stmt="continuing_continue_nested"]
+
+  [:stmt="continuing_continuing"]
+
+  [:stmt="continuing_dec"]
+
+  [:stmt="continuing_discard"]
+
+  [:stmt="continuing_empty"]
+
+  [:stmt="continuing_for"]
+
+  [:stmt="continuing_for_break"]
+
+  [:stmt="continuing_functionn_call"]
+
+  [:stmt="continuing_if"]
+
+  [:stmt="continuing_inc"]
+
+  [:stmt="continuing_let"]
+
+  [:stmt="continuing_loop"]
+
+  [:stmt="continuing_loop_nested_continuing"]
+
+  [:stmt="continuing_semicolon"]
+
+  [:stmt="continuing_switch"]
+
+  [:stmt="continuing_switch_break"]
+
+  [:stmt="continuing_var"]
+
+  [:stmt="continuing_while"]
+
+  [:stmt="continuing_while_break"]
+
+  [:stmt="for"]
+
+  [:stmt="if"]
+
+  [:stmt="if_body"]
+
+  [:stmt="if_else"]
+
+  [:stmt="no_body"]
+
+  [:stmt="return"]
+
+  [:stmt="return_for_nested_in_continue"]
+
+  [:stmt="return_if_nested_in_continue"]
+
+  [:stmt="return_in_continue"]
+
+  [:stmt="switch"]
+
+  [:stmt="switch_case"]
+
+  [:stmt="while"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:after_other_directives:*]
@@ -94675,48 +101752,1339 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:conflicting_attribute_different_location:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:loc="compound";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="error";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="error";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="error";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="info";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="info";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="info";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="off";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="off";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="off";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="warning";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="warning";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="warning";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:conflicting_attribute_same_location:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:loc="compound";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="error";s2="info"]
+
+  [:loc="compound";s1="error";s2="off"]
+
+  [:loc="compound";s1="error";s2="warning"]
+
+  [:loc="compound";s1="info";s2="error"]
+
+  [:loc="compound";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="info";s2="off"]
+
+  [:loc="compound";s1="info";s2="warning"]
+
+  [:loc="compound";s1="off";s2="error"]
+
+  [:loc="compound";s1="off";s2="info"]
+
+  [:loc="compound";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="compound";s1="off";s2="warning"]
+
+  [:loc="compound";s1="warning";s2="error"]
+
+  [:loc="compound";s1="warning";s2="info"]
+
+  [:loc="compound";s1="warning";s2="off"]
+
+  [:loc="compound";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_body";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_body";s1="error";s2="info"]
+
+  [:loc="for_body";s1="error";s2="off"]
+
+  [:loc="for_body";s1="error";s2="warning"]
+
+  [:loc="for_body";s1="info";s2="error"]
+
+  [:loc="for_body";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_body";s1="info";s2="off"]
+
+  [:loc="for_body";s1="info";s2="warning"]
+
+  [:loc="for_body";s1="off";s2="error"]
+
+  [:loc="for_body";s1="off";s2="info"]
+
+  [:loc="for_body";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_body";s1="off";s2="warning"]
+
+  [:loc="for_body";s1="warning";s2="error"]
+
+  [:loc="for_body";s1="warning";s2="info"]
+
+  [:loc="for_body";s1="warning";s2="off"]
+
+  [:loc="for_body";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="error";s2="info"]
+
+  [:loc="for_stmt";s1="error";s2="off"]
+
+  [:loc="for_stmt";s1="error";s2="warning"]
+
+  [:loc="for_stmt";s1="info";s2="error"]
+
+  [:loc="for_stmt";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="info";s2="off"]
+
+  [:loc="for_stmt";s1="info";s2="warning"]
+
+  [:loc="for_stmt";s1="off";s2="error"]
+
+  [:loc="for_stmt";s1="off";s2="info"]
+
+  [:loc="for_stmt";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="for_stmt";s1="off";s2="warning"]
+
+  [:loc="for_stmt";s1="warning";s2="error"]
+
+  [:loc="for_stmt";s1="warning";s2="info"]
+
+  [:loc="for_stmt";s1="warning";s2="off"]
+
+  [:loc="for_stmt";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="function";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="function";s1="error";s2="info"]
+
+  [:loc="function";s1="error";s2="off"]
+
+  [:loc="function";s1="error";s2="warning"]
+
+  [:loc="function";s1="info";s2="error"]
+
+  [:loc="function";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="function";s1="info";s2="off"]
+
+  [:loc="function";s1="info";s2="warning"]
+
+  [:loc="function";s1="off";s2="error"]
+
+  [:loc="function";s1="off";s2="info"]
+
+  [:loc="function";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="function";s1="off";s2="warning"]
+
+  [:loc="function";s1="warning";s2="error"]
+
+  [:loc="function";s1="warning";s2="info"]
+
+  [:loc="function";s1="warning";s2="off"]
+
+  [:loc="function";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_else";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_else";s1="error";s2="info"]
+
+  [:loc="if_else";s1="error";s2="off"]
+
+  [:loc="if_else";s1="error";s2="warning"]
+
+  [:loc="if_else";s1="info";s2="error"]
+
+  [:loc="if_else";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_else";s1="info";s2="off"]
+
+  [:loc="if_else";s1="info";s2="warning"]
+
+  [:loc="if_else";s1="off";s2="error"]
+
+  [:loc="if_else";s1="off";s2="info"]
+
+  [:loc="if_else";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_else";s1="off";s2="warning"]
+
+  [:loc="if_else";s1="warning";s2="error"]
+
+  [:loc="if_else";s1="warning";s2="info"]
+
+  [:loc="if_else";s1="warning";s2="off"]
+
+  [:loc="if_else";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="error";s2="info"]
+
+  [:loc="if_stmt";s1="error";s2="off"]
+
+  [:loc="if_stmt";s1="error";s2="warning"]
+
+  [:loc="if_stmt";s1="info";s2="error"]
+
+  [:loc="if_stmt";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="info";s2="off"]
+
+  [:loc="if_stmt";s1="info";s2="warning"]
+
+  [:loc="if_stmt";s1="off";s2="error"]
+
+  [:loc="if_stmt";s1="off";s2="info"]
+
+  [:loc="if_stmt";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_stmt";s1="off";s2="warning"]
+
+  [:loc="if_stmt";s1="warning";s2="error"]
+
+  [:loc="if_stmt";s1="warning";s2="info"]
+
+  [:loc="if_stmt";s1="warning";s2="off"]
+
+  [:loc="if_stmt";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_then";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_then";s1="error";s2="info"]
+
+  [:loc="if_then";s1="error";s2="off"]
+
+  [:loc="if_then";s1="error";s2="warning"]
+
+  [:loc="if_then";s1="info";s2="error"]
+
+  [:loc="if_then";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_then";s1="info";s2="off"]
+
+  [:loc="if_then";s1="info";s2="warning"]
+
+  [:loc="if_then";s1="off";s2="error"]
+
+  [:loc="if_then";s1="off";s2="info"]
+
+  [:loc="if_then";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="if_then";s1="off";s2="warning"]
+
+  [:loc="if_then";s1="warning";s2="error"]
+
+  [:loc="if_then";s1="warning";s2="info"]
+
+  [:loc="if_then";s1="warning";s2="off"]
+
+  [:loc="if_then";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_body";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_body";s1="error";s2="info"]
+
+  [:loc="loop_body";s1="error";s2="off"]
+
+  [:loc="loop_body";s1="error";s2="warning"]
+
+  [:loc="loop_body";s1="info";s2="error"]
+
+  [:loc="loop_body";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_body";s1="info";s2="off"]
+
+  [:loc="loop_body";s1="info";s2="warning"]
+
+  [:loc="loop_body";s1="off";s2="error"]
+
+  [:loc="loop_body";s1="off";s2="info"]
+
+  [:loc="loop_body";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_body";s1="off";s2="warning"]
+
+  [:loc="loop_body";s1="warning";s2="error"]
+
+  [:loc="loop_body";s1="warning";s2="info"]
+
+  [:loc="loop_body";s1="warning";s2="off"]
+
+  [:loc="loop_body";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_continuing";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_continuing";s1="error";s2="info"]
+
+  [:loc="loop_continuing";s1="error";s2="off"]
+
+  [:loc="loop_continuing";s1="error";s2="warning"]
+
+  [:loc="loop_continuing";s1="info";s2="error"]
+
+  [:loc="loop_continuing";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_continuing";s1="info";s2="off"]
+
+  [:loc="loop_continuing";s1="info";s2="warning"]
+
+  [:loc="loop_continuing";s1="off";s2="error"]
+
+  [:loc="loop_continuing";s1="off";s2="info"]
+
+  [:loc="loop_continuing";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_continuing";s1="off";s2="warning"]
+
+  [:loc="loop_continuing";s1="warning";s2="error"]
+
+  [:loc="loop_continuing";s1="warning";s2="info"]
+
+  [:loc="loop_continuing";s1="warning";s2="off"]
+
+  [:loc="loop_continuing";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="error";s2="info"]
+
+  [:loc="loop_stmt";s1="error";s2="off"]
+
+  [:loc="loop_stmt";s1="error";s2="warning"]
+
+  [:loc="loop_stmt";s1="info";s2="error"]
+
+  [:loc="loop_stmt";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="info";s2="off"]
+
+  [:loc="loop_stmt";s1="info";s2="warning"]
+
+  [:loc="loop_stmt";s1="off";s2="error"]
+
+  [:loc="loop_stmt";s1="off";s2="info"]
+
+  [:loc="loop_stmt";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="loop_stmt";s1="off";s2="warning"]
+
+  [:loc="loop_stmt";s1="warning";s2="error"]
+
+  [:loc="loop_stmt";s1="warning";s2="info"]
+
+  [:loc="loop_stmt";s1="warning";s2="off"]
+
+  [:loc="loop_stmt";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="error";s2="info"]
+
+  [:loc="switch_body";s1="error";s2="off"]
+
+  [:loc="switch_body";s1="error";s2="warning"]
+
+  [:loc="switch_body";s1="info";s2="error"]
+
+  [:loc="switch_body";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="info";s2="off"]
+
+  [:loc="switch_body";s1="info";s2="warning"]
+
+  [:loc="switch_body";s1="off";s2="error"]
+
+  [:loc="switch_body";s1="off";s2="info"]
+
+  [:loc="switch_body";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_body";s1="off";s2="warning"]
+
+  [:loc="switch_body";s1="warning";s2="error"]
+
+  [:loc="switch_body";s1="warning";s2="info"]
+
+  [:loc="switch_body";s1="warning";s2="off"]
+
+  [:loc="switch_body";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="error";s2="info"]
+
+  [:loc="switch_case";s1="error";s2="off"]
+
+  [:loc="switch_case";s1="error";s2="warning"]
+
+  [:loc="switch_case";s1="info";s2="error"]
+
+  [:loc="switch_case";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="info";s2="off"]
+
+  [:loc="switch_case";s1="info";s2="warning"]
+
+  [:loc="switch_case";s1="off";s2="error"]
+
+  [:loc="switch_case";s1="off";s2="info"]
+
+  [:loc="switch_case";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_case";s1="off";s2="warning"]
+
+  [:loc="switch_case";s1="warning";s2="error"]
+
+  [:loc="switch_case";s1="warning";s2="info"]
+
+  [:loc="switch_case";s1="warning";s2="off"]
+
+  [:loc="switch_case";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_default";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_default";s1="error";s2="info"]
+
+  [:loc="switch_default";s1="error";s2="off"]
+
+  [:loc="switch_default";s1="error";s2="warning"]
+
+  [:loc="switch_default";s1="info";s2="error"]
+
+  [:loc="switch_default";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_default";s1="info";s2="off"]
+
+  [:loc="switch_default";s1="info";s2="warning"]
+
+  [:loc="switch_default";s1="off";s2="error"]
+
+  [:loc="switch_default";s1="off";s2="info"]
+
+  [:loc="switch_default";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_default";s1="off";s2="warning"]
+
+  [:loc="switch_default";s1="warning";s2="error"]
+
+  [:loc="switch_default";s1="warning";s2="info"]
+
+  [:loc="switch_default";s1="warning";s2="off"]
+
+  [:loc="switch_default";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="error";s2="info"]
+
+  [:loc="switch_stmt";s1="error";s2="off"]
+
+  [:loc="switch_stmt";s1="error";s2="warning"]
+
+  [:loc="switch_stmt";s1="info";s2="error"]
+
+  [:loc="switch_stmt";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="info";s2="off"]
+
+  [:loc="switch_stmt";s1="info";s2="warning"]
+
+  [:loc="switch_stmt";s1="off";s2="error"]
+
+  [:loc="switch_stmt";s1="off";s2="info"]
+
+  [:loc="switch_stmt";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="switch_stmt";s1="off";s2="warning"]
+
+  [:loc="switch_stmt";s1="warning";s2="error"]
+
+  [:loc="switch_stmt";s1="warning";s2="info"]
+
+  [:loc="switch_stmt";s1="warning";s2="off"]
+
+  [:loc="switch_stmt";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_body";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_body";s1="error";s2="info"]
+
+  [:loc="while_body";s1="error";s2="off"]
+
+  [:loc="while_body";s1="error";s2="warning"]
+
+  [:loc="while_body";s1="info";s2="error"]
+
+  [:loc="while_body";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_body";s1="info";s2="off"]
+
+  [:loc="while_body";s1="info";s2="warning"]
+
+  [:loc="while_body";s1="off";s2="error"]
+
+  [:loc="while_body";s1="off";s2="info"]
+
+  [:loc="while_body";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_body";s1="off";s2="warning"]
+
+  [:loc="while_body";s1="warning";s2="error"]
+
+  [:loc="while_body";s1="warning";s2="info"]
+
+  [:loc="while_body";s1="warning";s2="off"]
+
+  [:loc="while_body";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="error";s2="info"]
+
+  [:loc="while_stmt";s1="error";s2="off"]
+
+  [:loc="while_stmt";s1="error";s2="warning"]
+
+  [:loc="while_stmt";s1="info";s2="error"]
+
+  [:loc="while_stmt";s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="info";s2="off"]
+
+  [:loc="while_stmt";s1="info";s2="warning"]
+
+  [:loc="while_stmt";s1="off";s2="error"]
+
+  [:loc="while_stmt";s1="off";s2="info"]
+
+  [:loc="while_stmt";s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:loc="while_stmt";s1="off";s2="warning"]
+
+  [:loc="while_stmt";s1="warning";s2="error"]
+
+  [:loc="while_stmt";s1="warning";s2="info"]
+
+  [:loc="while_stmt";s1="warning";s2="off"]
+
+  [:loc="while_stmt";s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:conflicting_directive:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:s1="error";s2="error"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:s1="error";s2="info"]
+
+  [:s1="error";s2="off"]
+
+  [:s1="error";s2="warning"]
+
+  [:s1="info";s2="error"]
+
+  [:s1="info";s2="info"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:s1="info";s2="off"]
+
+  [:s1="info";s2="warning"]
+
+  [:s1="off";s2="error"]
+
+  [:s1="off";s2="info"]
+
+  [:s1="off";s2="off"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:s1="off";s2="warning"]
+
+  [:s1="warning";s2="error"]
+
+  [:s1="warning";s2="info"]
+
+  [:s1="warning";s2="off"]
+
+  [:s1="warning";s2="warning"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:invalid_locations:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="attribute";location="function_const"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="function_let"]
+
+  [:type="attribute";location="function_params"]
+
+  [:type="attribute";location="function_var"]
+
+  [:type="attribute";location="module_const"]
+
+  [:type="attribute";location="module_override"]
+
+  [:type="attribute";location="module_var"]
+
+  [:type="attribute";location="pre_case"]
+
+  [:type="attribute";location="pre_continuing"]
+
+  [:type="attribute";location="pre_default"]
+
+  [:type="attribute";location="pre_else"]
+
+  [:type="attribute";location="pre_for_params"]
+
+  [:type="attribute";location="struct"]
+
+  [:type="attribute";location="struct_member"]
+
+  [:type="directive";location="function_const"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="directive";location="function_let"]
+
+  [:type="directive";location="function_params"]
+
+  [:type="directive";location="function_var"]
+
+  [:type="directive";location="module_const"]
+
+  [:type="directive";location="module_override"]
+
+  [:type="directive";location="module_var"]
+
+  [:type="directive";location="pre_case"]
+
+  [:type="directive";location="pre_continuing"]
+
+  [:type="directive";location="pre_default"]
+
+  [:type="directive";location="pre_else"]
+
+  [:type="directive";location="pre_for_params"]
+
+  [:type="directive";location="struct"]
+
+  [:type="directive";location="struct_member"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:invalid_severity:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:severity="fatal";type="attribute"]
+
+  [:severity="fatal";type="directive"]
+
+  [:severity="goose";type="attribute"]
+
+  [:severity="goose";type="directive"]
+
+  [:severity="none";type="attribute"]
+
+  [:severity="none";type="directive"]
+
+  [:severity="severe";type="attribute"]
+
+  [:severity="severe";type="directive"]
+
+  [:severity="warn";type="attribute"]
+
+  [:severity="warn";type="directive"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:valid_locations:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="attribute";location="compound"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="for_body"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="for_stmt"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="function"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="if_else"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="if_stmt"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="if_then"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="loop_body"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="loop_continuing"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="loop_stmt"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="module"]
+
+  [:type="attribute";location="switch_body"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="switch_case"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="switch_default"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="switch_stmt"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="while_body"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";location="while_stmt"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="directive";location="compound"]
+
+  [:type="directive";location="for_body"]
+
+  [:type="directive";location="for_stmt"]
+
+  [:type="directive";location="function"]
+
+  [:type="directive";location="if_else"]
+
+  [:type="directive";location="if_stmt"]
+
+  [:type="directive";location="if_then"]
+
+  [:type="directive";location="loop_body"]
+
+  [:type="directive";location="loop_continuing"]
+
+  [:type="directive";location="loop_stmt"]
+
+  [:type="directive";location="module"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="directive";location="switch_body"]
+
+  [:type="directive";location="switch_case"]
+
+  [:type="directive";location="switch_default"]
+
+  [:type="directive";location="switch_stmt"]
+
+  [:type="directive";location="while_body"]
+
+  [:type="directive";location="while_stmt"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:valid_params:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:severity="error";rule="derivative_uniformity";type="attribute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="error";rule="derivative_uniformity";type="directive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="info";rule="derivative_uniformity";type="attribute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="info";rule="derivative_uniformity";type="directive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="off";rule="derivative_uniformity";type="attribute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="off";rule="derivative_uniformity";type="directive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="warning";rule="derivative_uniformity";type="attribute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:severity="warning";rule="derivative_uniformity";type="directive"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,diagnostic:warning_unknown_rule:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="attribute";rule="blahblahblah"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";rule="derivative_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="attribute";rule="unknown"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="directive";rule="blahblahblah"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="directive";rule="derivative_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="directive";rule="unknown"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,discard:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:place="compute"]
+
+  [:place="fragment"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:place="module"]
+
+  [:place="subcomp"]
+
+  [:place="subfrag"]
+
+  [:place="subvert"]
+
+  [:place="vertex"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,enable:enable:*]
@@ -94748,73 +103116,6177 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:alias_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:function_const_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="Foo"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="_0foo"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="r%C3%A9flexion"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:function_let_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:function_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:function_param_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:function_var_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:module_const_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:module_var_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:non_normalized:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:override_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,identifiers:struct_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:ident="%CE%94%CE%AD%CE%BB%CF%84%CE%B1"]
+
+  [:ident="%D0%9A%D1%8B%D0%B7%D1%8B%D0%BB"]
+
+  [:ident="%D6%83%D5%AB%D6%80%D5%B8%D6%82%D5%A6"]
+
+  [:ident="%D7%A9%D6%B8%D7%81%D7%9C%D7%95%D6%B9%D7%9D"]
+
+  [:ident="%D8%B3%D9%84%D8%A7%D9%85"]
+
+  [:ident="%E0%A4%97%E0%A5%81%E0%A4%B2%E0%A4%BE%E0%A4%AC%E0%A5%80"]
+
+  [:ident="%E6%9C%9D%E7%84%BC%E3%81%91"]
+
+  [:ident="%EA%B2%80%EC%A0%95"]
+
+  [:ident="%F0%90%B0%93%F0%90%B0%8F%F0%90%B0%87"]
+
+  [:ident="0foo"]
+
+  [:ident="FOO"]
+
+  [:ident="Foo"]
+
+  [:ident="NULL"]
+
+  [:ident="Self"]
+
+  [:ident="_"]
+
+  [:ident="_0"]
+
+  [:ident="_0foo"]
+
+  [:ident="__"]
+
+  [:ident="__foo"]
+
+  [:ident="_foo0"]
+
+  [:ident="abstract"]
+
+  [:ident="active"]
+
+  [:ident="alias"]
+
+  [:ident="alignas"]
+
+  [:ident="alignof"]
+
+  [:ident="array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="as"]
+
+  [:ident="asm"]
+
+  [:ident="asm_fragment"]
+
+  [:ident="async"]
+
+  [:ident="atomic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="attribute"]
+
+  [:ident="auto"]
+
+  [:ident="await"]
+
+  [:ident="become"]
+
+  [:ident="bf16"]
+
+  [:ident="binding_array"]
+
+  [:ident="bitcast"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="break"]
+
+  [:ident="case"]
+
+  [:ident="cast"]
+
+  [:ident="catch"]
+
+  [:ident="class"]
+
+  [:ident="co_await"]
+
+  [:ident="co_return"]
+
+  [:ident="co_yield"]
+
+  [:ident="coherent"]
+
+  [:ident="column_major"]
+
+  [:ident="common"]
+
+  [:ident="compile"]
+
+  [:ident="compile_fragment"]
+
+  [:ident="concept"]
+
+  [:ident="const"]
+
+  [:ident="const_assert"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="const_cast"]
+
+  [:ident="consteval"]
+
+  [:ident="constexpr"]
+
+  [:ident="constinit"]
+
+  [:ident="continue"]
+
+  [:ident="continuing"]
+
+  [:ident="crate"]
+
+  [:ident="debugger"]
+
+  [:ident="decltype"]
+
+  [:ident="default"]
+
+  [:ident="delete"]
+
+  [:ident="demote"]
+
+  [:ident="demote_to_helper"]
+
+  [:ident="diagnostic"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="discard"]
+
+  [:ident="do"]
+
+  [:ident="dynamic_cast"]
+
+  [:ident="else"]
+
+  [:ident="enable"]
+
+  [:ident="enum"]
+
+  [:ident="explicit"]
+
+  [:ident="export"]
+
+  [:ident="extends"]
+
+  [:ident="extern"]
+
+  [:ident="external"]
+
+  [:ident="f16"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="f64"]
+
+  [:ident="fallthrough"]
+
+  [:ident="false"]
+
+  [:ident="filter"]
+
+  [:ident="final"]
+
+  [:ident="finally"]
+
+  [:ident="fn"]
+
+  [:ident="foo!bar"]
+
+  [:ident="foo"]
+
+  [:ident="foo%23bar"]
+
+  [:ident="foo%2Bbar"]
+
+  [:ident="foo%2Fbar"]
+
+  [:ident="foo%40bar"]
+
+  [:ident="foo%5C%5Cbar"]
+
+  [:ident="foo,bar"]
+
+  [:ident="foo-bar"]
+
+  [:ident="foo.bar"]
+
+  [:ident="foo::bar"]
+
+  [:ident="foo__0"]
+
+  [:ident="for"]
+
+  [:ident="friend"]
+
+  [:ident="from"]
+
+  [:ident="fxgroup"]
+
+  [:ident="get"]
+
+  [:ident="goto"]
+
+  [:ident="groupshared"]
+
+  [:ident="highp"]
+
+  [:ident="i16"]
+
+  [:ident="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="i8"]
+
+  [:ident="if"]
+
+  [:ident="impl"]
+
+  [:ident="implements"]
+
+  [:ident="import"]
+
+  [:ident="inline"]
+
+  [:ident="instanceof"]
+
+  [:ident="interface"]
+
+  [:ident="layout"]
+
+  [:ident="let"]
+
+  [:ident="loop"]
+
+  [:ident="lowp"]
+
+  [:ident="macro"]
+
+  [:ident="macro_rules"]
+
+  [:ident="mat2x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat2x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat3x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="mat4x4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="match"]
+
+  [:ident="mediump"]
+
+  [:ident="meta"]
+
+  [:ident="mod"]
+
+  [:ident="module"]
+
+  [:ident="move"]
+
+  [:ident="mut"]
+
+  [:ident="mutable"]
+
+  [:ident="namespace"]
+
+  [:ident="new"]
+
+  [:ident="nil"]
+
+  [:ident="noexcept"]
+
+  [:ident="noinline"]
+
+  [:ident="nointerpolation"]
+
+  [:ident="noperspective"]
+
+  [:ident="null"]
+
+  [:ident="nullptr"]
+
+  [:ident="of"]
+
+  [:ident="operator"]
+
+  [:ident="override"]
+
+  [:ident="package"]
+
+  [:ident="packoffset"]
+
+  [:ident="partition"]
+
+  [:ident="pass"]
+
+  [:ident="patch"]
+
+  [:ident="pixelfragment"]
+
+  [:ident="precise"]
+
+  [:ident="precision"]
+
+  [:ident="premerge"]
+
+  [:ident="priv"]
+
+  [:ident="protected"]
+
+  [:ident="ptr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="pub"]
+
+  [:ident="public"]
+
+  [:ident="quat"]
+
+  [:ident="r%C3%A9flexion"]
+
+  [:ident="readonly"]
+
+  [:ident="ref"]
+
+  [:ident="regardless"]
+
+  [:ident="register"]
+
+  [:ident="reinterpret_cast"]
+
+  [:ident="require"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="requires"]
+
+  [:ident="resource"]
+
+  [:ident="restrict"]
+
+  [:ident="return"]
+
+  [:ident="sampler"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sampler_comparison"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="self"]
+
+  [:ident="set"]
+
+  [:ident="shared"]
+
+  [:ident="signed"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="sizeof"]
+
+  [:ident="smooth"]
+
+  [:ident="snorm"]
+
+  [:ident="static"]
+
+  [:ident="static_assert"]
+
+  [:ident="static_cast"]
+
+  [:ident="std"]
+
+  [:ident="struct"]
+
+  [:ident="subroutine"]
+
+  [:ident="super"]
+
+  [:ident="switch"]
+
+  [:ident="target"]
+
+  [:ident="template"]
+
+  [:ident="texture_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_cube_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_depth_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_multisampled_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_1d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_2d_array"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="texture_storage_3d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="this"]
+
+  [:ident="thread_local"]
+
+  [:ident="throw"]
+
+  [:ident="trait"]
+
+  [:ident="true"]
+
+  [:ident="try"]
+
+  [:ident="type"]
+
+  [:ident="typedef"]
+
+  [:ident="typeid"]
+
+  [:ident="typename"]
+
+  [:ident="typeof"]
+
+  [:ident="u16"]
+
+  [:ident="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u64"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="u8"]
+
+  [:ident="union"]
+
+  [:ident="unless"]
+
+  [:ident="unorm"]
+
+  [:ident="unsafe"]
+
+  [:ident="unsigned"]
+
+  [:ident="unsized"]
+
+  [:ident="use"]
+
+  [:ident="using"]
+
+  [:ident="var"]
+
+  [:ident="varying"]
+
+  [:ident="vec2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="vec4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:ident="virtual"]
+
+  [:ident="volatile"]
+
+  [:ident="wgsl"]
+
+  [:ident="where"]
+
+  [:ident="while"]
+
+  [:ident="with"]
+
+  [:ident="writeonly"]
+
+  [:ident="yield"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:abstract_float:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val=".0"]
+
+  [:val=".12"]
+
+  [:val=".12f"]
+
+  [:val=".1e-2"]
+
+  [:val=".1h"]
+
+  [:val=".e-2"]
+
+  [:val=".f"]
+
+  [:val="0.0"]
+
+  [:val="0.0f"]
+
+  [:val="00012."]
+
+  [:val="0X.3"]
+
+  [:val="0X1.fp-4"]
+
+  [:val="0f"]
+
+  [:val="0h"]
+
+  [:val="0x.3"]
+
+  [:val="0x.p2"]
+
+  [:val="0x1.00000001pf0"]
+
+  [:val="0x1.0p%2B999999999999f"]
+
+  [:val="0x1.0p%2B999999h"]
+
+  [:val="0x1P%2B4f"]
+
+  [:val="0x1p"]
+
+  [:val="0x1p%5E"]
+
+  [:val="0x3.2p%2B2h"]
+
+  [:val="0x3h"]
+
+  [:val="0x3p%2B2h"]
+
+  [:val="0xE.fp%2B2"]
+
+  [:val="0xEp-2h"]
+
+  [:val="0xa.fP%2B2"]
+
+  [:val="0xa.fp%2B2"]
+
+  [:val="0xep2h"]
+
+  [:val="0xf.h"]
+
+  [:val="1.0e%2B999999999999f"]
+
+  [:val="1.0e%2B999999h"]
+
+  [:val="1.1E%2B2h"]
+
+  [:val="1.1e!2h"]
+
+  [:val="1.1e%2Bh"]
+
+  [:val="1.1e2h"]
+
+  [:val="1.1eh"]
+
+  [:val="1.2E2"]
+
+  [:val="1.2e%2B2"]
+
+  [:val="1.2e2"]
+
+  [:val="1.e%262f"]
+
+  [:val="1.e%2Bf"]
+
+  [:val="1.ef"]
+
+  [:val="12."]
+
+  [:val="12.223f"]
+
+  [:val="12.f"]
+
+  [:val="1e-4f"]
+
+  [:val="1h"]
+
+  [:val="2.4e%2B4f"]
+
+  [:val="2.4e-2"]
+
+  [:val="2.4e-2f"]
+
+  [:val="2.4e-2h"]
+
+  [:val="2.e%2B4f"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:abstract_int:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val="-0x123"]
+
+  [:val="-0x3f"]
+
+  [:val="-123"]
+
+  [:val="-1u"]
+
+  [:val="-2147483647"]
+
+  [:val="-2147483647i"]
+
+  [:val="-2147483648"]
+
+  [:val="-2147483649i"]
+
+  [:val="0"]
+
+  [:val="0123"]
+
+  [:val="0u"]
+
+  [:val="0x123"]
+
+  [:val="0x3f"]
+
+  [:val="123"]
+
+  [:val="2147483647"]
+
+  [:val="2147483647i"]
+
+  [:val="2147483648i"]
+
+  [:val="4294967295"]
+
+  [:val="4294967295i"]
+
+  [:val="4294967295u"]
+
+  [:val="4294967296u"]
+
+  [:val="42u"]
+
+  [:val="94i"]
+
+  [:val="i32(-2147483648)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:bools:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val="false"]
+
+  [:val="true"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:f16:*]
@@ -94912,83 +109384,1189 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:f32:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val="-1"]
+
+  [:val=".0"]
+
+  [:val=".12"]
+
+  [:val=".12f"]
+
+  [:val=".1e-2"]
+
+  [:val=".1h"]
+
+  [:val=".e-2"]
+
+  [:val=".f"]
+
+  [:val="0.0"]
+
+  [:val="0.0f"]
+
+  [:val="00012."]
+
+  [:val="0X.3"]
+
+  [:val="0X1.fp-4"]
+
+  [:val="0f"]
+
+  [:val="0h"]
+
+  [:val="0x.3"]
+
+  [:val="0x.p2"]
+
+  [:val="0x1.00000001pf0"]
+
+  [:val="0x1.0p%2B999999999999f"]
+
+  [:val="0x1P%2B4f"]
+
+  [:val="0x1p"]
+
+  [:val="0x1p%5E"]
+
+  [:val="0x3.2p%2B2h"]
+
+  [:val="0x3p%2B2h"]
+
+  [:val="0xE.fp%2B2"]
+
+  [:val="0xEp-2h"]
+
+  [:val="0xa.fP%2B2"]
+
+  [:val="0xa.fp%2B2"]
+
+  [:val="0xep2h"]
+
+  [:val="1"]
+
+  [:val="1.0e%2B999999999999f"]
+
+  [:val="1.1E%2B2h"]
+
+  [:val="1.1e2h"]
+
+  [:val="1.2E2"]
+
+  [:val="1.2e%2B2"]
+
+  [:val="1.2e2"]
+
+  [:val="1.e%262f"]
+
+  [:val="1.e%2Bf"]
+
+  [:val="1.ef"]
+
+  [:val="12."]
+
+  [:val="12.223f"]
+
+  [:val="12.f"]
+
+  [:val="1e-4f"]
+
+  [:val="1h"]
+
+  [:val="1i"]
+
+  [:val="1u"]
+
+  [:val="2.4e%2B4f"]
+
+  [:val="2.4e-2"]
+
+  [:val="2.4e-2f"]
+
+  [:val="2.4e-2h"]
+
+  [:val="2.e%2B4f"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:i32:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val="-0x123"]
+
+  [:val="-0x3f"]
+
+  [:val="-123"]
+
+  [:val="-2147483647"]
+
+  [:val="-2147483647i"]
+
+  [:val="-2147483648"]
+
+  [:val="-2147483649"]
+
+  [:val="-2147483649i"]
+
+  [:val="0"]
+
+  [:val="0u"]
+
+  [:val="0x123"]
+
+  [:val="0x3f"]
+
+  [:val="1.0"]
+
+  [:val="1.0f"]
+
+  [:val="1.0h"]
+
+  [:val="123"]
+
+  [:val="2147483647"]
+
+  [:val="2147483647i"]
+
+  [:val="2147483648"]
+
+  [:val="2147483648i"]
+
+  [:val="4294967295u"]
+
+  [:val="42u"]
+
+  [:val="94i"]
+
+  [:val="i32(-2147483648)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,literal:u32:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val="-0x123"]
+
+  [:val="-0x3f"]
+
+  [:val="-1"]
+
+  [:val="-123"]
+
+  [:val="-2147483647"]
+
+  [:val="-2147483647i"]
+
+  [:val="-2147483648"]
+
+  [:val="0"]
+
+  [:val="0u"]
+
+  [:val="0x123"]
+
+  [:val="0x3f"]
+
+  [:val="1.0"]
+
+  [:val="1.0f"]
+
+  [:val="1.0h"]
+
+  [:val="123"]
+
+  [:val="2147483647"]
+
+  [:val="2147483647i"]
+
+  [:val="4294967295"]
+
+  [:val="4294967295u"]
+
+  [:val="4294967296"]
+
+  [:val="4294967296u"]
+
+  [:val="42u"]
+
+  [:val="94i"]
+
+  [:val="i32(-2147483648)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,must_use:builtin_must_use:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:call="abs";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="abs";use=true]
+
+  [:call="acos";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="acos";use=true]
+
+  [:call="acosh";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="acosh";use=true]
+
+  [:call="all";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="all";use=true]
+
+  [:call="any";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="any";use=true]
+
+  [:call="arrayLength";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="arrayLength";use=true]
+
+  [:call="asin";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="asin";use=true]
+
+  [:call="asinh";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="asinh";use=true]
+
+  [:call="atan";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atan";use=true]
+
+  [:call="atan2";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atan2";use=true]
+
+  [:call="atanh";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atanh";use=true]
+
+  [:call="bitcast";use=false]
+
+  [:call="bitcast";use=true]
+
+  [:call="ceil";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="ceil";use=true]
+
+  [:call="clamp";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="clamp";use=true]
+
+  [:call="cos";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="cos";use=true]
+
+  [:call="cosh";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="cosh";use=true]
+
+  [:call="countLeadingZeros";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="countLeadingZeros";use=true]
+
+  [:call="countOneBits";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="countOneBits";use=true]
+
+  [:call="countTrailingZeros";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="countTrailingZeros";use=true]
+
+  [:call="cross";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="cross";use=true]
+
+  [:call="degrees";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="degrees";use=true]
+
+  [:call="determinant";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="determinant";use=true]
+
+  [:call="distance";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="distance";use=true]
+
+  [:call="dot";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dot";use=true]
+
+  [:call="dpdx";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dpdx";use=true]
+
+  [:call="dpdxCoarse";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dpdxCoarse";use=true]
+
+  [:call="dpdxFine";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dpdxFine";use=true]
+
+  [:call="dpdy";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dpdy";use=true]
+
+  [:call="dpdyCoarse";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dpdyCoarse";use=true]
+
+  [:call="dpdyFine";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="dpdyFine";use=true]
+
+  [:call="exp";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="exp";use=true]
+
+  [:call="exp2";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="exp2";use=true]
+
+  [:call="extractBits";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="extractBits";use=true]
+
+  [:call="faceForward";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="faceForward";use=true]
+
+  [:call="firstLeadingBit";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="firstLeadingBit";use=true]
+
+  [:call="firstTrailingBit";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="firstTrailingBit";use=true]
+
+  [:call="floor";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="floor";use=true]
+
+  [:call="fma";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="fma";use=true]
+
+  [:call="fract";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="fract";use=true]
+
+  [:call="frexp";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="frexp";use=true]
+
+  [:call="fwidth";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="fwidth";use=true]
+
+  [:call="fwidthCoarse";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="fwidthCoarse";use=true]
+
+  [:call="fwidthFine";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="fwidthFine";use=true]
+
+  [:call="i32";use=false]
+
+  [:call="i32";use=true]
+
+  [:call="insertBits";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="insertBits";use=true]
+
+  [:call="inverseSqrt";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="inverseSqrt";use=true]
+
+  [:call="ldexp";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="ldexp";use=true]
+
+  [:call="length";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="length";use=true]
+
+  [:call="log";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="log";use=true]
+
+  [:call="log2";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="log2";use=true]
+
+  [:call="max";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="max";use=true]
+
+  [:call="min";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="min";use=true]
+
+  [:call="mix";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="mix";use=true]
+
+  [:call="modf";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="modf";use=true]
+
+  [:call="normalize";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="normalize";use=true]
+
+  [:call="pack2x16float";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="pack2x16float";use=true]
+
+  [:call="pack2x16snorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="pack2x16snorm";use=true]
+
+  [:call="pack2x16unorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="pack2x16unorm";use=true]
+
+  [:call="pack4x8snorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="pack4x8snorm";use=true]
+
+  [:call="pack4x8unorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="pack4x8unorm";use=true]
+
+  [:call="pow";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="pow";use=true]
+
+  [:call="quantizeToF16";use=false]
+
+  [:call="quantizeToF16";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="radians";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="radians";use=true]
+
+  [:call="reflect";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="reflect";use=true]
+
+  [:call="refract";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="refract";use=true]
+
+  [:call="reverseBits";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="reverseBits";use=true]
+
+  [:call="round";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="round";use=true]
+
+  [:call="saturate";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="saturate";use=true]
+
+  [:call="select";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="select";use=true]
+
+  [:call="sign";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="sign";use=true]
+
+  [:call="sin";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="sin";use=true]
+
+  [:call="sinh";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="sinh";use=true]
+
+  [:call="smoothstep";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="smoothstep";use=true]
+
+  [:call="sqrt";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="sqrt";use=true]
+
+  [:call="step";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="step";use=true]
+
+  [:call="struct";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="struct";use=true]
+
+  [:call="tan";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="tan";use=true]
+
+  [:call="tanh";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="tanh";use=true]
+
+  [:call="textureDimensions";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureDimensions";use=true]
+
+  [:call="textureGather";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureGather";use=true]
+
+  [:call="textureGatherCompare";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureGatherCompare";use=true]
+
+  [:call="textureLoad";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureLoad";use=true]
+
+  [:call="textureNumLayers";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureNumLayers";use=true]
+
+  [:call="textureNumLevels";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureNumLevels";use=true]
+
+  [:call="textureNumSamples";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureNumSamples";use=true]
+
+  [:call="textureSample";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSample";use=true]
+
+  [:call="textureSampleBaseClampToEdge";use=false]
+
+  [:call="textureSampleBaseClampToEdge";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSampleBias";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSampleBias";use=true]
+
+  [:call="textureSampleCompare";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSampleCompare";use=true]
+
+  [:call="textureSampleCompareLevel";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSampleCompareLevel";use=true]
+
+  [:call="textureSampleGrad";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSampleGrad";use=true]
+
+  [:call="textureSampleLevel";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="textureSampleLevel";use=true]
+
+  [:call="transpose";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="transpose";use=true]
+
+  [:call="trunc";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="trunc";use=true]
+
+  [:call="u32";use=false]
+
+  [:call="u32";use=true]
+
+  [:call="unpack2x16float";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="unpack2x16float";use=true]
+
+  [:call="unpack2x16snorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="unpack2x16snorm";use=true]
+
+  [:call="unpack2x16unorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="unpack2x16unorm";use=true]
+
+  [:call="unpack4x8snorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="unpack4x8snorm";use=true]
+
+  [:call="unpack4x8unorm";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="unpack4x8unorm";use=true]
+
+  [:call="workgroupUniformLoad";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="workgroupUniformLoad";use=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,must_use:builtin_no_must_use:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:call="atomicAdd";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicAdd";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicAnd";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicAnd";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicCompareExchangeWeak";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicCompareExchangeWeak";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicExchange";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicExchange";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicLoad";use=false]
+
+  [:call="atomicLoad";use=true]
+
+  [:call="atomicMax";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicMax";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicMin";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicMin";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicOr";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicOr";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicSub";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicSub";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicXor";use=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:call="atomicXor";use=true]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,must_use:call:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:use="";call="condition"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="let"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="local_var"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="matrix_elem"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="no_call"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="param"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="phony"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="pointer"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="private_var"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="return"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="statement"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="storage_var"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="";call="vector_elem"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="condition"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="let"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="local_var"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="matrix_elem"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="no_call"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="param"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="phony"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="pointer"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="private_var"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="return"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="statement"]
+
+  [:use="%40must_use";call="storage_var"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use="%40must_use";call="vector_elem"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,must_use:declaration:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:test="empty_parameter"]
+
+  [:test="function_call"]
+
+  [:test="function_no_return"]
+
+  [:test="function_parameter"]
+
+  [:test="function_scalar_return"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:test="function_struct_return"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:test="function_var"]
+
+  [:test="parameter"]
+
+  [:test="var"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,must_use:ignore_result_of_non_must_use_that_returns_call_of_must_use:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:compute_parsing:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val=""]
+
+  [:val="%40%2F%5Ecomment%5E%2Fcompute"]
+
+  [:val="%40%5Ctcompute"]
+
+  [:val="%40compute"]
+
+  [:val="%40compute%20)"]
+
+  [:val="%40compute("]
+
+  [:val="%40compute()"]
+
+  [:val="%40mcompute"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:extra_on_compute_function:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:extra="";before=false]
+
+  [:extra="";before=true]
+
+  [:extra="%40compute";before=false]
+
+  [:extra="%40compute";before=true]
+
+  [:extra="%40fragment";before=false]
+
+  [:extra="%40fragment";before=true]
+
+  [:extra="%40vertex";before=false]
+
+  [:extra="%40vertex";before=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:extra_on_fragment_function:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:extra="";before=false]
+
+  [:extra="";before=true]
+
+  [:extra="%40compute";before=false]
+
+  [:extra="%40compute";before=true]
+
+  [:extra="%40fragment";before=false]
+
+  [:extra="%40fragment";before=true]
+
+  [:extra="%40vertex";before=false]
+
+  [:extra="%40vertex";before=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:extra_on_vertex_function:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:extra="";before=false]
+
+  [:extra="";before=true]
+
+  [:extra="%40compute";before=false]
+
+  [:extra="%40compute";before=true]
+
+  [:extra="%40fragment";before=false]
+
+  [:extra="%40fragment";before=true]
+
+  [:extra="%40vertex";before=false]
+
+  [:extra="%40vertex";before=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:fragment_parsing:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val=""]
+
+  [:val="%40%2F%5Ecomment%5E%2Ffragment"]
+
+  [:val="%40%5Ctfragment"]
+
+  [:val="%40fragment"]
+
+  [:val="%40fragment%20)"]
+
+  [:val="%40fragment("]
+
+  [:val="%40fragment()"]
+
+  [:val="%40mfragment"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:multiple_entry_points:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:placement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:scope="_undef_";attr="%40compute"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="_undef_";attr="%40fragment"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="_undef_";attr="%40vertex"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:scope="fn-param";attr="%40compute"]
+
+  [:scope="fn-param";attr="%40fragment"]
+
+  [:scope="fn-param";attr="%40vertex"]
+
+  [:scope="fn-return";attr="%40compute"]
+
+  [:scope="fn-return";attr="%40fragment"]
+
+  [:scope="fn-return";attr="%40vertex"]
+
+  [:scope="fn-var";attr="%40compute"]
+
+  [:scope="fn-var";attr="%40fragment"]
+
+  [:scope="fn-var";attr="%40vertex"]
+
+  [:scope="private-var";attr="%40compute"]
+
+  [:scope="private-var";attr="%40fragment"]
+
+  [:scope="private-var";attr="%40vertex"]
+
+  [:scope="storage-var";attr="%40compute"]
+
+  [:scope="storage-var";attr="%40fragment"]
+
+  [:scope="storage-var";attr="%40vertex"]
+
+  [:scope="struct-member";attr="%40compute"]
+
+  [:scope="struct-member";attr="%40fragment"]
+
+  [:scope="struct-member";attr="%40vertex"]
+
+  [:scope="while-stmt";attr="%40compute"]
+
+  [:scope="while-stmt";attr="%40fragment"]
+
+  [:scope="while-stmt";attr="%40vertex"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,pipeline_stage:vertex_parsing:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:val=""]
+
+  [:val="%40%2F%5Ecomment%5E%2Fvertex"]
+
+  [:val="%40%5Ctvertex"]
+
+  [:val="%40mvertex"]
+
+  [:val="%40vertex"]
+
+  [:val="%40vertex%20)"]
+
+  [:val="%40vertex("]
+
+  [:val="%40vertex()"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,requires:requires:*]
@@ -95034,53 +110612,45 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_assignment:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_call:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_case:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_case_break:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_compound_statement:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_continuing:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_default_case:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_default_case_break:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_diagnostic:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_discard:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_enable:*]
@@ -95088,83 +110658,73 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_fn_const_assert:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_fn_const_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_fn_var_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_for:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_for_break:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_func_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_if:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_if_else:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_let_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_loop:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_loop_break:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_loop_break_if:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_loop_continue:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_member:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_module_const_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_module_var_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_requires:*]
@@ -95172,108 +110732,247 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_return:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_struct_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_switch:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_type_alias_decl:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_while:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_while_break:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:after_while_continue:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:compound_statement_multiple:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:compound_statement_single:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:function_body_multiple:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:function_body_single:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:module_scope_multiple:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,semicolon:module_scope_single:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,source:empty:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,source:invalid_source:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,source:valid_source:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,unary_ops:all:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stmt="not_bool_expr"]
+
+  [:stmt="not_bool_literal"]
+
+  [:stmt="not_int_expr"]
+
+  [:stmt="not_int_literal"]
+
+  [:stmt="not_not_bool_expr"]
+
+  [:stmt="not_not_bool_literal"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,var_and_let:initializer_type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:variableOrConstant="let"]
+
+  [:variableOrConstant="var"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,var_and_let:var_access_mode_bad_other_template_contents:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:accessMode="read";prefix="";suffix=""]
+
+  [:accessMode="read";prefix="";suffix=","]
+
+  [:accessMode="read";prefix="";suffix=",read"]
+
+  [:accessMode="read";prefix="";suffix=",storage"]
+
+  [:accessMode="read";prefix=",";suffix=""]
+
+  [:accessMode="read";prefix=",";suffix=","]
+
+  [:accessMode="read";prefix=",";suffix=",read"]
+
+  [:accessMode="read";prefix=",";suffix=",storage"]
+
+  [:accessMode="read";prefix="storage,";suffix=""]
+
+  [:accessMode="read";prefix="storage,";suffix=","]
+
+  [:accessMode="read";prefix="storage,";suffix=",read"]
+
+  [:accessMode="read";prefix="storage,";suffix=",storage"]
+
+  [:accessMode="read_write";prefix="";suffix=""]
+
+  [:accessMode="read_write";prefix="";suffix=","]
+
+  [:accessMode="read_write";prefix="";suffix=",read"]
+
+  [:accessMode="read_write";prefix="";suffix=",storage"]
+
+  [:accessMode="read_write";prefix=",";suffix=""]
+
+  [:accessMode="read_write";prefix=",";suffix=","]
+
+  [:accessMode="read_write";prefix=",";suffix=",read"]
+
+  [:accessMode="read_write";prefix=",";suffix=",storage"]
+
+  [:accessMode="read_write";prefix="storage,";suffix=""]
+
+  [:accessMode="read_write";prefix="storage,";suffix=","]
+
+  [:accessMode="read_write";prefix="storage,";suffix=",read"]
+
+  [:accessMode="read_write";prefix="storage,";suffix=",storage"]
 
 
 [cts.https.html?q=webgpu:shader,validation,parse,var_and_let:var_access_mode_bad_template_delim:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:accessMode="read";prefix="";suffix=""]
+
+  [:accessMode="read";prefix="";suffix="%3C"]
+
+  [:accessMode="read";prefix="";suffix="%3E"]
+
+  [:accessMode="read";prefix="";suffix=","]
+
+  [:accessMode="read";prefix="%3C";suffix=""]
+
+  [:accessMode="read";prefix="%3C";suffix="%3C"]
+
+  [:accessMode="read";prefix="%3C";suffix="%3E"]
+
+  [:accessMode="read";prefix="%3C";suffix=","]
+
+  [:accessMode="read";prefix="%3E";suffix=""]
+
+  [:accessMode="read";prefix="%3E";suffix="%3C"]
+
+  [:accessMode="read";prefix="%3E";suffix="%3E"]
+
+  [:accessMode="read";prefix="%3E";suffix=","]
+
+  [:accessMode="read";prefix=",";suffix=""]
+
+  [:accessMode="read";prefix=",";suffix="%3C"]
+
+  [:accessMode="read";prefix=",";suffix="%3E"]
+
+  [:accessMode="read";prefix=",";suffix=","]
+
+  [:accessMode="read_write";prefix="";suffix=""]
+
+  [:accessMode="read_write";prefix="";suffix="%3C"]
+
+  [:accessMode="read_write";prefix="";suffix="%3E"]
+
+  [:accessMode="read_write";prefix="";suffix=","]
+
+  [:accessMode="read_write";prefix="%3C";suffix=""]
+
+  [:accessMode="read_write";prefix="%3C";suffix="%3C"]
+
+  [:accessMode="read_write";prefix="%3C";suffix="%3E"]
+
+  [:accessMode="read_write";prefix="%3C";suffix=","]
+
+  [:accessMode="read_write";prefix="%3E";suffix=""]
+
+  [:accessMode="read_write";prefix="%3E";suffix="%3C"]
+
+  [:accessMode="read_write";prefix="%3E";suffix="%3E"]
+
+  [:accessMode="read_write";prefix="%3E";suffix=","]
+
+  [:accessMode="read_write";prefix=",";suffix=""]
+
+  [:accessMode="read_write";prefix=",";suffix="%3C"]
+
+  [:accessMode="read_write";prefix=",";suffix="%3E"]
+
+  [:accessMode="read_write";prefix=",";suffix=","]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,binding:binding:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="const_expr"]
+
+  [:attr="f32_val"]
+
+  [:attr="f32_val_literal"]
+
+  [:attr="hex_literal"]
+
+  [:attr="int_literal"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="missing_value"]
+
+  [:attr="misspelling"]
+
+  [:attr="multi_binding"]
+
+  [:attr="multiple_values"]
+
+  [:attr="negative"]
+
+  [:attr="no_params"]
+
+  [:attr="one"]
+
+  [:attr="override_expr"]
+
+  [:attr="split_line"]
+
+  [:attr="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="uint_literal"]
+
+  [:attr="zero"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,binding:binding_f16:*]
@@ -95281,63 +110980,765 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,builtins:duplicates:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:first="p1";second="p2"]
+
+  [:first="p1";second="rb"]
+
+  [:first="p1";second="s1b"]
+
+  [:first="p1";second="s2b"]
+
+  [:first="ra";second="p2"]
+
+  [:first="ra";second="rb"]
+
+  [:first="ra";second="s1b"]
+
+  [:first="ra";second="s2b"]
+
+  [:first="s1a";second="p2"]
+
+  [:first="s1a";second="rb"]
+
+  [:first="s1a";second="s1b"]
+
+  [:first="s1a";second="s2b"]
+
+  [:first="s2a";second="p2"]
+
+  [:first="s2a";second="rb"]
+
+  [:first="s2a";second="s1b"]
+
+  [:first="s2a";second="s2b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,builtins:missing_vertex_position:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:use_struct=false;attribute="%40builtin(position)"]
+
+  [:use_struct=false;attribute="%40location(0)"]
+
+  [:use_struct=true;attribute="%40builtin(position)"]
+
+  [:use_struct=true;attribute="%40location(0)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,builtins:nesting:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target_stage="";target_io="in"]
+
+  [:target_stage="";target_io="out"]
+
+  [:target_stage="fragment";target_io="in"]
+
+  [:target_stage="fragment";target_io="out"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,builtins:reuse_builtin_name:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use="alias"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use="function"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use="function-var"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use="module-var"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use="struct"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use="alias"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use="function"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use="function-var"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use="module-var"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use="struct"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="alias"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="function"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="function-var"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="module-var"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="struct"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use="alias"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use="function"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use="function-var"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use="module-var"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use="struct"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="alias"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="function"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="function-var"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="module-var"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="struct"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use="alias"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use="function"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use="function-var"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use="module-var"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use="struct"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use="alias"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use="function"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use="function-var"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use="module-var"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use="struct"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use="alias"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use="function"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use="function-var"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use="module-var"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use="struct"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use="alias"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use="function"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use="function-var"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use="module-var"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use="struct"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use="alias"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use="function"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use="function-var"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use="module-var"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use="struct"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use="alias"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use="function"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use="function-var"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use="module-var"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use="struct"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use="alias"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use="function"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use="function-var"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use="module-var"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use="struct"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use="alias"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use="function"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use="function-var"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use="module-var"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use="struct"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="alias"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="function"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="function-var"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="module-var"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use="struct"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,builtins:stage_inout:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true;target_stage="vertex";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="compute";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="compute";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true;target_stage="vertex";target_io="out"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,builtins:type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:name="frag_depth";stage="fragment";io="out";type="f32"]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool"]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E"]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32"]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E"]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32"]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E"]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E"]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E"]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32"]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32"]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32"]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32"]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,entry_point:missing_attribute_on_param:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target_stage=""]
+
+  [:target_stage="compute"]
+
+  [:target_stage="fragment"]
+
+  [:target_stage="vertex"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,entry_point:missing_attribute_on_param_struct:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target_stage=""]
+
+  [:target_stage="compute"]
+
+  [:target_stage="fragment"]
+
+  [:target_stage="vertex"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,entry_point:missing_attribute_on_return_type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target_stage=""]
+
+  [:target_stage="fragment"]
+
+  [:target_stage="vertex"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,entry_point:missing_attribute_on_return_type_struct:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target_stage=""]
+
+  [:target_stage="fragment"]
+
+  [:target_stage="vertex"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,entry_point:no_entry_point_provided:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group:group:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="const_expr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="f32_val"]
+
+  [:attr="f32_val_literal"]
+
+  [:attr="hex_literal"]
+
+  [:attr="int_literal"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="missing_value"]
+
+  [:attr="misspelling"]
+
+  [:attr="multi_group"]
+
+  [:attr="multiple_values"]
+
+  [:attr="negative"]
+
+  [:attr="no_params"]
+
+  [:attr="one"]
+
+  [:attr="override_expr"]
+
+  [:attr="split_line"]
+
+  [:attr="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="uint_literal"]
+
+  [:attr="zero"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group:group_f16:*]
@@ -95345,43 +111746,1411 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:binding_attributes:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="compute";has_group=false;has_binding=false;resource="sampler"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="sampler_comparison"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="storage"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_1d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_2d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_2d_array"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_3d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_cube"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_cube_array"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_depth_2d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_depth_2d_array"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_depth_cube"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_depth_cube_array"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_depth_multisampled_2d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_external"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_multisampled_2d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_storage_1d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_storage_2d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_storage_2d_array"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="texture_storage_3d"]
+
+  [:stage="compute";has_group=false;has_binding=false;resource="uniform"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="sampler"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="sampler_comparison"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="storage"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_1d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_2d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_2d_array"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_3d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_cube"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_cube_array"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_depth_2d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_depth_2d_array"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_depth_cube"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_depth_cube_array"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_depth_multisampled_2d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_external"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_multisampled_2d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_storage_1d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_storage_2d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_storage_2d_array"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="texture_storage_3d"]
+
+  [:stage="compute";has_group=false;has_binding=true;resource="uniform"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="sampler"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="sampler_comparison"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="storage"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_1d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_2d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_2d_array"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_3d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_cube"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_cube_array"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_depth_2d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_depth_2d_array"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_depth_cube"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_depth_cube_array"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_depth_multisampled_2d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_external"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_multisampled_2d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_storage_1d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_storage_2d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_storage_2d_array"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="texture_storage_3d"]
+
+  [:stage="compute";has_group=true;has_binding=false;resource="uniform"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="sampler"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="sampler_comparison"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="storage"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_1d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_2d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_2d_array"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_3d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_cube"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_cube_array"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_depth_2d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_depth_2d_array"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_depth_cube"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_depth_cube_array"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_depth_multisampled_2d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_external"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_multisampled_2d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_storage_1d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_storage_2d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_storage_2d_array"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="texture_storage_3d"]
+
+  [:stage="compute";has_group=true;has_binding=true;resource="uniform"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="sampler"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="sampler_comparison"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="storage"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_1d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_2d_array"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_3d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_cube"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_cube_array"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_depth_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_depth_2d_array"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_depth_cube"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_depth_cube_array"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_depth_multisampled_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_external"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_multisampled_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_storage_1d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_storage_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_storage_2d_array"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="texture_storage_3d"]
+
+  [:stage="fragment";has_group=false;has_binding=false;resource="uniform"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="sampler"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="sampler_comparison"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="storage"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_1d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_2d_array"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_3d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_cube"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_cube_array"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_depth_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_depth_2d_array"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_depth_cube"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_depth_cube_array"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_depth_multisampled_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_external"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_multisampled_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_storage_1d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_storage_2d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_storage_2d_array"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="texture_storage_3d"]
+
+  [:stage="fragment";has_group=false;has_binding=true;resource="uniform"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="sampler"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="sampler_comparison"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="storage"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_1d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_2d_array"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_3d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_cube"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_cube_array"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_depth_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_depth_2d_array"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_depth_cube"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_depth_cube_array"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_depth_multisampled_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_external"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_multisampled_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_storage_1d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_storage_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_storage_2d_array"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="texture_storage_3d"]
+
+  [:stage="fragment";has_group=true;has_binding=false;resource="uniform"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="sampler"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="sampler_comparison"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="storage"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_1d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_2d_array"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_3d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_cube"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_cube_array"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_depth_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_depth_2d_array"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_depth_cube"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_depth_cube_array"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_depth_multisampled_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_external"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_multisampled_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_storage_1d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_storage_2d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_storage_2d_array"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="texture_storage_3d"]
+
+  [:stage="fragment";has_group=true;has_binding=true;resource="uniform"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="sampler"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="sampler_comparison"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="storage"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_1d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_2d_array"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_3d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_cube"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_cube_array"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_depth_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_depth_2d_array"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_depth_cube"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_depth_cube_array"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_depth_multisampled_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_external"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_multisampled_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_storage_1d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_storage_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_storage_2d_array"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="texture_storage_3d"]
+
+  [:stage="vertex";has_group=false;has_binding=false;resource="uniform"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="sampler"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="sampler_comparison"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="storage"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_1d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_2d_array"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_3d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_cube"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_cube_array"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_depth_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_depth_2d_array"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_depth_cube"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_depth_cube_array"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_depth_multisampled_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_external"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_multisampled_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_storage_1d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_storage_2d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_storage_2d_array"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="texture_storage_3d"]
+
+  [:stage="vertex";has_group=false;has_binding=true;resource="uniform"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="sampler"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="sampler_comparison"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="storage"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_1d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_2d_array"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_3d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_cube"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_cube_array"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_depth_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_depth_2d_array"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_depth_cube"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_depth_cube_array"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_depth_multisampled_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_external"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_multisampled_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_storage_1d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_storage_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_storage_2d_array"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="texture_storage_3d"]
+
+  [:stage="vertex";has_group=true;has_binding=false;resource="uniform"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="sampler"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="sampler_comparison"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="storage"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_1d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_2d_array"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_3d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_cube"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_cube_array"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_depth_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_depth_2d_array"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_depth_cube"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_depth_cube_array"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_depth_multisampled_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_external"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_multisampled_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_storage_1d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_storage_2d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_storage_2d_array"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="texture_storage_3d"]
+
+  [:stage="vertex";has_group=true;has_binding=true;resource="uniform"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:different_entry_points:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:a_stage="compute";b_stage="compute";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="compute";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="compute";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="compute";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="fragment";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="fragment";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="vertex";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="compute";b_stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="compute";b_stage="vertex";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="compute";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="compute";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="compute";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="fragment";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="fragment";b_stage="vertex";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="compute";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="compute";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="compute";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="fragment";a_kind="uniform";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="storage";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="storage";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="storage";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="uniform";b_kind="uniform";usage="direct"]
+
+  [:a_stage="vertex";b_stage="vertex";a_kind="uniform";b_kind="uniform";usage="transitive"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:function_scope:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:function_scope_texture:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:private_function_scope:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:private_module_scope:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,group_and_binding:single_entry_point:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="compute";a_kind="storage";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="storage";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="storage";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="uniform";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="compute";a_kind="uniform";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="storage";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="storage";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="storage";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="uniform";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";a_kind="uniform";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="storage";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="storage";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="storage";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="storage";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="storage";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_2d";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_2d";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_2d";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_external";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_external";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_external";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="texture_external";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="uniform";b_kind="texture_3d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="uniform";b_kind="texture_storage_1d";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="uniform";b_kind="uniform";usage="direct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";a_kind="uniform";b_kind="uniform";usage="transitive"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,id:id:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="const_expr"]
+
+  [:attr="duplicate"]
+
+  [:attr="empty"]
+
+  [:attr="f32"]
+
+  [:attr="f32_literal"]
+
+  [:attr="hex"]
+
+  [:attr="i32"]
+
+  [:attr="largest"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="misspelling"]
+
+  [:attr="multi_value"]
+
+  [:attr="negative"]
+
+  [:attr="newline"]
+
+  [:attr="no_params"]
+
+  [:attr="one"]
+
+  [:attr="overide_expr"]
+
+  [:attr="too_large"]
+
+  [:attr="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="ui32"]
+
+  [:attr="zero"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,id:id_fp16:*]
@@ -95391,63 +113160,1369 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,id:id_in_function:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:id=""]
+
+  [:id="%40id(1)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,id:id_non_override:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:type="const"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:type="override"]
+
+  [:type="var"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,id:id_struct_member:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:id=""]
+
+  [:id="%40id(1)"]
+
+  [:id="%40id(1)%20override"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,interpolate:duplicate:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr=""]
+
+  [:attr="%40interpolate(flat)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,interpolate:integral_types:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="fragment";type="i32";use_struct=false;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute=""]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute=""]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute=""]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute=""]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)"]
+
+  [:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,interpolate:interpolation_validation:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="missing_comma"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_parens"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="missing_value_and_left_paren"]
+
+  [:attr="newline"]
+
+  [:attr="no_params"]
+
+  [:attr="no_space"]
+
+  [:attr="numeric"]
+
+  [:attr="numeric_second_param"]
+
+  [:attr="trailing_comma_one_arg"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="trailing_comma_two_arg"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="valid"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,interpolate:require_location:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="fragment";attribute="%40builtin(position)";use_struct=false]
+
+  [:stage="fragment";attribute="%40builtin(position)";use_struct=true]
+
+  [:stage="fragment";attribute="%40location(0)";use_struct=false]
+
+  [:stage="fragment";attribute="%40location(0)";use_struct=true]
+
+  [:stage="vertex";attribute="%40builtin(position)";use_struct=false]
+
+  [:stage="vertex";attribute="%40builtin(position)";use_struct=true]
+
+  [:stage="vertex";attribute="%40location(0)";use_struct=false]
+
+  [:stage="vertex";attribute="%40location(0)";use_struct=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,interpolate:type_and_sampling:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:stage="fragment";io="in";use_struct=false;type="";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=false;type="";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=false;type="";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="center";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="centroid";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling="center"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling="centroid"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="flat";sampling="sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="linear";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="perspective";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=false;type="sample";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="center";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="centroid";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling="center"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling="centroid"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="flat";sampling="sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="linear";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="perspective";sampling="sample"]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling=""]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling="center"]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling="centroid"]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling="flat"]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling="linear"]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling="perspective"]
+
+  [:stage="fragment";io="in";use_struct=true;type="sample";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="center";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="centroid";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling="center"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling="centroid"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="flat";sampling="sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="linear";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="perspective";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=false;type="sample";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="center";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="centroid";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling="center"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling="centroid"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="flat";sampling="sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="linear";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="perspective";sampling="sample"]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling=""]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling="center"]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling="centroid"]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling="flat"]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling="linear"]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling="perspective"]
+
+  [:stage="fragment";io="out";use_struct=true;type="sample";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="center";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="centroid";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="flat";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="linear";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="perspective";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=false;type="sample";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="center";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="centroid";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling="center"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling="centroid"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="flat";sampling="sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="linear";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="perspective";sampling="sample"]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling=""]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling="center"]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling="centroid"]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling="flat"]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling="linear"]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling="perspective"]
+
+  [:stage="vertex";io="in";use_struct=true;type="sample";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="center";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="centroid";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="flat";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="linear";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="perspective";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=false;type="sample";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="center";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="centroid";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling="center"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling="centroid"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="flat";sampling="sample"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="linear";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="perspective";sampling="sample"]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling=""]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling="center"]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling="centroid"]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling="flat"]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling="linear"]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling="perspective"]
+
+  [:stage="vertex";io="out";use_struct=true;type="sample";sampling="sample"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,invariant:not_valid_on_user_defined_io:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:use_invariant=false]
+
+  [:use_invariant=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,invariant:parsing:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="duplicate"]
+
+  [:attr="empty_parens"]
+
+  [:attr="invariant"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="split_line"]
+
+  [:attr="value"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,invariant:valid_only_with_vertex_position_builtin:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=false]
+
+  [:name="frag_depth";stage="fragment";io="out";type="f32";use_struct=true]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=false]
+
+  [:name="front_facing";stage="fragment";io="in";type="bool";use_struct=true]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false]
+
+  [:name="global_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=false]
+
+  [:name="instance_index";stage="vertex";io="in";type="u32";use_struct=true]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false]
+
+  [:name="local_invocation_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=false]
+
+  [:name="local_invocation_index";stage="compute";io="in";type="u32";use_struct=true]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false]
+
+  [:name="num_workgroups";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=false]
+
+  [:name="position";stage="fragment";io="in";type="vec4%3Cf32%3E";use_struct=true]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=false]
+
+  [:name="position";stage="vertex";io="out";type="vec4%3Cf32%3E";use_struct=true]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=false]
+
+  [:name="sample_index";stage="fragment";io="in";type="u32";use_struct=true]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=false]
+
+  [:name="sample_mask";stage="fragment";io="in";type="u32";use_struct=true]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=false]
+
+  [:name="sample_mask";stage="fragment";io="out";type="u32";use_struct=true]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=false]
+
+  [:name="vertex_index";stage="vertex";io="in";type="u32";use_struct=true]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=false]
+
+  [:name="workgroup_id";stage="compute";io="in";type="vec3%3Cu32%3E";use_struct=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:duplicates:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:first="p1";second="p2"]
+
+  [:first="p1";second="rb"]
+
+  [:first="p1";second="s1b"]
+
+  [:first="p1";second="s2b"]
+
+  [:first="ra";second="p2"]
+
+  [:first="ra";second="rb"]
+
+  [:first="ra";second="s1b"]
+
+  [:first="ra";second="s2b"]
+
+  [:first="s1a";second="p2"]
+
+  [:first="s1a";second="rb"]
+
+  [:first="s1a";second="s1b"]
+
+  [:first="s1a";second="s2b"]
+
+  [:first="s2a";second="p2"]
+
+  [:first="s2a";second="rb"]
+
+  [:first="s2a";second="s1b"]
+
+  [:first="s2a";second="s2b"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:location_fp16:*]
@@ -95457,33 +114532,489 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:nesting:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target_stage="";target_io="in"]
+
+  [:target_stage="";target_io="out"]
+
+  [:target_stage="fragment";target_io="in"]
+
+  [:target_stage="fragment";target_io="out"]
+
+  [:target_stage="vertex";target_io="in"]
+
+  [:target_stage="vertex";target_io="out"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:stage_inout:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:use_struct=false;target_stage="compute";target_io="in"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use_struct=false;target_stage="compute";target_io="out"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use_struct=false;target_stage="fragment";target_io="in"]
+
+  [:use_struct=false;target_stage="fragment";target_io="out"]
+
+  [:use_struct=false;target_stage="vertex";target_io="in"]
+
+  [:use_struct=false;target_stage="vertex";target_io="out"]
+
+  [:use_struct=true;target_stage="compute";target_io="in"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use_struct=true;target_stage="compute";target_io="out"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:use_struct=true;target_stage="fragment";target_io="in"]
+
+  [:use_struct=true;target_stage="fragment";target_io="out"]
+
+  [:use_struct=true;target_stage="vertex";target_io="in"]
+
+  [:use_struct=true;target_stage="vertex";target_io="out"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:use_struct=false;type="MyAlias"]
+
+  [:use_struct=false;type="MyStruct"]
+
+  [:use_struct=false;type="array%3Cbool,%2012%3E"]
+
+  [:use_struct=false;type="array%3Cf32,%2012%3E"]
+
+  [:use_struct=false;type="array%3Ci32,%2012%3E"]
+
+  [:use_struct=false;type="array%3Cu32,%2012%3E"]
+
+  [:use_struct=false;type="atomic%3Ci32%3E"]
+
+  [:use_struct=false;type="atomic%3Cu32%3E"]
+
+  [:use_struct=false;type="bool"]
+
+  [:use_struct=false;type="f16"]
+
+  [:use_struct=false;type="f32"]
+
+  [:use_struct=false;type="i32"]
+
+  [:use_struct=false;type="mat2x2%3Cf32%3E"]
+
+  [:use_struct=false;type="mat2x2f"]
+
+  [:use_struct=false;type="mat2x2h"]
+
+  [:use_struct=false;type="mat2x3%3Cf32%3E"]
+
+  [:use_struct=false;type="mat2x3f"]
+
+  [:use_struct=false;type="mat2x3h"]
+
+  [:use_struct=false;type="mat2x4%3Cf32%3E"]
+
+  [:use_struct=false;type="mat2x4f"]
+
+  [:use_struct=false;type="mat2x4h"]
+
+  [:use_struct=false;type="mat3x2%3Cf32%3E"]
+
+  [:use_struct=false;type="mat3x2f"]
+
+  [:use_struct=false;type="mat3x2h"]
+
+  [:use_struct=false;type="mat3x3%3Cf32%3E"]
+
+  [:use_struct=false;type="mat3x3f"]
+
+  [:use_struct=false;type="mat3x3h"]
+
+  [:use_struct=false;type="mat3x4%3Cf32%3E"]
+
+  [:use_struct=false;type="mat3x4f"]
+
+  [:use_struct=false;type="mat3x4h"]
+
+  [:use_struct=false;type="mat4x2%3Cf32%3E"]
+
+  [:use_struct=false;type="mat4x2f"]
+
+  [:use_struct=false;type="mat4x2h"]
+
+  [:use_struct=false;type="mat4x3%3Cf32%3E"]
+
+  [:use_struct=false;type="mat4x3f"]
+
+  [:use_struct=false;type="mat4x3h"]
+
+  [:use_struct=false;type="mat4x4%3Cf32%3E"]
+
+  [:use_struct=false;type="mat4x4f"]
+
+  [:use_struct=false;type="mat4x4h"]
+
+  [:use_struct=false;type="sampler"]
+
+  [:use_struct=false;type="sampler_comparison"]
+
+  [:use_struct=false;type="texture_1d%3Ci32%3E"]
+
+  [:use_struct=false;type="texture_2d%3Cf32%3E"]
+
+  [:use_struct=false;type="texture_2d_array%3Ci32%3E"]
+
+  [:use_struct=false;type="texture_3d%3Cf32%3E"]
+
+  [:use_struct=false;type="texture_cube%3Cu32%3E"]
+
+  [:use_struct=false;type="texture_cube_array%3Ci32%3E"]
+
+  [:use_struct=false;type="texture_depth_2d"]
+
+  [:use_struct=false;type="texture_depth_2d_array"]
+
+  [:use_struct=false;type="texture_depth_cube"]
+
+  [:use_struct=false;type="texture_depth_cube_array"]
+
+  [:use_struct=false;type="texture_depth_multisampled_2d"]
+
+  [:use_struct=false;type="texture_external"]
+
+  [:use_struct=false;type="texture_multisampled_2d%3Ci32%3E"]
+
+  [:use_struct=false;type="texture_storage_1d%3Crgba8unorm,%20write%3E"]
+
+  [:use_struct=false;type="texture_storage_2d%3Crg32float,%20write%3E"]
+
+  [:use_struct=false;type="texture_storage_2d_array%3Cr32float,%20write%3E"]
+
+  [:use_struct=false;type="texture_storage_3d%3Cr32float,%20write%3E"]
+
+  [:use_struct=false;type="u32"]
+
+  [:use_struct=false;type="vec2%3Cbool%3E"]
+
+  [:use_struct=false;type="vec2%3Cf32%3E"]
+
+  [:use_struct=false;type="vec2%3Ci32%3E"]
+
+  [:use_struct=false;type="vec2%3Cu32%3E"]
+
+  [:use_struct=false;type="vec2f"]
+
+  [:use_struct=false;type="vec2h"]
+
+  [:use_struct=false;type="vec2i"]
+
+  [:use_struct=false;type="vec2u"]
+
+  [:use_struct=false;type="vec3%3Cbool%3E"]
+
+  [:use_struct=false;type="vec3%3Cf32%3E"]
+
+  [:use_struct=false;type="vec3%3Ci32%3E"]
+
+  [:use_struct=false;type="vec3%3Cu32%3E"]
+
+  [:use_struct=false;type="vec3f"]
+
+  [:use_struct=false;type="vec3h"]
+
+  [:use_struct=false;type="vec3i"]
+
+  [:use_struct=false;type="vec3u"]
+
+  [:use_struct=false;type="vec4%3Cbool%3E"]
+
+  [:use_struct=false;type="vec4%3Cf32%3E"]
+
+  [:use_struct=false;type="vec4%3Ci32%3E"]
+
+  [:use_struct=false;type="vec4%3Cu32%3E"]
+
+  [:use_struct=false;type="vec4f"]
+
+  [:use_struct=false;type="vec4h"]
+
+  [:use_struct=false;type="vec4i"]
+
+  [:use_struct=false;type="vec4u"]
+
+  [:use_struct=true;type="MyAlias"]
+
+  [:use_struct=true;type="MyStruct"]
+
+  [:use_struct=true;type="array%3Cbool,%2012%3E"]
+
+  [:use_struct=true;type="array%3Cf32,%2012%3E"]
+
+  [:use_struct=true;type="array%3Ci32,%2012%3E"]
+
+  [:use_struct=true;type="array%3Cu32,%2012%3E"]
+
+  [:use_struct=true;type="atomic%3Ci32%3E"]
+
+  [:use_struct=true;type="atomic%3Cu32%3E"]
+
+  [:use_struct=true;type="bool"]
+
+  [:use_struct=true;type="f16"]
+
+  [:use_struct=true;type="f32"]
+
+  [:use_struct=true;type="i32"]
+
+  [:use_struct=true;type="mat2x2%3Cf32%3E"]
+
+  [:use_struct=true;type="mat2x2f"]
+
+  [:use_struct=true;type="mat2x2h"]
+
+  [:use_struct=true;type="mat2x3%3Cf32%3E"]
+
+  [:use_struct=true;type="mat2x3f"]
+
+  [:use_struct=true;type="mat2x3h"]
+
+  [:use_struct=true;type="mat2x4%3Cf32%3E"]
+
+  [:use_struct=true;type="mat2x4f"]
+
+  [:use_struct=true;type="mat2x4h"]
+
+  [:use_struct=true;type="mat3x2%3Cf32%3E"]
+
+  [:use_struct=true;type="mat3x2f"]
+
+  [:use_struct=true;type="mat3x2h"]
+
+  [:use_struct=true;type="mat3x3%3Cf32%3E"]
+
+  [:use_struct=true;type="mat3x3f"]
+
+  [:use_struct=true;type="mat3x3h"]
+
+  [:use_struct=true;type="mat3x4%3Cf32%3E"]
+
+  [:use_struct=true;type="mat3x4f"]
+
+  [:use_struct=true;type="mat3x4h"]
+
+  [:use_struct=true;type="mat4x2%3Cf32%3E"]
+
+  [:use_struct=true;type="mat4x2f"]
+
+  [:use_struct=true;type="mat4x2h"]
+
+  [:use_struct=true;type="mat4x3%3Cf32%3E"]
+
+  [:use_struct=true;type="mat4x3f"]
+
+  [:use_struct=true;type="mat4x3h"]
+
+  [:use_struct=true;type="mat4x4%3Cf32%3E"]
+
+  [:use_struct=true;type="mat4x4f"]
+
+  [:use_struct=true;type="mat4x4h"]
+
+  [:use_struct=true;type="sampler"]
+
+  [:use_struct=true;type="sampler_comparison"]
+
+  [:use_struct=true;type="texture_1d%3Ci32%3E"]
+
+  [:use_struct=true;type="texture_2d%3Cf32%3E"]
+
+  [:use_struct=true;type="texture_2d_array%3Ci32%3E"]
+
+  [:use_struct=true;type="texture_3d%3Cf32%3E"]
+
+  [:use_struct=true;type="texture_cube%3Cu32%3E"]
+
+  [:use_struct=true;type="texture_cube_array%3Ci32%3E"]
+
+  [:use_struct=true;type="texture_depth_2d"]
+
+  [:use_struct=true;type="texture_depth_2d_array"]
+
+  [:use_struct=true;type="texture_depth_cube"]
+
+  [:use_struct=true;type="texture_depth_cube_array"]
+
+  [:use_struct=true;type="texture_depth_multisampled_2d"]
+
+  [:use_struct=true;type="texture_external"]
+
+  [:use_struct=true;type="texture_multisampled_2d%3Ci32%3E"]
+
+  [:use_struct=true;type="texture_storage_1d%3Crgba8unorm,%20write%3E"]
+
+  [:use_struct=true;type="texture_storage_2d%3Crg32float,%20write%3E"]
+
+  [:use_struct=true;type="texture_storage_2d_array%3Cr32float,%20write%3E"]
+
+  [:use_struct=true;type="texture_storage_3d%3Cr32float,%20write%3E"]
+
+  [:use_struct=true;type="u32"]
+
+  [:use_struct=true;type="vec2%3Cbool%3E"]
+
+  [:use_struct=true;type="vec2%3Cf32%3E"]
+
+  [:use_struct=true;type="vec2%3Ci32%3E"]
+
+  [:use_struct=true;type="vec2%3Cu32%3E"]
+
+  [:use_struct=true;type="vec2f"]
+
+  [:use_struct=true;type="vec2h"]
+
+  [:use_struct=true;type="vec2i"]
+
+  [:use_struct=true;type="vec2u"]
+
+  [:use_struct=true;type="vec3%3Cbool%3E"]
+
+  [:use_struct=true;type="vec3%3Cf32%3E"]
+
+  [:use_struct=true;type="vec3%3Ci32%3E"]
+
+  [:use_struct=true;type="vec3%3Cu32%3E"]
+
+  [:use_struct=true;type="vec3f"]
+
+  [:use_struct=true;type="vec3h"]
+
+  [:use_struct=true;type="vec3i"]
+
+  [:use_struct=true;type="vec3u"]
+
+  [:use_struct=true;type="vec4%3Cbool%3E"]
+
+  [:use_struct=true;type="vec4%3Cf32%3E"]
+
+  [:use_struct=true;type="vec4%3Ci32%3E"]
+
+  [:use_struct=true;type="vec4%3Cu32%3E"]
+
+  [:use_struct=true;type="vec4f"]
+
+  [:use_struct=true;type="vec4h"]
+
+  [:use_struct=true;type="vec4i"]
+
+  [:use_struct=true;type="vec4u"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,locations:validation:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="const_expr"]
+
+  [:attr="empty_params"]
+
+  [:attr="extra_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="extra_params"]
+
+  [:attr="f32"]
+
+  [:attr="f32_literal"]
+
+  [:attr="hex"]
+
+  [:attr="i32"]
+
+  [:attr="max"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="misspelling"]
+
+  [:attr="negative"]
+
+  [:attr="newline"]
+
+  [:attr="no_parens"]
+
+  [:attr="one"]
+
+  [:attr="override_expr"]
+
+  [:attr="u32"]
+
+  [:attr="vec"]
+
+  [:attr="zero"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,size:size:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="constant"]
+
+  [:attr="duplicate"]
+
+  [:attr="f32"]
+
+  [:attr="f32_literal"]
+
+  [:attr="hex"]
+
+  [:attr="i32"]
+
+  [:attr="large"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_parens"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="misspelling"]
+
+  [:attr="multiple_values"]
+
+  [:attr="negative"]
+
+  [:attr="no_value"]
+
+  [:attr="non_align_size"]
+
+  [:attr="override"]
+
+  [:attr="too_small"]
+
+  [:attr="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="u32"]
+
+  [:attr="valid"]
+
+  [:attr="whitespace"]
+
+  [:attr="zero"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,size:size_creation_fixed_footprint:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:array_size=""]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:array_size=",%204"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,size:size_fp16:*]
@@ -95493,18 +115024,145 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,size:size_non_struct:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="array"]
+
+  [:attr="constant"]
+
+  [:attr="control"]
+
+  [:attr="mat"]
+
+  [:attr="scalar"]
+
+  [:attr="struct"]
+
+  [:attr="vec"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:attr="comment"]
+
+  [:attr="const_expr"]
+
+  [:attr="duplicate"]
+
+  [:attr="empty"]
+
+  [:attr="empty_x"]
+
+  [:attr="empty_y"]
+
+  [:attr="invalid_entry"]
+
+  [:attr="max_values"]
+
+  [:attr="missing_left_paren"]
+
+  [:attr="missing_right_paren"]
+
+  [:attr="misspelling"]
+
+  [:attr="mix_ux"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="mix_uy"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="mix_uz"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="mixed_abstract_signed"]
+
+  [:attr="mixed_abstract_unsigned"]
+
+  [:attr="mixed_signed_unsigned"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="multi_line"]
+
+  [:attr="negative_x"]
+
+  [:attr="negative_y"]
+
+  [:attr="negative_z"]
+
+  [:attr="no_params"]
+
+  [:attr="override"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="override_expr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="override_no_default"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="trailing_comma_x"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="trailing_comma_y"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="trailing_comma_z"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:attr="x_only_abstract"]
+
+  [:attr="x_only_float"]
+
+  [:attr="x_only_float_literal"]
+
+  [:attr="x_only_hex"]
+
+  [:attr="x_only_signed"]
+
+  [:attr="x_only_unsigned"]
+
+  [:attr="xy_only_abstract"]
+
+  [:attr="xy_only_float"]
+
+  [:attr="xy_only_float_literal"]
+
+  [:attr="xy_only_hex"]
+
+  [:attr="xy_only_signed"]
+
+  [:attr="xy_only_unsigned"]
+
+  [:attr="xyz_abstract"]
+
+  [:attr="xyz_float"]
+
+  [:attr="xyz_float_literal"]
+
+  [:attr="xyz_hex"]
+
+  [:attr="xyz_signed"]
+
+  [:attr="xyz_unsigned"]
+
+  [:attr="zero_x"]
+
+  [:attr="zero_y"]
+
+  [:attr="zero_z"]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_const:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_fp16:*]
@@ -95514,158 +115172,1797 @@
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_fragment_shader:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_function:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_var:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_vertex_shader:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_direct_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="T"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_array_element:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="A"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_array_size:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="A"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_atomic:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="A"]
+
+  [:target="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_matrix_element:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="M"]
+
+  [:target="f32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_ptr_store_type:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="P"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_struct_attribute:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S";attribute="align"]
+
+  [:target="S";attribute="location"]
+
+  [:target="S";attribute="size"]
+
+  [:target="i32";attribute="align"]
+
+  [:target="i32";attribute="location"]
+
+  [:target="i32";attribute="size"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_struct_member:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,alias:no_indirect_recursion_via_vector_element:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="V"]
+
+  [:target="i32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,types,struct:no_direct_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,struct:no_indirect_recursion:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,struct:no_indirect_recursion_via_array_element:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,struct:no_indirect_recursion_via_array_size:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:target="S2"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,struct:no_indirect_recursion_via_struct_attribute:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="S1";attribute="align"]
+
+  [:target="S1";attribute="location"]
+
+  [:target="S1";attribute="size"]
+
+  [:target="S2";attribute="align"]
+
+  [:target="S2";attribute="location"]
+
+  [:target="S2";attribute="size"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,struct:no_indirect_recursion_via_struct_member_nested_in_alias:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:target="A"]
+
+  [:target="i32"]
 
 
 [cts.https.html?q=webgpu:shader,validation,types,vector:vector:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="aliased_el_ty"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="missing_el_ty"]
+
+  [:case="missing_t_left"]
+
+  [:case="missing_t_right"]
+
+  [:case="no_bool_shortform"]
+
+  [:case="trailing_comma"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="vec"]
+
+  [:case="vec1_i32"]
+
+  [:case="vec2_bool"]
+
+  [:case="vec2_f16"]
+
+  [:case="vec2_f32"]
+
+  [:case="vec2_i32"]
+
+  [:case="vec2_u32"]
+
+  [:case="vec2f"]
+
+  [:case="vec2h"]
+
+  [:case="vec2i"]
+
+  [:case="vec2u"]
+
+  [:case="vec3_bool"]
+
+  [:case="vec3_f16"]
+
+  [:case="vec3_f32"]
+
+  [:case="vec3_i32"]
+
+  [:case="vec3_u32"]
+
+  [:case="vec3f"]
+
+  [:case="vec3h"]
+
+  [:case="vec3i"]
+
+  [:case="vec3u"]
+
+  [:case="vec4_bool"]
+
+  [:case="vec4_f16"]
+
+  [:case="vec4_f32"]
+
+  [:case="vec4_i32"]
+
+  [:case="vec4_u32"]
+
+  [:case="vec4f"]
+
+  [:case="vec4h"]
+
+  [:case="vec4i"]
+
+  [:case="vec4u"]
+
+  [:case="vec5_u32"]
+
+  [:case="vec_f32"]
+
+  [:case="vec_of_array"]
+
+  [:case="vec_of_atomic"]
+
+  [:case="vec_of_matrix"]
+
+  [:case="vec_of_runtime_array"]
+
+  [:case="vec_of_struct"]
+
+  [:case="vec_of_vec"]
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:basics:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:statement="for"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:statement="if"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:statement="switch"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:statement="while"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:binary_expressions:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:e1="literal";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="literal";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index1";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_index2";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="nonuniform_struct";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_index";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="nonuniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e1="uniform_struct";e2="uniform_struct"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:compute_builtin_values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:builtin="global_invocation_id";type="vec3%3Cu32%3E";uniform=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:builtin="local_invocation_id";type="vec3%3Cf32%3E";uniform=false]
+
+  [:builtin="local_invocation_index";type="u32";uniform=false]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:builtin="num_workgroups";type="vec3%3Cu32%3E";uniform=true]
+
+  [:builtin="workgroup_id";type="vec3%3Cu32%3E";uniform=true]
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:fragment_builtin_values:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:builtin="front_facing";type="bool"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:builtin="position";type="vec4%3Cf32%3E"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:builtin="sample_index";type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:builtin="sample_mask";type="u32"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:function_pointer_parameters:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="nonuniform_conditional_call_assign_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nonuniform_param_nonuniform_assignment"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nonuniform_param_uniform_assignment"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_codependent1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_codependent2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_codependent3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_codependent4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_depends_on_nonpointer_param_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_depends_on_nonpointer_param_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_depends_on_pointer_param_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_depends_on_pointer_param_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_nonuniform_passthrough_value"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_store_nonuniform_value"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_store_uniform_value"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="pointer_uniform_passthrough_value"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_failure"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_success"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_conditional_call_assign_nonuniform1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_conditional_call_assign_nonuniform2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_conditional_call_assign_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_param_nonuniform_assignment"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_param_uniform_assignment"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:function_variables:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="after_loop_with_nonuniform_break";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_nonuniform_break";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_nonuniform_break";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_uniform_break_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_uniform_break_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_uniform_break_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_uniform_break_uniform";init="no_init"]
+
+  [:case="after_loop_with_uniform_break_uniform";init="nonuniform"]
+
+  [:case="after_loop_with_uniform_break_uniform";init="uniform"]
+
+  [:case="after_loop_with_uniform_breaks";init="no_init"]
+
+  [:case="after_loop_with_uniform_breaks";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_loop_with_uniform_breaks";init="uniform"]
+
+  [:case="after_switch_all_uniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_all_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_all_uniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_some_assign";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_some_assign";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_some_assign";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_with_break_nonuniform1";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_with_break_nonuniform1";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_with_break_nonuniform1";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_with_break_nonuniform2";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_with_break_nonuniform2";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="after_switch_with_break_nonuniform2";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="compound_assign_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="compound_assign_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="compound_assign_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="compound_assign_uniform";init="no_init"]
+
+  [:case="compound_assign_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="compound_assign_uniform";init="uniform"]
+
+  [:case="for_loop_nonuniform_body";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_body";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_body";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_body_no_condition";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_body_no_condition";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_body_no_condition";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_increment";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_increment";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_increment";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_init";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_init";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_nonuniform_init";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_uniform_body";init="no_init"]
+
+  [:case="for_loop_uniform_body";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_uniform_body";init="uniform"]
+
+  [:case="for_loop_uniform_body_no_condition";init="no_init"]
+
+  [:case="for_loop_uniform_body_no_condition";init="nonuniform"]
+
+  [:case="for_loop_uniform_body_no_condition";init="uniform"]
+
+  [:case="for_loop_uniform_increment";init="no_init"]
+
+  [:case="for_loop_uniform_increment";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="for_loop_uniform_increment";init="uniform"]
+
+  [:case="for_loop_uniform_init";init="no_init"]
+
+  [:case="for_loop_uniform_init";init="nonuniform"]
+
+  [:case="for_loop_uniform_init";init="uniform"]
+
+  [:case="if_else_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_else_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_else_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_else_split";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_else_split";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_else_split";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_else_uniform";init="no_init"]
+
+  [:case="if_else_uniform";init="nonuniform"]
+
+  [:case="if_else_uniform";init="uniform"]
+
+  [:case="if_no_else_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_else_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_else_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_else_uniform";init="no_init"]
+
+  [:case="if_no_else_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_else_uniform";init="uniform"]
+
+  [:case="if_no_then_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_then_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_then_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_then_uniform";init="no_init"]
+
+  [:case="if_no_then_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_no_then_uniform";init="uniform"]
+
+  [:case="if_nonescaping_nonuniform";init="no_init"]
+
+  [:case="if_nonescaping_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_nonescaping_nonuniform";init="uniform"]
+
+  [:case="if_unreachable_else_none";init="no_init"]
+
+  [:case="if_unreachable_else_none";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_else_none";init="uniform"]
+
+  [:case="if_unreachable_else_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_else_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_else_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_else_uniform";init="no_init"]
+
+  [:case="if_unreachable_else_uniform";init="nonuniform"]
+
+  [:case="if_unreachable_else_uniform";init="uniform"]
+
+  [:case="if_unreachable_then_none";init="no_init"]
+
+  [:case="if_unreachable_then_none";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_then_none";init="uniform"]
+
+  [:case="if_unreachable_then_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_then_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_then_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="if_unreachable_then_uniform";init="no_init"]
+
+  [:case="if_unreachable_then_uniform";init="nonuniform"]
+
+  [:case="if_unreachable_then_uniform";init="uniform"]
+
+  [:case="loop_body_depends_on_continuing_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_depends_on_continuing_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_depends_on_continuing_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_depends_on_continuing_uniform";init="no_init"]
+
+  [:case="loop_body_depends_on_continuing_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_depends_on_continuing_uniform";init="uniform"]
+
+  [:case="loop_body_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_nonuniform_cond";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_nonuniform_cond";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_nonuniform_cond";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_body_uniform";init="no_init"]
+
+  [:case="loop_body_uniform";init="nonuniform"]
+
+  [:case="loop_body_uniform";init="uniform"]
+
+  [:case="loop_continuing_from_body_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split1";init="no_init"]
+
+  [:case="loop_continuing_from_body_split1";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split1";init="uniform"]
+
+  [:case="loop_continuing_from_body_split2";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split2";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split2";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split3";init="no_init"]
+
+  [:case="loop_continuing_from_body_split3";init="nonuniform"]
+
+  [:case="loop_continuing_from_body_split3";init="uniform"]
+
+  [:case="loop_continuing_from_body_split4";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split4";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split4";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split5";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split5";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_split5";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_continuing_from_body_uniform";init="no_init"]
+
+  [:case="loop_continuing_from_body_uniform";init="nonuniform"]
+
+  [:case="loop_continuing_from_body_uniform";init="uniform"]
+
+  [:case="loop_in_loop_with_continue_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_in_loop_with_continue_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_in_loop_with_continue_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_in_loop_with_continue_uniform";init="no_init"]
+
+  [:case="loop_in_loop_with_continue_uniform";init="nonuniform"]
+
+  [:case="loop_in_loop_with_continue_uniform";init="uniform"]
+
+  [:case="loop_unreachable_continuing";init="no_init"]
+
+  [:case="loop_unreachable_continuing";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="loop_unreachable_continuing";init="uniform"]
+
+  [:case="nested1";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nested1";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nested1";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nested2";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nested2";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nested2";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="no_assign";init="no_init"]
+
+  [:case="no_assign";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="no_assign";init="uniform"]
+
+  [:case="partial_assignment_all_members_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_all_members_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_all_members_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_all_members_uniform";init="no_init"]
+
+  [:case="partial_assignment_all_members_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_all_members_uniform";init="uniform"]
+
+  [:case="partial_assignment_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_array_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_array_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_array_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_array_uniform";init="no_init"]
+
+  [:case="partial_assignment_single_element_array_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_array_uniform";init="uniform"]
+
+  [:case="partial_assignment_single_element_struct_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_struct_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_struct_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_struct_uniform";init="no_init"]
+
+  [:case="partial_assignment_single_element_struct_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_single_element_struct_uniform";init="uniform"]
+
+  [:case="partial_assignment_uniform";init="no_init"]
+
+  [:case="partial_assignment_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="partial_assignment_uniform";init="uniform"]
+
+  [:case="simple_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="simple_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="simple_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="simple_uniform";init="no_init"]
+
+  [:case="simple_uniform";init="nonuniform"]
+
+  [:case="simple_uniform";init="uniform"]
+
+  [:case="switch_nonuniform_case";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="switch_nonuniform_case";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="switch_nonuniform_case";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="switch_uniform_case";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="switch_uniform_case";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="switch_uniform_case";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="unreachable_nonuniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="unreachable_nonuniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="unreachable_nonuniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="unreachable_uniform";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="unreachable_uniform";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="unreachable_uniform";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="while_loop_nonuniform_body";init="no_init"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="while_loop_nonuniform_body";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="while_loop_nonuniform_body";init="uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="while_loop_uniform_body";init="no_init"]
+
+  [:case="while_loop_uniform_body";init="nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="while_loop_uniform_body";init="uniform"]
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:functions:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="combined_parameters1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="combined_parameters2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="combined_parameters3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="combined_parameters4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="dpdxCoarse_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="dpdxFine_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="dpdx_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="dpdyCoarse_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="dpdyFine_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="dpdy_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="fwidthCoarse_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="fwidthFine_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="fwidth_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="min_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nonuniform_passthrough_parameter"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="nonuniform_return_is_uniform_after_call"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_function_call_depends_on_nonuniform_param"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_function_call_depends_on_uniform_param"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_function_call_in_nonuniform_cf"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_function_call_in_nonuniform_cf2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="required_uniform_function_call_in_uniform_cf"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureDimensions_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureGatherCompare_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureGather_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureLoad_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureNumLayers_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureNumLevels_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureNumSamples_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSampleBaseClampToEdge_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSampleBias_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSampleCompareLevel_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSampleCompare_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSampleGrad_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSampleLevel_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="textureSample_nonuniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_parameter_cf_after_nonuniform_expr"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_passthrough_parameter"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="value_constructor_uniform_input_uniform_result"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:pointers:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="address_nonuniform_chain1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="address_nonuniform_chain2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="address_nonuniform_value"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="address_uniform_chain"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="address_uniform_literal"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="address_uniform_value"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_array_nonuniform_index1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_array_nonuniform_index2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_array_nonuniform_index3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_array_uniform_index"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_pointer_deref2"]
+
+  [:case="contents_lhs_pointer_deref2a"]
+
+  [:case="contents_lhs_pointer_deref3"]
+
+  [:case="contents_lhs_pointer_deref3a"]
+
+  [:case="contents_lhs_pointer_deref4"]
+
+  [:case="contents_lhs_pointer_deref4a"]
+
+  [:case="contents_lhs_pointer_deref4b"]
+
+  [:case="contents_lhs_pointer_deref4c"]
+
+  [:case="contents_lhs_pointer_deref4d"]
+
+  [:case="contents_lhs_pointer_deref4e"]
+
+  [:case="contents_lhs_ref_pointer_deref1"]
+
+  [:case="contents_lhs_ref_pointer_deref1a"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref2a"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref3"]
+
+  [:case="contents_lhs_ref_pointer_deref3a"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref4"]
+
+  [:case="contents_lhs_ref_pointer_deref4a"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref4b"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref4c"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref4d"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_lhs_ref_pointer_deref4e"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_rhs_pointer_deref1"]
+
+  [:case="contents_rhs_pointer_deref1a"]
+
+  [:case="contents_rhs_pointer_deref2"]
+
+  [:case="contents_scalar_alias_nonuniform1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_alias_nonuniform2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_alias_nonuniform3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_alias_nonuniform4"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_alias_nonuniform5"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_alias_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_nonuniform1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_nonuniform2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_uniform1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_uniform2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_scalar_uniform3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_chain_nonuniform1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_chain_nonuniform2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_chain_nonuniform3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_chain_uniform"]
+
+  [:case="contents_struct_nonuniform1"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_nonuniform2"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_nonuniform3"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="contents_struct_uniform"]
+
+  [:case="wg_uniform_load_is_uniform"]
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:short_circuit_expressions:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:case="and_nonuniform_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="and_nonuniform_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="and_uniform_first_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="and_uniform_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="and_uniform_second_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="and_uniform_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="or_nonuniform_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="or_nonuniform_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="or_uniform_first_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="or_uniform_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="or_uniform_second_nonuniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:case="or_uniform_uniform"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:shader,validation,uniformity,uniformity:unary_expressions:*]
-  expected:
-    if os == "linux" and not debug: CRASH
+  [:e="literal";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="literal";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="literal";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_index1";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_index1";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_index1";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_index2";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_index2";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_index2";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_struct";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_struct";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="nonuniform_struct";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform_index";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform_index";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform_index";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform_struct";op="!b_tmp"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform_struct";op="-i32(i_tmp)%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
+
+  [:e="uniform_struct";op="~i_tmp%20%3E%200"]
+    expected:
+      if os == "linux" and not debug: FAIL
 
 
 [cts.https.html?q=webgpu:util,texture,color_space_conversions:util_matches_2d_canvas:*]


### PR DESCRIPTION
[`webgpu:api,operation,shader_module,compilation_info:*`](https://gpuweb.github.io/cts/standalone/?runnow=1&q=webgpu:api,operation,shader_module,compilation_info:*) passes. There are many new expectations (they were crashes before).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in CTS
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
