### PR TITLE
 Replace null-byte terminated string literals with C-string literals

### DIFF
--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -69,7 +69,7 @@ impl NonCallbackInterfaceObjectClass {
     ) -> NonCallbackInterfaceObjectClass {
         NonCallbackInterfaceObjectClass {
             class: JSClass {
-                name: b"Function\0" as *const _ as *const libc::c_char,
+                name: c"Function".as_ptr(),
                 flags: 0,
                 cOps: &constructor_behavior.0,
                 spec: 0 as *const _,
@@ -344,7 +344,7 @@ pub fn create_named_constructors(
             assert!(JS_DefineProperty3(
                 *cx,
                 constructor.handle(),
-                b"prototype\0".as_ptr() as *const libc::c_char,
+                c"prototype".as_ptr(),
                 interface_prototype_object,
                 (JSPROP_PERMANENT | JSPROP_READONLY) as u32
             ));
@@ -504,7 +504,7 @@ fn define_name(cx: SafeJSContext, obj: HandleObject, name: &[u8]) {
         assert!(JS_DefineProperty4(
             *cx,
             obj,
-            b"name\0".as_ptr() as *const libc::c_char,
+            c"name".as_ptr(),
             name.handle(),
             JSPROP_READONLY as u32
         ));
@@ -516,7 +516,7 @@ fn define_length(cx: SafeJSContext, obj: HandleObject, length: i32) {
         assert!(JS_DefineProperty5(
             *cx,
             obj,
-            b"length\0".as_ptr() as *const libc::c_char,
+            c"length".as_ptr(),
             length,
             JSPROP_READONLY as u32
         ));
@@ -666,7 +666,7 @@ pub fn get_desired_proto(
         if !JS_GetProperty(
             *cx,
             original_new_target.handle().into(),
-            b"prototype\0".as_ptr() as *const libc::c_char,
+            c"prototype".as_ptr(),
             proto_val.handle_mut().into(),
         ) {
             return Err(());

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -697,7 +697,7 @@ unsafe fn append_cross_origin_allowlisted_prop_keys(
 ) {
     rooted!(in(*cx) let mut id: jsid);
 
-    let jsstring = JS_AtomizeAndPinString(*cx, b"then\0".as_ptr() as *const c_char);
+    let jsstring = JS_AtomizeAndPinString(*cx, c"then".as_ptr());
     rooted!(in(*cx) let rooted = jsstring);
     RUST_INTERNED_STRING_TO_JSID(*cx, rooted.handle().get(), id.handle_mut());
     AppendToIdVector(props, id.handle());

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -168,10 +168,10 @@ impl CustomElementRegistry {
 
         // Step 4
         Ok(LifecycleCallbacks {
-            connected_callback: get_callback(cx, prototype, b"connectedCallback\0")?,
-            disconnected_callback: get_callback(cx, prototype, b"disconnectedCallback\0")?,
-            adopted_callback: get_callback(cx, prototype, b"adoptedCallback\0")?,
-            attribute_changed_callback: get_callback(cx, prototype, b"attributeChangedCallback\0")?,
+            connected_callback: get_callback(cx, prototype, c"connectedCallback")?,
+            disconnected_callback: get_callback(cx, prototype, c"disconnectedCallback")?,
+            adopted_callback: get_callback(cx, prototype, c"adoptedCallback")?,
+            attribute_changed_callback: get_callback(cx, prototype, c"attributeChangedCallback")?,
 
             form_associated_callback: None,
             form_disabled_callback: None,
@@ -191,11 +191,11 @@ impl CustomElementRegistry {
         let cx = self.window.get_cx();
 
         callbacks.form_associated_callback =
-            get_callback(cx, prototype, b"formAssociatedCallback\0")?;
-        callbacks.form_reset_callback = get_callback(cx, prototype, b"formResetCallback\0")?;
-        callbacks.form_disabled_callback = get_callback(cx, prototype, b"formDisabledCallback\0")?;
+            get_callback(cx, prototype, c"formAssociatedCallback")?;
+        callbacks.form_reset_callback = get_callback(cx, prototype, c"formResetCallback")?;
+        callbacks.form_disabled_callback = get_callback(cx, prototype, c"formDisabledCallback")?;
         callbacks.form_state_restore_callback =
-            get_callback(cx, prototype, b"formStateRestoreCallback\0")?;
+            get_callback(cx, prototype, c"formStateRestoreCallback")?;
 
         Ok(())
     }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 use std::collections::VecDeque;
+use std::ffi::CStr;
 use std::rc::Rc;
 use std::{mem, ptr};
 
@@ -143,7 +144,7 @@ impl CustomElementRegistry {
             if !JS_GetProperty(
                 *GlobalScope::get_cx(),
                 constructor,
-                b"prototype\0".as_ptr() as *const _,
+                c"prototype".as_ptr(),
                 prototype,
             ) {
                 return Err(Error::JSFailed);
@@ -208,7 +209,7 @@ impl CustomElementRegistry {
             !JS_GetProperty(
                 *cx,
                 constructor,
-                b"observedAttributes\0".as_ptr() as *const _,
+                c"observedAttributes".as_ptr(),
                 observed_attributes.handle_mut(),
             )
         } {
@@ -243,7 +244,7 @@ impl CustomElementRegistry {
             !JS_GetProperty(
                 *cx,
                 constructor,
-                b"formAssociated\0".as_ptr() as *const _,
+                c"formAssociated".as_ptr(),
                 form_associated_value.handle_mut(),
             )
         } {
@@ -273,7 +274,7 @@ impl CustomElementRegistry {
             !JS_GetProperty(
                 *cx,
                 constructor,
-                b"disabledFeatures\0".as_ptr() as *const _,
+                c"disabledFeatures".as_ptr(),
                 disabled_features.handle_mut(),
             )
         } {
@@ -305,7 +306,7 @@ impl CustomElementRegistry {
 fn get_callback(
     cx: JSContext,
     prototype: HandleObject,
-    name: &[u8],
+    name: &CStr,
 ) -> Fallible<Option<Rc<Function>>> {
     rooted!(in(*cx) let mut callback = UndefinedValue());
     unsafe {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -519,13 +519,13 @@ impl EventTarget {
         let name = CString::new(format!("on{}", &**ty)).unwrap();
 
         // Step 3.9, subsection ParameterList
-        const ARG_NAMES: &[*const c_char] = &[b"event\0" as *const u8 as *const c_char];
+        const ARG_NAMES: &[*const c_char] = &[c"event".as_ptr()];
         const ERROR_ARG_NAMES: &[*const c_char] = &[
-            b"event\0" as *const u8 as *const c_char,
-            b"source\0" as *const u8 as *const c_char,
-            b"lineno\0" as *const u8 as *const c_char,
-            b"colno\0" as *const u8 as *const c_char,
-            b"error\0" as *const u8 as *const c_char,
+            c"event".as_ptr(),
+            c"source".as_ptr(),
+            c"lineno".as_ptr(),
+            c"colno".as_ptr(),
+            c"error".as_ptr(),
         ];
         let is_error = ty == &atom!("error") && self.is::<Window>();
         let args = if is_error { ERROR_ARG_NAMES } else { ARG_NAMES };

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -34,7 +34,6 @@ use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
-use crate::dom::bindings::utils::AsCCharPtrPtr;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::PromiseNativeHandler;
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
@@ -67,7 +66,7 @@ impl PromiseHelper for Rc<Promise> {
             assert!(AddRawValueRoot(
                 *cx,
                 self.permanent_js_root.get_unsafe(),
-                b"Promise::root\0".as_c_char_ptr()
+                c"Promise::root".as_ptr(),
             ));
         }
     }

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -215,13 +215,13 @@ unsafe extern "C" fn is_extensible(
 
 #[allow(unsafe_code)]
 unsafe extern "C" fn class_name(_cx: *mut JSContext, _proxy: HandleObject) -> *const libc::c_char {
-    &b"WindowProperties\0" as *const _ as *const _
+    c"WindowProperties".as_ptr()
 }
 
 // Maybe this should be a DOMJSClass. See https://bugzilla.mozilla.org/show_bug.cgi?id=787070
 #[allow(unsafe_code)]
 static CLASS: JSClass = JSClass {
-    name: b"WindowProperties\0" as *const u8 as *const libc::c_char,
+    name: c"WindowProperties".as_ptr(),
     flags: JSClass_NON_NATIVE |
         JSCLASS_IS_PROXY |
         JSCLASS_DELAY_METADATA_BUILDER |


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I've replaced all null-byte terminated string literals that I could find  by looking for anything in the form of `b"...\0"`. This means that I did not replace strings like `b'\0'`. Reasoning being that I thought `c""` would be more confusing than `b'\0'`, but please let me know if that doesn't seem right.

Most of the byte strings that are being replaced are arguments to mozjs functions which are specifically expecting  `*const c_char` which is why I kept or added the `.as_ptr()` method to the c-strings. 

Will the mozjs functions be getting updated so that they expect `CStrings` instead?

The only byte string that I left untouched was the following:
https://github.com/servo/servo/blob/59d0f1fe1aec4bec736bf2839e43de886eaebf32/components/script/script_runtime.rs#L828-L829
because the compiler complained that `count_bytes()` was too new when I tried to replace `servo_id.len()` with `servo_id.count_bytes()` and I couldn't find a way around that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32628 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the type that is being used in the end even after converting the byte strings to c-strings remains the same, so there should not be any real functional changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
