### PR TITLE
Bump duplicated nix to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
  "libc",
  "log",
  "mach2",
- "nix 0.27.1",
+ "nix",
  "serde_json",
  "unwind-sys",
 ]
@@ -2155,7 +2155,7 @@ dependencies = [
  "libc",
  "libudev-sys",
  "log",
- "nix 0.29.0",
+ "nix",
  "uuid",
  "vec_map",
  "wasm-bindgen",
@@ -4237,17 +4237,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "nix"

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -29,5 +29,5 @@ lazy_static = { workspace = true }
 mach2 = "0.4"
 
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64"))))'.dependencies]
-nix = { version = "0.27", features = ["signal"] }
+nix = { version = "0.29", features = ["signal"] }
 unwind-sys = "0.1.4"

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -25,7 +25,6 @@ packages = [
     "cookie",
     "futures",
     "hermit-abi",
-    "nix",
     "redox_syscall",
     "syn",
     "synstructure",


### PR DESCRIPTION
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix: Remove duplicated nix dependency

