### PR TITLE
Remove unused `debug` implementation for `Length`

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -181,19 +181,6 @@ impl<T: Zero> LogicalRect<T> {
     }
 }
 
-impl fmt::Debug for LogicalRect<Length> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Rect(i{}×b{} @ (i{},b{}))",
-            self.size.inline.px(),
-            self.size.block.px(),
-            self.start_corner.inline.px(),
-            self.start_corner.block.px(),
-        )
-    }
-}
-
 impl fmt::Debug for LogicalRect<Au> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(


### PR DESCRIPTION
Remove unused fmt::Debug implmentation for `Length`. We are using `Au` now

Signed-off-by: atbrakhi <atbrakhi@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)