### PR TITLE
Remove a comment related to a TODO which is done.

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -788,8 +788,6 @@ impl From<NetTraitsRequestMode> for RequestMode {
     }
 }
 
-// TODO
-// When whatwg/fetch PR #346 is merged, fix this.
 impl From<ReferrerPolicy> for MsgReferrerPolicy {
     fn from(policy: ReferrerPolicy) -> Self {
         match policy {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removes a confusing TODO comment. This is mentioned in this [issue](https://github.com/servo/servo/issues/25680): 

"A nearby comment mentions https://github.com/whatwg/fetch/pull/346, which ended up closed without merging; that comment should get taken out when fixing this."

The [commit](https://github.com/servo/servo/pull/26006) which addressed the issue left the comment in.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no code changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
