### PR TITLE
layout: Improve layout of table captions

### DIFF
--- a/components/layout_2020/flow/inline/construct.rs
+++ b/components/layout_2020/flow/inline/construct.rs
@@ -103,7 +103,7 @@ impl InlineFormattingContextBuilder {
                 InlineItem::TextRun(_) => true,
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(_) => false,
                 InlineItem::OutOfFlowFloatBox(_) => false,
-                InlineItem::Atomic(_) => false,
+                InlineItem::Atomic(..) => false,
             }
         }
 
@@ -116,7 +116,10 @@ impl InlineFormattingContextBuilder {
         &mut self,
         independent_formatting_context: IndependentFormattingContext,
     ) -> ArcRefCell<InlineItem> {
-        let inline_level_box = ArcRefCell::new(InlineItem::Atomic(independent_formatting_context));
+        let inline_level_box = ArcRefCell::new(InlineItem::Atomic(
+            independent_formatting_context,
+            self.current_text_offset,
+        ));
         self.inline_items.push(inline_level_box.clone());
 
         // Push an object replacement character for this atomic, which will ensure that the line breaker

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -30,11 +30,11 @@ use crate::fragment_tree::BaseFragmentInfo;
 
 // These constants are the xi-unicode line breaking classes that are defined in
 // `table.rs`. Unfortunately, they are only identified by number.
-const XI_LINE_BREAKING_CLASS_CM: u8 = 9;
-const XI_LINE_BREAKING_CLASS_GL: u8 = 12;
-const XI_LINE_BREAKING_CLASS_ZW: u8 = 28;
-const XI_LINE_BREAKING_CLASS_WJ: u8 = 30;
-const XI_LINE_BREAKING_CLASS_ZWJ: u8 = 40;
+pub(crate) const XI_LINE_BREAKING_CLASS_CM: u8 = 9;
+pub(crate) const XI_LINE_BREAKING_CLASS_GL: u8 = 12;
+pub(crate) const XI_LINE_BREAKING_CLASS_ZW: u8 = 28;
+pub(crate) const XI_LINE_BREAKING_CLASS_WJ: u8 = 30;
+pub(crate) const XI_LINE_BREAKING_CLASS_ZWJ: u8 = 40;
 
 /// <https://www.w3.org/TR/css-display-3/#css-text-run>
 #[derive(Debug, Serialize)]
@@ -47,16 +47,6 @@ pub(crate) struct TextRun {
     /// The text of this [`TextRun`] with a font selected, broken into unbreakable
     /// segments, and shaped.
     pub shaped_text: Vec<TextRunSegment>,
-
-    /// Whether or not to prevent a soft wrap opportunity at the start of this [`TextRun`].
-    /// This depends on the whether the first character in the run prevents a soft wrap
-    /// opportunity.
-    prevent_soft_wrap_opportunity_at_start: bool,
-
-    /// Whether or not to prevent a soft wrap opportunity at the end of this [`TextRun`].
-    /// This depends on the whether the last character in the run prevents a soft wrap
-    /// opportunity.
-    prevent_soft_wrap_opportunity_at_end: bool,
 }
 
 // There are two reasons why we might want to break at the start:
@@ -70,7 +60,6 @@ pub(crate) struct TextRun {
 #[derive(PartialEq)]
 enum SegmentStartSoftWrapPolicy {
     Force,
-    Prevent,
     FollowLinebreaker,
 }
 
@@ -153,13 +142,11 @@ impl TextRunSegment {
                 ifc.defer_forced_line_break();
                 continue;
             }
-
             // Break before each unbreakable run in this TextRun, except the first unless the
             // linebreaker was set to break before the first run.
             if run_index != 0 || soft_wrap_policy == SegmentStartSoftWrapPolicy::Force {
                 ifc.process_soft_wrap_opportunity();
             }
-
             ifc.push_glyph_store_to_unbreakable_segment(
                 run.glyph_store.clone(),
                 text_run,
@@ -332,8 +319,6 @@ impl TextRun {
             parent_style,
             text_range,
             shaped_text: Vec::new(),
-            prevent_soft_wrap_opportunity_at_start: false,
-            prevent_soft_wrap_opportunity_at_end: false,
         }
     }
 
@@ -417,13 +402,6 @@ impl TextRun {
             let current_byte_index = next_byte_index;
             next_byte_index += character.len_utf8();
 
-            let prevents_soft_wrap_opportunity =
-                char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character);
-            if current_byte_index == self.text_range.start && prevents_soft_wrap_opportunity {
-                self.prevent_soft_wrap_opportunity_at_start = true;
-            }
-            self.prevent_soft_wrap_opportunity_at_end = prevents_soft_wrap_opportunity;
-
             if char_does_not_change_font(character) {
                 continue;
             }
@@ -496,9 +474,8 @@ impl TextRun {
         // character it should also override the LineBreaker's indication to break at the start.
         let have_deferred_soft_wrap_opportunity =
             mem::replace(&mut ifc.have_deferred_soft_wrap_opportunity, false);
-        let mut soft_wrap_policy = match self.prevent_soft_wrap_opportunity_at_start {
-            true => SegmentStartSoftWrapPolicy::Prevent,
-            false if have_deferred_soft_wrap_opportunity => SegmentStartSoftWrapPolicy::Force,
+        let mut soft_wrap_policy = match have_deferred_soft_wrap_opportunity {
+            true => SegmentStartSoftWrapPolicy::Force,
             false => SegmentStartSoftWrapPolicy::FollowLinebreaker,
         };
 
@@ -506,31 +483,7 @@ impl TextRun {
             segment.layout_into_line_items(self, soft_wrap_policy, ifc);
             soft_wrap_policy = SegmentStartSoftWrapPolicy::FollowLinebreaker;
         }
-
-        ifc.prevent_soft_wrap_opportunity_before_next_atomic =
-            self.prevent_soft_wrap_opportunity_at_end;
     }
-}
-
-/// Whether or not this character will rpevent a soft wrap opportunity when it
-/// comes before or after an atomic inline element.
-///
-/// From <https://www.w3.org/TR/css-text-3/#line-break-details>:
-///
-/// > For Web-compatibility there is a soft wrap opportunity before and after each
-/// > replaced element or other atomic inline, even when adjacent to a character that
-/// > would normally suppress them, including U+00A0 NO-BREAK SPACE. However, with
-/// > the exception of U+00A0 NO-BREAK SPACE, there must be no soft wrap opportunity
-/// > between atomic inlines and adjacent characters belonging to the Unicode GL, WJ,
-/// > or ZWJ line breaking classes.
-fn char_prevents_soft_wrap_opportunity_when_before_or_after_atomic(character: char) -> bool {
-    if character == '\u{00A0}' {
-        return false;
-    }
-    let class = linebreak_property(character);
-    class == XI_LINE_BREAKING_CLASS_GL ||
-        class == XI_LINE_BREAKING_CLASS_WJ ||
-        class == XI_LINE_BREAKING_CLASS_ZWJ
 }
 
 /// Whether or not this character should be able to change the font during segmentation.  Certain

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -926,7 +926,7 @@ impl NonReplacedFormattingContext {
     ///
     /// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
     /// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
-    fn layout_in_flow_block_level(
+    pub(crate) fn layout_in_flow_block_level(
         &self,
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
@@ -1367,7 +1367,7 @@ struct ContainingBlockPaddingAndBorder<'a> {
     max_box_size: LogicalVec2<Option<Length>>,
 }
 
-pub(crate) struct ResolvedMargins {
+struct ResolvedMargins {
     /// Used value for the margin properties, as exposed in getComputedStyle().
     pub margin: LogicalSides<Au>,
 
@@ -1440,7 +1440,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
 /// Note that in the presence of floats, this shouldn't be used for a block-level box
 /// that establishes an independent formatting context (or is replaced), since the
 /// margins could then be incorrect.
-pub(crate) fn solve_margins(
+fn solve_margins(
     containing_block: &ContainingBlock<'_>,
     pbm: &PaddingBorderMargin,
     inline_size: Au,

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -79,7 +79,9 @@ use style::properties::ComputedValues;
 use style_traits::dom::OpaqueNode;
 
 use super::flow::BlockFormattingContext;
+use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
+use crate::formatting_contexts::NonReplacedFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
 
 pub type TableSize = Size2D<usize, UnknownUnit>;
@@ -316,12 +318,5 @@ impl TableTrackGroup {
 #[derive(Debug, Serialize)]
 pub struct TableCaption {
     /// The contents of this cell, with its own layout.
-    contents: BlockFormattingContext,
-
-    /// The style of this table cell.
-    #[serde(skip_serializing)]
-    style: Arc<ComputedValues>,
-
-    /// The [`BaseFragmentInfo`] of this cell.
-    base_fragment_info: BaseFragmentInfo,
+    context: ArcRefCell<NonReplacedFormattingContext>,
 }

--- a/tests/wpt/meta/css/CSS2/abspos/table-caption-passes-abspos-up-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/abspos/table-caption-passes-abspos-up-001.html.ini
@@ -1,2 +1,0 @@
-[table-caption-passes-abspos-up-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[background-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-attachment-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-attachment-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[background-attachment-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[background-color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-image-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-image-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[background-image-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-position-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-position-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[background-position-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/backgrounds/background-repeat-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/backgrounds/background-repeat-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[background-repeat-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-left-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-left-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-left-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-left-color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-left-color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-left-color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-left-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-left-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-left-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-right-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-right-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-right-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-right-color-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-right-color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-right-color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-right-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-right-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-right-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[border-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[clear-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/vertical-align-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/vertical-align-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[vertical-align-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[margin-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-left-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-left-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[margin-left-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/margin-padding-clear/margin-right-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[margin-right-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-formatting-contexts-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-formatting-contexts-012.xht.ini
@@ -1,2 +1,0 @@
-[block-formatting-contexts-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/height-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/height-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[height-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-height-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-height-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[max-height-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/max-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[max-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-height-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-height-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[min-height-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/min-width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/min-width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[min-width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/width-applies-to-015.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/width-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[width-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/clear-applies-to-016.xht.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/clear-applies-to-016.xht.ini
@@ -1,2 +1,0 @@
-[clear-applies-to-016.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/clear-applies-to-017.xht.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/clear-applies-to-017.xht.ini
@@ -1,2 +1,0 @@
-[clear-applies-to-017.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
@@ -26,8 +26,5 @@
   [.target > * 18]
     expected: FAIL
 
-  [.target > * 19]
-    expected: FAIL
-
   [.target > * 21]
     expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-last-001.html.ini
@@ -32,8 +32,5 @@
   [.target > * 18]
     expected: FAIL
 
-  [.target > * 19]
-    expected: FAIL
-
   [.target > * 21]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/caption.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/caption.html.ini
@@ -1,15 +1,3 @@
 [caption.html]
-  [table 1]
-    expected: FAIL
-
-  [table 2]
-    expected: FAIL
-
-  [table 3]
-    expected: FAIL
-
-  [table 12]
-    expected: FAIL
-
   [table 13]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/column-widths.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/column-widths.html.ini
@@ -1,26 +1,8 @@
 [column-widths.html]
-  [table 1]
-    expected: FAIL
-
   [table 3]
     expected: FAIL
 
-  [table 5]
-    expected: FAIL
-
-  [table 8]
-    expected: FAIL
-
-  [table 11]
-    expected: FAIL
-
-  [table 13]
-    expected: FAIL
-
   [table 14]
-    expected: FAIL
-
-  [table 17]
     expected: FAIL
 
   [table 19]
@@ -48,7 +30,4 @@
     expected: FAIL
 
   [table 33]
-    expected: FAIL
-
-  [table 4]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
@@ -4,3 +4,6 @@
 
   [table 3]
     expected: FAIL
+
+  [table 6]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed-padding.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed-padding.html.ini
@@ -2,9 +2,6 @@
   [table 1]
     expected: FAIL
 
-  [table 2]
-    expected: FAIL
-
   [table 4]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
@@ -5,9 +5,6 @@
   [table 4]
     expected: FAIL
 
-  [table 5]
-    expected: FAIL
-
   [table 7]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution.html.ini
@@ -1,41 +1,11 @@
 [table-width-redistribution.html]
-  [table 1]
-    expected: FAIL
-
-  [table 2]
-    expected: FAIL
-
   [table 3]
-    expected: FAIL
-
-  [table 4]
     expected: FAIL
 
   [table 5]
     expected: FAIL
 
   [table 6]
-    expected: FAIL
-
-  [table 9]
-    expected: FAIL
-
-  [table 10]
-    expected: FAIL
-
-  [table 11]
-    expected: FAIL
-
-  [table 12]
-    expected: FAIL
-
-  [table 13]
-    expected: FAIL
-
-  [table 14]
-    expected: FAIL
-
-  [table 15]
     expected: FAIL
 
   [table 20]

--- a/tests/wpt/meta/css/css-tables/width-distribution/computing-table-width-0.html.ini
+++ b/tests/wpt/meta/css/css-tables/width-distribution/computing-table-width-0.html.ini
@@ -1,3 +1,0 @@
-[computing-table-width-0.html]
-  [Width is 100px due to 100px content size of caption]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/table-client-props.html.ini
+++ b/tests/wpt/meta/css/cssom-view/table-client-props.html.ini
@@ -1,27 +1,6 @@
 [table-client-props.html]
-  [Caption with margin]
-    expected: FAIL
-
   [Table with separated border]
     expected: FAIL
 
   [Table with collapsed border]
-    expected: FAIL
-
-  [Table and wider caption]
-    expected: FAIL
-
-  [Table and narrower caption]
-    expected: FAIL
-
-  [Basic caption]
-    expected: FAIL
-
-  [Caption with padding]
-    expected: FAIL
-
-  [Caption with border]
-    expected: FAIL
-
-  [Bottom caption]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/table-offset-props.html.ini
+++ b/tests/wpt/meta/css/cssom-view/table-offset-props.html.ini
@@ -1,24 +1,3 @@
 [table-offset-props.html]
-  [Caption with margin]
-    expected: FAIL
-
   [Table with collapsed border]
-    expected: FAIL
-
-  [Table and wider caption]
-    expected: FAIL
-
-  [Table and narrower caption]
-    expected: FAIL
-
-  [Basic caption]
-    expected: FAIL
-
-  [Caption with padding]
-    expected: FAIL
-
-  [Caption with border]
-    expected: FAIL
-
-  [Bottom caption]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/table-scroll-props.html.ini
+++ b/tests/wpt/meta/css/cssom-view/table-scroll-props.html.ini
@@ -1,24 +1,3 @@
 [table-scroll-props.html]
-  [Caption with margin]
-    expected: FAIL
-
   [Table with collapsed border]
-    expected: FAIL
-
-  [Table and wider caption]
-    expected: FAIL
-
-  [Table and narrower caption]
-    expected: FAIL
-
-  [Basic caption]
-    expected: FAIL
-
-  [Caption with padding]
-    expected: FAIL
-
-  [Caption with border]
-    expected: FAIL
-
-  [Bottom caption]
     expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/button-layout/shrink-wrap.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/button-layout/shrink-wrap.html.ini
@@ -14,25 +14,10 @@
   [display: inline - available width: 300px]
     expected: FAIL
 
-  [display: inline-block - available width: 50px]
-    expected: FAIL
-
-  [display: inline-block - available width: 200px]
-    expected: FAIL
-
   [display: list-item - available width: 50px]
     expected: FAIL
 
   [display: list-item - available width: 300px]
-    expected: FAIL
-
-  [display: table - available width: 50px]
-    expected: FAIL
-
-  [display: table-row - available width: 50px]
-    expected: FAIL
-
-  [display: table-cell - available width: 50px]
     expected: FAIL
 
   [float: left - available width: 50px]
@@ -42,13 +27,4 @@
     expected: FAIL
 
   [float: left - available width: 300px]
-    expected: FAIL
-
-  [display: table - available width: 200px]
-    expected: FAIL
-
-  [display: table-row - available width: 200px]
-    expected: FAIL
-
-  [display: table-cell - available width: 200px]
     expected: FAIL

--- a/tests/wpt/meta/quirks/table-cell-width-calculation-applies-to.html.ini
+++ b/tests/wpt/meta/quirks/table-cell-width-calculation-applies-to.html.ini
@@ -1,3 +1,0 @@
-[table-cell-width-calculation-applies-to.html]
-  [table 1]
-    expected: FAIL

--- a/tests/wpt/meta/quirks/table-cell-width-calculation.html.ini
+++ b/tests/wpt/meta/quirks/table-cell-width-calculation.html.ini
@@ -11,29 +11,8 @@
   [The table cell width calculation quirk, the don't-wrap rule is only for the purpose of calculating the width of the cell]
     expected: FAIL
 
-  [The table cell width calculation quirk, the quirk only applies when the cell is the containing block]
-    expected: FAIL
-
-  [The table cell width calculation quirk, zero width on cell, specified with on table]
-    expected: FAIL
-
   [The table cell width calculation quirk, display:table-cell on span]
     expected: FAIL
 
   [The table cell width calculation quirk, display:table-cell on span, wbr]
-    expected: FAIL
-
-  [The table cell width calculation quirk, the quirk shouldn't apply for generated content]
-    expected: FAIL
-
-  [The table cell width calculation quirk, the quirk shouldn't apply for <input>]
-    expected: FAIL
-
-  [The table cell width calculation quirk, the quirk shouldn't apply for <video poster>]
-    expected: FAIL
-
-  [The table cell width calculation quirk, non-auto width on cell]
-    expected: FAIL
-
-  [The table cell width calculation quirk, the quirk shouldn't apply for <object>]
     expected: FAIL


### PR DESCRIPTION
- Instead of treating captions as a `BlockFormattingContext`, treat it as
  a `NonReplacedFormattingContext`, which allows reusing flow layout for
  captions -- fixing some issues with sizing.
- Pass in the proper size of the containing block when laying out,
  fixing margin calculation.
- Follow the unspecified rules about how various size properties on
  captions affect their size.
- Improve linebreaking around atomics, which is tested by
  caption-related tests. This fixes intrinsic size calculation regarding
  soft wrap opportunities around atomic and also makes the code making
  these actual soft wrap opportunities a bit better.
    
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
