### PR TITLE
readme: Clarify that `rust` and `cargo` must be in your path after rustup runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,15 @@ manually, try the [manual build setup][manual-build].
 - Ensure that the version showed by `python --version` is >= 3.10:
 - Install [Xcode](https://developer.apple.com/xcode/)
 - Install [Homebrew](https://brew.sh/)
-- Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`. Ensure that `rust`
+  and `cargo` are available commands &mdash; you may need to restart your shell.
 - Run `./mach bootstrap`<br/>
   *Note: This will install the recommended version of GStreamer globally on your system.*
 
 ### Linux
 
-- Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- Run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`. Ensure that `rust`
+  and `cargo` are available commands &mdash; you may need to restart your shell.
 - Install Python (version >= 3.10):
     - **Debian-like:** Run `sudo apt install python3-pip python3-venv`
     - **Fedora:** Run `sudo dnf install python3 python3-pip python3-devel`


### PR DESCRIPTION
Fixes #32670.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are just a README update.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
