### PR TITLE
Remove media element state changes triggered by network responses

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2828,13 +2828,6 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         }
 
         if status.is_ok() && self.latest_fetched_content != 0 {
-            if elem.ready_state.get() == ReadyState::HaveNothing {
-                // Make sure that we don't skip the HaveMetadata and HaveCurrentData
-                // states for short streams.
-                elem.change_ready_state(ReadyState::HaveMetadata);
-            }
-            elem.change_ready_state(ReadyState::HaveEnoughData);
-
             elem.upcast::<EventTarget>().fire_event(atom!("progress"));
 
             elem.network_state.set(NetworkState::Idle);

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -615,6 +615,10 @@ impl HTMLMediaElement {
             return;
         }
 
+        if old_ready_state == ready_state {
+            return;
+        }
+
         let window = window_from_node(self);
         let task_source = window.task_manager().media_element_task_source();
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2847,8 +2847,6 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             elem.network_state.set(NetworkState::Idle);
 
             elem.upcast::<EventTarget>().fire_event(atom!("suspend"));
-
-            elem.delay_load_event(false);
         }
         // => "If the connection is interrupted after some media data has been received..."
         else if elem.ready_state.get() != ReadyState::HaveNothing {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1546,6 +1546,9 @@ impl HTMLMediaElement {
                                     }),
                                     window.upcast(),
                                 );
+
+                                // https://html.spec.whatwg.org/multipage/#dom-media-have_current_data
+                                self.change_ready_state(ReadyState::HaveCurrentData);
                             }
                         },
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1822,6 +1822,8 @@ impl HTMLMediaElement {
                 }
             },
             PlayerEvent::EnoughData => {
+                self.change_ready_state(ReadyState::HaveEnoughData);
+
                 // The player has enough data and it is asking us to stop pushing
                 // bytes, so we cancel the ongoing fetch request iff we are able
                 // to restart it from where we left. Otherwise, we continue the

--- a/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-video.html.ini
+++ b/tests/wpt/meta/css/compositing/mix-blend-mode/mix-blend-mode-video.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-video.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/overflow-video.html.ini
+++ b/tests/wpt/meta/css/css-overflow/overflow-video.html.ini
@@ -1,0 +1,2 @@
+[overflow-video.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/media/media-playback-state.html.ini
+++ b/tests/wpt/meta/css/selectors/media/media-playback-state.html.ini
@@ -1,4 +1,5 @@
 [media-playback-state.html]
+  expected: TIMEOUT
   [Test :pseudo-class syntax is supported without throwing a SyntaxError]
     expected: FAIL
 
@@ -6,7 +7,7 @@
     expected: FAIL
 
   [Test :paused pseudo-classes]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Test :seeking pseudo-class]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/fetch/orb/tentative/known-mime-type.sub.any.js.ini
+++ b/tests/wpt/meta/fetch/orb/tentative/known-mime-type.sub.any.js.ini
@@ -27,101 +27,26 @@
   [ORB should block opaque text/plain: fetch(..., {mode: "no-cors"})]
     expected: FAIL
 
-  [ORB should block opaque text/plain: <audio src=...>]
-    expected: TIMEOUT
-
-  [ORB should block opaque text/plain: <video src=...>]
-    expected: NOTRUN
-
   [ORB should block opaque text/plain: <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque application/json (non-empty): fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json (non-empty): <img src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json (non-empty): <audio src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json (non-empty): <video src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque application/json (non-empty): <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque application/json (empty): fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json (empty): <img src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json (empty): <audio src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json (empty): <video src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque application/json (empty): <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque application/json which contains non ascii characters: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json which contains non ascii characters: <img src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json which contains non ascii characters: <audio src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque application/json which contains non ascii characters: <video src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque application/json which contains non ascii characters: <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque image/png: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque image/png: <img src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript: <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript (utf16 encoded with BOM): fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript (utf16 encoded with BOM): <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript (utf16 encoded without BOM but charset is provided in content-type): fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript (utf16 encoded without BOM but charset is provided in content-type): <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript (iso-8559-1 encoded): fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque text/javascript (iso-8559-1 encoded): <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block text/javascript with valid asm.js: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block text/javascript with valid asm.js: <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block text/javascript with invalid asm.js: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block text/javascript with invalid asm.js: <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [known-mime-type.sub.any.worker.html]

--- a/tests/wpt/meta/fetch/orb/tentative/nosniff.sub.any.js.ini
+++ b/tests/wpt/meta/fetch/orb/tentative/nosniff.sub.any.js.ini
@@ -1,73 +1,25 @@
 [nosniff.sub.any.html]
-  expected: TIMEOUT
-  [ORB should block opaque text/plain with nosniff]
-    expected: FAIL
-
-  [ORB should block opaque-response-blocklisted MIME type with nosniff]
-    expected: FAIL
-
-  [ORB should block opaque response with empty Content-Type and nosniff]
-    expected: FAIL
-
+  expected: ERROR
   [ORB should block opaque text/plain with nosniff: fetch(..., {mode: "no-cors"})]
     expected: FAIL
 
-  [ORB should block opaque text/plain with nosniff: <audio src=...>]
-    expected: TIMEOUT
-
-  [ORB should block opaque text/plain with nosniff: <video src=...>]
-    expected: NOTRUN
-
   [ORB should block opaque text/plain with nosniff: <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque-response-blocklisted MIME type with nosniff: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB should block opaque-response-blocklisted MIME type with nosniff: <img src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque-response-blocklisted MIME type with nosniff: <audio src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque-response-blocklisted MIME type with nosniff: <video src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque-response-blocklisted MIME type with nosniff: <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque response with empty Content-Type and nosniff: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB should block opaque response with empty Content-Type and nosniff: <img src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque response with empty Content-Type and nosniff: <audio src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque response with empty Content-Type and nosniff: <video src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque response with empty Content-Type and nosniff: <script src=...>]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque image with empty Content-Type and nosniff: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB shouldn't block opaque image with empty Content-Type and nosniff: <img src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [nosniff.sub.any.worker.html]
-  [ORB should block opaque text/plain with nosniff]
-    expected: FAIL
-
-  [ORB should block opaque-response-blocklisted MIME type with nosniff]
-    expected: FAIL
-
-  [ORB should block opaque response with empty Content-Type and nosniff]
-    expected: FAIL
-
   [ORB should block opaque text/plain with nosniff: fetch(..., {mode: "no-cors"})]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/orb/tentative/status.sub.any.js.ini
+++ b/tests/wpt/meta/fetch/orb/tentative/status.sub.any.js.ini
@@ -1,5 +1,5 @@
 [status.sub.any.html]
-  expected: TIMEOUT
+  expected: ERROR
   [ORB should block opaque-response-blocklisted MIME type with status 206]
     expected: FAIL
 
@@ -9,29 +9,11 @@
   [ORB should block opaque-response-blocklisted MIME type with status 206: fetch(..., {mode: "no-cors"})]
     expected: FAIL
 
-  [ORB should block opaque-response-blocklisted MIME type with status 206: <audio src=...>]
-    expected: TIMEOUT
-
-  [ORB should block opaque-response-blocklisted MIME type with status 206: <video src=...>]
-    expected: NOTRUN
-
   [ORB should block opaque-response-blocklisted MIME type with status 206: <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
   [ORB should block opaque response with non-ok status: fetch(..., {mode: "no-cors"})]
-    expected: NOTRUN
-
-  [ORB should block opaque response with non-ok status: <img src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque response with non-ok status: <audio src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque response with non-ok status: <video src=...>]
-    expected: NOTRUN
-
-  [ORB should block opaque response with non-ok status: <script src=...>]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [status.sub.any.worker.html]

--- a/tests/wpt/meta/fetch/range/non-matching-range-response.html.ini
+++ b/tests/wpt/meta/fetch/range/non-matching-range-response.html.ini
@@ -1,0 +1,3 @@
+[non-matching-range-response.html]
+  [Range response out of range of request should succeed]
+    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
@@ -1,4 +1,5 @@
 [createImageBitmap-colorSpaceConversion.html]
+  expected: ERROR
   [createImageBitmap from a bitmap HTMLImageElement, and drawImage on the created ImageBitmap with colorSpaceConversion: none]
     expected: FAIL
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html.ini
@@ -1,5 +1,5 @@
 [createImageBitmap-drawImage.html]
-  expected: TIMEOUT
+  expected: ERROR
   [createImageBitmap from an OffscreenCanvas resized, and drawImage on the created ImageBitmap]
     expected: NOTRUN
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html.ini
@@ -1,5 +1,5 @@
 [createImageBitmap-invalid-args.html]
-  expected: TIMEOUT
+  expected: ERROR
   [createImageBitmap with a vector HTMLImageElement source and sw set to 0]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/audio_loop_base.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/audio_loop_base.html.ini
@@ -1,5 +1,0 @@
-[audio_loop_base.html]
-  expected: TIMEOUT
-  [Check if audio.loop is set to true that expecting the seeking event is fired more than once]
-    expected: NOTRUN
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/audio_loop_seek_to_eos.html.ini
@@ -1,3 +1,0 @@
-[audio_loop_seek_to_eos.html]
-  [seeking to the end of looping audio]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/playing-the-media-resource/loop-from-ended.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/playing-the-media-resource/loop-from-ended.tentative.html.ini
@@ -1,7 +1,8 @@
 [loop-from-ended.tentative.html]
+  expected: TIMEOUT
   [Test looping edge case to verify http://crbug.com/364442.]
     expected: FAIL
 
   [play() with loop set to true after playback ended]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-mutable-fragment.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-cue-mutable-fragment.html.ini
@@ -1,4 +1,5 @@
 [track-cue-mutable-fragment.html]
+  expected: TIMEOUT
   [Cue fragment is mutable]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-mode-not-changed-by-new-track.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/track/track-element/track-mode-not-changed-by-new-track.html.ini
@@ -1,4 +1,5 @@
 [track-mode-not-changed-by-new-track.html]
+  expected: TIMEOUT
   [A track appended after the initial track configuration does not change other tracks]
-    expected: FAIL
+    expected: TIMEOUT
 


### PR DESCRIPTION
This PR contains a series of changes that address #31415 and subsequent test failures exposed by making the media element code more spec-compliant. Media element state changes should be driven by player events, but our tests often complete before those players events are processed because we remove the load-blocking flag from the element as soon as the network response EOF is received.

By ensuring that we process all player events correctly in our tests, we expose:
1. the media backend only reports some errors when informed that no more data is forthcoming (we never provide that signal)
1. some tests load unsupported media types as a side effect (eg. setting the video src to ".", which loads a text/html response)
1. the network and media backend can race to report an error, resulting in multiple events for the same content

By addressing each of these points in this PR, our media test results become more accurate.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31415
- [x] There are tests for these changes