### PR TITLE
Move legacy layout behind a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ dependencies = [
  "bluetooth_traits",
  "canvas",
  "canvas_traits",
+ "cfg-if",
  "compositing",
  "compositing_traits",
  "constellation",

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -16,6 +16,7 @@ debugmozjs = ["script/debugmozjs"]
 googlevr = ["webxr/googlevr"]
 jitspew = ["script/jitspew"]
 js_backtrace = ["script/js_backtrace"]
+layout_2013 = ["dep:layout_thread_2013"]
 max_log_level = ["log/release_max_level_info"]
 media-gstreamer = ["servo-media-gstreamer", "gstreamer"]
 multiview = ["compositing/multiview", "constellation/multiview"]
@@ -39,6 +40,7 @@ bluetooth = { path = "../bluetooth" }
 bluetooth_traits = { workspace = true }
 canvas = { path = "../canvas", default-features = false }
 canvas_traits = { workspace = true }
+cfg-if = { workspace = true }
 compositing = { path = "../compositing" }
 compositing_traits = { workspace = true }
 constellation = { path = "../constellation" }
@@ -54,7 +56,7 @@ gleam = { workspace = true }
 gstreamer = { workspace = true, optional = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
-layout_thread_2013 = { path = "../layout_thread" }
+layout_thread_2013 = { path = "../layout_thread", optional = true }
 layout_thread_2020 = { path = "../layout_thread_2020" }
 log = { workspace = true }
 media = { path = "../media" }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -67,6 +67,8 @@ use fonts::FontCacheThread;
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods};
 pub use gleam::gl;
 use ipc_channel::ipc::{self, IpcSender};
+#[cfg(feature = "layout_2013")]
+pub use layout_thread_2013;
 use log::{error, trace, warn, Log, Metadata, Record};
 use media::{GLPlayerThreads, GlApi, NativeDisplay, WindowGLContext};
 use net::resource_thread::new_resource_threads;
@@ -98,10 +100,9 @@ use webrender_traits::{
 pub use {
     background_hang_monitor, base, bluetooth, bluetooth_traits, canvas, canvas_traits, compositing,
     constellation, devtools, devtools_traits, embedder_traits, euclid, fonts, ipc_channel,
-    keyboard_types, layout_thread_2013, layout_thread_2020, media, net, net_traits, profile,
-    profile_traits, script, script_layout_interface, script_traits, servo_config as config,
-    servo_config, servo_geometry, servo_url as url, servo_url, style, style_traits, webgpu,
-    webrender_api, webrender_traits,
+    keyboard_types, layout_thread_2020, media, net, net_traits, profile, profile_traits, script,
+    script_layout_interface, script_traits, servo_config as config, servo_config, servo_geometry,
+    servo_url as url, servo_url, style, style_traits, webgpu, webrender_api, webrender_traits,
 };
 
 #[cfg(feature = "webdriver")]
@@ -968,6 +969,22 @@ fn create_compositor_channel(
     )
 }
 
+fn get_layout_factory(legacy_layout: bool) -> Arc<dyn LayoutFactory> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "layout_2013")] {
+            if legacy_layout {
+                return Arc::new(layout_thread_2013::LayoutFactoryImpl());
+            }
+        } else {
+            if legacy_layout {
+                warn!("Runtime option `legacy_layout` was enabled, but the `layout_2013` \
+                feature was not enabled at compiletime - falling back to layout 2020! ");
+           }
+        }
+    }
+    Arc::new(layout_thread_2020::LayoutFactoryImpl())
+}
+
 fn create_constellation(
     user_agent: Cow<'static, str>,
     config_dir: Option<PathBuf>,
@@ -1034,11 +1051,7 @@ fn create_constellation(
         wgpu_image_map,
     };
 
-    let layout_factory: Arc<dyn LayoutFactory> = if opts::get().legacy_layout {
-        Arc::new(layout_thread_2013::LayoutFactoryImpl())
-    } else {
-        Arc::new(layout_thread_2020::LayoutFactoryImpl())
-    };
+    let layout_factory: Arc<dyn LayoutFactory> = get_layout_factory(opts::get().legacy_layout);
 
     Constellation::<
         script::script_thread::ScriptThread,
@@ -1213,11 +1226,8 @@ pub fn run_content_process(token: String) {
             set_logger(content.script_to_constellation_chan().clone());
 
             let background_hang_monitor_register = content.register_with_background_hang_monitor();
-            let layout_factory: Arc<dyn LayoutFactory> = if opts::get().legacy_layout {
-                Arc::new(layout_thread_2013::LayoutFactoryImpl())
-            } else {
-                Arc::new(layout_thread_2020::LayoutFactoryImpl())
-            };
+            let layout_factory: Arc<dyn LayoutFactory> =
+                get_layout_factory(opts::get().legacy_layout);
 
             content.start_all::<script::script_thread::ScriptThread>(
                 true,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -978,7 +978,7 @@ fn get_layout_factory(legacy_layout: bool) -> Arc<dyn LayoutFactory> {
         } else {
             if legacy_layout {
                 warn!("Runtime option `legacy_layout` was enabled, but the `layout_2013` \
-                feature was not enabled at compiletime - falling back to layout 2020! ");
+                feature was not enabled at compile time. Falling back to layout 2020! ");
            }
         }
     }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -38,9 +38,10 @@ ProductName = "Servo"
 
 [features]
 debugmozjs = ["libservo/debugmozjs"]
-default = ["max_log_level", "webdriver"]
+default = ["layout_2013", "max_log_level", "webdriver"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]
+layout_2013 = ["libservo/layout_2013"]
 max_log_level = ["log/release_max_level_info"]
 media-gstreamer = ["libservo/media-gstreamer"]
 multiview = ["libservo/multiview"]


### PR DESCRIPTION
For now the new feature flag would still be enabled by default. 
Disabling the `layout_2013` feature, gives the following binary size improvements for servoshell on Linux:
- in debug mode from 1278MB -> 1201 MB
- in release mode from 144MB -> 140MB
- in production mode from 108MB -> 106MB

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes ~~fix~~ optionally allow slightly improving the binary size.
