### PR TITLE
Remove the WebXR dependency on ancient `time@0.1` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,6 @@ dependencies = [
  "style",
  "style_traits",
  "surfman",
- "time 0.1.45",
  "unicode-script",
  "webrender",
  "webrender_api",
@@ -670,7 +669,6 @@ dependencies = [
  "servo_config",
  "sparkle",
  "style",
- "time 0.1.45",
  "webrender_api",
  "webxr-api",
 ]
@@ -7382,7 +7380,6 @@ dependencies = [
  "ipc-channel",
  "log",
  "serde",
- "time 0.1.45",
 ]
 
 [[package]]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -12,7 +12,6 @@ path = "lib.rs"
 
 [features]
 webgl_backtrace = ["canvas_traits/webgl_backtrace"]
-xr-profile = ["webxr-api/profile", "time"]
 
 [dependencies]
 app_units = { workspace = true }
@@ -41,7 +40,6 @@ sparkle = { workspace = true }
 style = { workspace = true }
 style_traits = { workspace = true }
 surfman = { workspace = true }
-time = { workspace = true, optional = true }
 unicode-script = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -51,11 +51,6 @@ use webxr_api::{
 
 use crate::webgl_limits::GLLimitsDetect;
 
-#[cfg(feature = "xr-profile")]
-fn to_ms(ns: u64) -> f64 {
-    ns as f64 / 1_000_000.
-}
-
 struct GLContextData {
     ctx: Context,
     gl: Rc<Gl>,
@@ -831,14 +826,6 @@ impl WebGLThread {
 
         #[allow(unused)]
         let mut end_swap = 0;
-        #[cfg(feature = "xr-profile")]
-        {
-            end_swap = time::precise_time_ns();
-            println!(
-                "WEBXR PROFILING [swap buffer]:\t{}ms",
-                to_ms(end_swap - start_swap)
-            );
-        }
         completed_sender.send(end_swap).unwrap();
     }
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -18,7 +18,6 @@ profilemozjs = ['js/profilemozjs']
 webgl_backtrace = ["canvas_traits/webgl_backtrace"]
 js_backtrace = []
 refcell_backtrace = ["accountable-refcell"]
-xr-profile = ["webxr-api/profile"]
 
 [build-dependencies]
 phf_codegen = "0.11"

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2912,10 +2912,6 @@ impl Document {
 
         #[allow(unused)]
         let mut time = 0;
-        #[cfg(feature = "xr-profile")]
-        {
-            time = time::precise_time_ns();
-        }
         let (sender, receiver) = webgl::webgl_channel().unwrap();
         self.window
             .webgl_chan()

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -30,7 +30,6 @@ webgl_backtrace = [
     "canvas/webgl_backtrace",
     "canvas_traits/webgl_backtrace",
 ]
-xr-profile = ["canvas/xr-profile", "canvas_traits/xr-profile", "script/xr-profile", "webxr/profile"]
 
 [dependencies]
 background_hang_monitor = { path = "../background_hang_monitor" }

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -12,7 +12,6 @@ path = "lib.rs"
 
 [features]
 webgl_backtrace = []
-xr-profile = ["webxr-api/profile", "time"]
 
 [dependencies]
 base = { workspace = true }
@@ -28,6 +27,5 @@ serde_bytes = { workspace = true }
 servo_config = { path = "../../config" }
 sparkle = { workspace = true }
 style = { workspace = true }
-time = { workspace = true, optional = true }
 webrender_api = { workspace = true }
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -50,7 +50,6 @@ profilemozjs = ["libservo/profilemozjs"]
 refcell_backtrace = ["libservo/refcell_backtrace"]
 webdriver = ["libservo/webdriver"]
 webgl_backtrace = ["libservo/webgl_backtrace"]
-xr-profile = ["libservo/xr-profile"]
 
 [dependencies]
 libc = { workspace = true }


### PR DESCRIPTION
`webxr` depends on a very old verison of `time`, which allowed serializing
monotonic clock output. This isn't possible on all platforms, so newer
versions of `time` do not allow this. In order to stop using the old
0.1 versions of `time` we have to stop relying on times passed from `webxr`
to Servo. This change does that, at the cost of removing the XR
profiling feature. It has to be rewritten in another way in the `webxr`
crate.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change testable functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
