### PR TITLE
[clippy] Rename enum FormSubmitter and its elements

### DIFF
--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -325,9 +325,9 @@ impl Validatable for HTMLButtonElement {
         // https://html.spec.whatwg.org/multipage/#the-button-element%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#enabling-and-disabling-form-controls%3A-the-disabled-attribute%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#the-datalist-element%3Abarred-from-constraint-validation
-        self.button_type.get() == ButtonType::Submit
-            && !self.upcast::<Element>().disabled_state()
-            && !is_barred_by_datalist_ancestor(self.upcast())
+        self.button_type.get() == ButtonType::Submit &&
+            !self.upcast::<Element>().disabled_state() &&
+            !is_barred_by_datalist_ancestor(self.upcast())
     }
 }
 

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -23,7 +23,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::htmlformelement::{
-    FormControl, FormDatum, FormDatumValue, FormSubmitter, HTMLFormElement, ResetFrom,
+    FormControl, FormDatum, FormDatumValue, FormSubmitterElement, HTMLFormElement, ResetFrom,
     SubmittedFrom,
 };
 use crate::dom::node::{window_from_node, BindContext, Node, UnbindContext};
@@ -192,11 +192,11 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
 impl HTMLButtonElement {
     /// <https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set>
     /// Steps range from 3.1 to 3.7 (specific to HTMLButtonElement)
-    pub fn form_datum(&self, submitter: Option<FormSubmitter>) -> Option<FormDatum> {
+    pub fn form_datum(&self, submitter: Option<FormSubmitterElement>) -> Option<FormDatum> {
         // Step 3.1: disabled state check is in get_unclean_dataset
 
         // Step 3.1: only run steps if this is the submitter
-        if let Some(FormSubmitter::ButtonElement(submitter)) = submitter {
+        if let Some(FormSubmitterElement::Button(submitter)) = submitter {
             if submitter != self {
                 return None;
             }
@@ -325,9 +325,9 @@ impl Validatable for HTMLButtonElement {
         // https://html.spec.whatwg.org/multipage/#the-button-element%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#enabling-and-disabling-form-controls%3A-the-disabled-attribute%3Abarred-from-constraint-validation
         // https://html.spec.whatwg.org/multipage/#the-datalist-element%3Abarred-from-constraint-validation
-        self.button_type.get() == ButtonType::Submit &&
-            !self.upcast::<Element>().disabled_state() &&
-            !is_barred_by_datalist_ancestor(self.upcast())
+        self.button_type.get() == ButtonType::Submit
+            && !self.upcast::<Element>().disabled_state()
+            && !is_barred_by_datalist_ancestor(self.upcast())
     }
 }
 
@@ -351,7 +351,7 @@ impl Activatable for HTMLButtonElement {
                 if let Some(owner) = self.form_owner() {
                     owner.submit(
                         SubmittedFrom::NotFromForm,
-                        FormSubmitter::ButtonElement(self),
+                        FormSubmitterElement::Button(self),
                     );
                 }
             },

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -144,9 +144,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .map_or(false, |c| c.is_listed_element())
-                        && (child.get_id().map_or(false, |i| i == *name)
-                            || child.get_name().map_or(false, |n| n == *name))
+                        .map_or(false, |c| c.is_listed_element()) &&
+                        (child.get_id().map_or(false, |i| i == *name) ||
+                            child.get_name().map_or(false, |n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -159,9 +159,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>()
-                        && (child.get_id().map_or(false, |i| i == *name)
-                            || child.get_name().map_or(false, |n| n == *name));
+                    return child.is::<HTMLImageElement>() &&
+                        (child.get_id().map_or(false, |i| i == *name) ||
+                            child.get_name().map_or(false, |n| n == *name));
                 },
             }
         }
@@ -579,8 +579,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>())
-                == 0
+                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
+                0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -590,9 +590,9 @@ impl HTMLFormElementMethods for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>())
-                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
-                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>()) &
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -851,11 +851,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _)
-            | ("about", _)
-            | ("data", FormMethod::Post)
-            | ("ftp", _)
-            | ("javascript", _) => {
+            ("file", _) |
+            ("about", _) |
+            ("data", FormMethod::Post) |
+            ("ftp", _) |
+            ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1151,8 +1151,8 @@ impl HTMLFormElement {
                 child_element
                     .downcast::<HTMLInputElement>()
                     .map_or(false, |input| {
-                        input.input_type() == InputType::Text
-                            || input.input_type() == InputType::Search
+                        input.input_type() == InputType::Text ||
+                            input.input_type() == InputType::Search
                     });
             let textarea_matches = child_element.is::<HTMLTextAreaElement>();
             let dirname = child_element.get_string_attribute(&local_name!("dirname"));
@@ -1539,9 +1539,9 @@ pub trait FormControl: DomObject {
             .next();
 
         // Step 1
-        if old_owner.is_some()
-            && !(self.is_listed() && has_form_id)
-            && nearest_form_ancestor == old_owner
+        if old_owner.is_some() &&
+            !(self.is_listed() && has_form_id) &&
+            nearest_form_ancestor == old_owner
         {
             return;
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -59,7 +59,7 @@ use crate::dom::htmldatalistelement::HTMLDataListElement;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::htmlformelement::{
-    FormControl, FormDatum, FormDatumValue, FormSubmitter, HTMLFormElement, ResetFrom,
+    FormControl, FormDatum, FormDatumValue, FormSubmitterElement, HTMLFormElement, ResetFrom,
     SubmittedFrom,
 };
 use crate::dom::keyboardevent::KeyboardEvent;
@@ -121,20 +121,20 @@ impl InputType {
     fn is_textual(&self) -> bool {
         matches!(
             *self,
-            InputType::Color |
-                InputType::Date |
-                InputType::DatetimeLocal |
-                InputType::Email |
-                InputType::Hidden |
-                InputType::Month |
-                InputType::Number |
-                InputType::Range |
-                InputType::Search |
-                InputType::Tel |
-                InputType::Text |
-                InputType::Time |
-                InputType::Url |
-                InputType::Week
+            InputType::Color
+                | InputType::Date
+                | InputType::DatetimeLocal
+                | InputType::Email
+                | InputType::Hidden
+                | InputType::Month
+                | InputType::Number
+                | InputType::Range
+                | InputType::Search
+                | InputType::Tel
+                | InputType::Text
+                | InputType::Time
+                | InputType::Url
+                | InputType::Week
         )
     }
 
@@ -369,28 +369,28 @@ impl HTMLInputElement {
     // https://html.spec.whatwg.org/multipage/#concept-input-apply
     fn value_mode(&self) -> ValueMode {
         match self.input_type() {
-            InputType::Submit |
-            InputType::Reset |
-            InputType::Button |
-            InputType::Image |
-            InputType::Hidden => ValueMode::Default,
+            InputType::Submit
+            | InputType::Reset
+            | InputType::Button
+            | InputType::Image
+            | InputType::Hidden => ValueMode::Default,
 
             InputType::Checkbox | InputType::Radio => ValueMode::DefaultOn,
 
-            InputType::Color |
-            InputType::Date |
-            InputType::DatetimeLocal |
-            InputType::Email |
-            InputType::Month |
-            InputType::Number |
-            InputType::Password |
-            InputType::Range |
-            InputType::Search |
-            InputType::Tel |
-            InputType::Text |
-            InputType::Time |
-            InputType::Url |
-            InputType::Week => ValueMode::Value,
+            InputType::Color
+            | InputType::Date
+            | InputType::DatetimeLocal
+            | InputType::Email
+            | InputType::Month
+            | InputType::Number
+            | InputType::Password
+            | InputType::Range
+            | InputType::Search
+            | InputType::Tel
+            | InputType::Text
+            | InputType::Time
+            | InputType::Url
+            | InputType::Week => ValueMode::Value,
 
             InputType::File => ValueMode::Filename,
         }
@@ -422,42 +422,42 @@ impl HTMLInputElement {
     fn does_readonly_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Email |
-                InputType::Password |
-                InputType::Date |
-                InputType::Month |
-                InputType::Week |
-                InputType::Time |
-                InputType::DatetimeLocal |
-                InputType::Number
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Email
+                | InputType::Password
+                | InputType::Date
+                | InputType::Month
+                | InputType::Week
+                | InputType::Time
+                | InputType::DatetimeLocal
+                | InputType::Number
         )
     }
 
     fn does_minmaxlength_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Email |
-                InputType::Password
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Email
+                | InputType::Password
         )
     }
 
     fn does_pattern_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Email |
-                InputType::Password
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Email
+                | InputType::Password
         )
     }
 
@@ -470,13 +470,13 @@ impl HTMLInputElement {
     fn does_value_as_number_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Date |
-                InputType::Month |
-                InputType::Week |
-                InputType::Time |
-                InputType::DatetimeLocal |
-                InputType::Number |
-                InputType::Range
+            InputType::Date
+                | InputType::Month
+                | InputType::Week
+                | InputType::Time
+                | InputType::DatetimeLocal
+                | InputType::Number
+                | InputType::Range
         )
     }
 
@@ -780,17 +780,18 @@ impl HTMLInputElement {
             },
             // https://html.spec.whatwg.org/multipage/#file-upload-state-(type%3Dfile)%3Asuffering-from-being-missing
             InputType::File => {
-                self.Required() &&
-                    self.filelist
+                self.Required()
+                    && self
+                        .filelist
                         .get()
                         .map_or(true, |files| files.Length() == 0)
             },
             // https://html.spec.whatwg.org/multipage/#the-required-attribute%3Asuffering-from-being-missing
             _ => {
-                self.Required() &&
-                    self.value_mode() == ValueMode::Value &&
-                    self.is_mutable() &&
-                    value.is_empty()
+                self.Required()
+                    && self.value_mode() == ValueMode::Value
+                    && self.is_mutable()
+                    && value.is_empty()
             },
         }
     }
@@ -1081,11 +1082,11 @@ impl TextControlElement for HTMLInputElement {
     fn selection_api_applies(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text |
-                InputType::Search |
-                InputType::Url |
-                InputType::Tel |
-                InputType::Password
+            InputType::Text
+                | InputType::Search
+                | InputType::Url
+                | InputType::Tel
+                | InputType::Password
         )
     }
 
@@ -1098,29 +1099,29 @@ impl TextControlElement for HTMLInputElement {
     // rendered as a text control: file
     fn has_selectable_text(&self) -> bool {
         match self.input_type() {
-            InputType::Text |
-            InputType::Search |
-            InputType::Url |
-            InputType::Tel |
-            InputType::Password |
-            InputType::Email |
-            InputType::Date |
-            InputType::Month |
-            InputType::Week |
-            InputType::Time |
-            InputType::DatetimeLocal |
-            InputType::Number |
-            InputType::Color => true,
+            InputType::Text
+            | InputType::Search
+            | InputType::Url
+            | InputType::Tel
+            | InputType::Password
+            | InputType::Email
+            | InputType::Date
+            | InputType::Month
+            | InputType::Week
+            | InputType::Time
+            | InputType::DatetimeLocal
+            | InputType::Number
+            | InputType::Color => true,
 
-            InputType::Button |
-            InputType::Checkbox |
-            InputType::File |
-            InputType::Hidden |
-            InputType::Image |
-            InputType::Radio |
-            InputType::Range |
-            InputType::Reset |
-            InputType::Submit => false,
+            InputType::Button
+            | InputType::Checkbox
+            | InputType::File
+            | InputType::Hidden
+            | InputType::Image
+            | InputType::Radio
+            | InputType::Range
+            | InputType::Reset
+            | InputType::Submit => false,
         }
     }
 
@@ -1647,9 +1648,9 @@ fn in_same_group(
         return false;
     }
 
-    if other.input_type() != InputType::Radio ||
-        other.form_owner().as_deref() != owner ||
-        other.radio_group_name().as_ref() != group
+    if other.input_type() != InputType::Radio
+        || other.form_owner().as_deref() != owner
+        || other.radio_group_name().as_ref() != group
     {
         return false;
     }
@@ -1679,7 +1680,7 @@ impl HTMLInputElement {
     /// Steps range from 5.1 to 5.10 (specific to HTMLInputElement)
     pub fn form_datums(
         &self,
-        submitter: Option<FormSubmitter>,
+        submitter: Option<FormSubmitterElement>,
         encoding: Option<&'static Encoding>,
     ) -> Vec<FormDatum> {
         // 3.1: disabled state check is in get_unclean_dataset
@@ -1690,7 +1691,7 @@ impl HTMLInputElement {
         // Step 5.4
         let name = self.Name();
         let is_submitter = match submitter {
-            Some(FormSubmitter::InputElement(s)) => self == s,
+            Some(FormSubmitterElement::Input(s)) => self == s,
             _ => false,
         };
 
@@ -2034,14 +2035,14 @@ impl HTMLInputElement {
             },
             // The following inputs don't have a value sanitization algorithm.
             // See https://html.spec.whatwg.org/multipage/#value-sanitization-algorithm
-            InputType::Button |
-            InputType::Checkbox |
-            InputType::File |
-            InputType::Hidden |
-            InputType::Image |
-            InputType::Radio |
-            InputType::Reset |
-            InputType::Submit => (),
+            InputType::Button
+            | InputType::Checkbox
+            | InputType::File
+            | InputType::Hidden
+            | InputType::Image
+            | InputType::Radio
+            | InputType::Reset
+            | InputType::Submit => (),
         }
     }
 
@@ -2085,21 +2086,21 @@ impl HTMLInputElement {
                     .unwrap()
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
                     .filter(|input| {
-                        input.form_owner() == owner &&
-                            matches!(
+                        input.form_owner() == owner
+                            && matches!(
                                 input.input_type(),
-                                InputType::Text |
-                                    InputType::Search |
-                                    InputType::Url |
-                                    InputType::Tel |
-                                    InputType::Email |
-                                    InputType::Password |
-                                    InputType::Date |
-                                    InputType::Month |
-                                    InputType::Week |
-                                    InputType::Time |
-                                    InputType::DatetimeLocal |
-                                    InputType::Number
+                                InputType::Text
+                                    | InputType::Search
+                                    | InputType::Url
+                                    | InputType::Tel
+                                    | InputType::Email
+                                    | InputType::Password
+                                    | InputType::Date
+                                    | InputType::Month
+                                    | InputType::Week
+                                    | InputType::Time
+                                    | InputType::DatetimeLocal
+                                    | InputType::Number
                             )
                     });
 
@@ -2107,7 +2108,7 @@ impl HTMLInputElement {
                     // lazily test for > 1 submission-blocking inputs
                     return;
                 }
-                form.submit(SubmittedFrom::NotFromForm, FormSubmitter::FormElement(form));
+                form.submit(SubmittedFrom::NotFromForm, FormSubmitterElement::Form(form));
             },
         }
     }
@@ -2322,8 +2323,8 @@ impl VirtualMethods for HTMLInputElement {
                         let new_value_mode = self.value_mode();
                         match (&old_value_mode, old_idl_value.is_empty(), new_value_mode) {
                             // Step 1
-                            (&ValueMode::Value, false, ValueMode::Default) |
-                            (&ValueMode::Value, false, ValueMode::DefaultOn) => {
+                            (&ValueMode::Value, false, ValueMode::Default)
+                            | (&ValueMode::Value, false, ValueMode::DefaultOn) => {
                                 self.SetValue(old_idl_value)
                                     .expect("Failed to set input value on type change to a default ValueMode.");
                             },
@@ -2537,9 +2538,9 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
             }
-        } else if event.type_() == atom!("keydown") &&
-            !event.DefaultPrevented() &&
-            self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keydown")
+            && !event.DefaultPrevented()
+            && self.input_type().is_textual_or_password()
         {
             if let Some(keyevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
@@ -2562,9 +2563,9 @@ impl VirtualMethods for HTMLInputElement {
                     Nothing => (),
                 }
             }
-        } else if event.type_() == atom!("keypress") &&
-            !event.DefaultPrevented() &&
-            self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keypress")
+            && !event.DefaultPrevented()
+            && self.input_type().is_textual_or_password()
         {
             if event.IsTrusted() {
                 let window = window_from_node(self);
@@ -2579,10 +2580,10 @@ impl VirtualMethods for HTMLInputElement {
                         &window,
                     );
             }
-        } else if (event.type_() == atom!("compositionstart") ||
-            event.type_() == atom!("compositionupdate") ||
-            event.type_() == atom!("compositionend")) &&
-            self.input_type().is_textual_or_password()
+        } else if (event.type_() == atom!("compositionstart")
+            || event.type_() == atom!("compositionupdate")
+            || event.type_() == atom!("compositionend"))
+            && self.input_type().is_textual_or_password()
         {
             // TODO: Update DOM on start and continue
             // and generally do proper CompositionEvent handling.
@@ -2659,9 +2660,9 @@ impl Validatable for HTMLInputElement {
         match self.input_type() {
             InputType::Hidden | InputType::Button | InputType::Reset => false,
             _ => {
-                !(self.upcast::<Element>().disabled_state() ||
-                    (self.ReadOnly() && self.does_readonly_apply()) ||
-                    is_barred_by_datalist_ancestor(self.upcast()))
+                !(self.upcast::<Element>().disabled_state()
+                    || (self.ReadOnly() && self.does_readonly_apply())
+                    || is_barred_by_datalist_ancestor(self.upcast()))
             },
         }
     }
@@ -2670,26 +2671,26 @@ impl Validatable for HTMLInputElement {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
 
-        if validate_flags.contains(ValidationFlags::VALUE_MISSING) &&
-            self.suffers_from_being_missing(&value)
+        if validate_flags.contains(ValidationFlags::VALUE_MISSING)
+            && self.suffers_from_being_missing(&value)
         {
             failed_flags.insert(ValidationFlags::VALUE_MISSING);
         }
 
-        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH) &&
-            self.suffers_from_type_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH)
+            && self.suffers_from_type_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::TYPE_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH) &&
-            self.suffers_from_pattern_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH)
+            && self.suffers_from_pattern_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::PATTERN_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::BAD_INPUT) &&
-            self.suffers_from_bad_input(&value)
+        if validate_flags.contains(ValidationFlags::BAD_INPUT)
+            && self.suffers_from_bad_input(&value)
         {
             failed_flags.insert(ValidationFlags::BAD_INPUT);
         }
@@ -2699,9 +2700,9 @@ impl Validatable for HTMLInputElement {
         }
 
         if validate_flags.intersects(
-            ValidationFlags::RANGE_UNDERFLOW |
-                ValidationFlags::RANGE_OVERFLOW |
-                ValidationFlags::STEP_MISMATCH,
+            ValidationFlags::RANGE_UNDERFLOW
+                | ValidationFlags::RANGE_OVERFLOW
+                | ValidationFlags::STEP_MISMATCH,
         ) {
             failed_flags |= self.suffers_from_range_issues(&value);
         }
@@ -2821,7 +2822,7 @@ impl Activatable for HTMLInputElement {
                 if let Some(o) = self.form_owner() {
                     o.submit(
                         SubmittedFrom::NotFromForm,
-                        FormSubmitter::InputElement(self),
+                        FormSubmitterElement::Input(self),
                     )
                 }
             },

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -121,20 +121,20 @@ impl InputType {
     fn is_textual(&self) -> bool {
         matches!(
             *self,
-            InputType::Color
-                | InputType::Date
-                | InputType::DatetimeLocal
-                | InputType::Email
-                | InputType::Hidden
-                | InputType::Month
-                | InputType::Number
-                | InputType::Range
-                | InputType::Search
-                | InputType::Tel
-                | InputType::Text
-                | InputType::Time
-                | InputType::Url
-                | InputType::Week
+            InputType::Color |
+                InputType::Date |
+                InputType::DatetimeLocal |
+                InputType::Email |
+                InputType::Hidden |
+                InputType::Month |
+                InputType::Number |
+                InputType::Range |
+                InputType::Search |
+                InputType::Tel |
+                InputType::Text |
+                InputType::Time |
+                InputType::Url |
+                InputType::Week
         )
     }
 
@@ -369,28 +369,28 @@ impl HTMLInputElement {
     // https://html.spec.whatwg.org/multipage/#concept-input-apply
     fn value_mode(&self) -> ValueMode {
         match self.input_type() {
-            InputType::Submit
-            | InputType::Reset
-            | InputType::Button
-            | InputType::Image
-            | InputType::Hidden => ValueMode::Default,
+            InputType::Submit |
+            InputType::Reset |
+            InputType::Button |
+            InputType::Image |
+            InputType::Hidden => ValueMode::Default,
 
             InputType::Checkbox | InputType::Radio => ValueMode::DefaultOn,
 
-            InputType::Color
-            | InputType::Date
-            | InputType::DatetimeLocal
-            | InputType::Email
-            | InputType::Month
-            | InputType::Number
-            | InputType::Password
-            | InputType::Range
-            | InputType::Search
-            | InputType::Tel
-            | InputType::Text
-            | InputType::Time
-            | InputType::Url
-            | InputType::Week => ValueMode::Value,
+            InputType::Color |
+            InputType::Date |
+            InputType::DatetimeLocal |
+            InputType::Email |
+            InputType::Month |
+            InputType::Number |
+            InputType::Password |
+            InputType::Range |
+            InputType::Search |
+            InputType::Tel |
+            InputType::Text |
+            InputType::Time |
+            InputType::Url |
+            InputType::Week => ValueMode::Value,
 
             InputType::File => ValueMode::Filename,
         }
@@ -422,42 +422,42 @@ impl HTMLInputElement {
     fn does_readonly_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Email
-                | InputType::Password
-                | InputType::Date
-                | InputType::Month
-                | InputType::Week
-                | InputType::Time
-                | InputType::DatetimeLocal
-                | InputType::Number
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Email |
+                InputType::Password |
+                InputType::Date |
+                InputType::Month |
+                InputType::Week |
+                InputType::Time |
+                InputType::DatetimeLocal |
+                InputType::Number
         )
     }
 
     fn does_minmaxlength_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Email
-                | InputType::Password
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Email |
+                InputType::Password
         )
     }
 
     fn does_pattern_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Email
-                | InputType::Password
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Email |
+                InputType::Password
         )
     }
 
@@ -470,13 +470,13 @@ impl HTMLInputElement {
     fn does_value_as_number_apply(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Date
-                | InputType::Month
-                | InputType::Week
-                | InputType::Time
-                | InputType::DatetimeLocal
-                | InputType::Number
-                | InputType::Range
+            InputType::Date |
+                InputType::Month |
+                InputType::Week |
+                InputType::Time |
+                InputType::DatetimeLocal |
+                InputType::Number |
+                InputType::Range
         )
     }
 
@@ -780,18 +780,17 @@ impl HTMLInputElement {
             },
             // https://html.spec.whatwg.org/multipage/#file-upload-state-(type%3Dfile)%3Asuffering-from-being-missing
             InputType::File => {
-                self.Required()
-                    && self
-                        .filelist
+                self.Required() &&
+                    self.filelist
                         .get()
                         .map_or(true, |files| files.Length() == 0)
             },
             // https://html.spec.whatwg.org/multipage/#the-required-attribute%3Asuffering-from-being-missing
             _ => {
-                self.Required()
-                    && self.value_mode() == ValueMode::Value
-                    && self.is_mutable()
-                    && value.is_empty()
+                self.Required() &&
+                    self.value_mode() == ValueMode::Value &&
+                    self.is_mutable() &&
+                    value.is_empty()
             },
         }
     }
@@ -1082,11 +1081,11 @@ impl TextControlElement for HTMLInputElement {
     fn selection_api_applies(&self) -> bool {
         matches!(
             self.input_type(),
-            InputType::Text
-                | InputType::Search
-                | InputType::Url
-                | InputType::Tel
-                | InputType::Password
+            InputType::Text |
+                InputType::Search |
+                InputType::Url |
+                InputType::Tel |
+                InputType::Password
         )
     }
 
@@ -1099,29 +1098,29 @@ impl TextControlElement for HTMLInputElement {
     // rendered as a text control: file
     fn has_selectable_text(&self) -> bool {
         match self.input_type() {
-            InputType::Text
-            | InputType::Search
-            | InputType::Url
-            | InputType::Tel
-            | InputType::Password
-            | InputType::Email
-            | InputType::Date
-            | InputType::Month
-            | InputType::Week
-            | InputType::Time
-            | InputType::DatetimeLocal
-            | InputType::Number
-            | InputType::Color => true,
+            InputType::Text |
+            InputType::Search |
+            InputType::Url |
+            InputType::Tel |
+            InputType::Password |
+            InputType::Email |
+            InputType::Date |
+            InputType::Month |
+            InputType::Week |
+            InputType::Time |
+            InputType::DatetimeLocal |
+            InputType::Number |
+            InputType::Color => true,
 
-            InputType::Button
-            | InputType::Checkbox
-            | InputType::File
-            | InputType::Hidden
-            | InputType::Image
-            | InputType::Radio
-            | InputType::Range
-            | InputType::Reset
-            | InputType::Submit => false,
+            InputType::Button |
+            InputType::Checkbox |
+            InputType::File |
+            InputType::Hidden |
+            InputType::Image |
+            InputType::Radio |
+            InputType::Range |
+            InputType::Reset |
+            InputType::Submit => false,
         }
     }
 
@@ -1648,9 +1647,9 @@ fn in_same_group(
         return false;
     }
 
-    if other.input_type() != InputType::Radio
-        || other.form_owner().as_deref() != owner
-        || other.radio_group_name().as_ref() != group
+    if other.input_type() != InputType::Radio ||
+        other.form_owner().as_deref() != owner ||
+        other.radio_group_name().as_ref() != group
     {
         return false;
     }
@@ -2035,14 +2034,14 @@ impl HTMLInputElement {
             },
             // The following inputs don't have a value sanitization algorithm.
             // See https://html.spec.whatwg.org/multipage/#value-sanitization-algorithm
-            InputType::Button
-            | InputType::Checkbox
-            | InputType::File
-            | InputType::Hidden
-            | InputType::Image
-            | InputType::Radio
-            | InputType::Reset
-            | InputType::Submit => (),
+            InputType::Button |
+            InputType::Checkbox |
+            InputType::File |
+            InputType::Hidden |
+            InputType::Image |
+            InputType::Radio |
+            InputType::Reset |
+            InputType::Submit => (),
         }
     }
 
@@ -2086,21 +2085,21 @@ impl HTMLInputElement {
                     .unwrap()
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
                     .filter(|input| {
-                        input.form_owner() == owner
-                            && matches!(
+                        input.form_owner() == owner &&
+                            matches!(
                                 input.input_type(),
-                                InputType::Text
-                                    | InputType::Search
-                                    | InputType::Url
-                                    | InputType::Tel
-                                    | InputType::Email
-                                    | InputType::Password
-                                    | InputType::Date
-                                    | InputType::Month
-                                    | InputType::Week
-                                    | InputType::Time
-                                    | InputType::DatetimeLocal
-                                    | InputType::Number
+                                InputType::Text |
+                                    InputType::Search |
+                                    InputType::Url |
+                                    InputType::Tel |
+                                    InputType::Email |
+                                    InputType::Password |
+                                    InputType::Date |
+                                    InputType::Month |
+                                    InputType::Week |
+                                    InputType::Time |
+                                    InputType::DatetimeLocal |
+                                    InputType::Number
                             )
                     });
 
@@ -2323,8 +2322,8 @@ impl VirtualMethods for HTMLInputElement {
                         let new_value_mode = self.value_mode();
                         match (&old_value_mode, old_idl_value.is_empty(), new_value_mode) {
                             // Step 1
-                            (&ValueMode::Value, false, ValueMode::Default)
-                            | (&ValueMode::Value, false, ValueMode::DefaultOn) => {
+                            (&ValueMode::Value, false, ValueMode::Default) |
+                            (&ValueMode::Value, false, ValueMode::DefaultOn) => {
                                 self.SetValue(old_idl_value)
                                     .expect("Failed to set input value on type change to a default ValueMode.");
                             },
@@ -2538,9 +2537,9 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
             }
-        } else if event.type_() == atom!("keydown")
-            && !event.DefaultPrevented()
-            && self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keydown") &&
+            !event.DefaultPrevented() &&
+            self.input_type().is_textual_or_password()
         {
             if let Some(keyevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
@@ -2563,9 +2562,9 @@ impl VirtualMethods for HTMLInputElement {
                     Nothing => (),
                 }
             }
-        } else if event.type_() == atom!("keypress")
-            && !event.DefaultPrevented()
-            && self.input_type().is_textual_or_password()
+        } else if event.type_() == atom!("keypress") &&
+            !event.DefaultPrevented() &&
+            self.input_type().is_textual_or_password()
         {
             if event.IsTrusted() {
                 let window = window_from_node(self);
@@ -2580,10 +2579,10 @@ impl VirtualMethods for HTMLInputElement {
                         &window,
                     );
             }
-        } else if (event.type_() == atom!("compositionstart")
-            || event.type_() == atom!("compositionupdate")
-            || event.type_() == atom!("compositionend"))
-            && self.input_type().is_textual_or_password()
+        } else if (event.type_() == atom!("compositionstart") ||
+            event.type_() == atom!("compositionupdate") ||
+            event.type_() == atom!("compositionend")) &&
+            self.input_type().is_textual_or_password()
         {
             // TODO: Update DOM on start and continue
             // and generally do proper CompositionEvent handling.
@@ -2660,9 +2659,9 @@ impl Validatable for HTMLInputElement {
         match self.input_type() {
             InputType::Hidden | InputType::Button | InputType::Reset => false,
             _ => {
-                !(self.upcast::<Element>().disabled_state()
-                    || (self.ReadOnly() && self.does_readonly_apply())
-                    || is_barred_by_datalist_ancestor(self.upcast()))
+                !(self.upcast::<Element>().disabled_state() ||
+                    (self.ReadOnly() && self.does_readonly_apply()) ||
+                    is_barred_by_datalist_ancestor(self.upcast()))
             },
         }
     }
@@ -2671,26 +2670,26 @@ impl Validatable for HTMLInputElement {
         let mut failed_flags = ValidationFlags::empty();
         let value = self.Value();
 
-        if validate_flags.contains(ValidationFlags::VALUE_MISSING)
-            && self.suffers_from_being_missing(&value)
+        if validate_flags.contains(ValidationFlags::VALUE_MISSING) &&
+            self.suffers_from_being_missing(&value)
         {
             failed_flags.insert(ValidationFlags::VALUE_MISSING);
         }
 
-        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH)
-            && self.suffers_from_type_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::TYPE_MISMATCH) &&
+            self.suffers_from_type_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::TYPE_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH)
-            && self.suffers_from_pattern_mismatch(&value)
+        if validate_flags.contains(ValidationFlags::PATTERN_MISMATCH) &&
+            self.suffers_from_pattern_mismatch(&value)
         {
             failed_flags.insert(ValidationFlags::PATTERN_MISMATCH);
         }
 
-        if validate_flags.contains(ValidationFlags::BAD_INPUT)
-            && self.suffers_from_bad_input(&value)
+        if validate_flags.contains(ValidationFlags::BAD_INPUT) &&
+            self.suffers_from_bad_input(&value)
         {
             failed_flags.insert(ValidationFlags::BAD_INPUT);
         }
@@ -2700,9 +2699,9 @@ impl Validatable for HTMLInputElement {
         }
 
         if validate_flags.intersects(
-            ValidationFlags::RANGE_UNDERFLOW
-                | ValidationFlags::RANGE_OVERFLOW
-                | ValidationFlags::STEP_MISMATCH,
+            ValidationFlags::RANGE_UNDERFLOW |
+                ValidationFlags::RANGE_OVERFLOW |
+                ValidationFlags::STEP_MISMATCH,
         ) {
             failed_flags |= self.suffers_from_range_issues(&value);
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix clippy warning 
```
all variants have the same postfix: `Element`
``` 
for enum FormSubmitter. Naming problem is tough but in this case renaming is convenient, imho. The only uncertainty - can it break logging or some logic that dependents on string representation? I found that it used mostly as a wrapper for a html element but I could miss something. 

I aggregated clippy output before and after with `./mach cargo-clippy 2>&1 | rg 'warning:' | sort | uniq -c`. The diff is:
```
*** before	Wed Jul 17 18:05:02 2024
--- after	Wed Jul 17 18:30:14 2024
***************
*** 5,13 ****
     1 warning: `libservo` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p libservo` to apply 1 suggestion)
!    1 warning: `script` (lib) generated 47 warnings
     1 warning: `servoshell` (lib) generated 1 warning
-    1 warning: all variants have the same postfix: `Element`
     1 warning: all variants have the same postfix: `Error`
--- 5,12 ----
     1 warning: `libservo` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p libservo` to apply 1 suggestion)
!    1 warning: `script` (lib) generated 46 warnings
     1 warning: `servoshell` (lib) generated 1 warning
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500

<!-- Either: -->
- [X] These changes do not require tests because they only rename enum

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
