### PR TITLE
ci: fix security issue in try job workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,15 +31,15 @@ jobs:
         arch: ['aarch64-linux-android', 'armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v4
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.number }}/head
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2 # This is necessary for `test-tidy`.
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.number }}/head
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4
       - name: Install taplo

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -32,15 +32,15 @@ jobs:
         arch: ['aarch64-unknown-linux-ohos']
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'issue_comment' && github.event_name != 'pull_request_target'
+        if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
-      # This is necessary to checkout the pull request if this run was triggered
-      # via an `issue_comment` action on a pull request.
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
       - uses: actions/checkout@v4
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.issue.number || github.event.number }}/head
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.4

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -82,9 +82,6 @@ jobs:
           python-version: '3.10'
       - uses: actions/checkout@v4
         with:
-          # This is necessary to checkout the pull request if this run was triggered
-          # via an `label` action on a pull request.
-          ref: refs/pull/${{ github.event.number }}/head
           sparse-checkout: |
             python/servo/try_parser.py
           sparse-checkout-cone-mode: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
-          ref: refs/pull/${{ github.event.number }}/head
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
       # Workaround for https://github.com/actions/runner-images/issues/10001:
       - name: Upgrade llvm


### PR DESCRIPTION
The issue is that `ref/pull/{pull_request_number}` points to the latest
commit of a PR and so it could be different than the commit that was
reviewed when the try label was applied. The fix is to use the exact commit
sha at the point when the try job is triggered, which is available in
the `github` context as  `github.event.pull_request.head.sha`.

This [issue][1] was reported by GitHub user @RedYetiDev via the Security
Advisory reporting mechanism on GitHub. The fix is also based on their
proposed solution.

[1]: https://github.com/servo/servo/security/advisories/GHSA-fxqr-xgh8-3577

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Co-authored-by: Aviv Keller <38299977+RedYetiDev@users.noreply.github.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just modify CI.

