### PR TITLE
layout: Add support for table captions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5400,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -5688,7 +5688,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "nodrop",
  "serde",
@@ -5698,7 +5698,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5885,7 +5885,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "static_assertions",
 ]
@@ -6026,7 +6026,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 
 [[package]]
 name = "strict-num"
@@ -6063,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "lazy_static",
 ]
@@ -6129,7 +6129,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "darling",
  "derive_common",
@@ -6160,7 +6160,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -6510,7 +6510,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6523,7 +6523,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#e8a14bce9453ad5939eb0c34de150ad2f10d1bc2"
+source = "git+https://github.com/servo/stylo?branch=2024-05-31#141446aeea5a0741927c3c83de54a9512e12f4ab"
 dependencies = [
  "darling",
  "derive_common",

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1367,9 +1367,9 @@ struct ContainingBlockPaddingAndBorder<'a> {
     max_box_size: LogicalVec2<Option<Length>>,
 }
 
-struct ResolvedMargins {
+pub(crate) struct ResolvedMargins {
     /// Used value for the margin properties, as exposed in getComputedStyle().
-    margin: LogicalSides<Au>,
+    pub margin: LogicalSides<Au>,
 
     /// Distance between the border box and the containing block on the inline-start side.
     /// This is typically the same as the inline-start margin, but can be greater when
@@ -1377,7 +1377,7 @@ struct ResolvedMargins {
     /// The reason we aren't just adjusting the used margin-inline-start is that
     /// this shouldn't be observable via getComputedStyle().
     /// <https://drafts.csswg.org/css-align/#justify-self-property>
-    effective_margin_inline_start: Au,
+    pub effective_margin_inline_start: Au,
 }
 
 /// Given the style for an in-flow box and its containing block, determine the containing
@@ -1440,7 +1440,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
 /// Note that in the presence of floats, this shouldn't be used for a block-level box
 /// that establishes an independent formatting context (or is replaced), since the
 /// margins could then be incorrect.
-fn solve_margins(
+pub(crate) fn solve_margins(
     containing_block: &ContainingBlock<'_>,
     pbm: &PaddingBorderMargin,
     inline_size: Au,

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use servo_arc::Arc;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
+use style::selector_parser::PseudoElement;
 use style::values::specified::text::TextDecorationLine;
 
 use crate::context::LayoutContext;
@@ -59,10 +60,19 @@ pub(crate) enum NonReplacedFormattingContextContents {
 
 /// The baselines of a layout or a [`crate::fragment_tree::BoxFragment`]. Some layout
 /// uses the first and some layout uses the last.
-#[derive(Debug, Default, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Serialize)]
 pub(crate) struct Baselines {
     pub first: Option<Au>,
     pub last: Option<Au>,
+}
+
+impl Baselines {
+    pub(crate) fn offset(&self, block_offset: Au) -> Baselines {
+        Self {
+            first: self.first.map(|first| first + block_offset),
+            last: self.last.map(|last| last + block_offset),
+        }
+    }
 }
 
 pub(crate) struct IndependentLayout {
@@ -83,15 +93,16 @@ pub(crate) struct IndependentLayout {
 }
 
 impl IndependentFormattingContext {
-    pub fn construct<'dom>(
+    pub fn construct<'dom, Node: NodeExt<'dom>>(
         context: &LayoutContext,
-        node_and_style_info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        node_and_style_info: &NodeAndStyleInfo<Node>,
         display_inside: DisplayInside,
         contents: Contents,
         propagated_text_decoration_line: TextDecorationLine,
     ) -> Self {
         match contents {
             Contents::NonReplaced(non_replaced_contents) => {
+                let mut base_fragment_info: BaseFragmentInfo = node_and_style_info.into();
                 let contents = match display_inside {
                     DisplayInside::Flow { is_list_item } |
                     DisplayInside::FlowRoot { is_list_item } => {
@@ -114,17 +125,27 @@ impl IndependentFormattingContext {
                         ))
                     },
                     DisplayInside::Table => {
+                        let table_grid_style = context
+                            .shared_context()
+                            .stylist
+                            .style_for_anonymous::<Node::ConcreteElement>(
+                            &context.shared_context().guards,
+                            &PseudoElement::ServoTableGrid,
+                            &node_and_style_info.style,
+                        );
+                        base_fragment_info.flags.insert(FragmentFlags::DO_NOT_PAINT);
                         NonReplacedFormattingContextContents::Table(Table::construct(
                             context,
                             node_and_style_info,
+                            table_grid_style,
                             non_replaced_contents,
                             propagated_text_decoration_line,
                         ))
                     },
                 };
                 Self::NonReplaced(NonReplacedFormattingContext {
-                    base_fragment_info: node_and_style_info.into(),
                     style: Arc::clone(&node_and_style_info.style),
+                    base_fragment_info,
                     content_sizes: None,
                     contents,
                 })

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -85,22 +85,23 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Serialize)]
     pub(crate) struct FragmentFlags: u8 {
         /// Whether or not the node that created this fragment is a `<body>` element on an HTML document.
-        const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 0b00000001;
+        const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 1 << 0;
         /// Whether or not the node that created this Fragment is a `<br>` element.
-        const IS_BR_ELEMENT = 0b00000010;
+        const IS_BR_ELEMENT = 1 << 1;
         /// Whether or not the node that created was a `<table>`, `<th>` or
         /// `<td>` element. Note that this does *not* include elements with
         /// `display: table` or `display: table-cell`.
-        const IS_TABLE_TH_OR_TD_ELEMENT = 0b00000100;
+        const IS_TABLE_TH_OR_TD_ELEMENT = 1 << 2;
         /// Whether or not this Fragment was created to contain a replaced element or is
         /// a replaced element.
-        const IS_REPLACED = 0b00001000;
+        const IS_REPLACED = 1 << 3;
         /// Whether or not this Fragment was created to contain a list item marker
         /// with a used value of `list-style-position: outside`.
-        const IS_OUTSIDE_LIST_ITEM_MARKER = 0b00010000;
-        /// Avoid painting the fragment, this is used for empty table cells when 'empty-cells' is 'hide'.
-        /// This flag doesn't avoid hit-testing.
-        const DO_NOT_PAINT = 0b00100000;
+        const IS_OUTSIDE_LIST_ITEM_MARKER = 1 << 4;
+        /// Avoid painting the borders, backgrounds, and drop shadow for this fragment, this is used
+        /// for empty table cells when 'empty-cells' is 'hide' and also table wrappers.  This flag
+        /// doesn't avoid hit-testing nor does it prevent the painting outlines.
+        const DO_NOT_PAINT = 1 << 5;
     }
 }
 

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -215,12 +215,16 @@ impl BoxFragment {
         )
     }
 
-    pub fn padding_rect(&self) -> LogicalRect<Au> {
+    pub(crate) fn padding_rect(&self) -> LogicalRect<Au> {
         self.content_rect.inflate(&self.padding)
     }
 
-    pub fn border_rect(&self) -> LogicalRect<Au> {
+    pub(crate) fn border_rect(&self) -> LogicalRect<Au> {
         self.padding_rect().inflate(&self.border)
+    }
+
+    pub(crate) fn margin_rect(&self) -> LogicalRect<Au> {
+        self.border_rect().inflate(&self.margin)
     }
 
     pub fn print(&self, tree: &mut PrintTree) {

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -370,6 +370,19 @@ impl<T: Add<Output = T> + Copy> Add<LogicalSides<T>> for LogicalSides<T> {
     }
 }
 
+impl<T: Sub<Output = T> + Copy> Sub<LogicalSides<T>> for LogicalSides<T> {
+    type Output = LogicalSides<T>;
+
+    fn sub(self, other: Self) -> Self::Output {
+        LogicalSides {
+            inline_start: self.inline_start - other.inline_start,
+            inline_end: self.inline_end - other.inline_end,
+            block_start: self.block_start - other.block_start,
+            block_end: self.block_end - other.block_end,
+        }
+    }
+}
+
 impl<T: Neg<Output = T> + Copy> Neg for LogicalSides<T> {
     type Output = LogicalSides<T>;
     fn neg(self) -> Self::Output {
@@ -384,7 +397,7 @@ impl<T: Neg<Output = T> + Copy> Neg for LogicalSides<T> {
 
 impl<T: Zero> LogicalSides<T> {
     pub(crate) fn zero() -> LogicalSides<T> {
-        LogicalSides {
+        Self {
             inline_start: T::zero(),
             inline_end: T::zero(),
             block_start: T::zero(),
@@ -395,7 +408,7 @@ impl<T: Zero> LogicalSides<T> {
 
 impl From<LogicalSides<CSSPixelLength>> for LogicalSides<Au> {
     fn from(value: LogicalSides<CSSPixelLength>) -> Self {
-        LogicalSides {
+        Self {
             inline_start: value.inline_start.into(),
             inline_end: value.inline_end.into(),
             block_start: value.block_start.into(),
@@ -406,7 +419,7 @@ impl From<LogicalSides<CSSPixelLength>> for LogicalSides<Au> {
 
 impl From<LogicalSides<Au>> for LogicalSides<CSSPixelLength> {
     fn from(value: LogicalSides<Au>) -> Self {
-        LogicalSides {
+        Self {
             inline_start: value.inline_start.into(),
             inline_end: value.inline_end.into(),
             block_start: value.block_start.into(),
@@ -435,7 +448,7 @@ impl<T> LogicalRect<T> {
         T: Add<Output = T> + Copy,
         T: Sub<Output = T> + Copy,
     {
-        LogicalRect {
+        Self {
             start_corner: LogicalVec2 {
                 inline: self.start_corner.inline - sides.inline_start,
                 block: self.start_corner.block - sides.block_start,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -134,6 +134,13 @@ impl PaddingBorderMargin {
             padding_border_sums: LogicalVec2::zero(),
         }
     }
+
+    pub(crate) fn border_padding_start(&self) -> LogicalVec2<Au> {
+        LogicalVec2 {
+            inline: self.border.inline_start + self.padding.inline_start,
+            block: self.border.block_start + self.padding.block_start,
+        }
+    }
 }
 
 pub(crate) trait ComputedValuesExt {

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -15,8 +15,8 @@ use style::str::char_is_whitespace;
 use style::values::specified::TextDecorationLine;
 
 use super::{
-    Table, TableSlot, TableSlotCell, TableSlotCoordinates, TableSlotOffset, TableTrack,
-    TableTrackGroup, TableTrackGroupType,
+    Table, TableCaption, TableSlot, TableSlotCell, TableSlotCoordinates, TableSlotOffset,
+    TableTrack, TableTrackGroup, TableTrackGroupType,
 };
 use crate::context::LayoutContext;
 use crate::dom::{BoxSlot, NodeExt};
@@ -73,12 +73,14 @@ impl Table {
     pub(crate) fn construct<'dom>(
         context: &LayoutContext,
         info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        grid_style: Arc<ComputedValues>,
         contents: NonReplacedContents,
         propagated_text_decoration_line: TextDecorationLine,
     ) -> Self {
         let text_decoration_line =
             propagated_text_decoration_line | info.style.clone_text_decoration_line();
-        let mut traversal = TableBuilderTraversal::new(context, info, text_decoration_line);
+        let mut traversal =
+            TableBuilderTraversal::new(context, info, grid_style, text_decoration_line);
         contents.traverse(context, info, &mut traversal);
         traversal.finish()
     }
@@ -92,7 +94,7 @@ impl Table {
     where
         Node: crate::dom::NodeExt<'dom>,
     {
-        let anonymous_style = context
+        let grid_and_wrapper_style = context
             .shared_context()
             .stylist
             .style_for_anonymous::<Node::ConcreteElement>(
@@ -100,10 +102,14 @@ impl Table {
                 &PseudoElement::ServoAnonymousTable,
                 &parent_info.style,
             );
-        let anonymous_info = parent_info.new_anonymous(anonymous_style.clone());
+        let anonymous_info = parent_info.new_anonymous(grid_and_wrapper_style.clone());
 
-        let mut table_builder =
-            TableBuilderTraversal::new(context, &anonymous_info, propagated_text_decoration_line);
+        let mut table_builder = TableBuilderTraversal::new(
+            context,
+            &anonymous_info,
+            grid_and_wrapper_style.clone(),
+            propagated_text_decoration_line,
+        );
 
         for content in contents {
             match content {
@@ -128,7 +134,7 @@ impl Table {
 
         IndependentFormattingContext::NonReplaced(NonReplacedFormattingContext {
             base_fragment_info: (&anonymous_info).into(),
-            style: anonymous_style,
+            style: grid_and_wrapper_style,
             content_sizes: None,
             contents: NonReplacedFormattingContextContents::Table(table),
         })
@@ -229,15 +235,23 @@ pub struct TableBuilder {
 }
 
 impl TableBuilder {
-    pub(super) fn new(style: Arc<ComputedValues>) -> Self {
+    pub(super) fn new(
+        style: Arc<ComputedValues>,
+        grid_style: Arc<ComputedValues>,
+        base_fragment_info: BaseFragmentInfo,
+    ) -> Self {
         Self {
-            table: Table::new(style),
+            table: Table::new(style, grid_style, base_fragment_info),
             incoming_rowspans: Vec::new(),
         }
     }
 
     pub fn new_for_tests() -> Self {
-        Self::new(ComputedValues::initial_values().to_arc())
+        Self::new(
+            ComputedValues::initial_values().to_arc(),
+            ComputedValues::initial_values().to_arc(),
+            BaseFragmentInfo::anonymous(),
+        )
     }
 
     pub fn last_row_index_in_row_group_at_row_n(&self, n: usize) -> usize {
@@ -622,13 +636,14 @@ where
     pub(crate) fn new(
         context: &'style LayoutContext<'style>,
         info: &'style NodeAndStyleInfo<Node>,
+        grid_style: Arc<ComputedValues>,
         text_decoration_line: TextDecorationLine,
     ) -> Self {
         TableBuilderTraversal {
             context,
             info,
             current_text_decoration_line: text_decoration_line,
-            builder: TableBuilder::new(info.style.clone()),
+            builder: TableBuilder::new(info.style.clone(), grid_style, info.into()),
             current_anonymous_row_content: Vec::new(),
             current_row_group_index: None,
         }
@@ -825,9 +840,28 @@ where
                     ::std::mem::forget(box_slot);
                 },
                 DisplayLayoutInternal::TableCaption => {
-                    // TODO: Handle table captions.
+                    let contents = match contents.try_into() {
+                        Ok(non_replaced_contents) => {
+                            BlockFormattingContext::construct(
+                                self.context,
+                                info,
+                                non_replaced_contents,
+                                self.current_text_decoration_line,
+                                false, /* is_list_item */
+                            )
+                        },
+                        Err(_replaced) => {
+                            unreachable!("Replaced should not have a LayoutInternal display type.");
+                        },
+                    };
+                    self.builder.table.captions.push(TableCaption {
+                        contents,
+                        style: info.style.clone(),
+                        base_fragment_info: info.into(),
+                    });
+
                     // We are doing this until we have actually set a Box for this `BoxSlot`.
-                    ::std::mem::forget(box_slot);
+                    ::std::mem::forget(box_slot)
                 },
                 DisplayLayoutInternal::TableCell => {
                     self.current_anonymous_row_content

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -86,9 +86,23 @@ pub type TableSize = Size2D<usize, UnknownUnit>;
 
 #[derive(Debug, Serialize)]
 pub struct Table {
-    /// The style of this table.
+    /// The style of this table. These are the properties that apply to the "wrapper" ie the element
+    /// that contains both the grid and the captions. Not all properties are actually used on the
+    /// wrapper though, such as background and borders, which apply to the grid.
     #[serde(skip_serializing)]
     style: Arc<ComputedValues>,
+
+    /// The style of this table's grid. This is an anonymous style based on the table's style, but
+    /// eliminating all the properties handled by the "wrapper."
+    #[serde(skip_serializing)]
+    grid_style: Arc<ComputedValues>,
+
+    /// The [`BaseFragmentInfo`] for this table's grid. This is necessary so that when the
+    /// grid has a background image, it can be associated with the table's node.
+    grid_base_fragment_info: BaseFragmentInfo,
+
+    /// The captions for this table.
+    pub captions: Vec<TableCaption>,
 
     /// The column groups for this table.
     pub column_groups: Vec<TableTrackGroup>,
@@ -114,9 +128,16 @@ pub struct Table {
 }
 
 impl Table {
-    pub(crate) fn new(style: Arc<ComputedValues>) -> Self {
+    pub(crate) fn new(
+        style: Arc<ComputedValues>,
+        grid_style: Arc<ComputedValues>,
+        base_fragment_info: BaseFragmentInfo,
+    ) -> Self {
         Self {
             style,
+            grid_style,
+            grid_base_fragment_info: base_fragment_info,
+            captions: Vec::new(),
             column_groups: Vec::new(),
             columns: Vec::new(),
             row_groups: Vec::new(),
@@ -290,4 +311,17 @@ impl TableTrackGroup {
     pub(super) fn is_empty(&self) -> bool {
         self.track_range.is_empty()
     }
+}
+
+#[derive(Debug, Serialize)]
+pub struct TableCaption {
+    /// The contents of this cell, with its own layout.
+    contents: BlockFormattingContext,
+
+    /// The style of this table cell.
+    #[serde(skip_serializing)]
+    style: Arc<ComputedValues>,
+
+    /// The [`BaseFragmentInfo`] of this cell.
+    base_fragment_info: BaseFragmentInfo,
 }

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -231,6 +231,41 @@ svg > * {
     display: table-cell;
 }
 
+*|*::-servo-table-grid {
+  all: inherit;
+  margin: unset;
+  float: unset;
+  clear: unset;
+  position: unset;
+  z-index: unset;
+  page-break-before: unset;
+  page-break-after: unset;
+  page-break-inside: unset;
+  vertical-align: unset;
+  line-height: unset;
+  transform: unset;
+  transform-origin: unset;
+  backface-visibility: unset;
+  clip: unset;
+  transform-style: unset;
+  rotate: unset;
+  scale: unset;
+  translate: unset;
+  align-self: unset;
+  justify-self: unset;
+  grid-column-start: unset;
+  grid-column-end: unset;
+  grid-row-start: unset;
+  grid-row-end: unset;
+  order: unset;
+  outline: unset;
+  outline-offset: unset;
+  column-span: unset;
+  contain: unset;
+  container: unset;
+  scroll-margin: unset;
+}
+
 *|*::-servo-legacy-anonymous-block {
     display: block;
     position: static;

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -204,7 +204,10 @@ dir, menu, ul { list-style-type: disc; }
 
 
 table { display: table; }
-caption { display: table-caption; }
+caption {
+  display: table-caption;
+  text-align: center;
+}
 colgroup, colgroup[hidden] { display: table-column-group; }
 col, col[hidden] { display: table-column; }
 thead, thead[hidden] { display: table-header-group; }

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-bottom-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-bottom-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-bottom-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-top-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-top-color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-top-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-top-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-top-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/display-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/display-015.xht.ini
@@ -1,2 +1,0 @@
-[display-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/colors/color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/colors/color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-variant-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-variant-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[font-variant-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/after-content-display-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/after-content-display-015.xht.ini
@@ -1,2 +1,0 @@
-[after-content-display-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/before-content-display-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/before-content-display-015.xht.ini
@@ -1,2 +1,0 @@
-[before-content-display-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/line-height-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/line-height-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[line-height-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/vertical-align-baseline-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/vertical-align-baseline-009.xht.ini
@@ -1,2 +1,0 @@
-[vertical-align-baseline-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/lists/list-style-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/lists/list-style-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[list-style-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/lists/list-style-type-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/lists/list-style-type-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[list-style-type-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-top-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-top-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[margin-top-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[padding-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-bottom-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[padding-bottom-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-left-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[padding-left-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-right-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[padding-right-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/padding-top-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[padding-top-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/margin-collapsing-in-table-caption-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/margin-collapsing-in-table-caption-001.html.ini
@@ -1,2 +1,0 @@
-[margin-collapsing-in-table-caption-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/margin-collapsing-in-table-caption-002.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/margin-collapsing-in-table-caption-002.html.ini
@@ -1,2 +1,0 @@
-[margin-collapsing-in-table-caption-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-position-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-position-001.xht.ini
@@ -1,2 +1,0 @@
-[caption-position-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-007.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-008.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-009.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-010.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-010.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-011.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-011.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-011.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-012.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-013.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-013.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-013.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/caption-side-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[caption-side-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/letter-spacing-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/letter-spacing-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[letter-spacing-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-decoration-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-decoration-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[text-decoration-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[text-indent-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[text-transform-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/word-spacing-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/word-spacing-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[word-spacing-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/ortho-table-item-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/ortho-table-item-001.html.ini
@@ -1,2 +1,0 @@
-[ortho-table-item-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-auto-min-width.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-auto-min-width.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-auto-min-width.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-fixed-min-width.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-fixed-min-width.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-fixed-min-width.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-row-1.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-inflexible-in-row-1.html.ini
@@ -1,0 +1,2 @@
+[table-as-item-inflexible-in-row-1.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-narrow-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-narrow-content.html.ini
@@ -1,0 +1,2 @@
+[table-as-item-narrow-content.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-specified-width-vertical.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-specified-width-vertical.html.ini
@@ -1,0 +1,2 @@
+[table-as-item-specified-width-vertical.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-wide-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-wide-content.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-wide-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-item-flex-percentage-min-width.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-item-flex-percentage-min-width.html.ini
@@ -1,0 +1,2 @@
+[table-item-flex-percentage-min-width.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-logical/animations/caption-side-no-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-logical/animations/caption-side-no-interpolation.html.ini
@@ -8,60 +8,6 @@
   [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (0.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (0.6) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (1) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (1.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (-0.3) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (0) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (0.3) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (0.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (0.6) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (1) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <caption-side> from [initial\] to [bottom\] at (1.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (-0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (0) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (0.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (0.6) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (1) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Animations: property <caption-side> from [initial\] to [bottom\] at (1.5) should be [bottom\]]
-    expected: FAIL
-
   [Web Animations: property <caption-side> from [initial\] to [bottom\] at (-0.3) should be [initial\]]
     expected: FAIL
 
@@ -83,15 +29,6 @@
   [Web Animations: property <caption-side> from [initial\] to [bottom\] at (1.5) should be [bottom\]]
     expected: FAIL
 
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (-0.3) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (0) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions: property <caption-side> from [initial\] to [bottom\] at (0.3) should be [bottom\]]
-    expected: FAIL
-
   [CSS Transitions with transition-behavior:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (-0.3) should be [initial\]]
     expected: FAIL
 
@@ -101,18 +38,6 @@
   [CSS Transitions with transition-behavior:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions with transition-behavior:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (0.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-behavior:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (0.6) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-behavior:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (1) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-behavior:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (1.5) should be [bottom\]]
-    expected: FAIL
-
   [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (-0.3) should be [initial\]]
     expected: FAIL
 
@@ -120,16 +45,4 @@
     expected: FAIL
 
   [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (0.5) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (0.6) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (1) should be [bottom\]]
-    expected: FAIL
-
-  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <caption-side> from [initial\] to [bottom\] at (1.5) should be [bottom\]]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/caption-side-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/caption-side-1.html.ini
@@ -1,6 +1,0 @@
-[caption-side-1.html]
-  [Caption-side inherits and reorder captions properly]
-    expected: FAIL
-
-  [Multiple captions can be rendered]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/inheritance.html.ini
+++ b/tests/wpt/meta/css/css-tables/inheritance.html.ini
@@ -2,12 +2,6 @@
   [Property border-spacing has initial value 0px 0px]
     expected: FAIL
 
-  [Property caption-side has initial value top]
-    expected: FAIL
-
-  [Property caption-side inherits]
-    expected: FAIL
-
   [Property table-layout has initial value auto]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/parsing/caption-side-computed.html.ini
+++ b/tests/wpt/meta/css/css-tables/parsing/caption-side-computed.html.ini
@@ -1,6 +1,0 @@
-[caption-side-computed.html]
-  [Property caption-side value 'top']
-    expected: FAIL
-
-  [Property caption-side value 'bottom']
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/parsing/caption-side-valid.html.ini
+++ b/tests/wpt/meta/css/css-tables/parsing/caption-side-valid.html.ini
@@ -1,6 +1,0 @@
-[caption-side-valid.html]
-  [e.style['caption-side'\] = "top" should set the property value]
-    expected: FAIL
-
-  [e.style['caption-side'\] = "bottom" should set the property value]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
@@ -31,3 +31,12 @@
 
   [Replaced elements outside a table cannot be table-row-group and are considered inline -- input=button elements]
     expected: FAIL
+
+  [Replaced elements outside a table cannot be table-caption and are considered inline -- input=text elements]
+    expected: FAIL
+
+  [Replaced elements outside a table cannot be table-caption and are considered inline -- input=button elements]
+    expected: FAIL
+
+  [Replaced elements outside a table cannot be table-caption and are considered inline -- input=file elements]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-model-fixup.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup.html.ini
@@ -8,9 +8,6 @@
   [2.2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-grouping box which are not table-row boxes. (2/3)]
     expected: FAIL
 
-  [3.2. An anonymous table or inline-table box must be generated around each sequence of consecutive proper table child box which are misparented]
-    expected: FAIL
-
   [2.2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-grouping box which are not table-row boxes. (3/3)]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/caption.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/caption.html.ini
@@ -8,24 +8,6 @@
   [table 3]
     expected: FAIL
 
-  [table 7]
-    expected: FAIL
-
-  [table 8]
-    expected: FAIL
-
-  [table 9]
-    expected: FAIL
-
-  [table 10]
-    expected: FAIL
-
-  [table 4]
-    expected: FAIL
-
-  [table 5]
-    expected: FAIL
-
   [table 12]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/table-minmax.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-minmax.html.ini
@@ -5,9 +5,6 @@
   [table 5]
     expected: FAIL
 
-  [table 16]
-    expected: FAIL
-
   [table 1]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-text/white-space/ws-break-spaces-applies-to-015.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/ws-break-spaces-applies-to-015.html.ini
@@ -1,2 +1,0 @@
-[ws-break-spaces-applies-to-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform-transformed-caption-contains-fixed-position.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-transformed-caption-contains-fixed-position.html.ini
@@ -1,2 +1,0 @@
-[transform-transformed-caption-contains-fixed-position.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/offsetTopLeft-table-caption.html.ini
+++ b/tests/wpt/meta/css/cssom-view/offsetTopLeft-table-caption.html.ini
@@ -1,3 +1,0 @@
-[offsetTopLeft-table-caption.html]
-  [offset* APIs on tables with captions.]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/table-scroll-props.html.ini
+++ b/tests/wpt/meta/css/cssom-view/table-scroll-props.html.ini
@@ -2,9 +2,6 @@
   [Caption with margin]
     expected: FAIL
 
-  [Table with separated border]
-    expected: FAIL
-
   [Table with collapsed border]
     expected: FAIL
 

--- a/tests/wpt/meta/css/cssom/serialize-values.html.ini
+++ b/tests/wpt/meta/css/cssom/serialize-values.html.ini
@@ -83,15 +83,6 @@
   [list-style-type: lower-roman]
     expected: FAIL
 
-  [caption-side: top]
-    expected: FAIL
-
-  [caption-side: bottom]
-    expected: FAIL
-
-  [caption-side: inherit]
-    expected: FAIL
-
   [direction: ltr]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/css/table_caption_bottom_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/table_caption_bottom_a.html.ini
@@ -1,2 +1,0 @@
-[table_caption_bottom_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/table_caption_top_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/table_caption_top_a.html.ini
@@ -1,2 +1,0 @@
-[table_caption_top_a.html]
-  expected: FAIL


### PR DESCRIPTION
This adds initial support for table captions. To do this, the idea of
the table wrapper becomes a bit more concrete. Even so, the wrapper is
still reponsible for allocating space for the grid's border and padding,
as those properties are specified on the wrapper and not grid in CSS.

In order to account for this weirdness of HTML/CSS captions and grid are
now laid out and placed with a negative offset in the table wrapper
content rect.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
