### PR TITLE
Fix a couple of simple clippy warnings

### DIFF
--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -567,7 +567,7 @@ impl GenericDrawTarget for raqote::DrawTarget {
                 };
 
                 self.draw_glyphs(
-                    &font,
+                    font,
                     run.font.descriptor.pt_size.to_f32_px(),
                     &ids,
                     &positions,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -340,7 +340,7 @@ fn run_server(
                 });
 
             // Add existing streams to the new browsing context
-            let browsing_context = actors.find::<BrowsingContextActor>(&name);
+            let browsing_context = actors.find::<BrowsingContextActor>(name);
             let mut streams = browsing_context.streams.borrow_mut();
             for (id, stream) in connections {
                 streams.insert(*id, stream.try_clone().unwrap());

--- a/components/fonts/platform/macos/core_text_font_cache.rs
+++ b/components/fonts/platform/macos/core_text_font_cache.rs
@@ -53,9 +53,7 @@ impl CoreTextFontCache {
         }
 
         let mut cache = cache.write();
-        let identifier_cache = cache
-            .entry(font_identifier.clone())
-            .or_insert_with(Default::default);
+        let identifier_cache = cache.entry(font_identifier.clone()).or_default();
 
         // It could be that between the time of the cache miss above and now, after the write lock
         // on the cache has been acquired, the cache was populated with the data that we need. Thus

--- a/components/fonts/shaper.rs
+++ b/components/fonts/shaper.rs
@@ -612,9 +612,7 @@ impl Shaper {
     }
 
     pub unsafe fn get_baseline(&self) -> Option<FontBaseline> {
-        if (*self.font).table_for_tag(BASE).is_none() {
-            return None;
-        }
+        (*self.font).table_for_tag(BASE)?;
 
         let mut hanging_baseline = 0;
         let mut alphabetic_baseline = 0;

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -188,7 +188,7 @@ impl WGPU {
                             move |result: BufferAccessResult| {
                                 drop(token);
                                 let response = result
-                                    .and_then(|_| {
+                                    .map(|_| {
                                         let global = &glob;
                                         let (slice_pointer, range_size) = gfx_select!(buffer_id =>
                                             global.buffer_get_mapped_range(buffer_id, 0, None))
@@ -201,7 +201,7 @@ impl WGPU {
                                             )
                                         };
 
-                                        Ok(IpcSharedMemory::from_bytes(data))
+                                        IpcSharedMemory::from_bytes(data)
                                     })
                                     .map_err(|e| e.to_string());
                                 if let Err(e) =
@@ -671,7 +671,7 @@ impl WGPU {
                         let response = self
                             .global
                             .request_adapter(&options, wgc::instance::AdapterInputs::IdSet(&ids))
-                            .and_then(|adapter_id| {
+                            .map(|adapter_id| {
                                 let adapter = WebGPUAdapter(adapter_id);
                                 self.adapters.push(adapter);
                                 // TODO: can we do this lazily
@@ -684,13 +684,13 @@ impl WGPU {
                                 let features =
                                     gfx_select!(adapter_id => global.adapter_features(adapter_id))
                                         .unwrap();
-                                Ok(Adapter {
+                                Adapter {
                                     adapter_info: info,
                                     adapter_id: adapter,
                                     features,
                                     limits,
                                     channel: WebGPU(self.sender.clone()),
-                                })
+                                }
                             })
                             .map_err(|e| e.to_string());
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixed a couple of clippy warnings:
- [Needless borrows](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
- [Use of `or_insert_with` to construct default value](https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_or_default)
- [Replaced `if`s with question marks](https://rust-lang.github.io/rust-clippy/master/index.html#/question_mark)
- [Replaced `and_then` with `map`](https://rust-lang.github.io/rust-clippy/master/index.html#/bind_instead_of_map)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are minor clippy issues

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
