### PR TITLE
DevTools: Display console messages and errors

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -349,7 +349,7 @@ impl BrowsingContextActor {
                 from: self.name(),
                 type_: "resource-available-form".into(),
                 resources: vec![ResourceAvailableMsg {
-                    has_native_console_api: None,
+                    has_native_console_api: Some(true),
                     name: name.into(),
                     new_uri: None,
                     resource_type: "document-event".into(),

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -12,7 +12,7 @@ use std::net::TcpStream;
 
 use base::id::{BrowsingContextId, PipelineId};
 use devtools_traits::DevtoolScriptControlMsg::{self, WantsLiveNotifications};
-use devtools_traits::{ConsoleAPI, DevtoolsPageInfo, NavigationState, PageError};
+use devtools_traits::{ConsoleLog, DevtoolsPageInfo, NavigationState, PageError};
 use ipc_channel::ipc::IpcSender;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -70,7 +70,6 @@ struct ResourceAvailableMsg {
     url: Option<String>,
 }
 
-// TODO: Its wrong
 #[derive(Serialize)]
 struct ConsoleMsg {
     from: String,
@@ -82,7 +81,7 @@ struct ConsoleMsg {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ConsoleMessageResource {
-    message: ConsoleAPI,
+    message: ConsoleLog,
     resource_type: String,
 }
 
@@ -392,7 +391,7 @@ impl BrowsingContextActor {
         }
     }
 
-    pub(crate) fn console_message(&self, message: ConsoleAPI) {
+    pub(crate) fn console_message(&self, message: ConsoleLog) {
         let msg = ConsoleMsg {
             from: self.name(),
             type_: "resource-available-form".into(),

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -229,7 +229,10 @@ impl ConsoleActor {
             from: self.name(),
             input,
             result,
-            timestamp: 0,
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
             exception: Value::Null,
             exception_message: Value::Null,
             helper_result: Value::Null,
@@ -243,8 +246,6 @@ impl ConsoleActor {
         id: UniqueId,
         registry: &ActorRegistry,
     ) {
-        log::warn!("page error! {:?}", page_error);
-
         self.cached_events
             .borrow_mut()
             .entry(id.clone())
@@ -275,7 +276,6 @@ impl ConsoleActor {
             _ => "log",
         }
         .to_owned();
-        log::info!("message! {:?}", console_message);
 
         let console_api = ConsoleAPI {
             type_: "ConsoleAPI".to_owned(),
@@ -286,7 +286,7 @@ impl ConsoleActor {
             time_stamp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
-                .as_nanos() as u64,
+                .as_millis() as u64,
             private: false,
             arguments: vec![console_message.message.clone()],
         };

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -252,11 +252,10 @@ impl ConsoleActor {
             .or_default()
             .push(CachedConsoleMessage::PageError(page_error.clone()));
         if id == self.current_unique_id(registry) {
-            match &self.root {
-                Root::BrowsingContext(bc) => registry
+            if let Root::BrowsingContext(bc) = &self.root {
+                registry
                     .find::<BrowsingContextActor>(bc)
-                    .page_error(page_error),
-                Root::DedicatedWorker(_) => (),
+                    .page_error(page_error)
             };
         }
     }
@@ -295,11 +294,10 @@ impl ConsoleActor {
             .or_default()
             .push(CachedConsoleMessage::ConsoleLog(console_api.clone()));
         if id == self.current_unique_id(registry) {
-            match &self.root {
-                Root::BrowsingContext(bc) => registry
+            if let Root::BrowsingContext(bc) = &self.root {
+                registry
                     .find::<BrowsingContextActor>(bc)
-                    .console_message(console_api),
-                Root::DedicatedWorker(_) => (),
+                    .console_message(console_api)
             };
         }
     }

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -26,6 +26,7 @@ impl Actor for ObjectActor {
         _: &mut TcpStream,
         _: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
+        // TODO: Handle enumSymbols for console object inspection
         Ok(ActorMessageStatus::Ignored)
     }
 }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use std::{mem, ptr};
 
 use base::id::{
@@ -2305,7 +2305,10 @@ impl GlobalScope {
                     line_number: 0,
                     column_number: 0,
                     category: "script".to_string(),
-                    time_stamp: 0, //TODO
+                    time_stamp: SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64,
                     error: false,
                     warning: true,
                     exception: true,
@@ -2493,7 +2496,10 @@ impl GlobalScope {
                             line_number: error_info.lineno,
                             column_number: error_info.column,
                             category: "script".to_string(),
-                            time_stamp: 0, //TODO
+                            time_stamp: SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_millis() as u64,
                             error: true,
                             warning: false,
                             exception: true,

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -283,22 +283,20 @@ pub struct PageError {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ConsoleAPI {
-    #[serde(rename = "_type")]
-    pub type_: String,
+pub struct ConsoleLog {
     pub level: String,
     pub filename: String,
     pub line_number: u32,
-    pub function_name: String,
+    pub column_number: u32,
     pub time_stamp: u64,
-    pub private: bool,
     pub arguments: Vec<String>,
+    // pub stacktrace: Vec<...>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CachedConsoleMessage {
     PageError(PageError),
-    ConsoleAPI(ConsoleAPI),
+    ConsoleLog(ConsoleLog),
 }
 
 #[derive(Debug, PartialEq)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -282,7 +282,7 @@ pub struct PageError {
     pub private: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConsoleAPI {
     #[serde(rename = "_type")]
     pub type_: String,


### PR DESCRIPTION
Pr #32509 restored the basic console functionality to Servo, allowing to execute javascript code interactively. However, page errors and console messages were not yet being printed.

At first I thought it was an issue of a change in the API, but while I was cleaning the code I found out that the main problem was that the console actor was trying to write to the browsing context streams, but these were empty, so the message was not going anywhere. The console was able to send messaged after adding the streams into the browsing context once a new connection was made.

Additionally, now the messages and error are sent as `resource-available-form` events from the browsing context instead of the console actor, so there was a slight shift in the code logic. Timestamps are also fixed now, so the messages are ordered.

![image](https://github.com/servo/servo/assets/22449369/b5ddd302-cfbd-4dfc-b96d-c1175840e692)

There are still some improvements that could be made to the console in the future, such as updating the Object actors to show the contents of a variable in an expression result or adding stack traces to errors.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #32404
- [x] These changes do not require tests because there are no tests yet for DevTools
