### PR TITLE
compositor: remove cursor_pos and update step on new frame

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -184,9 +184,6 @@ pub struct IOCompositor<Window: WindowMethods + ?Sized> {
     /// Current mouse cursor.
     cursor: Cursor,
 
-    /// Current cursor position.
-    cursor_pos: DevicePoint,
-
     /// Offscreen framebuffer object to render our next frame to.
     /// We use this and `prev_offscreen_framebuffer` for double buffering when compositing to
     /// [`CompositeTarget::Fbo`].
@@ -406,7 +403,6 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             webxr_main_thread: state.webxr_main_thread,
             pending_paint_metrics: HashMap::new(),
             cursor: Cursor::None,
-            cursor_pos: DevicePoint::new(0.0, 0.0),
             next_offscreen_framebuffer: OnceCell::new(),
             prev_offscreen_framebuffer: None,
             invalidate_prev_offscreen_framebuffer: false,
@@ -621,12 +617,6 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
             CompositorMsg::NewWebRenderFrameReady(recomposite_needed) => {
                 self.pending_frames -= 1;
-
-                if recomposite_needed {
-                    if let Some(result) = self.hit_test_at_point(self.cursor_pos) {
-                        self.update_cursor(result);
-                    }
-                }
 
                 if recomposite_needed || self.animation_callbacks_active() {
                     self.composite_if_necessary(CompositingReason::NewWebRenderFrame)

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -59,7 +59,7 @@ pub enum EmbedderEvent {
     LoadUrl(TopLevelBrowsingContextId, ServoUrl),
     /// Sent when a mouse hit test is to be performed.
     MouseWindowEventClass(MouseWindowEvent),
-    /// Sent when a mouse move.
+    /// Sent when a mouse move. This will send back a `EmbedderMsg::SetCursor` message.
     MouseWindowMoveEventClass(DevicePoint),
     /// Touch event: type, identifier, point
     Touch(TouchEventType, TouchId, DevicePoint),

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -172,7 +172,7 @@ pub enum EmbedderMsg {
     GetClipboardContents(IpcSender<String>),
     /// Sets system clipboard contents
     SetClipboardContents(String),
-    /// Changes the cursor.
+    /// Changes the cursor. This is triggered by `EmbedderEvent::MouseWindowMoveEventClass` event.
     SetCursor(Cursor),
     /// A favicon was detected
     NewFavicon(ServoUrl),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
There's a bug when updating the cursor on a new frame because `cursor_pos` isn't updated at all. I would like to take this chance to remove it. It will be the embedder's responsibility to decide when it should update its cursor. In general cases, users will move their mouse, and the cursor should be updated.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32632

<!-- Either: -->
- [x] These changes do not require tests, but the servoshell should be built successfully.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
