### PR TITLE
script: Use the new C string literal in the DOM bindings

### DIFF
--- a/components/script/dom/bindings/constant.rs
+++ b/components/script/dom/bindings/constant.rs
@@ -4,6 +4,8 @@
 
 //! WebIDL constants.
 
+use std::ffi::CStr;
+
 use js::jsapi::{JSPROP_ENUMERATE, JSPROP_PERMANENT, JSPROP_READONLY};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, JSVal, NullValue, UInt32Value};
 use js::rust::wrappers::JS_DefineProperty;
@@ -15,7 +17,7 @@ use crate::script_runtime::JSContext;
 #[derive(Clone)]
 pub struct ConstantSpec {
     /// name of the constant.
-    pub name: &'static [u8],
+    pub name: &'static CStr,
     /// value of the constant.
     pub value: ConstantVal,
 }
@@ -58,7 +60,7 @@ pub fn define_constants(cx: JSContext, obj: HandleObject, constants: &[ConstantS
             assert!(JS_DefineProperty(
                 *cx,
                 obj,
-                spec.name.as_ptr() as *const libc::c_char,
+                spec.name.as_ptr(),
                 value.handle(),
                 (JSPROP_ENUMERATE | JSPROP_READONLY | JSPROP_PERMANENT) as u32
             ));

--- a/components/script/dom/bindings/namespace.rs
+++ b/components/script/dom/bindings/namespace.rs
@@ -4,6 +4,7 @@
 
 //! Machinery to initialise namespace objects.
 
+use std::ffi::CStr;
 use std::ptr;
 
 use js::jsapi::{JSClass, JSFunctionSpec};
@@ -22,9 +23,9 @@ unsafe impl Sync for NamespaceObjectClass {}
 
 impl NamespaceObjectClass {
     /// Create a new `NamespaceObjectClass` structure.
-    pub const unsafe fn new(name: &'static [u8]) -> Self {
+    pub const unsafe fn new(name: &'static CStr) -> Self {
         NamespaceObjectClass(JSClass {
-            name: name as *const _ as *const libc::c_char,
+            name: name.as_ptr(),
             flags: 0,
             cOps: 0 as *mut _,
             spec: ptr::null(),
@@ -43,7 +44,7 @@ pub fn create_namespace_object(
     class: &'static NamespaceObjectClass,
     methods: &[Guard<&'static [JSFunctionSpec]>],
     constants: &[Guard<&'static [ConstantSpec]>],
-    name: &[u8],
+    name: &CStr,
     rval: MutableHandleObject,
 ) {
     create_object(cx, global, proto, &class.0, methods, &[], constants, rval);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -732,7 +732,7 @@ impl WindowMethods for Window {
             assert!(JS_DefineProperty(
                 *cx,
                 obj,
-                "opener\0".as_ptr() as *const libc::c_char,
+                c"opener".as_ptr(),
                 value,
                 JSPROP_ENUMERATE as u32
             ));

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1469,7 +1469,7 @@ unsafe extern "C" fn HostPopulateImportMeta(
     JS_DefineProperty4(
         cx,
         meta_object,
-        "url\0".as_ptr() as *const _,
+        c"url".as_ptr(),
         url_string.handle().into_handle(),
         JSPROP_ENUMERATE.into(),
     )


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Most of the changes in this PR are converting byte strings to c-strings in `CodegenRust.py`. However, some of the functions from the code that is being generated by `CodegenRust.py` that use these strings expect `*const i8` i.e. `*const c_char` and some other functions expect `&[u8]` which is a byte slice. Hence, the old helper, `str_to_const_array()`, was changed to `str_to_cstr_ptr()` and an additional helper, `str_to_byte_slice()`, was added for the conversion to `&[u8]`

This was the best solution I could think of, but I imagine there is probably a better solution. Any suggestions would be appreciated.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32628

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
