### PR TITLE
compositor: set compositor's `cursor_pos` properly

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1550,6 +1550,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             None => return,
         };
 
+        self.cursor_pos = cursor;
         let event = MouseMoveEvent(result.point_in_viewport, Some(result.node.into()), 0);
         let msg = ConstellationMsg::ForwardEvent(result.pipeline_id, event);
         if let Err(e) = self.constellation_chan.send(msg) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
After discussion in #32662, it seems it's better for the compositor to update the cursor, too. This PR should fix the bug.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32632

<!-- Either: -->
- [x] These changes do not require tests, but the servoshell should be built successfully.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
