### PR TITLE
Mark `test/wpt` and all subdirecdtories as vendored in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 * text=auto eol=lf
-tests/* linguist-vendored
+tests/wpt/** linguist-vendored
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary


### PR DESCRIPTION
Instead of only marking the directory `tests`, mark `tests/wpt` and all subdirectories as vendored for language statistics. Although metadata and and `_mozilla` are not vendored, they are probably not relevant for language statistics.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it only applies to GitHub lang stats 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
