### PR TITLE
ohos: Add default log filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5794,6 +5794,7 @@ dependencies = [
  "egui",
  "egui-winit",
  "egui_glow",
+ "env_filter",
  "euclid",
  "getopts",
  "gilrs",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -77,6 +77,7 @@ webxr = { git = "https://github.com/servo/webxr" }
 backtrace = { workspace = true }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
+env_filter = "0.1.0"
 # force inprocess, until libc-rs 0.2.156 is released containing
 # https://github.com/rust-lang/libc/commit/9e248e212c5602cb4e98676e4c21ea0382663a12
 ipc-channel = { workspace = true, features = ["force-inprocess"] }

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -325,6 +325,23 @@ fn initialize_logging_once() {
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         let mut builder = hilog::Builder::new();
+        let filters = [
+            "fonts",
+            "servo",
+            "servoshell",
+            "servoshell::egl:gl_glue",
+            // Show JS errors by default.
+            "script::dom::bindings::error",
+            // Show GL errors by default.
+            "canvas::webgl_thread",
+            "compositing::compositor",
+            "constellation::constellation",
+        ];
+        let mut filter_builder = env_filter::Builder::new();
+        for &module in &filters {
+            filter_builder.filter_module(module, log::LevelFilter::Debug);
+        }
+
         builder.filter_level(LevelFilter::Debug).init();
 
         info!("Servo Register callback called!");


### PR DESCRIPTION
Adds a default log filter on openharmony. 
The filter is mostly the same as on android, but I'm also interested in logging in fonts by default, since that is currently a problematic area on OH.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] These changes do not require tests because: Trivial change.