### PR TITLE
ohos: Bump ohos-sys to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,8 @@ dependencies = [
 [[package]]
 name = "ohos-sys"
 version = "0.1.0"
-source = "git+https://github.com/jschwe/ohos-sys.git#bf0625fc7ea8035c2991626fb0a593e06c9c8c21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4948c565d42c324e658fe83b9d99511d922c562701572179df7763777be327"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "ohos-sys"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4948c565d42c324e658fe83b9d99511d922c562701572179df7763777be327"
+checksum = "576650788dcfcb1321ce967707fea478dece87c2c02bbd1e99ddddc4e53a4b8d"
 
 [[package]]
 name = "once_cell"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -87,7 +87,7 @@ napi-ohos = "0.1"
 serde_json = { workspace = true }
 surfman = { workspace = true, features = ["sm-angle-default"] }
 webxr = { git = "https://github.com/servo/webxr" }
-ohos-sys = "0.1"
+ohos-sys = { version = "0.2.1", features = ["xcomponent"] }
 
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -87,7 +87,7 @@ napi-ohos = "0.1"
 serde_json = { workspace = true }
 surfman = { workspace = true, features = ["sm-angle-default"] }
 webxr = { git = "https://github.com/servo/webxr" }
-ohos-sys = { git = "https://github.com/jschwe/ohos-sys.git" }
+ohos-sys = "0.1"
 
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -18,9 +18,10 @@ use napi_ohos::threadsafe_function::{
     ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode,
 };
 use napi_ohos::{Env, JsFunction, JsObject, JsString, NapiRaw};
-use ohos_sys::ace::xcomponent::native_interface_xcomponent::{
+use ohos_sys::xcomponent::{
     OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetTouchEvent,
-    OH_NativeXComponent_TouchEvent, OH_NativeXComponent_TouchEventType,
+    OH_NativeXComponent_RegisterCallback, OH_NativeXComponent_TouchEvent,
+    OH_NativeXComponent_TouchEventType,
 };
 use servo::embedder_traits::PromptResult;
 use servo::euclid::Point2D;
@@ -395,7 +396,6 @@ fn register_xcomponent_callbacks(env: &Env, xcomponent: &JsObject) -> napi_ohos:
         OnSurfaceDestroyed: Some(on_surface_destroyed_cb),
         DispatchTouchEvent: Some(on_dispatch_touch_event_cb),
     });
-    use ohos_sys::ace::xcomponent::native_interface_xcomponent::OH_NativeXComponent_RegisterCallback;
     let res =
         unsafe { OH_NativeXComponent_RegisterCallback(nativeXComponent, Box::leak(cbs) as *mut _) };
     if res != 0 {

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -8,9 +8,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use log::{debug, error, info};
-use ohos_sys::ace::xcomponent::native_interface_xcomponent::{
-    OH_NativeXComponent, OH_NativeXComponent_GetXComponentSize,
-};
+use ohos_sys::xcomponent::{OH_NativeXComponent, OH_NativeXComponent_GetXComponentSize};
 use servo::compositing::windowing::EmbedderEvent;
 use servo::compositing::CompositeTarget;
 use servo::embedder_traits::resources;


### PR DESCRIPTION
- Use crates.io instead of git
- Bump to v0.2.1. This release changed the location of the xcomponent module and added feature guards for the components.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix~~
