### PR TITLE
Clarify the Code of Conduct (closes servo/servo.org#164)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-The Servo Project follows the [**Rust Code of Conduct**](https://www.rust-lang.org/policies/code-of-conduct), with two differences.
+The Servo Project follows the [**Rust Code of Conduct**](https://www.rust-lang.org/policies/code-of-conduct), with the differences below.
 
 Our code of conduct applies to the [Servo Zulip channels](https://servo.zulipchat.com/), [GitHub repositories](https://github.com/servo), and all official Servo venues, rather than the Rust project.
 


### PR DESCRIPTION
This patch rewords the Code of Conduct to clarify that the differences in ours are on separate paragraphs.

See also servo/servo.org#166.

---
<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes