### PR TITLE
android: sign release APK with a custom key.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -71,9 +71,19 @@ jobs:
         id: setup-ndk
         with:
           ndk-version: r25c
+      - name: Setup Key Store for APK Signing
+        env:
+          KEYSTORE_BASE64: ${{ secrets.APK_KEYSTORE_BASE64 }}
+        run: |
+          APK_SIGNING_KEY_STORE_PATH="${PWD}/servo_keystore.jks"
+          echo "${KEYSTORE_BASE64}" | base64 -d > "${APK_SIGNING_KEY_STORE_PATH}"
+          echo "APK_SIGNING_KEY_STORE_PATH=${APK_SIGNING_KEY_STORE_PATH}" >> ${GITHUB_ENV}
       - name: Build (arch ${{ matrix.arch }} profile ${{ inputs.profile }})
         env:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          APK_SIGNING_KEY_STORE_PASS: ${{ secrets.APK_SIGNING_KEY_STORE_PASS }}
+          APK_SIGNING_KEY_ALIAS: ${{ secrets.APK_SIGNING_KEY_ALIAS }}
+          APK_SIGNING_KEY_PASS: ${{ secrets.APK_SIGNING_KEY_PASS }}
         run: |
           python3 ./mach build --use-crown --locked --android --target ${{ matrix.arch }} --${{ inputs.profile }}
           cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.arch }}

--- a/support/android/apk/build.gradle
+++ b/support/android/apk/build.gradle
@@ -65,3 +65,17 @@ ext.getNdkDir = { ->
     }
     return ndkDir.absolutePath
 }
+
+ext.getSigningKeyInfo = { ->
+    def storeFilePath = System.getenv("APK_SIGNING_KEY_STORE_PATH")
+    if (storeFilePath != null) {
+        return  [
+            storeFile: new File(storeFilePath),
+            storePassword: System.getenv("APK_SIGNING_KEY_STORE_PASS"),
+            keyAlias: System.getenv("APK_SIGNING_KEY_ALIAS"),
+            keyPassword: System.getenv("APK_SIGNING_KEY_PASS"),
+        ]
+    } else {
+        return null
+    }
+}

--- a/support/android/apk/servoapp/build.gradle
+++ b/support/android/apk/servoapp/build.gradle
@@ -50,12 +50,25 @@ android {
     }
 
 
+    def signingKeyInfo = getSigningKeyInfo()
+
+    if (signingKeyInfo) {
+        signingConfigs {
+            release {
+               storeFile signingKeyInfo.storeFile
+               storePassword signingKeyInfo.storePassword
+               keyAlias signingKeyInfo.keyAlias
+               keyPassword signingKeyInfo.keyPassword
+            }
+        }
+    }
+
     buildTypes {
         debug {
         }
 
         release {
-            signingConfig signingConfigs.debug // Change this to sign with a production key
+            signingConfig signingKeyInfo ? signingConfigs.release : signingConfigs.debug
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
This PR adds support for signing all APKs we produce on the CI
with a custom signing key. Currently the logic falls back to
the debug key (which is generated by AGP and not persistent) if
the environment variable for the keystore is not set. This allows
local developer builds to work without requiring a key store.
Once #32720 is resolved, we could sign just the production builds
and remove the conditional logic.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they modify packaging and CI logic.

