### PR TITLE
layout_2013: Remove code preventing writing mode assertion failures

### DIFF
--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -163,9 +163,7 @@ impl Floats {
 
     /// Adjusts the recorded offset of the flow relative to the first float.
     pub fn translate(&mut self, delta: LogicalSize<Au>) {
-        // TODO(servo#30577) revert once underlying bug is fixed
-        // self.offset = self.offset + delta
-        self.offset = self.offset.add_or_warn(delta)
+        self.offset = self.offset + delta
     }
 
     /// Returns the position of the last float in flow coordinates.

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1505,9 +1505,7 @@ impl Fragment {
         if let Some(ref inline_fragment_context) = self.inline_context {
             for node in &inline_fragment_context.nodes {
                 if node.style.get_box().position == Position::Relative {
-                    // TODO(servo#30577) revert once underlying bug is fixed
-                    // rel_pos = rel_pos + from_style(&*node.style, containing_block_size);
-                    rel_pos = rel_pos.add_or_warn(from_style(&node.style, containing_block_size));
+                    rel_pos = rel_pos + from_style(&*node.style, containing_block_size);
                 }
             }
         }

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1771,10 +1771,7 @@ impl Flow for InlineFlow {
                         first_fragment.style.logical_border_width())
                     .start;
                     containing_block_positions.push(
-                        // TODO(servo#30577) revert once underlying bug is fixed
-                        // padding_box_origin.to_physical(self.base.writing_mode, container_size),
-                        padding_box_origin
-                            .to_physical_or_warn(self.base.writing_mode, container_size),
+                        padding_box_origin.to_physical(self.base.writing_mode, container_size),
                     );
                 },
                 SpecificFragmentInfo::InlineBlock(_) if fragment.is_positioned() => {

--- a/tests/wpt/meta-legacy-layout/css/css-logical/logical-values-float-clear-3.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-logical/logical-values-float-clear-3.html.ini
@@ -1,2 +1,2 @@
 [logical-values-float-clear-3.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-logical/logical-values-float-clear-4.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-logical/logical-values-float-clear-4.html.ini
@@ -1,2 +1,2 @@
 [logical-values-float-clear-4.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vlr-ltr-rtl-in-multicol.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vlr-ltr-rtl-in-multicol.tentative.html.ini
@@ -1,2 +1,2 @@
 [vlr-ltr-rtl-in-multicol.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vlr-rtl-ltr-in-multicol.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vlr-rtl-ltr-in-multicol.tentative.html.ini
@@ -1,2 +1,2 @@
 [vlr-rtl-ltr-in-multicol.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vrl-ltr-rtl-in-multicol.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vrl-ltr-rtl-in-multicol.tentative.html.ini
@@ -1,2 +1,2 @@
 [vrl-ltr-rtl-in-multicol.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vrl-rtl-ltr-in-multicol.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/static-position/vrl-rtl-ltr-in-multicol.tentative.html.ini
@@ -1,2 +1,2 @@
 [vrl-rtl-ltr-in-multicol.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/vlr-ltr-rtl-in-multicols.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/vlr-ltr-rtl-in-multicols.tentative.html.ini
@@ -1,2 +1,2 @@
 [vlr-ltr-rtl-in-multicols.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/vlr-rtl-ltr-in-multicols.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/vlr-rtl-ltr-in-multicols.tentative.html.ini
@@ -1,2 +1,2 @@
 [vlr-rtl-ltr-in-multicols.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/vrl-ltr-rtl-in-multicols.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/vrl-ltr-rtl-in-multicols.tentative.html.ini
@@ -1,2 +1,2 @@
 [vrl-ltr-rtl-in-multicols.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/multicol/vrl-rtl-ltr-in-multicols.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/multicol/vrl-rtl-ltr-in-multicols.tentative.html.ini
@@ -1,2 +1,2 @@
 [vrl-rtl-ltr-in-multicols.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/static-position/htb-ltr-rtl.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/static-position/htb-ltr-rtl.tentative.html.ini
@@ -1,2 +1,2 @@
 [htb-ltr-rtl.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/static-position/htb-rtl-ltr.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/static-position/htb-rtl-ltr.tentative.html.ini
@@ -1,2 +1,2 @@
 [htb-rtl-ltr.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/static-position/vlr-ltr-rtl.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/static-position/vlr-ltr-rtl.tentative.html.ini
@@ -1,2 +1,2 @@
 [vlr-ltr-rtl.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/static-position/vlr-rtl-ltr.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/static-position/vlr-rtl-ltr.tentative.html.ini
@@ -1,2 +1,2 @@
 [vlr-rtl-ltr.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/static-position/vrl-ltr-rtl.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/static-position/vrl-ltr-rtl.tentative.html.ini
@@ -1,2 +1,2 @@
 [vrl-ltr-rtl.tentative.html]
-  expected: FAIL
+  expected: CRASH

--- a/tests/wpt/meta-legacy-layout/css/css-position/static-position/vrl-rtl-ltr.tentative.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-position/static-position/vrl-rtl-ltr.tentative.html.ini
@@ -1,2 +1,2 @@
 [vrl-rtl-ltr.tentative.html]
-  expected: FAIL
+  expected: CRASH


### PR DESCRIPTION
It's actually kind of useful that this code crashes, as it points out a
problem. Additionally, we aren't going to be maintaining Layout 2013 any
longer so it is very unlikely that these bugs will ever be fixed. This
allows us to reduce our diff with upstream Stylo.

Closes #30577.
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
