### PR TITLE
Upgrade stylo to 2024-07-16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5888,7 +5888,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "static_assertions",
 ]
@@ -6029,7 +6029,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 
 [[package]]
 name = "strict-num"
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6125,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "lazy_static",
 ]
@@ -6133,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "darling",
  "derive_common",
@@ -6164,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -6514,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6527,7 +6527,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#eceb838e855e3b73a28df602b69494899f6d168b"
 dependencies = [
  "darling",
  "derive_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1418,6 +1418,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "dom"
+version = "0.0.1"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3588,7 +3596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3760,13 +3768,14 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "accountable-refcell",
  "app_units",
  "content-security-policy",
  "crossbeam-channel",
  "cssparser",
+ "dom",
  "euclid",
  "http",
  "indexmap",
@@ -4248,12 +4257,6 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nohash-hasher"
@@ -5210,6 +5213,7 @@ dependencies = [
  "data-url",
  "deny_public_fields",
  "devtools_traits",
+ "dom",
  "dom_struct",
  "domobject_derive",
  "embedder_traits",
@@ -5399,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -5687,9 +5691,8 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
- "nodrop",
  "serde",
  "stable_deref_trait",
 ]
@@ -5697,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5885,7 +5888,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "static_assertions",
 ]
@@ -6026,7 +6029,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 
 [[package]]
 name = "strict-num"
@@ -6063,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6072,6 +6075,7 @@ dependencies = [
  "byteorder",
  "cssparser",
  "derive_more",
+ "dom",
  "encoding_rs",
  "euclid",
  "fxhash",
@@ -6121,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "lazy_static",
 ]
@@ -6129,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "darling",
  "derive_common",
@@ -6160,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -6510,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6523,7 +6527,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-05-31#f6cb33f86468ba272d5329f64f78a75df8e9fcbe"
+source = "git+https://github.com/servo/stylo?branch=upgrade-squash#ec9d7fb1b9ac5cb617e8602087606e72f89b5ef1"
 dependencies = [
  "darling",
  "derive_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ keyboard-types = "0.7"
 lazy_static = "1.5"
 libc = "0.2"
 log = "0.4"
-malloc_size_of = { git = "https://github.com/servo/stylo", branch = "upgrade-squash", features = ["servo"] }
+malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2024-07-16", features = ["servo"] }
 malloc_size_of_derive = "0.1"
 mime = "0.3.13"
 mime_guess = "2.0.5"
@@ -97,31 +97,31 @@ rustls = { version = "0.21.12", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 serde = "1.0.204"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
-servo_atoms = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
-size_of_test = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
+servo_atoms = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
+size_of_test = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 sparkle = "0.1.26"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", branch = "upgrade-squash", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
-style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "upgrade-squash" }
-style_traits = { git = "https://github.com/servo/stylo", branch = "upgrade-squash", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "2024-07-16", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
+style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "2024-07-16" }
+style_traits = { git = "https://github.com/servo/stylo", branch = "2024-07-16", features = ["servo"] }
 surfman = { version = "0.9", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
-to_shmem = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
+to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 tokio = "1"
 tokio-rustls = "0.24"
 tungstenite = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ keyboard-types = "0.7"
 lazy_static = "1.5"
 libc = "0.2"
 log = "0.4"
-malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2024-05-31", features = ["servo"] }
+malloc_size_of = { git = "https://github.com/servo/stylo", branch = "upgrade-squash", features = ["servo"] }
 malloc_size_of_derive = "0.1"
 mime = "0.3.13"
 mime_guess = "2.0.5"
@@ -97,30 +97,31 @@ rustls = { version = "0.21.12", features = ["dangerous_configuration"] }
 rustls-pemfile = "1.0.4"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
+selectors = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
 serde = "1.0.204"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
-servo_atoms = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
-size_of_test = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
+servo_atoms = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
+size_of_test = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
 smallbitvec = "2.5.3"
 smallvec = "1.13"
 sparkle = "0.1.26"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
-style = { git = "https://github.com/servo/stylo", branch = "2024-05-31", features = ["servo"] }
-style_config = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
-style_traits = { git = "https://github.com/servo/stylo", branch = "2024-05-31", features = ["servo"] }
+style = { git = "https://github.com/servo/stylo", branch = "upgrade-squash", features = ["servo"] }
+style_config = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
+style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "upgrade-squash" }
+style_traits = { git = "https://github.com/servo/stylo", branch = "upgrade-squash", features = ["servo"] }
 surfman = { version = "0.9", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
-to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-05-31" }
+to_shmem = { git = "https://github.com/servo/stylo", branch = "upgrade-squash" }
 tokio = "1"
 tokio-rustls = "0.24"
 tungstenite = "0.20"

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -3007,15 +3007,15 @@ pub trait ISizeAndMarginsComputer {
                 ) => {
                     // servo_left, servo_right, and servo_center are used to implement
                     // the "align descendants" rule in HTML5 § 14.2.
-                    if block_align == TextAlign::ServoCenter {
+                    if block_align == TextAlign::MozCenter {
                         // Ignore any existing margins, and make the inline-start and
                         // inline-end margins equal.
                         let margin = (available_inline_size - inline_size).scale_by(0.5);
                         (margin, inline_size, margin)
                     } else {
                         let ignore_end_margin = match block_align {
-                            TextAlign::ServoLeft => block_mode.is_bidi_ltr(),
-                            TextAlign::ServoRight => !block_mode.is_bidi_ltr(),
+                            TextAlign::MozLeft => block_mode.is_bidi_ltr(),
+                            TextAlign::MozRight => !block_mode.is_bidi_ltr(),
                             _ => parent_has_same_direction,
                         };
                         if ignore_end_margin {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1035,13 +1035,13 @@ impl InlineFlow {
         let is_ltr = fragments.fragments[0].style().writing_mode.is_bidi_ltr();
         let line_align = match (line_align, is_ltr) {
             (TextAlign::Left, true) |
-            (TextAlign::ServoLeft, true) |
+            (TextAlign::MozLeft, true) |
             (TextAlign::Right, false) |
-            (TextAlign::ServoRight, false) => TextAlign::Start,
+            (TextAlign::MozRight, false) => TextAlign::Start,
             (TextAlign::Left, false) |
-            (TextAlign::ServoLeft, false) |
+            (TextAlign::MozLeft, false) |
             (TextAlign::Right, true) |
-            (TextAlign::ServoRight, true) => TextAlign::End,
+            (TextAlign::MozRight, true) => TextAlign::End,
             _ => line_align,
         };
 
@@ -1053,11 +1053,11 @@ impl InlineFlow {
                 InlineFlow::justify_inline_fragments(fragments, line, slack_inline_size)
             },
             TextAlign::Justify | TextAlign::Start => {},
-            TextAlign::Center | TextAlign::ServoCenter => {
+            TextAlign::Center | TextAlign::MozCenter => {
                 inline_start_position_for_fragment += slack_inline_size.scale_by(0.5)
             },
             TextAlign::End => inline_start_position_for_fragment += slack_inline_size,
-            TextAlign::Left | TextAlign::ServoLeft | TextAlign::Right | TextAlign::ServoRight => {
+            TextAlign::Left | TextAlign::MozLeft | TextAlign::Right | TextAlign::MozRight => {
                 unreachable!()
             },
         }

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -932,16 +932,16 @@ impl<'a, 'b> InlineFormattingContextState<'a, 'b> {
 
         let text_align = match text_align_keyword {
             TextAlignKeyword::Start => TextAlign::Start,
-            TextAlignKeyword::Center | TextAlignKeyword::ServoCenter => TextAlign::Center,
+            TextAlignKeyword::Center | TextAlignKeyword::MozCenter => TextAlign::Center,
             TextAlignKeyword::End => TextAlign::End,
-            TextAlignKeyword::Left | TextAlignKeyword::ServoLeft => {
+            TextAlignKeyword::Left | TextAlignKeyword::MozLeft => {
                 if style.writing_mode.line_left_is_inline_start() {
                     TextAlign::Start
                 } else {
                     TextAlign::End
                 }
             },
-            TextAlignKeyword::Right | TextAlignKeyword::ServoRight => {
+            TextAlignKeyword::Right | TextAlignKeyword::MozRight => {
                 if style.writing_mode.line_left_is_inline_start() {
                     TextAlign::End
                 } else {

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -1478,13 +1478,9 @@ fn justify_self_alignment(containing_block: &ContainingBlock, free_space: Au) ->
     let style = containing_block.style;
     debug_assert!(free_space >= Au::zero());
     match style.clone_text_align() {
-        TextAlignKeyword::ServoCenter => free_space / 2,
-        TextAlignKeyword::ServoLeft if !style.writing_mode.line_left_is_inline_start() => {
-            free_space
-        },
-        TextAlignKeyword::ServoRight if style.writing_mode.line_left_is_inline_start() => {
-            free_space
-        },
+        TextAlignKeyword::MozCenter => free_space / 2,
+        TextAlignKeyword::MozLeft if !style.writing_mode.line_left_is_inline_start() => free_space,
+        TextAlignKeyword::MozRight if style.writing_mode.line_left_is_inline_start() => free_space,
         _ => Au::zero(),
     }
 }

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -605,6 +605,7 @@ impl From<stylo::Display> for Display {
                 is_list_item: packed.is_list_item(),
             },
             stylo::DisplayInside::Flex => DisplayInside::Flex,
+            stylo::DisplayInside::Grid => todo!("Grid support is not yet implemented."),
 
             // These should not be values of DisplayInside, but oh well
             stylo::DisplayInside::None => return Display::None,

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -102,6 +102,7 @@ servo_url = { path = "../url" }
 smallvec = { workspace = true, features = ["union"] }
 sparkle = { workspace = true }
 style = { workspace = true }
+style_dom = { workspace = true }
 style_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -58,7 +58,7 @@ use style::stylesheets::{CssRuleType, UrlExtraData};
 use style::values::generics::NonNegative;
 use style::values::{computed, specified, AtomIdent, AtomString, CSSFloat};
 use style::{dom_apis, thread_state, CaseSensitivityExt};
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 use xml5ever::serialize as xmlSerialize;
 use xml5ever::serialize::TraversalScope::{
     ChildrenOnly as XmlChildrenOnly, IncludeNode as XmlIncludeNode,

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 use dom_struct::dom_struct;
 use html5ever::{local_name, namespace_url, LocalName, Prefix};
 use js::rust::HandleObject;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -11,7 +11,7 @@ use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
 use js::rust::HandleObject;
 use script_layout_interface::QueryMsg;
 use style::attr::AttrValue;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -7,7 +7,7 @@ use std::default::Default;
 use dom_struct::dom_struct;
 use html5ever::{local_name, LocalName, Prefix};
 use js::rust::HandleObject;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -20,7 +20,7 @@ use servo_atoms::Atom;
 use servo_rand::random;
 use style::attr::AttrValue;
 use style::str::split_html_space_chars;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use super::bindings::trace::{HashMapTracedValues, NoTrace};
 use crate::body::Extractable;

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -29,7 +29,7 @@ use script_traits::ScriptToConstellationChan;
 use servo_atoms::Atom;
 use style::attr::AttrValue;
 use style::str::{split_commas, str_join};
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 use unicode_bidi::{bidi_class, BidiClass};
 use url::Url;
 

--- a/components/script/dom/htmloptgroupelement.rs
+++ b/components/script/dom/htmloptgroupelement.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::{local_name, LocalName, Prefix};
 use js::rust::HandleObject;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLOptGroupElementBinding::HTMLOptGroupElementMethods;

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use html5ever::{local_name, namespace_url, ns, LocalName, Prefix, QualName};
 use js::rust::HandleObject;
 use style::str::{split_html_space_chars, str_join};
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -9,7 +9,7 @@ use dom_struct::dom_struct;
 use html5ever::{local_name, LocalName, Prefix};
 use js::rust::HandleObject;
 use style::attr::AttrValue;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -11,7 +11,7 @@ use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
 use js::rust::HandleObject;
 use script_traits::ScriptToConstellationChan;
 use style::attr::AttrValue;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/svgelement.rs
+++ b/components/script/dom/svgelement.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
 use js::rust::HandleObject;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::bindings::codegen::Bindings::SVGElementBinding::SVGElementMethods;
 use crate::dom::bindings::inheritance::Castable;

--- a/components/script/dom/svggraphicselement.rs
+++ b/components/script/dom/svggraphicselement.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::document::Document;

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use itertools::Itertools;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use super::bindings::codegen::Bindings::ElementInternalsBinding::ValidityStateFlags;
 use crate::dom::bindings::cell::{DomRefCell, Ref};

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -34,7 +34,7 @@ use style::shared_lock::Locked as StyleLocked;
 use style::values::computed::Display;
 use style::values::{AtomIdent, AtomString};
 use style::CaseSensitivityExt;
-use style_traits::dom::ElementState;
+use style_dom::ElementState;
 
 use crate::dom::attr::AttrHelpersForLayout;
 use crate::dom::bindings::inheritance::{

--- a/resources/presentational-hints.css
+++ b/resources/presentational-hints.css
@@ -7,9 +7,9 @@ https://html.spec.whatwg.org/multipage/#presentational-hints
 
 pre[wrap] { white-space: pre-wrap; }
 
-div[align=left i] { text-align: -servo-left; }
-div[align=right i] { text-align: -servo-right; }
-div[align=center i], div[align=middle i] { text-align: -servo-center; }
+div[align=left i] { text-align: -moz-left; }
+div[align=right i] { text-align: -moz-right; }
+div[align=center i], div[align=middle i] { text-align: -moz-center; }
 div[align=justify i] { text-align: justify; }
 
 

--- a/resources/quirks-mode.css
+++ b/resources/quirks-mode.css
@@ -25,7 +25,7 @@ table {
 /*
  * FIXME(pcwalton): Actually saying `text-align: initial` above breaks `<table>` inside `<center>`
  * in quirks mode. This is because we (following Gecko, WebKit, and Blink) implement the  HTML5
- * align-descendants rules with a special `text-align: -servo-center`. `text-align: initial`, if
+ * align-descendants rules with a special `text-align: -moz-center`. `text-align: initial`, if
  * placed on the `<table>` element per the spec, would break this behavior. So we place it on
  * `<tbody>` instead.
  */

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -112,7 +112,7 @@ td[align="left"]    { text-align: left; }
 td[align="center"]  { text-align: center; }
 td[align="right"]   { text-align: right; }
 
-center { text-align: -servo-center; }
+center { text-align: -moz-center; }
 
 label { cursor: default; }
 

--- a/tests/wpt/meta-legacy-layout/css/css-values/rlh-unit-001.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-values/rlh-unit-001.html.ini
@@ -1,2 +1,0 @@
-[rlh-unit-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-cascade/scope-featureless.html.ini
+++ b/tests/wpt/meta/css/css-cascade/scope-featureless.html.ini
@@ -1,2 +1,0 @@
-[scope-featureless.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/fixed-layout-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/fixed-layout-2.html.ini
@@ -1,6 +1,0 @@
-[fixed-layout-2.html]
-  [Table-layout:fixed reports fixed when width is auto]
-    expected: FAIL
-
-  [Table-layout:fixed reports fixed when width is max-content]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/inheritance.html.ini
+++ b/tests/wpt/meta/css/css-tables/inheritance.html.ini
@@ -1,9 +1,3 @@
 [inheritance.html]
   [Property border-spacing has initial value 0px 0px]
     expected: FAIL
-
-  [Property table-layout has initial value auto]
-    expected: FAIL
-
-  [Property table-layout does not inherit]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/parsing/table-layout-computed.html.ini
+++ b/tests/wpt/meta/css/css-tables/parsing/table-layout-computed.html.ini
@@ -1,6 +1,0 @@
-[table-layout-computed.html]
-  [Property table-layout value 'auto']
-    expected: FAIL
-
-  [Property table-layout value 'fixed']
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/parsing/table-layout-valid.html.ini
+++ b/tests/wpt/meta/css/css-tables/parsing/table-layout-valid.html.ini
@@ -1,6 +1,0 @@
-[table-layout-valid.html]
-  [e.style['table-layout'\] = "auto" should set the property value]
-    expected: FAIL
-
-  [e.style['table-layout'\] = "fixed" should set the property value]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-values/rlh-unit-001.html.ini
+++ b/tests/wpt/meta/css/css-values/rlh-unit-001.html.ini
@@ -1,2 +1,0 @@
-[rlh-unit-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/cssom/serialize-values.html.ini
+++ b/tests/wpt/meta/css/cssom/serialize-values.html.ini
@@ -92,15 +92,6 @@
   [direction: inherit]
     expected: FAIL
 
-  [table-layout: auto]
-    expected: FAIL
-
-  [table-layout: fixed]
-    expected: FAIL
-
-  [table-layout: inherit]
-    expected: FAIL
-
   [unicode-bidi: normal]
     expected: FAIL
 


### PR DESCRIPTION
This is based on https://github.com/servo/servo/pull/32606

Changelog:

   - Servo fixups: https://github.com/servo/stylo/compare/f2fbf5520e9fe1f45d0fe868c3f8e2d100b6d3a8...fafff4ca2cc971acc5278977ee69d6351cfbbaca
   - In addition, all changes are now squashed into a single commit and many unnecessary differences from upstream are eliminated.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
