### PR TITLE
flex: handle ‘align-self: [ first | last ]? && baseline’

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -989,7 +989,7 @@ impl FlexLine<'_> {
                         layout_result
                             .baseline_relative_to_margin_box
                             .unwrap_or_else(|| {
-                                item.synthesized_baselines_relative_to_margin_box(*used_cross_size)
+                                item.synthesized_baseline_relative_to_margin_box(*used_cross_size)
                             }),
                     )
                 } else {
@@ -1363,7 +1363,7 @@ impl<'a> FlexItem<'a> {
         )
     }
 
-    fn synthesized_baselines_relative_to_margin_box(&self, content_size: Au) -> Au {
+    fn synthesized_baseline_relative_to_margin_box(&self, content_size: Au) -> Au {
         // If the item does not have a baseline in the necessary axis,
         // then one is synthesized from the flex item’s border box.
         // https://drafts.csswg.org/css-flexbox/#valdef-align-items-baseline
@@ -1401,7 +1401,7 @@ impl<'items> FlexLine<'items> {
                 let baseline = item_result
                     .baseline_relative_to_margin_box
                     .unwrap_or_else(|| {
-                        item.synthesized_baselines_relative_to_margin_box(
+                        item.synthesized_baseline_relative_to_margin_box(
                             item_result.hypothetical_cross_size,
                         )
                     });

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1307,6 +1307,10 @@ impl<'a> FlexItem<'a> {
                                 self.content_max_size.cross,
                             );
 
+                        // FIXME: css/css-flexbox/align-items-baseline-overflow-non-visible.html
+                        // we need to pick first always, unless ‘align-self’ is ‘last baseline’.
+                        // do not use pick_baseline, which uses the ‘baseline-source’ logic for inline layout.
+                        // see also: https://github.com/w3c/csswg-drafts/issues/7638
                         // TODO: synthesize baseline if None?
                         // https://drafts.csswg.org/css-align-3/#synthesize-baseline
                         let propagated_baseline = self.box_.pick_baseline(&baselines);

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2084,7 +2084,7 @@ impl IndependentFormattingContext {
     /// Picks either the first or the last baseline, depending on `baseline-source`.
     /// TODO: clarify that this is not to be used for box alignment in flex/grid
     /// <https://drafts.csswg.org/css-inline/#baseline-source>
-    pub fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
+    fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
         match self.style().clone_baseline_source() {
             BaselineSource::First => baselines.first,
             BaselineSource::Last => baselines.last,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2082,6 +2082,7 @@ impl IndependentFormattingContext {
     }
 
     /// Picks either the first or the last baseline, depending on `baseline-source`.
+    /// TODO: clarify that this is not to be used for box alignment in flex/grid
     /// <https://drafts.csswg.org/css-inline/#baseline-source>
     pub fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
         match self.style().clone_baseline_source() {

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2083,7 +2083,7 @@ impl IndependentFormattingContext {
 
     /// Picks either the first or the last baseline, depending on `baseline-source`.
     /// <https://drafts.csswg.org/css-inline/#baseline-source>
-    fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
+    pub fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
         match self.style().clone_baseline_source() {
             BaselineSource::First => baselines.first,
             BaselineSource::Last => baselines.last,

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-005.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-005.html.ini
@@ -1,6 +1,3 @@
 [flex-align-baseline-005.html]
-  [#target > div 1]
-    expected: FAIL
-
   [#target > div 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-006.html.ini
@@ -1,6 +1,3 @@
 [flex-align-baseline-006.html]
-  [#target > div 1]
-    expected: FAIL
-
   [#target > div 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-007.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-007.html.ini
@@ -1,6 +1,3 @@
 [flex-align-baseline-007.html]
-  [#target > div 1]
-    expected: FAIL
-
   [#target > div 3]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-grid-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-grid-001.html.ini
@@ -11,8 +11,5 @@
   [.target > * 7]
     expected: FAIL
 
-  [.target > * 9]
-    expected: FAIL
-
   [.target > * 11]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative.html.ini
@@ -1,35 +1,11 @@
 [flex-align-baseline-line-clamp-001.tentative.html]
-  [.target > * 1]
-    expected: FAIL
-
   [.target > * 3]
-    expected: FAIL
-
-  [.target > * 5]
-    expected: FAIL
-
-  [.target > * 7]
-    expected: FAIL
-
-  [.target > * 9]
-    expected: FAIL
-
-  [.target > * 11]
-    expected: FAIL
-
-  [.target > * 13]
     expected: FAIL
 
   [.target > * 15]
     expected: FAIL
 
-  [.target > * 17]
-    expected: FAIL
-
   [.target > * 19]
-    expected: FAIL
-
-  [.target > * 21]
     expected: FAIL
 
   [.target > * 23]

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-multicol-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-multicol-001.html.ini
@@ -1,17 +1,8 @@
 [flex-align-baseline-multicol-001.html]
-  [.target > * 1]
-    expected: FAIL
-
   [.target > * 3]
     expected: FAIL
 
-  [.target > * 5]
-    expected: FAIL
-
   [.target > * 7]
-    expected: FAIL
-
-  [.target > * 9]
     expected: FAIL
 
   [.target > * 11]

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-overflow-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-overflow-001.html.ini
@@ -1,10 +1,4 @@
 [flex-align-baseline-overflow-001.html]
-  [.target > * 1]
-    expected: FAIL
-
-  [.target > * 3]
-    expected: FAIL
-
   [.target > * 6]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-table-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-table-001.html.ini
@@ -1,10 +1,4 @@
 [flex-align-baseline-table-001.html]
-  [.target > * 1]
-    expected: FAIL
-
-  [.target > * 3]
-    expected: FAIL
-
   [.target > * 5]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-baseline-horiz-001a.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-baseline-horiz-001a.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-baseline-horiz-001a.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_align-items-baseline.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_align-items-baseline.html.ini
@@ -1,2 +1,0 @@
-[flexbox_align-items-baseline.html]
-  expected: FAIL


### PR DESCRIPTION
This patch implements layout for flex items with ‘baseline’ (‘first baseline’) or ‘last baseline’ alignment, except for the inline axis and auto cross margins checks when [calculating the cross size of each flex line](https://drafts.csswg.org/css-flexbox/#algo-cross-line).

We calculate and store the baseline relative to the margin cross start edge for each item, then use that when [calculating the cross size of each flex line](https://drafts.csswg.org/css-flexbox/#algo-cross-line) and [aligning all flex items along the cross-axis](https://drafts.csswg.org/css-flexbox/#algo-cross-align). When we need to synthesize baselines for an item, we take the hypothetical cross size or the used cross size respectively, adding cross-axis pbm sizes such that [the baseline is the border cross end edge](https://drafts.csswg.org/css-flexbox/#valdef-align-items-baseline).

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Signed-off-by: Delan Azabani <dazabani@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

**Diff against #32790:** https://github.com/servo/servo/pull/32787/files/ab08695506911c4ac6d6b9a5834e8a89fc63a9c9..d583ed0669c356bd944bc520b438dc60b844a73a