### PR TITLE
layout: Properly handle min/max cross container size

### DIFF
--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -228,6 +228,7 @@ impl NonReplacedFormattingContext {
                 layout_context,
                 positioning_context,
                 containing_block_for_children,
+                containing_block,
             ),
             NonReplacedFormattingContextContents::Table(table) => table.layout(
                 layout_context,

--- a/tests/wpt/meta/css/css-flexbox/fieldset-as-container-justify-center.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/fieldset-as-container-justify-center.tentative.html.ini
@@ -1,0 +1,3 @@
+[fieldset-as-container-justify-center.tentative.html]
+  [.item 1]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-definite-sizes-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-definite-sizes-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-definite-sizes-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-single-line-clamp-1.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-single-line-clamp-1.html.ini
@@ -1,2 +1,0 @@
-[flexbox-single-line-clamp-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-single-line-clamp-3.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-single-line-clamp-3.html.ini
@@ -1,2 +1,0 @@
-[flexbox-single-line-clamp-3.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-003.html.ini
@@ -1,9 +1,6 @@
 [percentage-heights-003.html]
-  [.flexbox 6]
-    expected: FAIL
-
-  [.flexbox 7]
-    expected: FAIL
-
   [.flexbox 2]
+    expected: FAIL
+
+  [.flexbox 3]
     expected: FAIL


### PR DESCRIPTION
We need to constrain the available cross size by the min/max cross size properties, but this was not yet implemented. This patch plumbs those in from the flex container’s own containing block.

There are three new passing tests, two new passing subtests, and two subtests regressing due to flex column layout not being implemented (#14123).

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Co-authored-by: Delan Azabani <dazabani@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___