### PR TITLE
Less nesting in webgpu response

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2069,7 +2069,7 @@ where
         match request {
             FromScriptMsg::RequestAdapter(response_sender, options, ids) => match webgpu_chan {
                 None => {
-                    if let Err(e) = response_sender.send(Ok(WebGPUResponse::None)) {
+                    if let Err(e) = response_sender.send(WebGPUResponse::None) {
                         warn!("Failed to send request adapter message: {}", e)
                     }
                 },

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -152,7 +152,7 @@ use servo_config::{opts, pref};
 use servo_rand::{random, Rng, ServoRng, SliceRandom};
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use style_traits::CSSPixel;
-use webgpu::{self, WebGPU, WebGPURequest};
+use webgpu::{self, WebGPU, WebGPURequest, WebGPUResponse};
 use webrender::{RenderApi, RenderApiSender};
 use webrender_api::DocumentId;
 use webrender_traits::{WebRenderNetApi, WebRenderScriptApi, WebrenderExternalImageRegistry};
@@ -2069,7 +2069,7 @@ where
         match request {
             FromScriptMsg::RequestAdapter(response_sender, options, ids) => match webgpu_chan {
                 None => {
-                    if let Err(e) = response_sender.send(None) {
+                    if let Err(e) = response_sender.send(Ok(WebGPUResponse::None)) {
                         warn!("Failed to send request adapter message: {}", e)
                     }
                 },

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -12,7 +12,7 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
 use js::typedarray::{ArrayBuffer, ArrayBufferU8};
 use webgpu::wgc::device::HostMap;
-use webgpu::{WebGPU, WebGPUBuffer, WebGPURequest, WebGPUResponse, WebGPUResponseResult};
+use webgpu::{WebGPU, WebGPUBuffer, WebGPURequest, WebGPUResponse};
 
 use super::bindings::buffer_source::{create_new_external_array_buffer, HeapBufferSource};
 use crate::dom::bindings::cell::DomRefCell;
@@ -350,9 +350,9 @@ impl GPUBufferMethods for GPUBuffer {
 }
 
 impl AsyncWGPUListener for GPUBuffer {
-    fn handle_response(&self, response: WebGPUResponseResult, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>) {
         match response {
-            Ok(WebGPUResponse::BufferMapAsync(bytes)) => {
+            WebGPUResponse::BufferMapAsync(Ok(bytes)) => {
                 *self
                     .map_info
                     .borrow_mut()
@@ -365,12 +365,11 @@ impl AsyncWGPUListener for GPUBuffer {
                 promise.resolve_native(&());
                 self.state.set(GPUBufferState::Mapped);
             },
-            Ok(WebGPUResponse::None) => unreachable!("Failed to get a response for BufferMapAsync"),
-            Err(e) => {
+            WebGPUResponse::BufferMapAsync(Err(e)) => {
                 warn!("Could not map buffer({:?})", e);
                 promise.reject_error(Error::Abort);
             },
-            Ok(_) => unreachable!("GPUBuffer received wrong WebGPUResponse"),
+            _ => unreachable!("GPUBuffer received wrong WebGPUResponse"),
         }
         *self.map_promise.borrow_mut() = None;
     }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -1010,9 +1010,9 @@ impl GPUDeviceMethods for GPUDevice {
 }
 
 impl AsyncWGPUListener for GPUDevice {
-    fn handle_response(&self, response: Option<WebGPUResponseResult>, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: WebGPUResponseResult, promise: &Rc<Promise>) {
         match response {
-            Some(Ok(WebGPUResponse::PoppedErrorScope(result))) => match result {
+            Ok(WebGPUResponse::PoppedErrorScope(result)) => match result {
                 Ok(None) | Err(PopError::Lost) => promise.resolve_native(&None::<Option<GPUError>>),
                 Err(PopError::Empty) => promise.reject_error(Error::Operation),
                 Ok(Some(error)) => {

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -17,7 +17,7 @@ use webgpu::wgc::id::{BindGroupLayoutId, PipelineLayoutId};
 use webgpu::wgc::{
     binding_model as wgpu_bind, command as wgpu_com, pipeline as wgpu_pipe, resource as wgpu_res,
 };
-use webgpu::{self, wgt, PopError, WebGPU, WebGPURequest, WebGPUResponse, WebGPUResponseResult};
+use webgpu::{self, wgt, PopError, WebGPU, WebGPURequest, WebGPUResponse};
 
 use super::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use super::bindings::error::Fallible;
@@ -1010,9 +1010,9 @@ impl GPUDeviceMethods for GPUDevice {
 }
 
 impl AsyncWGPUListener for GPUDevice {
-    fn handle_response(&self, response: WebGPUResponseResult, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>) {
         match response {
-            Ok(WebGPUResponse::PoppedErrorScope(result)) => match result {
+            WebGPUResponse::PoppedErrorScope(result) => match result {
                 Ok(None) | Err(PopError::Lost) => promise.resolve_native(&None::<Option<GPUError>>),
                 Err(PopError::Empty) => promise.reject_error(Error::Operation),
                 Ok(Some(error)) => {

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -208,11 +208,11 @@ impl GPUQueueMethods for GPUQueue {
 impl AsyncWGPUListener for GPUQueue {
     fn handle_response(
         &self,
-        response: Option<Result<webgpu::WebGPUResponse, String>>,
+        response: Result<webgpu::WebGPUResponse, String>,
         promise: &Rc<Promise>,
     ) {
         match response {
-            Some(Ok(WebGPUResponse::SubmittedWorkDone)) => {
+            Ok(WebGPUResponse::SubmittedWorkDone) => {
                 promise.resolve_native(&());
             },
             _ => {

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -206,13 +206,9 @@ impl GPUQueueMethods for GPUQueue {
 }
 
 impl AsyncWGPUListener for GPUQueue {
-    fn handle_response(
-        &self,
-        response: Result<webgpu::WebGPUResponse, String>,
-        promise: &Rc<Promise>,
-    ) {
+    fn handle_response(&self, response: webgpu::WebGPUResponse, promise: &Rc<Promise>) {
         match response {
-            Ok(WebGPUResponse::SubmittedWorkDone) => {
+            WebGPUResponse::SubmittedWorkDone => {
                 promise.resolve_native(&());
             },
             _ => {

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -5,7 +5,7 @@
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use webgpu::{WebGPU, WebGPURequest, WebGPUResponse, WebGPUResponseResult, WebGPUShaderModule};
+use webgpu::{WebGPU, WebGPURequest, WebGPUResponse, WebGPUShaderModule};
 
 use super::gpu::AsyncWGPUListener;
 use super::gpucompilationinfo::GPUCompilationInfo;
@@ -89,9 +89,9 @@ impl GPUShaderModuleMethods for GPUShaderModule {
 }
 
 impl AsyncWGPUListener for GPUShaderModule {
-    fn handle_response(&self, response: WebGPUResponseResult, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>) {
         match response {
-            Ok(WebGPUResponse::CompilationInfo(info)) => {
+            WebGPUResponse::CompilationInfo(info) => {
                 let info = GPUCompilationInfo::from(&self.global(), info);
                 promise.resolve_native(&info);
             },

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -89,9 +89,9 @@ impl GPUShaderModuleMethods for GPUShaderModule {
 }
 
 impl AsyncWGPUListener for GPUShaderModule {
-    fn handle_response(&self, response: Option<WebGPUResponseResult>, promise: &Rc<Promise>) {
+    fn handle_response(&self, response: WebGPUResponseResult, promise: &Rc<Promise>) {
         match response {
-            Some(Ok(WebGPUResponse::CompilationInfo(info))) => {
+            Ok(WebGPUResponse::CompilationInfo(info)) => {
                 let info = GPUCompilationInfo::from(&self.global(), info);
                 promise.resolve_native(&info);
             },

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -257,7 +257,7 @@ pub enum ScriptMsg {
     MediaSessionEvent(PipelineId, MediaSessionEvent),
     /// Create a WebGPU Adapter instance
     RequestAdapter(
-        IpcSender<Option<WebGPUResponseResult>>,
+        IpcSender<WebGPUResponseResult>,
         wgc::instance::RequestAdapterOptions,
         SmallVec<[wgc::id::AdapterId; 4]>,
     ),

--- a/components/shared/script/script_msg.rs
+++ b/components/shared/script/script_msg.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use smallvec::SmallVec;
 use style_traits::CSSPixel;
-use webgpu::{wgc, WebGPU, WebGPUResponseResult};
+use webgpu::{wgc, WebGPU, WebGPUResponse};
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 
 use crate::{
@@ -257,7 +257,7 @@ pub enum ScriptMsg {
     MediaSessionEvent(PipelineId, MediaSessionEvent),
     /// Create a WebGPU Adapter instance
     RequestAdapter(
-        IpcSender<WebGPUResponseResult>,
+        IpcSender<WebGPUResponse>,
         wgc::instance::RequestAdapterOptions,
         SmallVec<[wgc::id::AdapterId; 4]>,
     ),

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -31,12 +31,12 @@ pub use {wgpu_core as wgc, wgpu_types as wgt};
 
 use crate::identity::*;
 use crate::render_commands::RenderCommand;
-use crate::{Error, ErrorFilter, WebGPUResponseResult, PRESENTATION_BUFFER_COUNT};
+use crate::{Error, ErrorFilter, WebGPUResponse, PRESENTATION_BUFFER_COUNT};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebGPURequest {
     BufferMapAsync {
-        sender: IpcSender<WebGPUResponseResult>,
+        sender: IpcSender<WebGPUResponse>,
         buffer_id: id::BufferId,
         device_id: id::DeviceId,
         host_map: HostMap,
@@ -126,7 +126,7 @@ pub enum WebGPURequest {
         program_id: id::ShaderModuleId,
         program: String,
         label: Option<String>,
-        sender: IpcSender<WebGPUResponseResult>,
+        sender: IpcSender<WebGPUResponse>,
     },
     CreateSwapChain {
         device_id: id::DeviceId,
@@ -182,12 +182,12 @@ pub enum WebGPURequest {
         device_id: id::DeviceId,
     },
     RequestAdapter {
-        sender: IpcSender<WebGPUResponseResult>,
+        sender: IpcSender<WebGPUResponse>,
         options: RequestAdapterOptions,
         ids: SmallVec<[id::AdapterId; 4]>,
     },
     RequestDevice {
-        sender: IpcSender<WebGPUResponseResult>,
+        sender: IpcSender<WebGPUResponse>,
         adapter_id: WebGPUAdapter,
         descriptor: wgt::DeviceDescriptor<Option<String>>,
         device_id: id::DeviceId,
@@ -280,7 +280,7 @@ pub enum WebGPURequest {
         data: IpcSharedMemory,
     },
     QueueOnSubmittedWorkDone {
-        sender: IpcSender<WebGPUResponseResult>,
+        sender: IpcSender<WebGPUResponse>,
         queue_id: id::QueueId,
     },
     PushErrorScope {
@@ -293,6 +293,6 @@ pub enum WebGPURequest {
     },
     PopErrorScope {
         device_id: id::DeviceId,
-        sender: IpcSender<WebGPUResponseResult>,
+        sender: IpcSender<WebGPUResponse>,
     },
 }

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -36,7 +36,7 @@ use crate::{Error, ErrorFilter, WebGPUResponseResult, PRESENTATION_BUFFER_COUNT}
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebGPURequest {
     BufferMapAsync {
-        sender: IpcSender<Option<WebGPUResponseResult>>,
+        sender: IpcSender<WebGPUResponseResult>,
         buffer_id: id::BufferId,
         device_id: id::DeviceId,
         host_map: HostMap,
@@ -126,7 +126,7 @@ pub enum WebGPURequest {
         program_id: id::ShaderModuleId,
         program: String,
         label: Option<String>,
-        sender: IpcSender<Option<WebGPUResponseResult>>,
+        sender: IpcSender<WebGPUResponseResult>,
     },
     CreateSwapChain {
         device_id: id::DeviceId,
@@ -182,12 +182,12 @@ pub enum WebGPURequest {
         device_id: id::DeviceId,
     },
     RequestAdapter {
-        sender: IpcSender<Option<WebGPUResponseResult>>,
+        sender: IpcSender<WebGPUResponseResult>,
         options: RequestAdapterOptions,
         ids: SmallVec<[id::AdapterId; 4]>,
     },
     RequestDevice {
-        sender: IpcSender<Option<WebGPUResponseResult>>,
+        sender: IpcSender<WebGPUResponseResult>,
         adapter_id: WebGPUAdapter,
         descriptor: wgt::DeviceDescriptor<Option<String>>,
         device_id: id::DeviceId,
@@ -280,7 +280,7 @@ pub enum WebGPURequest {
         data: IpcSharedMemory,
     },
     QueueOnSubmittedWorkDone {
-        sender: IpcSender<Option<WebGPUResponseResult>>,
+        sender: IpcSender<WebGPUResponseResult>,
         queue_id: id::QueueId,
     },
     PushErrorScope {
@@ -293,6 +293,6 @@ pub enum WebGPURequest {
     },
     PopErrorScope {
         device_id: id::DeviceId,
-        sender: IpcSender<Option<WebGPUResponseResult>>,
+        sender: IpcSender<WebGPUResponseResult>,
     },
 }

--- a/components/webgpu/ipc_messages/to_dom.rs
+++ b/components/webgpu/ipc_messages/to_dom.rs
@@ -55,26 +55,31 @@ impl ShaderCompilationInfo {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct Adapter {
+    pub adapter_info: wgt::AdapterInfo,
+    pub adapter_id: WebGPUAdapter,
+    pub features: wgt::Features,
+    pub limits: wgt::Limits,
+    pub channel: WebGPU,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Device {
+    pub device_id: WebGPUDevice,
+    pub queue_id: WebGPUQueue,
+    pub descriptor: wgt::DeviceDescriptor<Option<String>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum WebGPUResponse {
     /// WebGPU is disabled
     None,
-    RequestAdapter {
-        adapter_info: wgt::AdapterInfo,
-        adapter_id: WebGPUAdapter,
-        features: wgt::Features,
-        limits: wgt::Limits,
-        channel: WebGPU,
-    },
-    RequestDevice {
-        device_id: WebGPUDevice,
-        queue_id: WebGPUQueue,
-        descriptor: wgt::DeviceDescriptor<Option<String>>,
-    },
-    BufferMapAsync(IpcSharedMemory),
+    // TODO: use wgpu errors
+    Adapter(Result<Adapter, String>),
+    Device(Result<Device, String>),
+    BufferMapAsync(Result<IpcSharedMemory, String>),
     SubmittedWorkDone,
     PoppedErrorScope(Result<Option<Error>, PopError>),
     CompilationInfo(Option<ShaderCompilationInfo>),
 }
-
-pub type WebGPUResponseResult = Result<WebGPUResponse, String>;

--- a/components/webgpu/ipc_messages/to_dom.rs
+++ b/components/webgpu/ipc_messages/to_dom.rs
@@ -57,6 +57,8 @@ impl ShaderCompilationInfo {
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum WebGPUResponse {
+    /// WebGPU is disabled
+    None,
     RequestAdapter {
         adapter_info: wgt::AdapterInfo,
         adapter_id: WebGPUAdapter,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -29,6 +29,7 @@ use wgc::pipeline::ShaderModuleDescriptor;
 use wgc::resource::{BufferMapCallback, BufferMapOperation};
 use wgc::{gfx_select, id};
 use wgpu_core::command::RenderPassDescriptor;
+use wgpu_core::resource::BufferAccessResult;
 use wgt::InstanceDescriptor;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
@@ -36,8 +37,8 @@ use crate::gpu_error::ErrorScope;
 use crate::poll_thread::Poller;
 use crate::render_commands::apply_render_command;
 use crate::{
-    ComputePassId, Error, PopError, PresentationData, RenderPassId, Transmute, WebGPU,
-    WebGPUAdapter, WebGPUDevice, WebGPUMsg, WebGPUQueue, WebGPURequest, WebGPUResponse,
+    Adapter, ComputePassId, Device, Error, PopError, PresentationData, RenderPassId, Transmute,
+    WebGPU, WebGPUAdapter, WebGPUDevice, WebGPUMsg, WebGPUQueue, WebGPURequest, WebGPUResponse,
 };
 
 pub const PRESENTATION_BUFFER_COUNT: usize = 10;
@@ -183,37 +184,33 @@ impl WGPU {
                         let glob = Arc::clone(&self.global);
                         let resp_sender = sender.clone();
                         let token = self.poller.token();
-                        let callback = BufferMapCallback::from_rust(Box::from(move |result| {
-                            drop(token);
-                            match result {
-                                Ok(()) => {
-                                    let global = &glob;
-                                    let (slice_pointer, range_size) = gfx_select!(buffer_id =>
-                                                global.buffer_get_mapped_range(buffer_id, 0, None))
-                                    .unwrap();
-                                    // SAFETY: guarantee to be safe from wgpu
-                                    let data = unsafe {
-                                        slice::from_raw_parts(slice_pointer, range_size as usize)
-                                    };
+                        let callback = BufferMapCallback::from_rust(Box::from(
+                            move |result: BufferAccessResult| {
+                                drop(token);
+                                let response = result
+                                    .and_then(|_| {
+                                        let global = &glob;
+                                        let (slice_pointer, range_size) = gfx_select!(buffer_id =>
+                                            global.buffer_get_mapped_range(buffer_id, 0, None))
+                                        .unwrap();
+                                        // SAFETY: guarantee to be safe from wgpu
+                                        let data = unsafe {
+                                            slice::from_raw_parts(
+                                                slice_pointer,
+                                                range_size as usize,
+                                            )
+                                        };
 
-                                    if let Err(e) =
-                                        resp_sender.send(Ok(WebGPUResponse::BufferMapAsync(
-                                            IpcSharedMemory::from_bytes(data),
-                                        )))
-                                    {
-                                        warn!("Could not send BufferMapAsync Response ({})", e);
-                                    }
-                                },
-                                Err(_) => {
-                                    warn!("Could not map buffer({:?})", buffer_id);
-                                    if let Err(e) =
-                                        resp_sender.send(Err(String::from("Failed to map Buffer")))
-                                    {
-                                        warn!("Could not send BufferMapAsync Response ({})", e);
-                                    }
-                                },
-                            };
-                        }));
+                                        Ok(IpcSharedMemory::from_bytes(data))
+                                    })
+                                    .map_err(|e| e.to_string());
+                                if let Err(e) =
+                                    resp_sender.send(WebGPUResponse::BufferMapAsync(response))
+                                {
+                                    warn!("Could not send BufferMapAsync Response ({})", e);
+                                }
+                            },
+                        ));
 
                         let operation = BufferMapOperation {
                             host: host_map,
@@ -228,7 +225,9 @@ impl WGPU {
                         ));
                         self.poller.wake();
                         if let Err(ref e) = result {
-                            if let Err(w) = sender.send(Err(format!("{:?}", e))) {
+                            if let Err(w) =
+                                sender.send(WebGPUResponse::BufferMapAsync(Err(e.to_string())))
+                            {
                                 warn!("Failed to send BufferMapAsync Response ({:?})", w);
                             }
                         }
@@ -482,11 +481,11 @@ impl WGPU {
                         };
                         let (_, error) = gfx_select!(program_id =>
                             global.device_create_shader_module(device_id, &desc, source, Some(program_id)));
-                        if let Err(e) = sender.send(Ok(WebGPUResponse::CompilationInfo(
+                        if let Err(e) = sender.send(WebGPUResponse::CompilationInfo(
                             error
                                 .as_ref()
                                 .map(|e| crate::ShaderCompilationInfo::from(e, &program)),
-                        ))) {
+                        )) {
                             warn!("Failed to send WebGPUResponse::CompilationInfo {e:?}");
                         }
                         self.maybe_dispatch_wgpu_error(device_id, error);
@@ -668,38 +667,38 @@ impl WGPU {
                         options,
                         ids,
                     } => {
-                        let adapter_id = match self
+                        let global = &self.global;
+                        let response = self
                             .global
                             .request_adapter(&options, wgc::instance::AdapterInputs::IdSet(&ids))
-                        {
-                            Ok(id) => id,
-                            Err(w) => {
-                                if let Err(e) = sender.send(Err(format!("{:?}", w))) {
-                                    warn!(
-                                    "Failed to send response to WebGPURequest::RequestAdapter ({})",
-                                    e
-                                )
-                                }
-                                break;
-                            },
-                        };
-                        let adapter = WebGPUAdapter(adapter_id);
-                        self.adapters.push(adapter);
-                        let global = &self.global;
-                        // TODO: can we do this lazily
-                        let info =
-                            gfx_select!(adapter_id => global.adapter_get_info(adapter_id)).unwrap();
-                        let limits =
-                            gfx_select!(adapter_id => global.adapter_limits(adapter_id)).unwrap();
-                        let features =
-                            gfx_select!(adapter_id => global.adapter_features(adapter_id)).unwrap();
-                        if let Err(e) = sender.send(Ok(WebGPUResponse::RequestAdapter {
-                            adapter_info: info,
-                            adapter_id: adapter,
-                            features,
-                            limits,
-                            channel: WebGPU(self.sender.clone()),
-                        })) {
+                            .and_then(|adapter_id| {
+                                let adapter = WebGPUAdapter(adapter_id);
+                                self.adapters.push(adapter);
+                                // TODO: can we do this lazily
+                                let info =
+                                    gfx_select!(adapter_id => global.adapter_get_info(adapter_id))
+                                        .unwrap();
+                                let limits =
+                                    gfx_select!(adapter_id => global.adapter_limits(adapter_id))
+                                        .unwrap();
+                                let features =
+                                    gfx_select!(adapter_id => global.adapter_features(adapter_id))
+                                        .unwrap();
+                                Ok(Adapter {
+                                    adapter_info: info,
+                                    adapter_id: adapter,
+                                    features,
+                                    limits,
+                                    channel: WebGPU(self.sender.clone()),
+                                })
+                            })
+                            .map_err(|e| e.to_string());
+
+                        if response.is_err() {
+                            break;
+                        }
+
+                        if let Err(e) = sender.send(WebGPUResponse::Adapter(response)) {
                             warn!(
                                 "Failed to send response to WebGPURequest::RequestAdapter ({})",
                                 e
@@ -719,24 +718,23 @@ impl WGPU {
                             required_limits: descriptor.required_limits.clone(),
                         };
                         let global = &self.global;
-                        let (device_id, queue_id) = match gfx_select!(device_id => global.adapter_request_device(
+                        let (device_id, queue_id, error) = gfx_select!(device_id => global.adapter_request_device(
                             adapter_id.0,
                             &desc,
                             None,
                             Some(device_id),
                             Some(device_id.transmute()),
-                        )) {
-                            (_, _, Some(e)) => {
-                                if let Err(w) = sender.send(Err(format!("{:?}", e))) {
-                                    warn!(
+                        ));
+                        if let Some(e) = error {
+                            if let Err(e) = sender.send(WebGPUResponse::Device(Err(e.to_string())))
+                            {
+                                warn!(
                                     "Failed to send response to WebGPURequest::RequestDevice ({})",
-                                    w
+                                    e
                                 )
-                                }
-                                break;
-                            },
-                            (device_id, queue_id, None) => (device_id, queue_id),
-                        };
+                            }
+                            break;
+                        }
                         let device = WebGPUDevice(device_id);
                         let queue = WebGPUQueue(queue_id);
                         {
@@ -782,11 +780,11 @@ impl WGPU {
                                 }
                             }));
                         gfx_select!(device_id => global.device_set_device_lost_closure(device_id, callback));
-                        if let Err(e) = sender.send(Ok(WebGPUResponse::RequestDevice {
+                        if let Err(e) = sender.send(WebGPUResponse::Device(Ok(Device {
                             device_id: device,
                             queue_id: queue,
                             descriptor,
-                        })) {
+                        }))) {
                             warn!(
                                 "Failed to send response to WebGPURequest::RequestDevice ({})",
                                 e
@@ -1237,7 +1235,7 @@ impl WGPU {
                         let token = self.poller.token();
                         let callback = SubmittedWorkDoneClosure::from_rust(Box::from(move || {
                             drop(token);
-                            if let Err(e) = sender.send(Ok(WebGPUResponse::SubmittedWorkDone)) {
+                            if let Err(e) = sender.send(WebGPUResponse::SubmittedWorkDone) {
                                 warn!("Could not send SubmittedWorkDone Response ({})", e);
                             }
                         }));
@@ -1377,26 +1375,24 @@ impl WGPU {
                             .expect("Device should not be dropped by this point");
                         if let Some(error_scope_stack) = &mut device_scope.error_scope_stack {
                             if let Some(error_scope) = error_scope_stack.pop() {
-                                if let Err(e) =
-                                    sender.send(Ok(WebGPUResponse::PoppedErrorScope(Ok(
-                                        // TODO: Do actual selection instead of selecting first error
-                                        error_scope.errors.first().cloned(),
-                                    ))))
-                                {
+                                if let Err(e) = sender.send(WebGPUResponse::PoppedErrorScope(Ok(
+                                    // TODO: Do actual selection instead of selecting first error
+                                    error_scope.errors.first().cloned(),
+                                ))) {
                                     warn!(
                                         "Unable to send {:?} to poperrorscope: {e:?}",
                                         error_scope.errors
                                     );
                                 }
-                            } else if let Err(e) = sender
-                                .send(Ok(WebGPUResponse::PoppedErrorScope(Err(PopError::Empty))))
+                            } else if let Err(e) =
+                                sender.send(WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)))
                             {
                                 warn!("Unable to send PopError::Empty: {e:?}");
                             }
                         } else {
                             // device lost
-                            if let Err(e) = sender
-                                .send(Ok(WebGPUResponse::PoppedErrorScope(Err(PopError::Lost))))
+                            if let Err(e) =
+                                sender.send(WebGPUResponse::PoppedErrorScope(Err(PopError::Lost)))
                             {
                                 warn!("Unable to send PopError::Lost due {e:?}");
                             }

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -197,17 +197,17 @@ impl WGPU {
                                     };
 
                                     if let Err(e) =
-                                        resp_sender.send(Some(Ok(WebGPUResponse::BufferMapAsync(
+                                        resp_sender.send(Ok(WebGPUResponse::BufferMapAsync(
                                             IpcSharedMemory::from_bytes(data),
-                                        ))))
+                                        )))
                                     {
                                         warn!("Could not send BufferMapAsync Response ({})", e);
                                     }
                                 },
                                 Err(_) => {
                                     warn!("Could not map buffer({:?})", buffer_id);
-                                    if let Err(e) = resp_sender
-                                        .send(Some(Err(String::from("Failed to map Buffer"))))
+                                    if let Err(e) =
+                                        resp_sender.send(Err(String::from("Failed to map Buffer")))
                                     {
                                         warn!("Could not send BufferMapAsync Response ({})", e);
                                     }
@@ -228,7 +228,7 @@ impl WGPU {
                         ));
                         self.poller.wake();
                         if let Err(ref e) = result {
-                            if let Err(w) = sender.send(Some(Err(format!("{:?}", e)))) {
+                            if let Err(w) = sender.send(Err(format!("{:?}", e))) {
                                 warn!("Failed to send BufferMapAsync Response ({:?})", w);
                             }
                         }
@@ -482,11 +482,11 @@ impl WGPU {
                         };
                         let (_, error) = gfx_select!(program_id =>
                             global.device_create_shader_module(device_id, &desc, source, Some(program_id)));
-                        if let Err(e) = sender.send(Some(Ok(WebGPUResponse::CompilationInfo(
+                        if let Err(e) = sender.send(Ok(WebGPUResponse::CompilationInfo(
                             error
                                 .as_ref()
                                 .map(|e| crate::ShaderCompilationInfo::from(e, &program)),
-                        )))) {
+                        ))) {
                             warn!("Failed to send WebGPUResponse::CompilationInfo {e:?}");
                         }
                         self.maybe_dispatch_wgpu_error(device_id, error);
@@ -674,7 +674,7 @@ impl WGPU {
                         {
                             Ok(id) => id,
                             Err(w) => {
-                                if let Err(e) = sender.send(Some(Err(format!("{:?}", w)))) {
+                                if let Err(e) = sender.send(Err(format!("{:?}", w))) {
                                     warn!(
                                     "Failed to send response to WebGPURequest::RequestAdapter ({})",
                                     e
@@ -693,13 +693,13 @@ impl WGPU {
                             gfx_select!(adapter_id => global.adapter_limits(adapter_id)).unwrap();
                         let features =
                             gfx_select!(adapter_id => global.adapter_features(adapter_id)).unwrap();
-                        if let Err(e) = sender.send(Some(Ok(WebGPUResponse::RequestAdapter {
+                        if let Err(e) = sender.send(Ok(WebGPUResponse::RequestAdapter {
                             adapter_info: info,
                             adapter_id: adapter,
                             features,
                             limits,
                             channel: WebGPU(self.sender.clone()),
-                        }))) {
+                        })) {
                             warn!(
                                 "Failed to send response to WebGPURequest::RequestAdapter ({})",
                                 e
@@ -727,7 +727,7 @@ impl WGPU {
                             Some(device_id.transmute()),
                         )) {
                             (_, _, Some(e)) => {
-                                if let Err(w) = sender.send(Some(Err(format!("{:?}", e)))) {
+                                if let Err(w) = sender.send(Err(format!("{:?}", e))) {
                                     warn!(
                                     "Failed to send response to WebGPURequest::RequestDevice ({})",
                                     w
@@ -782,11 +782,11 @@ impl WGPU {
                                 }
                             }));
                         gfx_select!(device_id => global.device_set_device_lost_closure(device_id, callback));
-                        if let Err(e) = sender.send(Some(Ok(WebGPUResponse::RequestDevice {
+                        if let Err(e) = sender.send(Ok(WebGPUResponse::RequestDevice {
                             device_id: device,
                             queue_id: queue,
                             descriptor,
-                        }))) {
+                        })) {
                             warn!(
                                 "Failed to send response to WebGPURequest::RequestDevice ({})",
                                 e
@@ -1237,8 +1237,7 @@ impl WGPU {
                         let token = self.poller.token();
                         let callback = SubmittedWorkDoneClosure::from_rust(Box::from(move || {
                             drop(token);
-                            if let Err(e) = sender.send(Some(Ok(WebGPUResponse::SubmittedWorkDone)))
-                            {
+                            if let Err(e) = sender.send(Ok(WebGPUResponse::SubmittedWorkDone)) {
                                 warn!("Could not send SubmittedWorkDone Response ({})", e);
                             }
                         }));
@@ -1379,26 +1378,26 @@ impl WGPU {
                         if let Some(error_scope_stack) = &mut device_scope.error_scope_stack {
                             if let Some(error_scope) = error_scope_stack.pop() {
                                 if let Err(e) =
-                                    sender.send(Some(Ok(WebGPUResponse::PoppedErrorScope(Ok(
+                                    sender.send(Ok(WebGPUResponse::PoppedErrorScope(Ok(
                                         // TODO: Do actual selection instead of selecting first error
                                         error_scope.errors.first().cloned(),
-                                    )))))
+                                    ))))
                                 {
                                     warn!(
                                         "Unable to send {:?} to poperrorscope: {e:?}",
                                         error_scope.errors
                                     );
                                 }
-                            } else if let Err(e) = sender.send(Some(Ok(
-                                WebGPUResponse::PoppedErrorScope(Err(PopError::Empty)),
-                            ))) {
+                            } else if let Err(e) = sender
+                                .send(Ok(WebGPUResponse::PoppedErrorScope(Err(PopError::Empty))))
+                            {
                                 warn!("Unable to send PopError::Empty: {e:?}");
                             }
                         } else {
                             // device lost
-                            if let Err(e) = sender.send(Some(Ok(WebGPUResponse::PoppedErrorScope(
-                                Err(PopError::Lost),
-                            )))) {
+                            if let Err(e) = sender
+                                .send(Ok(WebGPUResponse::PoppedErrorScope(Err(PopError::Lost))))
+                            {
                                 warn!("Unable to send PopError::Lost due {e:?}");
                             }
                         }


### PR DESCRIPTION
This PR only contains refactor (no changes to expectation changes needed). request{Device, Adapter} and #32621 will be worked on as a followup.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32766
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
