### PR TITLE
layout: use `Au` in `TextFragment`

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -961,7 +961,7 @@ fn rgba(color: AbsoluteColor) -> wr::ColorF {
 fn glyphs(
     glyph_runs: &[Arc<GlyphStore>],
     mut baseline_origin: PhysicalPoint<Au>,
-    justification_adjustment: Length,
+    justification_adjustment: Au,
 ) -> Vec<wr::GlyphInstance> {
     use fonts_traits::ByteIndex;
     use range::Range;
@@ -983,7 +983,7 @@ fn glyphs(
             }
 
             if glyph.char_is_word_separator() {
-                baseline_origin.x += justification_adjustment.into();
+                baseline_origin.x += justification_adjustment;
             }
             baseline_origin.x += glyph.advance();
         }

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -245,7 +245,7 @@ impl TextRunLineItem {
             font_key: self.font_key,
             glyphs: self.text,
             text_decoration_line: self.text_decoration_line,
-            justification_adjustment: state.justification_adjustment,
+            justification_adjustment: state.justification_adjustment.into(),
         })
     }
 }

--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -11,7 +11,6 @@ use fonts::{FontMetrics, GlyphStore};
 use serde::Serialize;
 use servo_arc::Arc as ServoArc;
 use style::properties::ComputedValues;
-use style::values::computed::Length;
 use style::values::specified::text::TextDecorationLine;
 use style::Zero;
 use webrender_api::{FontInstanceKey, ImageKey};
@@ -75,7 +74,7 @@ pub(crate) struct TextFragment {
     pub text_decoration_line: TextDecorationLine,
 
     /// Extra space to add for each justification opportunity.
-    pub justification_adjustment: Length,
+    pub justification_adjustment: Au,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Use `Au` in `TextFragment`, also ran cargo-clippy to fix some complains

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
