### PR TITLE
clippy: Fix remaining warnings in `layout_2020`

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -712,7 +712,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         // is used).
         if let BackgroundMode::Extra(ref extra_backgrounds) = self.fragment.background_mode {
             for extra_background in extra_backgrounds {
-                let positioning_area = extra_background.rect.clone();
+                let positioning_area = extra_background.rect;
                 let painter = BackgroundPainter {
                     style: &extra_background.style,
                     painting_area_override: None,

--- a/components/layout_2020/flow/inline/construct.rs
+++ b/components/layout_2020/flow/inline/construct.rs
@@ -268,7 +268,7 @@ impl InlineFormattingContextBuilder {
         for identifier in self.inline_box_stack.iter() {
             new_builder.start_inline_box(
                 self.inline_boxes
-                    .get(&identifier)
+                    .get(identifier)
                     .borrow()
                     .split_around_block(),
             );

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1738,7 +1738,7 @@ impl InlineFormattingContext {
 
             match item {
                 InlineItem::StartInlineBox(identifier) => {
-                    ifc.start_inline_box(&*self.inline_boxes.get(identifier).borrow());
+                    ifc.start_inline_box(&self.inline_boxes.get(identifier).borrow());
                 },
                 InlineItem::EndInlineBox => ifc.finish_inline_box(),
                 InlineItem::TextRun(run) => run.layout_into_line_items(&mut ifc),
@@ -2369,7 +2369,7 @@ struct ContentSizesComputation<'a> {
 impl<'a> ContentSizesComputation<'a> {
     fn traverse(mut self, inline_formatting_context: &InlineFormattingContext) -> ContentSizes {
         for inline_item in inline_formatting_context.inline_items.iter() {
-            self.process_item(&mut *inline_item.borrow_mut(), inline_formatting_context);
+            self.process_item(&mut inline_item.borrow_mut(), inline_formatting_context);
         }
 
         self.forced_line_break();

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -376,11 +376,6 @@ impl BoxFragment {
             (content_rect.origin.x, cb_width - content_rect.max_x())
         };
 
-        convert_to_length_or_auto(PhysicalSides::new(
-            top.into(),
-            right.into(),
-            bottom.into(),
-            left.into(),
-        ))
+        convert_to_length_or_auto(PhysicalSides::new(top, right, bottom, left))
     }
 }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -632,10 +632,9 @@ impl HoistedAbsolutelyPositionedBox {
 
                         let (block_size, inline_size) =
                             match independent_layout.content_inline_size_for_table {
-                                Some(inline_size) => (
-                                    independent_layout.content_block_size.into(),
-                                    inline_size.into(),
-                                ),
+                                Some(inline_size) => {
+                                    (independent_layout.content_block_size, inline_size)
+                                },
                                 None => (
                                     size.auto_is(|| independent_layout.content_block_size),
                                     inline_size,


### PR DESCRIPTION


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500.