### PR TITLE
webgpu: Update wgpu to 22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,8 +1197,8 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.20.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=f25e07b984ab391628d9568296d5970981d79d8b#f25e07b984ab391628d9568296d5970981d79d8b"
+version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
 dependencies = [
  "bitflags 2.6.0",
  "libloading",
@@ -3882,9 +3882,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
  "bitflags 2.6.0",
  "block",
@@ -4039,12 +4039,13 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "naga"
-version = "0.20.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=f25e07b984ab391628d9568296d5970981d79d8b#f25e07b984ab391628d9568296d5970981d79d8b"
+version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.6.0",
+ "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -7403,8 +7404,8 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu-core"
-version = "0.20.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=f25e07b984ab391628d9568296d5970981d79d8b#f25e07b984ab391628d9568296d5970981d79d8b"
+version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -7428,8 +7429,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.20.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=f25e07b984ab391628d9568296d5970981d79d8b#f25e07b984ab391628d9568296d5970981d79d8b"
+version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7449,7 +7450,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal 0.28.0",
+ "metal 0.29.0",
  "naga",
  "ndk-sys",
  "objc",
@@ -7469,8 +7470,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.20.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=f25e07b984ab391628d9568296d5970981d79d8b#f25e07b984ab391628d9568296d5970981d79d8b"
+version = "22.0.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,18 +391,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -1198,7 +1198,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "d3d12"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=65b6e15f0fdf46b109df66ec57b75aa6be9b067d#65b6e15f0fdf46b109df66ec57b75aa6be9b067d"
 dependencies = [
  "bitflags 2.6.0",
  "libloading",
@@ -1521,7 +1521,7 @@ dependencies = [
  "bytemuck",
  "egui",
  "egui-winit",
- "glow",
+ "glow 0.13.1",
  "log",
  "memoffset",
  "wasm-bindgen",
@@ -2268,6 +2268,18 @@ name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f865cbd94bd355b89611211e49508da98a1fce0ad755c1e8448fb96711b24528"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -4040,7 +4052,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 [[package]]
 name = "naga"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=65b6e15f0fdf46b109df66ec57b75aa6be9b067d#65b6e15f0fdf46b109df66ec57b75aa6be9b067d"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -5809,7 +5821,7 @@ dependencies = [
  "gilrs",
  "gl_generator",
  "gleam",
- "glow",
+ "glow 0.13.1",
  "hilog",
  "image",
  "ipc-channel",
@@ -7405,7 +7417,7 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=65b6e15f0fdf46b109df66ec57b75aa6be9b067d#65b6e15f0fdf46b109df66ec57b75aa6be9b067d"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -7430,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=65b6e15f0fdf46b109df66ec57b75aa6be9b067d#65b6e15f0fdf46b109df66ec57b75aa6be9b067d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7441,7 +7453,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "core-graphics-types",
  "d3d12",
- "glow",
+ "glow 0.14.0",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-descriptor",
@@ -7471,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=c0e7c1ef945a7dd61c81fb951ea554213811aee0#c0e7c1ef945a7dd61c81fb951ea554213811aee0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=65b6e15f0fdf46b109df66ec57b75aa6be9b067d#65b6e15f0fdf46b109df66ec57b75aa6be9b067d"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.64", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
 webrender_traits = { path = "components/shared/webrender" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "f25e07b984ab391628d9568296d5970981d79d8b" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "f25e07b984ab391628d9568296d5970981d79d8b" }
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "c0e7c1ef945a7dd61c81fb951ea554213811aee0" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "c0e7c1ef945a7dd61c81fb951ea554213811aee0" }
 windows-sys = "0.52"
 xi-unicode = "0.1.0"
 xml5ever = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.64", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.64" }
 webrender_traits = { path = "components/shared/webrender" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "c0e7c1ef945a7dd61c81fb951ea554213811aee0" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "c0e7c1ef945a7dd61c81fb951ea554213811aee0" }
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "65b6e15f0fdf46b109df66ec57b75aa6be9b067d" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "65b6e15f0fdf46b109df66ec57b75aa6be9b067d" }
 windows-sys = "0.52"
 xi-unicode = "0.1.0"
 xml5ever = "0.18"

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
+use webgpu::wgt::MemoryHints;
 use webgpu::{wgt, WebGPU, WebGPUAdapter, WebGPURequest, WebGPUResponse};
 
 use super::gpusupportedfeatures::GPUSupportedFeatures;
@@ -124,6 +125,7 @@ impl GPUAdapterMethods for GPUAdapter {
             required_features: features,
             required_limits: wgt::Limits::default(),
             label: None,
+            memory_hints: MemoryHints::MemoryUsage,
         };
         if let Some(limits) = &descriptor.requiredLimits {
             for (limit, value) in (*limits).iter() {

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -256,23 +256,16 @@ impl GPUDeviceMethods for GPUDevice {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
     fn CreateBuffer(&self, descriptor: &GPUBufferDescriptor) -> Fallible<DomRoot<GPUBuffer>> {
-        let desc =
-            wgt::BufferUsages::from_bits(descriptor.usage).map(|usg| wgpu_res::BufferDescriptor {
-                label: convert_label(&descriptor.parent),
-                size: descriptor.size as wgt::BufferAddress,
-                usage: usg,
-                mapped_at_creation: descriptor.mappedAtCreation,
-            });
+        let desc = wgpu_res::BufferDescriptor {
+            label: convert_label(&descriptor.parent),
+            size: descriptor.size as wgt::BufferAddress,
+            usage: wgt::BufferUsages::from_bits_retain(descriptor.usage),
+            mapped_at_creation: descriptor.mappedAtCreation,
+        };
         let id = self
             .global()
             .wgpu_id_hub()
             .create_buffer_id(self.device.0.backend());
-
-        if desc.is_none() {
-            self.dispatch_error(webgpu::Error::Validation(String::from(
-                "Invalid GPUBufferUsage",
-            )));
-        }
 
         self.channel
             .0

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -581,7 +581,6 @@ impl GPUDeviceMethods for GPUDevice {
                 entry_point: Some(Cow::Owned(descriptor.compute.entryPoint.to_string())),
                 constants: Cow::Owned(HashMap::new()),
                 zero_initialize_workgroup_memory: true,
-                vertex_pulling_transform: false,
             },
             cache: None,
         };
@@ -772,7 +771,6 @@ impl GPUDeviceMethods for GPUDevice {
                         )),
                         constants: Cow::Owned(HashMap::new()),
                         zero_initialize_workgroup_memory: true,
-                        vertex_pulling_transform: false,
                     },
                     buffers: Cow::Owned(
                         descriptor
@@ -809,7 +807,6 @@ impl GPUDeviceMethods for GPUDevice {
                             entry_point: Some(Cow::Owned(stage.parent.entryPoint.to_string())),
                             constants: Cow::Owned(HashMap::new()),
                             zero_initialize_workgroup_memory: true,
-                            vertex_pulling_transform: false,
                         },
                         targets: Cow::Owned(
                             stage

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -89,7 +89,7 @@ pub enum WebGPURequest {
     CreateBuffer {
         device_id: id::DeviceId,
         buffer_id: id::BufferId,
-        descriptor: Option<BufferDescriptor<'static>>,
+        descriptor: BufferDescriptor<'static>,
     },
     CreateCommandEncoder {
         device_id: id::DeviceId,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -173,6 +173,7 @@ impl WGPU {
     pub(crate) fn run(&mut self) {
         loop {
             if let Ok(msg) = self.receiver.recv() {
+                log::trace!("recv: {msg:?}");
                 match msg {
                     WebGPURequest::BufferMapAsync {
                         sender,
@@ -356,11 +357,11 @@ impl WGPU {
                         descriptor,
                     } => {
                         let global = &self.global;
-                                                    let (_, error) = gfx_select!(buffer_id =>
-                                global.device_create_buffer(device_id, &descriptor, Some(buffer_id)));
+                        let (_, error) = gfx_select!(buffer_id =>
+                            global.device_create_buffer(device_id, &descriptor, Some(buffer_id)));
 
-                            self.maybe_dispatch_wgpu_error(device_id, error);
-                                            },
+                        self.maybe_dispatch_wgpu_error(device_id, error);
+                    },
                     WebGPURequest::CreateCommandEncoder {
                         device_id,
                         command_encoder_id,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -356,13 +356,11 @@ impl WGPU {
                         descriptor,
                     } => {
                         let global = &self.global;
-                        if let Some(desc) = descriptor {
-                            let (_, error) = gfx_select!(buffer_id =>
-                                global.device_create_buffer(device_id, &desc, Some(buffer_id)));
+                                                    let (_, error) = gfx_select!(buffer_id =>
+                                global.device_create_buffer(device_id, &descriptor, Some(buffer_id)));
 
                             self.maybe_dispatch_wgpu_error(device_id, error);
-                        }
-                    },
+                                            },
                     WebGPURequest::CreateCommandEncoder {
                         device_id,
                         command_encoder_id,

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -51,6 +51,7 @@ packages = [
     "foreign-types",
     "foreign-types-shared",
     "metal",
+    "glow",
 
     # quickcheck (required by layout_2020 for tests) is
     # stuck on 0.8.4 with no new releases.

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_display_after_device_lost.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_display_after_device_lost.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_display_after_device_lost.https.html]
   expected:
-    if os == "linux" and not debug: TIMEOUT
+    if os == "linux" and not debug: FAIL


### PR DESCRIPTION
Mostly because I need https://github.com/gfx-rs/wgpu/pull/5992.

The only real change is in https://github.com/servo/servo/pull/32827/commits/e6a710b29d288efe175dc9e3831ce31c3700ed59, that is needed because wgpu panics if id is not created.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
