### PR TITLE
shell: set `no-wgl` flag in servoshell instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ string_cache_codegen = "0.5"
 style = { git = "https://github.com/servo/stylo", branch = "2024-05-31", features = ["servo"] }
 style_config = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
 style_traits = { git = "https://github.com/servo/stylo", branch = "2024-05-31", features = ["servo"] }
-# NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
 surfman = { version = "0.9", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ style = { git = "https://github.com/servo/stylo", branch = "2024-05-31", feature
 style_config = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
 style_traits = { git = "https://github.com/servo/stylo", branch = "2024-05-31", features = ["servo"] }
 # NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
-surfman = { version = "0.9", features = ["chains", "sm-angle", "sm-angle-default"] }
+surfman = { version = "0.9", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -11,7 +11,6 @@ name = "canvas"
 path = "lib.rs"
 
 [features]
-no-wgl = ["surfman/sm-no-wgl"]
 webgl_backtrace = ["canvas_traits/webgl_backtrace"]
 xr-profile = ["webxr-api/profile", "time"]
 

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -20,7 +20,7 @@ max_log_level = ["log/release_max_level_info"]
 media-gstreamer = ["servo-media-gstreamer", "gstreamer"]
 multiview = ["compositing/multiview", "constellation/multiview"]
 native-bluetooth = ["bluetooth/native-bluetooth"]
-no-wgl = ["canvas/no-wgl"]
+no-wgl = ["mozangle/egl", "mozangle/build_dlls", "surfman/sm-angle-default"]
 dynamic_freetype = ["webrender/dynamic_freetype"]
 profilemozjs = ["script/profilemozjs"]
 refcell_backtrace = ["script/refcell_backtrace"]
@@ -86,6 +86,3 @@ webxr-api = { git = "https://github.com/servo/webxr" }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
 gaol = "0.2.1"
-
-[target.'cfg(target_os = "windows")'.dependencies]
-mozangle = { workspace = true, features = ["egl", "build_dlls"] }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -525,10 +525,16 @@ where
     fn get_native_media_display_and_gl_context(
         rendering_context: &RenderingContext,
     ) -> Option<(NativeDisplay, GlContext)> {
-        let gl_context = GlContext::Egl(rendering_context.native_context().egl_context as usize);
-        let native_display =
-            NativeDisplay::Egl(rendering_context.native_device().egl_display as usize);
-        Some((native_display, gl_context))
+        #[cfg(feature = "no-wgl")]
+        {
+            let gl_context =
+                GlContext::Egl(rendering_context.native_context().egl_context as usize);
+            let native_display =
+                NativeDisplay::Egl(rendering_context.native_device().egl_display as usize);
+            Some((native_display, gl_context))
+        }
+        #[cfg(not(feature = "no-wgl"))]
+        None
     }
 
     #[cfg(not(any(

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -45,7 +45,6 @@ max_log_level = ["log/release_max_level_info"]
 media-gstreamer = ["libservo/media-gstreamer"]
 multiview = ["libservo/multiview"]
 native-bluetooth = ["libservo/native-bluetooth"]
-no-wgl = ["libservo/no-wgl"]
 profilemozjs = ["libservo/profilemozjs"]
 refcell_backtrace = ["libservo/refcell_backtrace"]
 webdriver = ["libservo/webdriver"]
@@ -116,3 +115,4 @@ sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
+libservo = { path = "../../components/servo", features = ["no-wgl"] }

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -862,7 +862,6 @@ class CommandBase(object):
                     action='store_true',
                     help='Build with frame pointer enabled, used by the background hang monitor.',
                 ),
-                CommandArgument('--without-wgl', group="Feature Selection", default=None, action='store_true'),
                 CommandArgument(
                     '--use-crown',
                     default=False,
@@ -982,7 +981,7 @@ class CommandBase(object):
         self, command: str, cargo_args: List[str],
         env=None, verbose=False,
         debug_mozjs=False, with_debug_assertions=False,
-        with_frame_pointer=False, without_wgl=False,
+        with_frame_pointer=False,
         use_crown=False,
         target_override: Optional[str] = None,
         **_kwargs
@@ -1042,8 +1041,6 @@ class CommandBase(object):
             if with_frame_pointer:
                 env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C force-frame-pointers=yes"
                 features.append("profilemozjs")
-            if without_wgl:
-                features.append("no-wgl")
             if self.config["build"]["webgl-backtrace"]:
                 features.append("webgl-backtrace")
             if self.config["build"]["dom-backtrace"]:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Servoshell already enables this flag, actually. What this flag does is enable `sm-angle-default` in Surfman and `egl`/`build_dlls` in Mozangle. This PR tries to cleanup a bit to reflect what servoshell really does. It also makes it easier to toggle WGL in the future.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32752

<!-- Either: -->
- [x] There are tests for these changes: existing CI should pass.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
