### PR TITLE
layout: Add a linebreak opportunity before atomics for preferred width calculation

### DIFF
--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -56,7 +56,7 @@ pub(crate) struct TextRun {
     /// Whether or not to prevent a soft wrap opportunity at the end of this [`TextRun`].
     /// This depends on the whether the last character in the run prevents a soft wrap
     /// opportunity.
-    prevent_soft_wrap_opportunity_at_end: bool,
+    pub(crate) prevent_soft_wrap_opportunity_at_end: bool,
 }
 
 // There are two reasons why we might want to break at the start:


### PR DESCRIPTION
There should be a linebreak before atomics, as long as the previous
character did not prevent it. Note that this code does not handle NoWrap
yet -- something that's common to all of preferred width calculation
currently.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
