### PR TITLE
script: Implement `CanvasRenderingContext2D.measureText`

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -234,6 +234,10 @@ impl<'a> CanvasPaintThread<'a> {
             Canvas2dMsg::Ellipse(ref center, radius_x, radius_y, rotation, start, end, ccw) => self
                 .canvas(canvas_id)
                 .ellipse(center, radius_x, radius_y, rotation, start, end, ccw),
+            Canvas2dMsg::MeasureText(text, sender) => {
+                let metrics = self.canvas(canvas_id).measure_text(text);
+                sender.send(metrics).unwrap();
+            },
             Canvas2dMsg::RestoreContext => self.canvas(canvas_id).restore_context_state(),
             Canvas2dMsg::SaveContext => self.canvas(canvas_id).save_context_state(),
             Canvas2dMsg::SetLineWidth(width) => self.canvas(canvas_id).set_line_width(width),

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -17,6 +17,7 @@ use core_text::font::CTFont;
 use core_text::font_descriptor::{
     kCTFontDefaultOrientation, CTFontTraits, SymbolicTraitAccessors, TraitAccessors,
 };
+use euclid::default::{Point2D, Rect, Size2D};
 use log::debug;
 use style::values::computed::font::{FontStretch, FontStyle, FontWeight};
 use webrender_api::FontInstanceFlags;
@@ -324,6 +325,16 @@ impl PlatformFontMethods for PlatformFont {
             return FontInstanceFlags::EMBEDDED_BITMAPS;
         }
         FontInstanceFlags::empty()
+    }
+
+    fn typographic_bounds(&self, glyph_id: GlyphId) -> Rect<f32> {
+        let rect = self
+            .ctfont
+            .get_bounding_rects_for_glyphs(kCTFontDefaultOrientation, &[glyph_id as u16]);
+        Rect::new(
+            Point2D::new(rect.origin.x as f32, rect.origin.y as f32),
+            Size2D::new(rect.size.width as f32, rect.size.height as f32),
+        )
     }
 }
 

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use app_units::Au;
 use dwrote::{FontFace, FontFile};
+use euclid::default::{Point2D, Rect, Size2D};
 use log::{debug, warn};
 use style::computed_values::font_stretch::T as StyleFontStretch;
 use style::computed_values::font_weight::T as StyleFontWeight;
@@ -272,5 +273,27 @@ impl PlatformFontMethods for PlatformFont {
 
     fn webrender_font_instance_flags(&self) -> FontInstanceFlags {
         FontInstanceFlags::empty()
+    }
+
+    fn typographic_bounds(&self, glyph_id: GlyphId) -> Rect<f32> {
+        let metrics = self
+            .face
+            .get_design_glyph_metrics(&[glyph_id as u16], false);
+        let metrics = &metrics[0];
+        let advance_width = metrics.advanceWidth as f32;
+        let advance_height = metrics.advanceHeight as f32;
+        let left_side_bearing = metrics.leftSideBearing as f32;
+        let right_side_bearing = metrics.rightSideBearing as f32;
+        let top_side_bearing = metrics.topSideBearing as f32;
+        let bottom_side_bearing = metrics.bottomSideBearing as f32;
+        let vertical_origin_y = metrics.verticalOriginY as f32;
+        let y_offset = vertical_origin_y + bottom_side_bearing - advance_height;
+        let width = advance_width - (left_side_bearing + right_side_bearing);
+        let height = advance_height - (top_side_bearing + bottom_side_bearing);
+
+        Rect::new(
+            Point2D::new(left_side_bearing, y_offset),
+            Size2D::new(width, height),
+        )
     }
 }

--- a/components/fonts/shaper.rs
+++ b/components/fonts/shaper.rs
@@ -19,20 +19,24 @@ use harfbuzz_sys::{
     hb_face_create_for_tables, hb_face_destroy, hb_face_t, hb_feature_t, hb_font_create,
     hb_font_destroy, hb_font_funcs_create, hb_font_funcs_set_glyph_h_advance_func,
     hb_font_funcs_set_nominal_glyph_func, hb_font_funcs_t, hb_font_set_funcs, hb_font_set_ppem,
-    hb_font_set_scale, hb_font_t, hb_glyph_info_t, hb_glyph_position_t, hb_position_t, hb_shape,
-    hb_tag_t, HB_DIRECTION_LTR, HB_DIRECTION_RTL, HB_MEMORY_MODE_READONLY,
+    hb_font_set_scale, hb_font_t, hb_glyph_info_t, hb_glyph_position_t, hb_ot_layout_get_baseline,
+    hb_position_t, hb_shape, hb_tag_t, HB_DIRECTION_LTR, HB_DIRECTION_RTL, HB_MEMORY_MODE_READONLY,
+    HB_OT_LAYOUT_BASELINE_TAG_HANGING, HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_BOTTOM_OR_LEFT,
+    HB_OT_LAYOUT_BASELINE_TAG_ROMAN,
 };
 use lazy_static::lazy_static;
 use log::debug;
 
 use crate::platform::font::FontTable;
 use crate::{
-    fixed_to_float, float_to_fixed, ot_tag, ByteIndex, Font, FontTableMethods, FontTableTag,
-    GlyphData, GlyphId, GlyphStore, ShapingFlags, ShapingOptions, KERN,
+    fixed_to_float, float_to_fixed, ot_tag, ByteIndex, Font, FontBaseline, FontTableMethods,
+    FontTableTag, GlyphData, GlyphId, GlyphStore, ShapingFlags, ShapingOptions, BASE, KERN,
 };
 
 const NO_GLYPH: i32 = -1;
 const LIGA: u32 = ot_tag!('l', 'i', 'g', 'a');
+const HB_OT_TAG_DEFAULT_SCRIPT: u32 = ot_tag!('D', 'F', 'L', 'T');
+const HB_OT_TAG_DEFAULT_LANGUAGE: u32 = ot_tag!('d', 'f', 'l', 't');
 
 pub struct ShapedGlyphData {
     count: usize,
@@ -605,6 +609,49 @@ impl Shaper {
         }
 
         advance
+    }
+
+    pub unsafe fn get_baseline(&self) -> Option<FontBaseline> {
+        if (*self.font).table_for_tag(BASE).is_none() {
+            return None;
+        }
+
+        let mut hanging_baseline = 0;
+        let mut alphabetic_baseline = 0;
+        let mut ideographic_baseline = 0;
+
+        hb_ot_layout_get_baseline(
+            self.hb_font,
+            HB_OT_LAYOUT_BASELINE_TAG_ROMAN,
+            HB_DIRECTION_LTR,
+            HB_OT_TAG_DEFAULT_SCRIPT,
+            HB_OT_TAG_DEFAULT_LANGUAGE,
+            &mut alphabetic_baseline as *mut _,
+        );
+
+        hb_ot_layout_get_baseline(
+            self.hb_font,
+            HB_OT_LAYOUT_BASELINE_TAG_HANGING,
+            HB_DIRECTION_LTR,
+            HB_OT_TAG_DEFAULT_SCRIPT,
+            HB_OT_TAG_DEFAULT_LANGUAGE,
+            &mut hanging_baseline as *mut _,
+        );
+
+        hb_ot_layout_get_baseline(
+            self.hb_font,
+            HB_OT_LAYOUT_BASELINE_TAG_IDEO_EMBOX_BOTTOM_OR_LEFT,
+            HB_DIRECTION_LTR,
+            HB_OT_TAG_DEFAULT_SCRIPT,
+            HB_OT_TAG_DEFAULT_LANGUAGE,
+            &mut ideographic_baseline as *mut _,
+        );
+
+        Some(FontBaseline {
+            ideographic_baseline: Shaper::fixed_to_float(ideographic_baseline) as f32,
+            alphabetic_baseline: Shaper::fixed_to_float(alphabetic_baseline) as f32,
+            hanging_baseline: Shaper::fixed_to_float(hanging_baseline) as f32,
+        })
     }
 }
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -292,7 +292,8 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
     fn MeasureText(&self, text: DOMString) -> DomRoot<TextMetrics> {
-        self.canvas_state.measure_text(&self.global(), text)
+        self.canvas_state
+            .measure_text(&self.global(), self.canvas.as_deref(), text)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -256,7 +256,8 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
     fn MeasureText(&self, text: DOMString) -> DomRoot<TextMetrics> {
-        self.canvas_state.measure_text(&self.global(), text)
+        self.canvas_state
+            .measure_text(&self.global(), self.htmlcanvas.as_deref(), text)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -58,6 +58,7 @@ pub enum Canvas2dMsg {
     IsPointInPath(f64, f64, FillRule, IpcSender<bool>),
     LineTo(Point2D<f32>),
     MoveTo(Point2D<f32>),
+    MeasureText(String, IpcSender<TextMetrics>),
     PutImageData(Rect<u64>, IpcBytesReceiver),
     QuadraticCurveTo(Point2D<f32>, Point2D<f32>),
     Rect(Rect<f32>),
@@ -473,4 +474,20 @@ impl FromStr for Direction {
             _ => Err(()),
         }
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
+pub struct TextMetrics {
+    pub width: f32,
+    pub actual_boundingbox_left: f32,
+    pub actual_boundingbox_right: f32,
+    pub actual_boundingbox_ascent: f32,
+    pub actual_boundingbox_descent: f32,
+    pub font_boundingbox_ascent: f32,
+    pub font_boundingbox_descent: f32,
+    pub em_height_ascent: f32,
+    pub em_height_descent: f32,
+    pub hanging_baseline: f32,
+    pub alphabetic_baseline: f32,
+    pub ideographic_baseline: f32,
 }

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.drawing.style.measure.rtl.text.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.drawing.style.measure.rtl.text.html.ini
@@ -1,3 +1,0 @@
-[2d.text.drawing.style.measure.rtl.text.html]
-  [Measurement should follow canvas direction instead text direction]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.drawing.style.measure.textAlign.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.drawing.style.measure.textAlign.html.ini
@@ -1,3 +1,0 @@
-[2d.text.drawing.style.measure.textAlign.html]
-  [Measurement should be related to textAlignment]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.fontVariantCaps2.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.fontVariantCaps2.html.ini
@@ -1,3 +1,0 @@
-[2d.text.fontVariantCaps2.html]
-  [Testing small caps setting in fontVariant]
-    expected: FAIL


### PR DESCRIPTION
Replace stub implementation of `CanvasRenderingContext2D.measureText` with real one.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #5411
- [x] These changes do not require tests because CSS Font loading API hasn't been implemented.
