### PR TITLE
Bump mozjs dep version to mitigate a segfault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,7 +4005,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#fb8225ed5eb87c0d6d0b4d6126c11f5bc98687ce"
+source = "git+https://github.com/servo/mozjs#6e4e55a002f493739c8dbe0f2d2b29b0017d5dd2"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
mozjs now has an extra null pointer check due to https://github.com/servo/mozjs/pull/477,
which avoids a segfault. This is the only new commit in mozjs since the
previously used version, so there is no other change in behavior.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32654
- [x] These changes do not require tests because it's a dependency upgrade.
