### PR TITLE
Bump nixpkgs and add cargo-deny in shell.nix

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -5,7 +5,7 @@
   buildAndroid ? false
 }:
 with import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/46ae0210ce163b3cba6c7da08840c1d63de9c701.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/63d37ccd2d178d54e7fb691d7ec76000740ea24a.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation (androidEnvironment // {
 
     rustup
     taplo
+    cargo-deny
     llvmPackages.bintools # provides lld
 
     udev # Needed by libudev-sys for GamePad API.


### PR DESCRIPTION
We need Android NDK r26c for the SM upgrade (#32769) and the fix in nixpkgs to
make r26 NDKs function correctly (NixOS/nixpkgs#298285). Both of those are not
available in the snapshot of nixpkgs we use currently. The version of the new 
snapshot is based on `nixos-24.05`.

Also add cargo-deny to shell.nix to make `./mach test-tidy` work.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only touch nixos support code.
