### PR TITLE
dependencies: Upgrade `cookie` and rename Servo's `Cookie` to `ServoCookie`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,18 +983,19 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.12.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
- "time 0.1.45",
+ "time 0.3.36",
+ "version_check",
 ]
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time 0.3.36",
  "version_check",
@@ -1278,6 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2905,7 +2907,7 @@ dependencies = [
 name = "hyper_serde"
 version = "0.13.2"
 dependencies = [
- "cookie 0.12.0",
+ "cookie 0.18.1",
  "headers",
  "http",
  "hyper",
@@ -2914,6 +2916,7 @@ dependencies = [
  "serde_bytes",
  "serde_test",
  "time 0.1.45",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -4137,7 +4140,7 @@ dependencies = [
  "bytes",
  "chrono",
  "content-security-policy",
- "cookie 0.12.0",
+ "cookie 0.18.1",
  "crossbeam-channel",
  "data-url",
  "devtools_traits",
@@ -4174,6 +4177,7 @@ dependencies = [
  "servo_url",
  "sha2",
  "time 0.1.45",
+ "time 0.3.36",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -4192,7 +4196,7 @@ version = "0.0.1"
 dependencies = [
  "base",
  "content-security-policy",
- "cookie 0.12.0",
+ "cookie 0.18.1",
  "embedder_traits",
  "headers",
  "http",
@@ -5198,7 +5202,7 @@ dependencies = [
  "canvas_traits",
  "chrono",
  "content-security-policy",
- "cookie 0.12.0",
+ "cookie 0.18.1",
  "crossbeam-channel",
  "cssparser",
  "data-url",
@@ -5336,7 +5340,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bluetooth_traits",
  "canvas_traits",
- "cookie 0.12.0",
+ "cookie 0.18.1",
  "crossbeam-channel",
  "devtools_traits",
  "embedder_traits",
@@ -7230,7 +7234,7 @@ dependencies = [
  "base",
  "base64",
  "compositing_traits",
- "cookie 0.12.0",
+ "cookie 0.18.1",
  "crossbeam-channel",
  "euclid",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cfg-if = "1.0.0"
 chrono = "0.4"
 compositing_traits = { path = "components/shared/compositing" }
 content-security-policy = { version = "0.5", features = ["serde"] }
-cookie = "0.12"
+cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
 cssparser = { version = "0.34", features = ["serde"] }
 darling = { version = "0.20", default-features = false }
@@ -121,6 +121,7 @@ syn = { version = "2", default-features = false, features = ["clone-impls", "der
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
+time_03 = { package = "time", version = "0.3", features = ["serde"] }
 to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 tokio = "1"
 tokio-rustls = "0.24"

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -24,6 +24,7 @@ mime = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 time = { workspace = true }
+time_03 = { workspace = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/components/hyper_serde/tests/tokens.rs
+++ b/components/hyper_serde/tests/tokens.rs
@@ -8,14 +8,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use cookie::Cookie;
+use cookie::{Cookie, CookieBuilder};
 use headers::ContentType;
 use http::header::{self, HeaderMap, HeaderValue};
 use http::StatusCode;
 use hyper::{Method, Uri};
 use hyper_serde::{De, Ser};
 use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
-use time::Duration;
+use time_03::Duration;
 
 #[test]
 fn test_content_type() {
@@ -31,13 +31,13 @@ fn test_cookie() {
     // Unfortunately we have to do the to_string().parse() dance here to avoid the object being a
     // string with a bunch of indices in it which apparently is different from the exact same
     // cookie but parsed as a bunch of strings.
-    let cookie: Cookie = Cookie::build("Hello", "World!")
+    let cookie: Cookie = CookieBuilder::new("Hello", "World!")
         .max_age(Duration::seconds(42))
         .domain("servo.org")
         .path("/")
         .secure(true)
         .http_only(false)
-        .finish()
+        .build()
         .to_string()
         .parse()
         .unwrap();

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -21,7 +21,7 @@ base64 = { workspace = true }
 brotli = "3"
 bytes = "1"
 content-security-policy = { workspace = true }
-cookie_rs = { package = "cookie", version = "0.12" }
+cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 data-url = { workspace = true }
 devtools_traits = { workspace = true }
@@ -58,6 +58,7 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 sha2 = "0.10"
 time = { workspace = true }
+time_03 = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tokio-rustls = { workspace = true }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -60,7 +60,7 @@ use crate::connector::{
     create_http_client, create_tls_config, CACertificates, CertificateErrorOverrideManager,
     Connector,
 };
-use crate::cookie;
+use crate::cookie::ServoCookie;
 use crate::cookie_storage::CookieStorage;
 use crate::decoder::Decoder;
 use crate::fetch::cors_cache::CorsCache;
@@ -328,7 +328,7 @@ fn set_cookie_for_url(cookie_jar: &RwLock<CookieStorage>, request: &ServoUrl, co
     let mut cookie_jar = cookie_jar.write().unwrap();
     let source = CookieSource::HTTP;
 
-    if let Some(cookie) = cookie::Cookie::from_cookie_string(cookie_val.into(), request, source) {
+    if let Some(cookie) = ServoCookie::from_cookie_string(cookie_val.into(), request, source) {
         cookie_jar.push(cookie, request, source);
     }
 }

--- a/components/net/tests/cookie.rs
+++ b/components/net/tests/cookie.rs
@@ -2,53 +2,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use net::cookie::Cookie;
+use net::cookie::ServoCookie;
 use net::cookie_storage::CookieStorage;
 use net_traits::CookieSource;
 use servo_url::ServoUrl;
 
 #[test]
 fn test_domain_match() {
-    assert!(Cookie::domain_match("foo.com", "foo.com"));
-    assert!(Cookie::domain_match("bar.foo.com", "foo.com"));
-    assert!(Cookie::domain_match("baz.bar.foo.com", "foo.com"));
+    assert!(ServoCookie::domain_match("foo.com", "foo.com"));
+    assert!(ServoCookie::domain_match("bar.foo.com", "foo.com"));
+    assert!(ServoCookie::domain_match("baz.bar.foo.com", "foo.com"));
 
-    assert!(!Cookie::domain_match("bar.foo.com", "bar.com"));
-    assert!(!Cookie::domain_match("bar.com", "baz.bar.com"));
-    assert!(!Cookie::domain_match("foo.com", "bar.com"));
+    assert!(!ServoCookie::domain_match("bar.foo.com", "bar.com"));
+    assert!(!ServoCookie::domain_match("bar.com", "baz.bar.com"));
+    assert!(!ServoCookie::domain_match("foo.com", "bar.com"));
 
-    assert!(!Cookie::domain_match("bar.com", "bbar.com"));
-    assert!(Cookie::domain_match("235.132.2.3", "235.132.2.3"));
-    assert!(!Cookie::domain_match("235.132.2.3", "1.1.1.1"));
-    assert!(!Cookie::domain_match("235.132.2.3", ".2.3"));
+    assert!(!ServoCookie::domain_match("bar.com", "bbar.com"));
+    assert!(ServoCookie::domain_match("235.132.2.3", "235.132.2.3"));
+    assert!(!ServoCookie::domain_match("235.132.2.3", "1.1.1.1"));
+    assert!(!ServoCookie::domain_match("235.132.2.3", ".2.3"));
 }
 
 #[test]
 fn test_path_match() {
-    assert!(Cookie::path_match("/", "/"));
-    assert!(Cookie::path_match("/index.html", "/"));
-    assert!(Cookie::path_match("/w/index.html", "/"));
-    assert!(Cookie::path_match("/w/index.html", "/w/index.html"));
-    assert!(Cookie::path_match("/w/index.html", "/w/"));
-    assert!(Cookie::path_match("/w/index.html", "/w"));
+    assert!(ServoCookie::path_match("/", "/"));
+    assert!(ServoCookie::path_match("/index.html", "/"));
+    assert!(ServoCookie::path_match("/w/index.html", "/"));
+    assert!(ServoCookie::path_match("/w/index.html", "/w/index.html"));
+    assert!(ServoCookie::path_match("/w/index.html", "/w/"));
+    assert!(ServoCookie::path_match("/w/index.html", "/w"));
 
-    assert!(!Cookie::path_match("/", "/w/"));
-    assert!(!Cookie::path_match("/a", "/w/"));
-    assert!(!Cookie::path_match("/", "/w"));
-    assert!(!Cookie::path_match("/w/index.html", "/w/index"));
-    assert!(!Cookie::path_match("/windex.html", "/w/"));
-    assert!(!Cookie::path_match("/windex.html", "/w"));
+    assert!(!ServoCookie::path_match("/", "/w/"));
+    assert!(!ServoCookie::path_match("/a", "/w/"));
+    assert!(!ServoCookie::path_match("/", "/w"));
+    assert!(!ServoCookie::path_match("/w/index.html", "/w/index"));
+    assert!(!ServoCookie::path_match("/windex.html", "/w/"));
+    assert!(!ServoCookie::path_match("/windex.html", "/w"));
 }
 
 #[test]
 fn test_default_path() {
-    assert_eq!(&*Cookie::default_path("/foo/bar/baz/"), "/foo/bar/baz");
-    assert_eq!(&*Cookie::default_path("/foo/bar/baz"), "/foo/bar");
-    assert_eq!(&*Cookie::default_path("/foo/"), "/foo");
-    assert_eq!(&*Cookie::default_path("/foo"), "/");
-    assert_eq!(&*Cookie::default_path("/"), "/");
-    assert_eq!(&*Cookie::default_path(""), "/");
-    assert_eq!(&*Cookie::default_path("foo"), "/");
+    assert_eq!(&*ServoCookie::default_path("/foo/bar/baz/"), "/foo/bar/baz");
+    assert_eq!(&*ServoCookie::default_path("/foo/bar/baz"), "/foo/bar");
+    assert_eq!(&*ServoCookie::default_path("/foo/"), "/foo");
+    assert_eq!(&*ServoCookie::default_path("/foo"), "/");
+    assert_eq!(&*ServoCookie::default_path("/"), "/");
+    assert_eq!(&*ServoCookie::default_path(""), "/");
+    assert_eq!(&*ServoCookie::default_path("foo"), "/");
 }
 
 #[test]
@@ -59,33 +59,33 @@ fn fn_cookie_constructor() {
 
     let gov_url = &ServoUrl::parse("http://gov.ac/foo").unwrap();
     // cookie name/value test
-    assert!(cookie_rs::Cookie::parse(" baz ").is_err());
-    assert!(cookie_rs::Cookie::parse(" = bar  ").is_err());
-    assert!(cookie_rs::Cookie::parse(" baz = ").is_ok());
+    assert!(cookie::Cookie::parse(" baz ").is_err());
+    assert!(cookie::Cookie::parse(" = bar  ").is_err());
+    assert!(cookie::Cookie::parse(" baz = ").is_ok());
 
     // cookie domains test
-    let cookie = cookie_rs::Cookie::parse(" baz = bar; Domain =  ").unwrap();
-    assert!(Cookie::new_wrapped(cookie.clone(), url, CookieSource::HTTP).is_some());
-    let cookie = Cookie::new_wrapped(cookie, url, CookieSource::HTTP).unwrap();
+    let cookie = cookie::Cookie::parse(" baz = bar; Domain =  ").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie.clone(), url, CookieSource::HTTP).is_some());
+    let cookie = ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).unwrap();
     assert_eq!(&**cookie.cookie.domain().as_ref().unwrap(), "example.com");
 
     // cookie public domains test
-    let cookie = cookie_rs::Cookie::parse(" baz = bar; Domain =  gov.ac").unwrap();
-    assert!(Cookie::new_wrapped(cookie.clone(), url, CookieSource::HTTP).is_none());
-    assert!(Cookie::new_wrapped(cookie, gov_url, CookieSource::HTTP).is_some());
+    let cookie = cookie::Cookie::parse(" baz = bar; Domain =  gov.ac").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie.clone(), url, CookieSource::HTTP).is_none());
+    assert!(ServoCookie::new_wrapped(cookie, gov_url, CookieSource::HTTP).is_some());
 
     // cookie domain matching test
-    let cookie = cookie_rs::Cookie::parse(" baz = bar ; Secure; Domain = bazample.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse(" baz = bar ; Secure; Domain = bazample.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
-    let cookie = cookie_rs::Cookie::parse(" baz = bar ; Secure; Path = /foo/bar/").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
+    let cookie = cookie::Cookie::parse(" baz = bar ; Secure; Path = /foo/bar/").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
 
-    let cookie = cookie_rs::Cookie::parse(" baz = bar ; HttpOnly").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::NonHTTP).is_none());
+    let cookie = cookie::Cookie::parse(" baz = bar ; HttpOnly").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::NonHTTP).is_none());
 
-    let cookie = cookie_rs::Cookie::parse(" baz = bar ; Secure; Path = /foo/bar/").unwrap();
-    let cookie = Cookie::new_wrapped(cookie, url, CookieSource::HTTP).unwrap();
+    let cookie = cookie::Cookie::parse(" baz = bar ; Secure; Path = /foo/bar/").unwrap();
+    let cookie = ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).unwrap();
     assert_eq!(cookie.cookie.value(), "bar");
     assert_eq!(cookie.cookie.name(), "baz");
     assert!(cookie.cookie.secure().unwrap_or(false));
@@ -94,77 +94,75 @@ fn fn_cookie_constructor() {
     assert!(cookie.host_only);
 
     let u = &ServoUrl::parse("http://example.com/foobar").unwrap();
-    let cookie = cookie_rs::Cookie::parse("foobar=value;path=/").unwrap();
-    assert!(Cookie::new_wrapped(cookie, u, CookieSource::HTTP).is_some());
+    let cookie = cookie::Cookie::parse("foobar=value;path=/").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, u, CookieSource::HTTP).is_some());
 }
 
 #[test]
 fn test_cookie_secure_prefix() {
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Secure-SID=12345").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Secure-SID=12345").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("http://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Secure-SID=12345; Secure").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Secure-SID=12345; Secure").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Secure-SID=12345; Secure").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
+    let cookie = cookie::Cookie::parse("__Secure-SID=12345; Secure").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Secure-SID=12345; Domain=example.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Secure-SID=12345; Domain=example.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("http://example.com").unwrap();
-    let cookie =
-        cookie_rs::Cookie::parse("__Secure-SID=12345; Secure; Domain=example.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Secure-SID=12345; Secure; Domain=example.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie =
-        cookie_rs::Cookie::parse("__Secure-SID=12345; Secure; Domain=example.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
+    let cookie = cookie::Cookie::parse("__Secure-SID=12345; Secure; Domain=example.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
 }
 
 #[test]
 fn test_cookie_host_prefix() {
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("http://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Secure").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Secure").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Secure").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Secure").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Domain=example.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Domain=example.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Domain=example.com; Path=/").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Domain=example.com; Path=/").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("http://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Secure; Domain=example.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Secure; Domain=example.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Secure; Domain=example.com").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Secure; Domain=example.com").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
     let cookie =
-        cookie_rs::Cookie::parse("__Host-SID=12345; Secure; Domain=example.com; Path=/").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
+        cookie::Cookie::parse("__Host-SID=12345; Secure; Domain=example.com; Path=/").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
 
     let url = &ServoUrl::parse("https://example.com").unwrap();
-    let cookie = cookie_rs::Cookie::parse("__Host-SID=12345; Secure; Path=/").unwrap();
-    assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
+    let cookie = cookie::Cookie::parse("__Host-SID=12345; Secure; Path=/").unwrap();
+    assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
 }
 
 #[cfg(target_os = "windows")]
@@ -185,12 +183,12 @@ fn test_sort_order() {
     use std::cmp::Ordering;
 
     let url = &ServoUrl::parse("http://example.com/foo").unwrap();
-    let a_wrapped = cookie_rs::Cookie::parse("baz=bar; Path=/foo/bar/").unwrap();
-    let a = Cookie::new_wrapped(a_wrapped.clone(), url, CookieSource::HTTP).unwrap();
+    let a_wrapped = cookie::Cookie::parse("baz=bar; Path=/foo/bar/").unwrap();
+    let a = ServoCookie::new_wrapped(a_wrapped.clone(), url, CookieSource::HTTP).unwrap();
     delay_to_ensure_different_timestamp();
-    let a_prime = Cookie::new_wrapped(a_wrapped, url, CookieSource::HTTP).unwrap();
-    let b = cookie_rs::Cookie::parse("baz=bar;Path=/foo/bar/baz/").unwrap();
-    let b = Cookie::new_wrapped(b, url, CookieSource::HTTP).unwrap();
+    let a_prime = ServoCookie::new_wrapped(a_wrapped, url, CookieSource::HTTP).unwrap();
+    let b = cookie::Cookie::parse("baz=bar;Path=/foo/bar/baz/").unwrap();
+    let b = ServoCookie::new_wrapped(b, url, CookieSource::HTTP).unwrap();
 
     assert!(b.cookie.path().as_ref().unwrap().len() > a.cookie.path().as_ref().unwrap().len());
     assert_eq!(CookieStorage::cookie_comparator(&a, &b), Ordering::Greater);
@@ -208,8 +206,8 @@ fn test_sort_order() {
 
 fn add_cookie_to_storage(storage: &mut CookieStorage, url: &ServoUrl, cookie_str: &str) {
     let source = CookieSource::HTTP;
-    let cookie = cookie_rs::Cookie::parse(cookie_str.to_owned()).unwrap();
-    let cookie = Cookie::new_wrapped(cookie, url, source).unwrap();
+    let cookie = cookie::Cookie::parse(cookie_str.to_owned()).unwrap();
+    let cookie = ServoCookie::new_wrapped(cookie, url, source).unwrap();
     storage.push(cookie, url, source);
 }
 
@@ -220,13 +218,13 @@ fn test_insecure_cookies_cannot_evict_secure_cookie() {
     let source = CookieSource::HTTP;
     let mut cookies = Vec::new();
 
-    cookies.push(cookie_rs::Cookie::parse("foo=bar; Secure; Domain=home.example.org").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo2=bar; Secure; Domain=.example.org").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo3=bar; Secure; Path=/foo").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo4=bar; Secure; Path=/foo/bar").unwrap());
+    cookies.push(cookie::Cookie::parse("foo=bar; Secure; Domain=home.example.org").unwrap());
+    cookies.push(cookie::Cookie::parse("foo2=bar; Secure; Domain=.example.org").unwrap());
+    cookies.push(cookie::Cookie::parse("foo3=bar; Secure; Path=/foo").unwrap());
+    cookies.push(cookie::Cookie::parse("foo4=bar; Secure; Path=/foo/bar").unwrap());
 
     for bare_cookie in cookies {
-        let cookie = Cookie::new_wrapped(bare_cookie, &secure_url, source).unwrap();
+        let cookie = ServoCookie::new_wrapped(bare_cookie, &secure_url, source).unwrap();
         storage.push(cookie, &secure_url, source);
     }
 
@@ -275,13 +273,13 @@ fn test_secure_cookies_eviction() {
     let source = CookieSource::HTTP;
     let mut cookies = Vec::new();
 
-    cookies.push(cookie_rs::Cookie::parse("foo=bar; Secure; Domain=home.example.org").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo2=bar; Secure; Domain=.example.org").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo3=bar; Secure; Path=/foo").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo4=bar; Secure; Path=/foo/bar").unwrap());
+    cookies.push(cookie::Cookie::parse("foo=bar; Secure; Domain=home.example.org").unwrap());
+    cookies.push(cookie::Cookie::parse("foo2=bar; Secure; Domain=.example.org").unwrap());
+    cookies.push(cookie::Cookie::parse("foo3=bar; Secure; Path=/foo").unwrap());
+    cookies.push(cookie::Cookie::parse("foo4=bar; Secure; Path=/foo/bar").unwrap());
 
     for bare_cookie in cookies {
-        let cookie = Cookie::new_wrapped(bare_cookie, &url, source).unwrap();
+        let cookie = ServoCookie::new_wrapped(bare_cookie, &url, source).unwrap();
         storage.push(cookie, &url, source);
     }
 
@@ -317,13 +315,13 @@ fn test_secure_cookies_eviction_non_http_source() {
     let source = CookieSource::NonHTTP;
     let mut cookies = Vec::new();
 
-    cookies.push(cookie_rs::Cookie::parse("foo=bar; Secure; Domain=home.example.org").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo2=bar; Secure; Domain=.example.org").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo3=bar; Secure; Path=/foo").unwrap());
-    cookies.push(cookie_rs::Cookie::parse("foo4=bar; Secure; Path=/foo/bar").unwrap());
+    cookies.push(cookie::Cookie::parse("foo=bar; Secure; Domain=home.example.org").unwrap());
+    cookies.push(cookie::Cookie::parse("foo2=bar; Secure; Domain=.example.org").unwrap());
+    cookies.push(cookie::Cookie::parse("foo3=bar; Secure; Path=/foo").unwrap());
+    cookies.push(cookie::Cookie::parse("foo4=bar; Secure; Path=/foo/bar").unwrap());
 
     for bare_cookie in cookies {
-        let cookie = Cookie::new_wrapped(bare_cookie, &url, source).unwrap();
+        let cookie = ServoCookie::new_wrapped(bare_cookie, &url, source).unwrap();
         storage.push(cookie, &url, source);
     }
 
@@ -363,7 +361,7 @@ fn add_retrieve_cookies(
 
     // Add all cookies to the store
     for str_cookie in set_cookies {
-        let cookie = Cookie::from_cookie_string(str_cookie.to_owned(), &url, source).unwrap();
+        let cookie = ServoCookie::from_cookie_string(str_cookie.to_owned(), &url, source).unwrap();
         storage.push(cookie, &url, source);
     }
 

--- a/components/net/tests/cookie_http_state.rs
+++ b/components/net/tests/cookie_http_state.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use net::cookie::Cookie;
+use net::cookie::ServoCookie;
 use net::cookie_storage::CookieStorage;
 use net_traits::CookieSource;
 use servo_url::ServoUrl;
@@ -14,7 +14,8 @@ fn run(set_location: &str, set_cookies: &[&str], final_location: &str) -> String
 
     // Add all cookies to the store
     for str_cookie in set_cookies {
-        if let Some(cookie) = Cookie::from_cookie_string(str_cookie.to_owned().into(), &url, source)
+        if let Some(cookie) =
+            ServoCookie::from_cookie_string(str_cookie.to_owned().into(), &url, source)
         {
             storage.push(cookie, &url, source);
         }

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use base::id::TEST_PIPELINE_ID;
-use cookie_rs::Cookie as CookiePair;
+use cookie::Cookie as CookiePair;
 use crossbeam_channel::{unbounded, Receiver};
 use devtools_traits::{
     ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest,
@@ -30,7 +30,7 @@ use http::{Method, StatusCode};
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
-use net::cookie::Cookie;
+use net::cookie::ServoCookie;
 use net::cookie_storage::CookieStorage;
 use net::http_loader::determine_requests_referrer;
 use net::resource_thread::AuthCacheEntry;
@@ -648,7 +648,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
 
     {
         let mut cookie_jar = context.state.cookie_jar.write().unwrap();
-        let cookie = Cookie::new_wrapped(
+        let cookie = ServoCookie::new_wrapped(
             CookiePair::new("mozillaIs".to_owned(), "theBest".to_owned()),
             &url,
             CookieSource::HTTP,
@@ -694,7 +694,7 @@ fn test_load_sends_cookie_if_nonhttp() {
 
     {
         let mut cookie_jar = context.state.cookie_jar.write().unwrap();
-        let cookie = Cookie::new_wrapped(
+        let cookie = ServoCookie::new_wrapped(
             CookiePair::new("mozillaIs".to_owned(), "theBest".to_owned()),
             &url,
             CookieSource::NonHTTP,
@@ -1192,7 +1192,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
     let mut context = new_fetch_context(None, None, None);
     {
         let mut cookie_jar = context.state.cookie_jar.write().unwrap();
-        let cookie_x = Cookie::new_wrapped(
+        let cookie_x = ServoCookie::new_wrapped(
             CookiePair::new("mozillaIsNot".to_owned(), "dotOrg".to_owned()),
             &url_x,
             CookieSource::HTTP,
@@ -1201,7 +1201,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
 
         cookie_jar.push(cookie_x, &url_x, CookieSource::HTTP);
 
-        let cookie_y = Cookie::new_wrapped(
+        let cookie_y = ServoCookie::new_wrapped(
             CookiePair::new("mozillaIs".to_owned(), "theBest".to_owned()),
             &url_y,
             CookieSource::HTTP,

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -39,7 +39,7 @@ use url::Url;
 
 use crate::async_runtime::HANDLE;
 use crate::connector::{create_tls_config, CACertificates, TlsConfig};
-use crate::cookie::Cookie;
+use crate::cookie::ServoCookie;
 use crate::fetch::methods::should_be_blocked_due_to_bad_port;
 use crate::hosts::replace_host;
 use crate::http_loader::HttpState;
@@ -127,7 +127,7 @@ fn process_ws_response(
     for cookie in response.headers().get_all(header::SET_COOKIE) {
         if let Ok(s) = std::str::from_utf8(cookie.as_bytes()) {
             if let Some(cookie) =
-                Cookie::from_cookie_string(s.into(), resource_url, CookieSource::HTTP)
+                ServoCookie::from_cookie_string(s.into(), resource_url, CookieSource::HTTP)
             {
                 jar.push(cookie, resource_url, CookieSource::HTTP);
             }

--- a/tests/wpt/tests/html/dom/documents/resource-metadata-management/document-cookie.html
+++ b/tests/wpt/tests/html/dom/documents/resource-metadata-management/document-cookie.html
@@ -26,7 +26,7 @@ for (const i in TEST_CASES) {
 
     // Cleanup
     if (document.cookie.includes("=")) {
-      document.cookie = document.cookie.split("=")[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+      document.cookie = document.cookie.split("=")[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
       assert_equals(document.cookie, "");
     }
   }, t.name);


### PR DESCRIPTION
This changes updates to the new version of the `cookie` crate in Servo
which no longer uses the old `time@0.1` data types. This requires using
a new version of `time` while we transition off of the old one. This is
the first step in that process.

In addition, the overloading of the `cookie::Cookie` name was causing a
great deal of confusion, so I've renamed the Servo wrapper to
`ServoCookie` like we do with `ServoUrl`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30150.
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
