### PR TITLE
android/ohos: fonts: Ignore ascii case when searching for font family

### DIFF
--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -259,11 +259,15 @@ impl FontList {
     }
 
     fn find_family(&self, name: &str) -> Option<&FontFamily> {
-        self.families.iter().find(|f| f.name == name)
+        self.families
+            .iter()
+            .find(|family| family.name.eq_ignore_ascii_case(name))
     }
 
     fn find_alias(&self, name: &str) -> Option<&FontAlias> {
-        self.aliases.iter().find(|f| f.from == name)
+        self.aliases
+            .iter()
+            .find(|family| family.from.eq_ignore_ascii_case(name))
     }
 
     // Parse family and font file names

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -108,11 +108,15 @@ impl FontList {
     }
 
     fn find_family(&self, name: &str) -> Option<&FontFamily> {
-        self.families.iter().find(|f| f.name == name)
+        self.families
+            .iter()
+            .find(|family| family.name.eq_ignore_ascii_case(name))
     }
 
     fn find_alias(&self, name: &str) -> Option<&FontAlias> {
-        self.aliases.iter().find(|f| f.from == name)
+        self.aliases
+            .iter()
+            .find(|family| family.from.eq_ignore_ascii_case(name))
     }
 }
 


### PR DESCRIPTION
The input for this function commonly comes from a `LowercaseString`, while our actual font family name has cases.
Since font family lookup should be case-neutral, we do a compare ignoring the ascii case.
I'm not too familiar with the CSS standard so I'm not 100% sure if this is sufficient, or if we need to use a different method to compare strings for arbitrary non-ascii font names.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
