### PR TITLE
Add production-stripped cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,12 @@ debug-assertions = true
 inherits = "release"
 debug-assertions = false
 
+[profile.production-stripped]
+inherits = "production"
+strip = true
+lto = "thin"
+codegen-units = 1
+
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,12 +152,12 @@ debug-assertions = true
 [profile.production]
 inherits = "release"
 debug-assertions = false
+lto = "thin"
+codegen-units = 1
 
 [profile.production-stripped]
 inherits = "production"
 strip = true
-lto = "thin"
-codegen-units = 1
 
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream


### PR DESCRIPTION
Stripping the binary significantly reduces the size  (in my tests to about 1/3 of the original size). Enabling LTO and setting `codegen-units = 1` allows further size optimizations at the cost of increased compile-time.

Probably not everyone wants a stripped binary, since it makes backtraces less useful.


