### PR TITLE
Remove failure breaks from webgpu thread

### DIFF
--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -694,10 +694,6 @@ impl WGPU {
                             })
                             .map_err(|e| e.to_string());
 
-                        if response.is_err() {
-                            break;
-                        }
-
                         if let Err(e) = sender.send(WebGPUResponse::Adapter(response)) {
                             warn!(
                                 "Failed to send response to WebGPURequest::RequestAdapter ({})",
@@ -733,7 +729,7 @@ impl WGPU {
                                     e
                                 )
                             }
-                            break;
+                            continue;
                         }
                         let device = WebGPUDevice(device_id);
                         let queue = WebGPUQueue(queue_id);


### PR DESCRIPTION
Only breaking of main loop for thread exit is allowed.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32621

<!-- Either: -->
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
