### PR TITLE
layout: use `Au` in Inline

### DIFF
--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -603,7 +603,7 @@ impl LineItem {
         }
     }
 
-    pub(super) fn trim_whitespace_at_end(&mut self, whitespace_trimmed: &mut Length) -> bool {
+    pub(super) fn trim_whitespace_at_end(&mut self, whitespace_trimmed: &mut Au) -> bool {
         match self {
             LineItem::StartInlineBoxPaddingBorderMargin(_) => true,
             LineItem::EndInlineBoxPaddingBorderMargin(_) => true,
@@ -614,7 +614,7 @@ impl LineItem {
         }
     }
 
-    pub(super) fn trim_whitespace_at_start(&mut self, whitespace_trimmed: &mut Length) -> bool {
+    pub(super) fn trim_whitespace_at_start(&mut self, whitespace_trimmed: &mut Au) -> bool {
         match self {
             LineItem::StartInlineBoxPaddingBorderMargin(_) => true,
             LineItem::EndInlineBoxPaddingBorderMargin(_) => true,
@@ -636,7 +636,7 @@ pub(super) struct TextRunLineItem {
 }
 
 impl TextRunLineItem {
-    fn trim_whitespace_at_end(&mut self, whitespace_trimmed: &mut Length) -> bool {
+    fn trim_whitespace_at_end(&mut self, whitespace_trimmed: &mut Au) -> bool {
         if matches!(
             self.parent_style.get_inherited_text().white_space_collapse,
             WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces
@@ -655,14 +655,14 @@ impl TextRunLineItem {
         *whitespace_trimmed += self
             .text
             .drain(first_whitespace_index..)
-            .map(|glyph| Length::from(glyph.total_advance()))
+            .map(|glyph| glyph.total_advance())
             .sum();
 
         // Only keep going if we only encountered whitespace.
         index_of_last_non_whitespace.is_none()
     }
 
-    fn trim_whitespace_at_start(&mut self, whitespace_trimmed: &mut Length) -> bool {
+    fn trim_whitespace_at_start(&mut self, whitespace_trimmed: &mut Au) -> bool {
         if matches!(
             self.parent_style.get_inherited_text().white_space_collapse,
             WhiteSpaceCollapse::Preserve | WhiteSpaceCollapse::BreakSpaces
@@ -679,7 +679,7 @@ impl TextRunLineItem {
         *whitespace_trimmed += self
             .text
             .drain(0..index_of_first_non_whitespace)
-            .map(|glyph| Length::from(glyph.total_advance()))
+            .map(|glyph| glyph.total_advance())
             .sum();
 
         // Only keep going if we only encountered whitespace.

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-005.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-006.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-007.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-008.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-009.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-010.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-010.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-010.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-011.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-011.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-011.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/fonts/font-weight-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[font-weight-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_item-clear.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_item-clear.html.ini
@@ -1,2 +1,0 @@
-[flexbox_item-clear.html]
-  expected: FAIL


### PR DESCRIPTION
Use `Au` at more places in Inline layout.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)