### PR TITLE
Use mallinfo only on target_env=gnu

### DIFF
--- a/components/profile/mem.rs
+++ b/components/profile/mem.rs
@@ -394,7 +394,7 @@ mod system_reporter {
     #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use std::ptr::null_mut;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     use libc::c_int;
     #[cfg(not(any(target_os = "windows", target_env = "ohos")))]
     use libc::{c_void, size_t};
@@ -455,12 +455,12 @@ mod system_reporter {
         request.reports_channel.send(reports);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     extern "C" {
         fn mallinfo() -> struct_mallinfo;
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     #[repr(C)]
     pub struct struct_mallinfo {
         arena: c_int,
@@ -475,7 +475,7 @@ mod system_reporter {
         keepcost: c_int,
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     fn system_heap_allocated() -> Option<usize> {
         let info: struct_mallinfo = unsafe { mallinfo() };
 
@@ -494,7 +494,7 @@ mod system_reporter {
         }
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
     fn system_heap_allocated() -> Option<usize> {
         None
     }


### PR DESCRIPTION
mallinfo isn't available on musl, causing linking issues on build;
make sure related functions are built only for GNU Libc

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because: this is ultimately a build system fix and a "proper" test for this would be musl CI/CD, or something

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
