### PR TITLE
Implement the `aspect-ratio` property for replaced elements

### DIFF
--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
@@ -1,10 +1,4 @@
 [box-sizing-dimensions.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
@@ -1,0 +1,18 @@
+[box-sizing-dimensions.html]
+  [.item 1]
+    expected: FAIL
+
+  [.item 2]
+    expected: FAIL
+
+  [.item 5]
+    expected: FAIL
+
+  [.item 6]
+    expected: FAIL
+
+  [.item 7]
+    expected: FAIL
+
+  [.item 8]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
@@ -1,25 +1,4 @@
 [box-sizing-squashed.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 7]
-    expected: FAIL
-
   [.item 10]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
@@ -1,0 +1,39 @@
+[box-sizing-squashed.html]
+  [.item 1]
+    expected: FAIL
+
+  [.item 2]
+    expected: FAIL
+
+  [.item 4]
+    expected: FAIL
+
+  [.item 6]
+    expected: FAIL
+
+  [.item 8]
+    expected: FAIL
+
+  [.item 5]
+    expected: FAIL
+
+  [.item 7]
+    expected: FAIL
+
+  [.item 10]
+    expected: FAIL
+
+  [.item 12]
+    expected: FAIL
+
+  [.item 13]
+    expected: FAIL
+
+  [.item 14]
+    expected: FAIL
+
+  [.item 15]
+    expected: FAIL
+
+  [.item 16]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-015.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-015.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-016.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-016.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-003.html.ini
@@ -1,2 +1,0 @@
-[grid-aspect-ratio-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-004.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-004.html.ini
@@ -1,2 +1,0 @@
-[grid-aspect-ratio-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-001.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-002.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-003.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-009.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-009.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-012.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-012.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-024.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-024.html.ini
@@ -1,0 +1,2 @@
+[replaced-element-024.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-025.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-025.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-025.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-026.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-026.html.ini
@@ -1,0 +1,2 @@
+[replaced-element-026.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-027.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-027.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-027.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-028.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-028.html.ini
@@ -1,0 +1,3 @@
+[replaced-element-028.html]
+  [CSS aspect-ratio: img]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-031.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-031.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-031.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-032.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-032.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-032.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-033.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-033.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-033.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-036.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-036.html.ini
@@ -1,6 +1,0 @@
-[replaced-element-036.html]
-  [display:block img should be 200px high]
-    expected: FAIL
-
-  [display:inline-block img should be 200px high]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-dynamic-aspect-ratio.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-dynamic-aspect-ratio.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-dynamic-aspect-ratio.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-dimensions.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-dimensions.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS aspect-ratio: uses content box when "auto" is present and box-sizing dimensions when it is absent</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content='CSS aspect-ratio: uses content box when "auto" is present and box-sizing dimensions when it is absent.'>
+<style>
+img {
+    border: 20px solid blue;
+    width: 100px;
+    height: auto;
+}
+
+.aspect {
+    aspect-ratio: 2 / 1;
+}
+
+.aspect-auto {
+    aspect-ratio: auto 2 / 1;
+}
+
+.border-box {
+    box-sizing: border-box;
+}
+
+.non-replaced {
+    background: green;
+    border: 20px solid blue;
+    width: 100px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.item')">
+
+<img class="item aspect" src="./support/20x50-green.png" width="20" height="50" data-expected-width="140" data-expected-height="90">
+
+<img class="item aspect border-box" src="./support/20x50-green.png" width="20" height="50" data-expected-width="100" data-expected-height="50">
+
+<img class="item aspect-auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="140" data-expected-height="290">
+
+<img class="item aspect-auto border-box" src="./support/20x50-green.png" width="20" height="50" data-expected-width="100" data-expected-height="190">
+
+<div class="item non-replaced aspect" data-expected-width="140" data-expected-height="90"></div>
+
+<div class="item non-replaced aspect border-box" data-expected-width="100" data-expected-height="50"></div>
+
+<div class="item non-replaced aspect-auto" data-expected-width="140" data-expected-height="90"></div>
+
+<div class="item non-replaced aspect-auto border-box" data-expected-width="100" data-expected-height="70"></div>

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-squashed.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-squashed.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS aspect-ratio: correct ratio maintained when box-sizing: border-box and one axis is clamped to 0</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content='CSS aspect-ratio: correct ratio maintained when box-sizing: border-box and one axis is clamped to 0.'>
+<style>
+.item {
+    box-sizing: border-box;
+    border: 20px solid blue;
+}
+
+.horizontal {
+    aspect-ratio: 2 / 1;
+}
+
+.vertical {
+    aspect-ratio: 1 / 2;
+}
+
+.non-replaced {
+    background: green;
+    /* Break the items apart to make them individually distinguishable */
+    margin-bottom: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.item')">
+
+<img class="item horizontal" style="width: 50px; height: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="50" data-expected-height="40">
+
+<img class="item horizontal"  style="width: auto; height: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="80" data-expected-height="40">
+
+<img class="item horizontal" style="max-width: 50px; height: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="40">
+
+<img class="item horizontal" style="width: auto; max-height: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="80" data-expected-height="40">
+
+<img class="item vertical" style="height: 50px; width: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="50">
+
+<img class="item vertical"  style="height: auto; width: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="80">
+
+<img class="item vertical" style="max-height: 50px; width: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="50">
+
+<img class="item vertical" style="height: auto; max-width: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="80">
+
+<div class="non-replaced item horizontal" style="width: 50px; height: auto" width="20" height="50" data-expected-width="50" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal"  style="width: auto; height: 20px" width="20" height="50" data-expected-width="80" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal" style="max-width: 50px; height: auto" width="20" height="50" data-expected-width="50" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal" style="width: auto; max-height: 20px" width="20" height="50" data-expected-width="80" data-expected-height="40"></div>
+
+<div class="non-replaced item vertical" style="height: 50px; width: auto" width="20" height="50" data-expected-width="40" data-expected-height="50"></div>
+
+<div class="non-replaced item vertical"  style="height: auto; width: 20px" width="20" height="50" data-expected-width="40" data-expected-height="80"></div>
+
+<div class="non-replaced item vertical" style="max-height: 50px; width: auto" width="20" height="50" data-expected-width="40" data-expected-height="50"></div>
+
+<div class="non-replaced item vertical" style="height: auto; max-width: 20px" width="20" height="50" data-expected-width="40" data-expected-height="80"></div>


### PR DESCRIPTION
First step towards fully implementing `aspect-ratio`. This is probably the easy part since replaced elements are already known to have an intrinsic aspect ratio and treated as such.

This PR touches the same code as #32777 and therefore depends on it.

This will require the `aspect-ratio` property to be enabled for layout 2020 in Stylo--I currently have it pointed to my fork which does so.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
