### PR TITLE
Enable OpenXR backend from the WebXR crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,6 +4450,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openxr"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a03958eb34719625119448d483ebd2fe008a2128b6286f2a7138b7e48072053"
+dependencies = [
+ "libc",
+ "libloading",
+ "ndk-context",
+ "openxr-sys",
+]
+
+[[package]]
+name = "openxr-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1534b2c14b56564e58b91f5015817e1d87bd43ca12a188eda6a9ea3859b0ec25"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "option-operations"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7354,11 +7375,14 @@ dependencies = [
  "gl_generator",
  "gvr-sys",
  "log",
+ "openxr",
  "serde",
  "sparkle",
  "surfman",
  "time 0.1.45",
  "webxr-api",
+ "winapi",
+ "wio",
 ]
 
 [[package]]

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -400,6 +400,9 @@ mod gen {
                     layers: {
                         enabled: bool,
                     },
+                    openxr: {
+                        enabled: bool,
+                    },
                     sessionavailable: bool,
                     #[serde(rename = "dom.webxr.unsafe-assume-user-intent")]
                     unsafe_assume_user_intent: bool,

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -106,7 +106,7 @@ raw-window-handle = "0.6"
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"
-webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
+webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
 winit = "0.29.10"
 
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "windows"))'.dependencies]
@@ -116,5 +116,6 @@ image = { workspace = true }
 sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -106,7 +106,7 @@ raw-window-handle = "0.6"
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"
-webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
+webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
 winit = "0.29.10"
 
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "windows"))'.dependencies]

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -19,6 +19,7 @@ use servo::servo_config::pref;
 use servo::Servo;
 use surfman::GLApi;
 use webxr::glwindow::GlWindowDiscovery;
+use webxr::openxr::OpenXrDiscovery;
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::WindowId;
@@ -27,7 +28,7 @@ use super::events_loop::{EventsLoop, WakerEvent};
 use super::minibrowser::Minibrowser;
 use super::webview::WebViewManager;
 use super::{headed_window, headless_window};
-use crate::desktop::embedder::EmbedderCallbacks;
+use crate::desktop::embedder::{EmbedderCallbacks, XrDiscovery};
 use crate::desktop::tracing::trace_winit_event;
 use crate::desktop::window_trait::WindowPortsMethods;
 use crate::parser::get_default_url;
@@ -153,12 +154,17 @@ impl App {
                         >(w.unwrap())
                     };
                     let factory = Box::new(move || Ok(window.new_glwindow(w)));
-                    Some(GlWindowDiscovery::new(
+                    Some(XrDiscovery::GlWindow(GlWindowDiscovery::new(
                         surfman.connection(),
                         surfman.adapter(),
                         surfman.context_attributes(),
                         factory,
-                    ))
+                    )))
+                } else if pref!(dom.webxr.openxr.enabled) &&
+                    !opts::get().headless &&
+                    cfg!(target_os = "windows")
+                {
+                    Some(XrDiscovery::OpenXr(OpenXrDiscovery::new(None)))
                 } else {
                     None
                 };

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -19,6 +19,7 @@ use servo::servo_config::pref;
 use servo::Servo;
 use surfman::GLApi;
 use webxr::glwindow::GlWindowDiscovery;
+#[cfg(target_os = "windows")]
 use webxr::openxr::OpenXrDiscovery;
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoopWindowTarget;
@@ -160,11 +161,13 @@ impl App {
                         surfman.context_attributes(),
                         factory,
                     )))
-                } else if pref!(dom.webxr.openxr.enabled) &&
-                    !opts::get().headless &&
-                    cfg!(target_os = "windows")
-                {
-                    Some(XrDiscovery::OpenXr(OpenXrDiscovery::new(None)))
+                } else if pref!(dom.webxr.openxr.enabled) && !opts::get().headless {
+                    #[cfg(target_os = "windows")]
+                    let openxr = Some(XrDiscovery::OpenXr(OpenXrDiscovery::new(None)));
+                    #[cfg(not(target_os = "windows"))]
+                    let openxr = None;
+
+                    openxr
                 } else {
                     None
                 };

--- a/ports/servoshell/desktop/embedder.rs
+++ b/ports/servoshell/desktop/embedder.rs
@@ -8,16 +8,22 @@ use servo::compositing::windowing::EmbedderMethods;
 use servo::embedder_traits::{EmbedderProxy, EventLoopWaker};
 use servo::servo_config::pref;
 use webxr::glwindow::GlWindowDiscovery;
+use webxr::openxr::OpenXrDiscovery;
+
+pub enum XrDiscovery {
+    GlWindow(GlWindowDiscovery),
+    OpenXr(OpenXrDiscovery),
+}
 
 pub struct EmbedderCallbacks {
     event_loop_waker: Box<dyn EventLoopWaker>,
-    xr_discovery: Option<GlWindowDiscovery>,
+    xr_discovery: Option<XrDiscovery>,
 }
 
 impl EmbedderCallbacks {
     pub fn new(
         event_loop_waker: Box<dyn EventLoopWaker>,
-        xr_discovery: Option<GlWindowDiscovery>,
+        xr_discovery: Option<XrDiscovery>,
     ) -> EmbedderCallbacks {
         EmbedderCallbacks {
             event_loop_waker,
@@ -39,7 +45,10 @@ impl EmbedderMethods for EmbedderCallbacks {
         if pref!(dom.webxr.test) {
             xr.register_mock(webxr::headless::HeadlessMockDiscovery::new());
         } else if let Some(xr_discovery) = self.xr_discovery.take() {
-            xr.register(xr_discovery);
+            match xr_discovery {
+                XrDiscovery::GlWindow(discovery) => xr.register(discovery),
+                XrDiscovery::OpenXr(discovery) => xr.register(discovery),
+            }
         }
     }
 }

--- a/ports/servoshell/desktop/embedder.rs
+++ b/ports/servoshell/desktop/embedder.rs
@@ -8,10 +8,12 @@ use servo::compositing::windowing::EmbedderMethods;
 use servo::embedder_traits::{EmbedderProxy, EventLoopWaker};
 use servo::servo_config::pref;
 use webxr::glwindow::GlWindowDiscovery;
+#[cfg(target_os = "windows")]
 use webxr::openxr::OpenXrDiscovery;
 
 pub enum XrDiscovery {
     GlWindow(GlWindowDiscovery),
+    #[cfg(target_os = "windows")]
     OpenXr(OpenXrDiscovery),
 }
 
@@ -47,6 +49,7 @@ impl EmbedderMethods for EmbedderCallbacks {
         } else if let Some(xr_discovery) = self.xr_discovery.take() {
             match xr_discovery {
                 XrDiscovery::GlWindow(discovery) => xr.register(discovery),
+                #[cfg(target_os = "windows")]
                 XrDiscovery::OpenXr(discovery) => xr.register(discovery),
             }
         }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -49,6 +49,7 @@
   "dom.webxr.glwindow.spherical": false,
   "dom.webxr.hands.enabled": false,
   "dom.webxr.layers.enabled": false,
+  "dom.webxr.openxr.enabled": false,
   "dom.webxr.sessionavailable": false,
   "dom.webxr.test": false,
   "dom.webxr.unsafe-assume-user-intent": false,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This enables the OpenXR backend from the WebXR crate, allowing Servo to display WebXR content on actual headsets as opposed to just the GL window. For now it is gated by a pref and the GL window remains the default.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32809

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they involve rendering to external devices, which I have verified is working as expected.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
