### PR TITLE
layout: Reduce the complexity of `FlexLine::layout`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3406,6 +3406,7 @@ dependencies = [
  "html5ever",
  "icu_segmenter",
  "ipc-channel",
+ "itertools 0.13.0",
  "lazy_static",
  "log",
  "net_traits",

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -27,6 +27,7 @@ fonts_traits = { workspace = true }
 html5ever = { workspace = true }
 icu_segmenter = { workspace = true }
 ipc-channel = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 net_traits = { workspace = true }
 parking_lot = { workspace = true }


### PR DESCRIPTION
Instead of a complex combination of iterators, use a flatter iteration
design when laying out a flex line.

Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>
Co-authored-by: Delan Azabani <dazabani@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
