### PR TITLE
Make task_info  `macos` specific

### DIFF
--- a/support/rust-task_info/build.rs
+++ b/support/rust-task_info/build.rs
@@ -3,7 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 fn main() {
-    cc::Build::new()
-        .file("src/task_info.c")
-        .compile("libtask_info.a");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if target_os == "macos" {
+        cc::Build::new()
+            .file("src/task_info.c")
+            .compile("libtask_info.a");
+    }
 }

--- a/support/rust-task_info/src/lib.rs
+++ b/support/rust-task_info/src/lib.rs
@@ -6,8 +6,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+//! A helper crate to get task information on macos.
 
-#![crate_name = "task_info"]
-#![crate_type = "rlib"]
-
+#[cfg(target_os = "macos")]
 pub mod task_basic_info;


### PR DESCRIPTION
rust-analyzer and the Jetbrains Rust plugin report errors on Linux (when invoked without mach), because it tries to `check` `task_info`, which includes running the build script and compiling the c files.
Since we don't use task_info on non-mac platforms, just make the crate empty on other platforms, to prevent the build script from failing.

<!-- Please describe your changes on the following line: -->


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix: Rustanalyzer without mach on non-macos
