### PR TITLE
Add customElements.getName

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -560,6 +560,16 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         }
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-getname>
+    fn GetName(&self, constructor: Rc<CustomElementConstructor>) -> Option<DOMString> {
+        self.definitions
+            .borrow()
+            .0
+            .values()
+            .find(|definition| definition.constructor == constructor)
+            .map(|definition| DOMString::from(definition.name.to_string()))
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-whendefined>
     #[allow(unsafe_code)]
     fn WhenDefined(&self, name: DOMString, comp: InRealm) -> Rc<Promise> {

--- a/components/script/dom/webidls/CustomElementRegistry.webidl
+++ b/components/script/dom/webidls/CustomElementRegistry.webidl
@@ -14,6 +14,8 @@ interface CustomElementRegistry {
 
   any get(DOMString name);
 
+  DOMString? getName(CustomElementConstructor constructor);
+
   Promise<CustomElementConstructor> whenDefined(DOMString name);
 
   [CEReactions] undefined upgrade(Node root);

--- a/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/dom/idlharness.https.html.ini
@@ -1610,9 +1610,6 @@
   [VisibilityStateEntry interface: attribute duration]
     expected: FAIL
 
-  [CustomElementRegistry interface: operation getName(CustomElementConstructor)]
-    expected: FAIL
-
   [Navigation interface: existence and properties of interface object]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/CustomElementRegistry-getName.html.ini
+++ b/tests/wpt/meta/custom-elements/CustomElementRegistry-getName.html.ini
@@ -1,9 +1,0 @@
-[CustomElementRegistry-getName.html]
-  [customElements.getName must return null when the registry does not contain an entry with the given constructor]
-    expected: FAIL
-
-  [customElements.getName returns the name of the entry with the given constructor when there is a matching entry.]
-    expected: FAIL
-
-  [customElements.getName returns the name of the entry with the given customized built in constructor when there is a matching entry.]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -1490,9 +1490,6 @@
   [ImageBitmap interface: attribute height]
     expected: FAIL
 
-  [CustomElementRegistry interface: operation getName(CustomElementConstructor)]
-    expected: FAIL
-
   [Navigation interface: existence and properties of interface object]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This could probably be a more efficient implementation, but nonetheless this implements `getName` on the `CustomElementRegistry`. See [spec](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-getname).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32714 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
