### PR TITLE
clippy: Fix four warnings

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -343,7 +343,7 @@ impl RangeMethods for Range {
         } else {
             // Step 3.
             self.set_start(node, offset);
-            if !(self.start() <= self.end()) {
+            if self.start() > self.end() {
                 // Step 4.
                 self.set_end(node, offset);
             }
@@ -362,7 +362,7 @@ impl RangeMethods for Range {
         } else {
             // Step 3.
             self.set_end(node, offset);
-            if !(self.end() >= self.start()) {
+            if self.end() < self.start() {
                 // Step 4.
                 self.set_start(node, offset);
             }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -333,7 +333,7 @@ impl RangeMethods for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstart>
-    #[allow(clippy::neg_cmp_op_on_partial_ord)] 
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn SetStart(&self, node: &Node, offset: u32) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -333,6 +333,7 @@ impl RangeMethods for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstart>
+    #[allow(clippy::neg_cmp_op_on_partial_ord)] 
     fn SetStart(&self, node: &Node, offset: u32) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.
@@ -343,7 +344,7 @@ impl RangeMethods for Range {
         } else {
             // Step 3.
             self.set_start(node, offset);
-            if self.start() > self.end() {
+            if !(self.start() <= self.end()) {
                 // Step 4.
                 self.set_end(node, offset);
             }
@@ -352,6 +353,7 @@ impl RangeMethods for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setend>
+    #[allow(clippy::neg_cmp_op_on_partial_ord)]
     fn SetEnd(&self, node: &Node, offset: u32) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.
@@ -362,7 +364,7 @@ impl RangeMethods for Range {
         } else {
             // Step 3.
             self.set_end(node, offset);
-            if self.end() < self.start() {
+            if !(self.end() >= self.start()) {
                 // Step 4.
                 self.set_start(node, offset);
             }

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -272,7 +272,7 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
                 .upcast::<Node>()
                 .content_boxes()
                 .pop()
-                .unwrap_or_else(|| Rect::zero())
+                .unwrap_or_else(Rect::zero)
         },
         // TODO(#31182): add support for border box, and device pixel size, calculations.
         _ => Rect::zero(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1131,10 +1131,11 @@ impl WindowMethods for Window {
         pseudo: Option<DOMString>,
     ) -> DomRoot<CSSStyleDeclaration> {
         // Steps 1-4.
-        let pseudo = match pseudo.map(|mut s| {
+        let pseudo = pseudo.map(|mut s| {
             s.make_ascii_lowercase();
             s
-        }) {
+        });
+        let pseudo = match pseudo {
             Some(ref pseudo) if pseudo == ":before" || pseudo == "::before" => {
                 Some(PseudoElement::Before)
             },


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes 4 clippy rules. I aggregated clippy output before and after with `./mach cargo-clippy 2>&1 | rg 'warning:' | sort | uniq -c`. The diff is:
```
*** before	Wed Jul 17 06:17:01 2024
--- after	Wed Jul 17 08:31:58 2024
***************
*** 5,11 ****
     1 warning: `layout_thread_2013` (lib) generated 1 warning
     1 warning: `layout_thread_2020` (lib) generated 2 warnings
     1 warning: `libservo` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p libservo` to apply 1 suggestion)
!    1 warning: `script` (lib) generated 51 warnings (run `cargo clippy --fix --lib -p script` to apply 1 suggestion)
     1 warning: `servoshell` (lib) generated 1 warning
     1 warning: all variants have the same postfix: `Element`
     1 warning: all variants have the same postfix: `Error`
--- 5,11 ----
     1 warning: `layout_thread_2013` (lib) generated 1 warning
     1 warning: `layout_thread_2020` (lib) generated 2 warnings
     1 warning: `libservo` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p libservo` to apply 1 suggestion)
!    1 warning: `script` (lib) generated 47 warnings
     1 warning: `servoshell` (lib) generated 1 warning
     1 warning: all variants have the same postfix: `Element`
     1 warning: all variants have the same postfix: `Error`
***************
*** 14,20 ****
     1 warning: all variants have the same prefix: `From`
     1 warning: constructor `in_realm` has the same name as the type
     1 warning: docs for unsafe trait missing `# Safety` section
-    1 warning: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
     1 warning: large size difference between variants
     2 warning: methods called `from_*` usually take no `self`
     4 warning: methods called `new` usually return `Self`
--- 14,19 ----
***************
*** 26,36 ****
     1 warning: name `SPHT` contains a capitalized acronym
     1 warning: name `URL` contains a capitalized acronym
     1 warning: name `UUID` contains a capitalized acronym
-    1 warning: redundant closure
     1 warning: statics have by default a `'static` lifetime
     1 warning: struct `Node` has a public `len` method, but no `is_empty` method
     1 warning: struct `TimeRangesContainer` has a public `len` method, but no `is_empty` method
-    2 warning: the use of negated comparison operators on partially ordered types produces code that is hard to read and refactor, please consider using the `partial_cmp` method instead, to make it clear that the two values could be incomparable
     2 warning: this expression creates a reference which is immediately dereferenced by the compiler
     2 warning: this function has too many arguments (12/7)
     1 warning: this function has too many arguments (16/7)
--- 25,33 ----
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500

<!-- Either: -->
- [X] These changes do not require tests because it doesn't change or reorganise logic.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
