### PR TITLE
clippy: Fix warning in `components/canvas`

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -251,7 +251,7 @@ impl<'a> UnshapedTextRun<'a> {
         }
     }
 
-    fn to_shaped_text_run(self) -> Option<TextRun> {
+    fn into_shaped_text_run(self) -> Option<TextRun> {
         let font = self.font?;
         if self.string.is_empty() {
             return None;
@@ -552,7 +552,7 @@ impl<'a> CanvasData<'a> {
         // to be some alignment along a baseline and also support for bidi text.
         let shaped_runs: Vec<_> = runs
             .into_iter()
-            .filter_map(UnshapedTextRun::to_shaped_text_run)
+            .filter_map(UnshapedTextRun::into_shaped_text_run)
             .collect();
         let total_advance = shaped_runs
             .iter()
@@ -635,7 +635,7 @@ impl<'a> CanvasData<'a> {
 
         let shaped_runs: Vec<_> = runs
             .into_iter()
-            .filter_map(UnshapedTextRun::to_shaped_text_run)
+            .filter_map(UnshapedTextRun::into_shaped_text_run)
             .collect();
         let total_advance = shaped_runs
             .iter()


### PR DESCRIPTION
Fixes a clippy warning in the components/canvas directory. It is part of https://github.com/servo/servo/issues/31500.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
