### PR TITLE
Un-enum-ify IndependentFormattingContext

### DIFF
--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -213,7 +213,7 @@ where
 
         // https://drafts.csswg.org/css-flexbox/#order-modified-document-order
         children.sort_by_key(|child| match &*child.borrow() {
-            FlexLevelBox::FlexItem(item) => item.style().clone_order(),
+            FlexLevelBox::FlexItem(item) => item.style.clone_order(),
 
             // “Absolutely-positioned children of a flex container are treated
             //  as having order: 0 for the purpose of determining their painting order

--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -15,8 +15,7 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo, NonReplacedContents, Trav
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 use crate::flow::{BlockContainer, BlockFormattingContext};
 use crate::formatting_contexts::{
-    IndependentFormattingContext, NonReplacedFormattingContext,
-    NonReplacedFormattingContextContents,
+    IndependentFormattingContext, NonReplacedFormattingContextContents,
 };
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::DisplayGeneratingBox;
@@ -167,18 +166,13 @@ where
                         BlockContainer::InlineFormattingContext(inline_formatting_context),
                     );
                     let info = &self.info.new_anonymous(anonymous_style.clone().unwrap());
-                    let non_replaced = NonReplacedFormattingContext {
-                        base_fragment_info: info.into(),
-                        style: info.style.clone(),
-                        content_sizes: None,
-                        contents: NonReplacedFormattingContextContents::Flow(
-                            block_formatting_context,
-                        ),
-                    };
+                    let non_replaced = IndependentFormattingContext::new_non_replaced(
+                        info.into(),
+                        info.style.clone(),
+                        NonReplacedFormattingContextContents::Flow(block_formatting_context),
+                    );
 
-                    Some(ArcRefCell::new(FlexLevelBox::FlexItem(
-                        IndependentFormattingContext::NonReplaced(non_replaced),
-                    )))
+                    Some(ArcRefCell::new(FlexLevelBox::FlexItem(non_replaced)))
                 },
                 FlexLevelJob::Element {
                     info,

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -287,7 +287,7 @@ where
         if inline_table {
             self.inline_formatting_context_builder.push_atomic(ifc);
         } else {
-            let anonymous_info = self.info.new_anonymous(ifc.style().clone());
+            let anonymous_info = self.info.new_anonymous(ifc.style.clone());
             let table_block = ArcRefCell::new(BlockLevelBox::Independent(ifc));
             self.end_ongoing_inline_formatting_context();
             self.block_level_boxes.push(BlockLevelJob {

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -889,7 +889,7 @@ impl FloatBox {
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
     ) -> BoxFragment {
-        let style = self.contents.style.clone();
+        let style = &self.contents.style;
         positioning_context.layout_maybe_position_relative_fragment(
             layout_context,
             containing_block,

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -889,7 +889,7 @@ impl FloatBox {
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
     ) -> BoxFragment {
-        let style = self.contents.style().clone();
+        let style = self.contents.style.clone();
         positioning_context.layout_maybe_position_relative_fragment(
             layout_context,
             containing_block,
@@ -981,7 +981,7 @@ impl FloatBox {
                 };
 
                 BoxFragment::new(
-                    self.contents.base_fragment_info(),
+                    self.contents.base_fragment_info,
                     style.clone(),
                     children,
                     content_rect.into(),

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -522,7 +522,7 @@ impl<'a> LineItemLayout<'a> {
 
     fn layout_absolute(&mut self, absolute: AbsolutelyPositionedLineItem) {
         let absolutely_positioned_box = (*absolute.absolutely_positioned_box).borrow();
-        let style = absolutely_positioned_box.context.style();
+        let style = &absolutely_positioned_box.context.style;
 
         // From https://drafts.csswg.org/css2/#abs-non-replaced-width
         // > The static-position containing block is the containing block of a

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1909,8 +1909,9 @@ impl IndependentFormattingContext {
         inline_formatting_context_state: &mut InlineFormattingContextState,
         offset_in_text: usize,
     ) {
-        let style = self.style();
-        let pbm = style.padding_border_margin(inline_formatting_context_state.containing_block);
+        let pbm = self
+            .style
+            .padding_border_margin(inline_formatting_context_state.containing_block);
         let margin = pbm.margin.auto_is(Au::zero);
         let pbm_sums = pbm.padding + pbm.border + margin;
         let mut child_positioning_context = None;
@@ -2085,7 +2086,7 @@ impl IndependentFormattingContext {
     /// TODO: clarify that this is not to be used for box alignment in flex/grid
     /// <https://drafts.csswg.org/css-inline/#baseline-source>
     fn pick_baseline(&self, baselines: &Baselines) -> Option<Au> {
-        match self.style().clone_baseline_source() {
+        match self.style.clone_baseline_source() {
             BaselineSource::First => baselines.first,
             BaselineSource::Last => baselines.last,
             BaselineSource::Auto => {
@@ -2107,7 +2108,7 @@ impl IndependentFormattingContext {
         block_size: Au,
         baseline_offset_in_content_area: Au,
     ) -> (LineBlockSizes, Au) {
-        let mut contribution = if !is_baseline_relative(self.style().clone_vertical_align()) {
+        let mut contribution = if !is_baseline_relative(self.style.clone_vertical_align()) {
             LineBlockSizes {
                 line_height: block_size,
                 baseline_relative_size_for_line_height: None,
@@ -2128,7 +2129,7 @@ impl IndependentFormattingContext {
         let baseline_offset = ifc
             .current_inline_container_state()
             .get_cumulative_baseline_offset_for_child(
-                self.style().clone_vertical_align(),
+                self.style.clone_vertical_align(),
                 &contribution,
             );
         contribution.adjust_for_baseline_offset(baseline_offset);

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -107,7 +107,7 @@ impl BlockLevelBox {
             BlockLevelBox::Independent(ref context) => {
                 // FIXME: If the element doesn't fit next to floats, it will get clearance.
                 // In that case this should be returning false.
-                context.style()
+                &context.style
             },
         };
 
@@ -360,7 +360,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
                     .contents
                     .outer_inline_content_sizes(layout_context, writing_mode)
                     .max(ContentSizes::zero());
-                let style_box = &float_box.contents.style().get_box();
+                let style_box = &float_box.contents.style.get_box();
                 Some((size, style_box.float, style_box.clear))
             },
             BlockLevelBox::SameFormattingContextBlock {
@@ -379,7 +379,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
                 let size = independent
                     .outer_inline_content_sizes(layout_context, writing_mode)
                     .max(ContentSizes::zero());
-                Some((size, Float::None, independent.style().get_box().clear))
+                Some((size, Float::None, independent.style.get_box().clear))
             },
         }
     };

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -173,16 +173,6 @@ impl IndependentFormattingContext {
         }
     }
 
-    // TODO(valadaptive): remove this since we no longer have to retrieve this from the "inner" struct?
-    pub fn style(&self) -> &Arc<ComputedValues> {
-        &self.style
-    }
-
-    // TODO(valadaptive): remove this since we no longer have to retrieve this from the "inner" struct?
-    pub fn base_fragment_info(&self) -> BaseFragmentInfo {
-        self.base_fragment_info
-    }
-
     pub fn inline_content_sizes(&self, layout_context: &LayoutContext) -> ContentSizes {
         match &self.contents {
             IndependentFormattingContextContents::NonReplaced(inner) => {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -98,7 +98,7 @@ impl AbsolutelyPositionedBox {
 
         let box_offsets = {
             let box_ = self_.borrow();
-            let box_offsets = box_.context.style().box_offsets(containing_block);
+            let box_offsets = box_.context.style.box_offsets(containing_block);
             LogicalVec2 {
                 inline: absolute_box_offsets(
                     initial_start_corner.inline,
@@ -298,7 +298,7 @@ impl PositioningContext {
                 .absolutely_positioned_box
                 .borrow()
                 .context
-                .style()
+                .style
                 .clone_position();
             match position {
                 Position::Fixed => {}, // fall through
@@ -483,7 +483,7 @@ impl HoistedAbsolutelyPositionedBox {
         let mut absolutely_positioned_box = self.absolutely_positioned_box.borrow_mut();
         let pbm = absolutely_positioned_box
             .context
-            .style()
+            .style
             .padding_border_margin(&containing_block.into());
 
         // TODO(valadaptive): See if this should be replaced with "has preferred aspect ratio"
@@ -537,7 +537,7 @@ impl HoistedAbsolutelyPositionedBox {
             block_axis_solver.solve_for_size(computed_size.block.map(|t| t.into()));
 
         let mut positioning_context =
-            PositioningContext::new_for_style(absolutely_positioned_box.context.style()).unwrap();
+            PositioningContext::new_for_style(&absolutely_positioned_box.context.style).unwrap();
         let mut new_fragment = {
             let content_size: LogicalVec2<Au>;
             let fragments;
@@ -720,8 +720,8 @@ impl HoistedAbsolutelyPositionedBox {
                 overconstrained.to_physical(containing_block.style.writing_mode);
 
             BoxFragment::new_with_overconstrained(
-                absolutely_positioned_box.context.base_fragment_info(),
-                absolutely_positioned_box.context.style().clone(),
+                absolutely_positioned_box.context.base_fragment_info,
+                absolutely_positioned_box.context.style.clone(),
                 fragments,
                 content_rect,
                 pbm.padding,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -6,7 +6,7 @@ use app_units::Au;
 use style::computed_values::mix_blend_mode::T as ComputedMixBlendMode;
 use style::computed_values::position::T as ComputedPosition;
 use style::computed_values::transform_style::T as ComputedTransformStyle;
-use style::logical_geometry::WritingMode;
+use style::logical_geometry::{Direction, WritingMode};
 use style::properties::longhands::backface_visibility::computed_value::T as BackfaceVisiblity;
 use style::properties::longhands::box_sizing::computed_value::T as BoxSizing;
 use style::properties::longhands::column_span::computed_value::T as ColumnSpan;
@@ -15,7 +15,9 @@ use style::values::computed::image::Image as ComputedImageLayer;
 use style::values::computed::{Length, LengthPercentage, NonNegativeLengthPercentage, Size};
 use style::values::generics::box_::Perspective;
 use style::values::generics::length::MaxSize;
+use style::values::generics::position::{GenericAspectRatio, PreferredRatio};
 use style::values::specified::{box_ as stylo, Overflow};
+use style::values::CSSFloat;
 use style::Zero;
 use webrender_api as wr;
 
@@ -143,6 +145,42 @@ impl PaddingBorderMargin {
     }
 }
 
+/// Resolved `aspect-ratio` property with respect to a specific element. Depends
+/// on that element's `box-sizing` (and padding and border, if that `box-sizing`
+/// is `border-box`).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AspectRatio {
+    /// If the element that this aspect ratio belongs to uses box-sizing:
+    /// border-box, and the aspect-ratio property does not contain "auto", then
+    /// the aspect ratio is in respect to the border box. This will then contain
+    /// the summed sizes of the padding and border. Otherwise, it's 0.
+    pb_adjust: LogicalVec2<Au>,
+    /// The ratio itself (inline over block).
+    i_over_b: CSSFloat,
+}
+
+impl AspectRatio {
+    /// Given one side length, compute the other one.
+    pub(crate) fn compute_dependent_size(
+        &self,
+        ratio_dependent_axis: Direction,
+        ratio_determining_size: Au,
+    ) -> Au {
+        match ratio_dependent_axis {
+            // Calculate the inline size from the block size
+            Direction::Inline => {
+                (ratio_determining_size + self.pb_adjust.block).scale_by(self.i_over_b) -
+                    self.pb_adjust.inline
+            },
+            // Calculate the block size from the inline size
+            Direction::Block => {
+                (ratio_determining_size + self.pb_adjust.inline).scale_by(1.0 / self.i_over_b) -
+                    self.pb_adjust.block
+            },
+        }
+    }
+}
+
 pub(crate) trait ComputedValuesExt {
     fn box_offsets(
         &self,
@@ -198,6 +236,11 @@ pub(crate) trait ComputedValuesExt {
         &self,
         fragment_flags: FragmentFlags,
     ) -> bool;
+    fn preferred_aspect_ratio(
+        &self,
+        natural_aspect_ratio: Option<CSSFloat>,
+        containing_block: &ContainingBlock,
+    ) -> Option<AspectRatio>;
     fn background_is_transparent(&self) -> bool;
     fn get_webrender_primitive_flags(&self) -> wr::PrimitiveFlags;
 }
@@ -533,6 +576,80 @@ impl ComputedValuesExt for ComputedValues {
 
         // TODO: We need to handle CSS Contain here.
         false
+    }
+
+    /// Resolve the preferred aspect ratio according to the given natural aspect
+    /// ratio and the `aspect-ratio` property.
+    /// https://drafts.csswg.org/css-sizing-4/#aspect-ratio
+    fn preferred_aspect_ratio(
+        &self,
+        natural_aspect_ratio: Option<CSSFloat>,
+        containing_block: &ContainingBlock,
+    ) -> Option<AspectRatio> {
+        let GenericAspectRatio {
+            auto,
+            ratio: mut preferred_ratio,
+        } = self.clone_aspect_ratio();
+
+        // For all cases where a ratio is specified:
+        // "If the <ratio> is degenerate, the property instead behaves as auto."
+        if let PreferredRatio::Ratio(ratio) = preferred_ratio {
+            if ratio.is_degenerate() {
+                preferred_ratio = PreferredRatio::None;
+            }
+        }
+
+        match (auto, preferred_ratio) {
+            // The value `auto`. Either the ratio was not specified, or was
+            // degenerate and set to PreferredRatio::None above.
+            //
+            // "Replaced elements with a natural aspect ratio use that aspect
+            // ratio; otherwise the box has no preferred aspect ratio. Size
+            // calculations involving the aspect ratio work with the content box
+            // dimensions always."
+            (_, PreferredRatio::None) => match natural_aspect_ratio {
+                Some(natural_ratio) => Some(AspectRatio {
+                    i_over_b: natural_ratio,
+                    pb_adjust: LogicalVec2::zero(),
+                }),
+                None => None,
+            },
+            // "If both auto and a <ratio> are specified together, the preferred
+            // aspect ratio is the specified ratio of width / height unless it
+            // is a replaced element with a natural aspect ratio, in which case
+            // that aspect ratio is used instead. In all cases, size
+            // calculations involving the aspect ratio work with the content box
+            // dimensions always."
+            (true, PreferredRatio::Ratio(preferred_ratio)) => match natural_aspect_ratio {
+                Some(natural_ratio) => Some(AspectRatio {
+                    i_over_b: natural_ratio,
+                    pb_adjust: LogicalVec2::zero(),
+                }),
+                None => Some(AspectRatio {
+                    i_over_b: (preferred_ratio.0).0 / (preferred_ratio.1).0,
+                    pb_adjust: LogicalVec2::zero(),
+                }),
+            },
+
+            // "The box’s preferred aspect ratio is the specified ratio of width
+            // / height. Size calculations involving the aspect ratio work with
+            // the dimensions of the box specified by box-sizing."
+            (false, PreferredRatio::Ratio(preferred_ratio)) => {
+                // If the `box-sizing` is `border-box`, use the padding and
+                // border when calculating the aspect ratio.
+                let pb_adjust = match self.clone_box_sizing() {
+                    BoxSizing::ContentBox => LogicalVec2::zero(),
+                    BoxSizing::BorderBox => {
+                        self.padding_border_margin(containing_block)
+                            .padding_border_sums
+                    },
+                };
+                Some(AspectRatio {
+                    i_over_b: (preferred_ratio.0).0 / (preferred_ratio.1).0,
+                    pb_adjust,
+                })
+            },
+        }
     }
 
     /// Whether or not this style specifies a non-transparent background.

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -25,8 +25,7 @@ use crate::dom::{BoxSlot, NodeExt};
 use crate::dom_traversal::{Contents, NodeAndStyleInfo, NonReplacedContents, TraversalHandler};
 use crate::flow::{BlockContainerBuilder, BlockFormattingContext};
 use crate::formatting_contexts::{
-    IndependentFormattingContext, NonReplacedFormattingContext,
-    NonReplacedFormattingContextContents,
+    IndependentFormattingContext, NonReplacedFormattingContextContents,
 };
 use crate::fragment_tree::BaseFragmentInfo;
 use crate::style_ext::{DisplayGeneratingBox, DisplayLayoutInternal};
@@ -134,12 +133,11 @@ impl Table {
         let mut table = table_builder.finish();
         table.anonymous = true;
 
-        IndependentFormattingContext::NonReplaced(NonReplacedFormattingContext {
-            base_fragment_info: (&anonymous_info).into(),
-            style: grid_and_wrapper_style,
-            content_sizes: None,
-            contents: NonReplacedFormattingContextContents::Table(table),
-        })
+        IndependentFormattingContext::new_non_replaced(
+            (&anonymous_info).into(),
+            grid_and_wrapper_style,
+            NonReplacedFormattingContextContents::Table(table),
+        )
     }
 
     /// Push a new slot into the last row of this table.
@@ -862,12 +860,11 @@ where
                     };
 
                     let caption = TableCaption {
-                        context: ArcRefCell::new(NonReplacedFormattingContext {
-                            style: info.style.clone(),
-                            base_fragment_info: info.into(),
-                            content_sizes: None,
+                        context: ArcRefCell::new(IndependentFormattingContext::new_non_replaced(
+                            info.into(),
+                            info.style.clone(),
                             contents,
-                        }),
+                        )),
                     };
 
                     self.builder.table.captions.push(caption);

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -2364,7 +2364,7 @@ impl Table {
     }
 
     pub(crate) fn inline_content_sizes(
-        &mut self,
+        &self,
         layout_context: &LayoutContext,
         writing_mode: WritingMode,
     ) -> ContentSizes {

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -82,7 +82,7 @@ use style_traits::dom::OpaqueNode;
 use super::flow::BlockFormattingContext;
 use crate::cell::ArcRefCell;
 use crate::flow::BlockContainer;
-use crate::formatting_contexts::NonReplacedFormattingContext;
+use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
 
 pub type TableSize = Size2D<usize, UnknownUnit>;
@@ -320,5 +320,5 @@ impl TableTrackGroup {
 #[derive(Debug, Serialize)]
 pub struct TableCaption {
     /// The contents of this cell, with its own layout.
-    context: ArcRefCell<NonReplacedFormattingContext>,
+    context: ArcRefCell<IndependentFormattingContext>,
 }

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
@@ -1,10 +1,4 @@
 [box-sizing-dimensions.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-dimensions.html.ini
@@ -1,0 +1,18 @@
+[box-sizing-dimensions.html]
+  [.item 1]
+    expected: FAIL
+
+  [.item 2]
+    expected: FAIL
+
+  [.item 5]
+    expected: FAIL
+
+  [.item 6]
+    expected: FAIL
+
+  [.item 7]
+    expected: FAIL
+
+  [.item 8]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
@@ -1,25 +1,4 @@
 [box-sizing-squashed.html]
-  [.item 1]
-    expected: FAIL
-
-  [.item 2]
-    expected: FAIL
-
-  [.item 4]
-    expected: FAIL
-
-  [.item 6]
-    expected: FAIL
-
-  [.item 8]
-    expected: FAIL
-
-  [.item 5]
-    expected: FAIL
-
-  [.item 7]
-    expected: FAIL
-
   [.item 10]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/box-sizing-squashed.html.ini
@@ -1,0 +1,39 @@
+[box-sizing-squashed.html]
+  [.item 1]
+    expected: FAIL
+
+  [.item 2]
+    expected: FAIL
+
+  [.item 4]
+    expected: FAIL
+
+  [.item 6]
+    expected: FAIL
+
+  [.item 8]
+    expected: FAIL
+
+  [.item 5]
+    expected: FAIL
+
+  [.item 7]
+    expected: FAIL
+
+  [.item 10]
+    expected: FAIL
+
+  [.item 12]
+    expected: FAIL
+
+  [.item 13]
+    expected: FAIL
+
+  [.item 14]
+    expected: FAIL
+
+  [.item 15]
+    expected: FAIL
+
+  [.item 16]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-015.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-015.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-016.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/flex-aspect-ratio-016.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-003.html.ini
@@ -1,2 +1,0 @@
-[grid-aspect-ratio-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-004.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/grid-aspect-ratio-004.html.ini
@@ -1,2 +1,0 @@
-[grid-aspect-ratio-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-001.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-002.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-003.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-009.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-009.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-012.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-012.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-024.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-024.html.ini
@@ -1,0 +1,2 @@
+[replaced-element-024.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-025.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-025.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-025.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-026.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-026.html.ini
@@ -1,0 +1,2 @@
+[replaced-element-026.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-027.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-027.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-027.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-028.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-028.html.ini
@@ -1,0 +1,3 @@
+[replaced-element-028.html]
+  [CSS aspect-ratio: img]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-031.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-031.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-031.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-032.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-032.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-032.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-033.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-033.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-033.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-036.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-036.html.ini
@@ -1,6 +1,0 @@
-[replaced-element-036.html]
-  [display:block img should be 200px high]
-    expected: FAIL
-
-  [display:inline-block img should be 200px high]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-dynamic-aspect-ratio.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-dynamic-aspect-ratio.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-dynamic-aspect-ratio.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-dimensions.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-dimensions.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS aspect-ratio: uses content box when "auto" is present and box-sizing dimensions when it is absent</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content='CSS aspect-ratio: uses content box when "auto" is present and box-sizing dimensions when it is absent.'>
+<style>
+img {
+    border: 20px solid blue;
+    width: 100px;
+    height: auto;
+}
+
+.aspect {
+    aspect-ratio: 2 / 1;
+}
+
+.aspect-auto {
+    aspect-ratio: auto 2 / 1;
+}
+
+.border-box {
+    box-sizing: border-box;
+}
+
+.non-replaced {
+    background: green;
+    border: 20px solid blue;
+    width: 100px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.item')">
+
+<img class="item aspect" src="./support/20x50-green.png" width="20" height="50" data-expected-width="140" data-expected-height="90">
+
+<img class="item aspect border-box" src="./support/20x50-green.png" width="20" height="50" data-expected-width="100" data-expected-height="50">
+
+<img class="item aspect-auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="140" data-expected-height="290">
+
+<img class="item aspect-auto border-box" src="./support/20x50-green.png" width="20" height="50" data-expected-width="100" data-expected-height="190">
+
+<div class="item non-replaced aspect" data-expected-width="140" data-expected-height="90"></div>
+
+<div class="item non-replaced aspect border-box" data-expected-width="100" data-expected-height="50"></div>
+
+<div class="item non-replaced aspect-auto" data-expected-width="140" data-expected-height="90"></div>
+
+<div class="item non-replaced aspect-auto border-box" data-expected-width="100" data-expected-height="70"></div>

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-squashed.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/box-sizing-squashed.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS aspect-ratio: correct ratio maintained when box-sizing: border-box and one axis is clamped to 0</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<meta name="assert" content='CSS aspect-ratio: correct ratio maintained when box-sizing: border-box and one axis is clamped to 0.'>
+<style>
+.item {
+    box-sizing: border-box;
+    border: 20px solid blue;
+}
+
+.horizontal {
+    aspect-ratio: 2 / 1;
+}
+
+.vertical {
+    aspect-ratio: 1 / 2;
+}
+
+.non-replaced {
+    background: green;
+    /* Break the items apart to make them individually distinguishable */
+    margin-bottom: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.item')">
+
+<img class="item horizontal" style="width: 50px; height: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="50" data-expected-height="40">
+
+<img class="item horizontal"  style="width: auto; height: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="80" data-expected-height="40">
+
+<img class="item horizontal" style="max-width: 50px; height: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="40">
+
+<img class="item horizontal" style="width: auto; max-height: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="80" data-expected-height="40">
+
+<img class="item vertical" style="height: 50px; width: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="50">
+
+<img class="item vertical"  style="height: auto; width: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="80">
+
+<img class="item vertical" style="max-height: 50px; width: auto" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="50">
+
+<img class="item vertical" style="height: auto; max-width: 20px" src="./support/20x50-green.png" width="20" height="50" data-expected-width="40" data-expected-height="80">
+
+<div class="non-replaced item horizontal" style="width: 50px; height: auto" width="20" height="50" data-expected-width="50" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal"  style="width: auto; height: 20px" width="20" height="50" data-expected-width="80" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal" style="max-width: 50px; height: auto" width="20" height="50" data-expected-width="50" data-expected-height="40"></div>
+
+<div class="non-replaced item horizontal" style="width: auto; max-height: 20px" width="20" height="50" data-expected-width="80" data-expected-height="40"></div>
+
+<div class="non-replaced item vertical" style="height: 50px; width: auto" width="20" height="50" data-expected-width="40" data-expected-height="50"></div>
+
+<div class="non-replaced item vertical"  style="height: auto; width: 20px" width="20" height="50" data-expected-width="40" data-expected-height="80"></div>
+
+<div class="non-replaced item vertical" style="max-height: 50px; width: auto" width="20" height="50" data-expected-width="40" data-expected-height="50"></div>
+
+<div class="non-replaced item vertical" style="height: auto; max-width: 20px" width="20" height="50" data-expected-width="40" data-expected-height="80"></div>


### PR DESCRIPTION
This builds on top of https://github.com/servo/servo/pull/32800 because later work will probably overlap with it and I want to avoid merge conflicts.

The layout code currently has a strong distinction between replaced and non-replaced elements, most of which comes from `IndependentFormattingContext` being an enum with `Replaced` and `NonReplaced` variants. In order to implement `aspect-ratio`, we need to stop treating elements as "replaced"/"not replaced" and instead treat them as "has a preferred aspect ratio"/"does not have a preferred aspect ratio".

The CSS spec [says that calculating the automatic sizes of an element with a preferred aspect ratio involves treating it as a replaced element](https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic), so we should be able to treat every element as replaced for the purposes of size calculation, in case they have `aspect-ratio` set.

This is a draft PR because actually implementing the "has a preferred ratio" check is left for a future commit, and I added a bunch of TODO comments so that I can remember to come back and place them in the appropriate spots. I'm opening it up for review to make sure I'm on the right track and there aren't any major concerns.

There are a few commits, but the first ("[Un-enum-ify IndependentFormattingContext](https://github.com/servo/servo/pull/32818/commits/1536cfdcbd3dd6945163a33e320e74f8492ed1af)") is probably the most useful one to review individually. You may want to hide whitespace changes because I moved some functions around scope-wise. After that is a pretty rote one that replaces all uses of the `style` and `base_fragment_info` getters with property accesses now that `IndependentFormattingContext` is not an enum, which makes a lot of one-line changes scattered throughout the code.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
