### PR TITLE
Correct the order of newline normalization in FormData

### DIFF
--- a/tests/wpt/meta-legacy-layout/html/semantics/forms/form-submission-0/newline-normalization.html.ini
+++ b/tests/wpt/meta-legacy-layout/html/semantics/forms/form-submission-0/newline-normalization.html.ini
@@ -23,24 +23,6 @@
   [Form newline normalization: \\n\\r in the filename stays unchanged]
     expected: FAIL
 
-  [Constructing the entry list shouldn't perform newline normalization: \\n in the value]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\r in the value]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\n\\r in the value]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\n in the name]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\r in the name]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\n\\r in the name]
-    expected: FAIL
-
   [Constructing the entry list shouldn't perform newline normalization: \\n in the filename]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/forms/form-submission-0/newline-normalization.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/form-submission-0/newline-normalization.html.ini
@@ -23,24 +23,6 @@
   [Form newline normalization: \\n\\r in the filename stays unchanged]
     expected: FAIL
 
-  [Constructing the entry list shouldn't perform newline normalization: \\n in the value]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\r in the value]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\n\\r in the value]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\n in the name]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\r in the name]
-    expected: FAIL
-
-  [Constructing the entry list shouldn't perform newline normalization: \\n\\r in the name]
-    expected: FAIL
-
   [Constructing the entry list shouldn't perform newline normalization: \\n in the filename]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Moves newline normalization of form data from "constructing the entry list" to the serialization stage. This was a spec change after the initial implementation in Servo.

See: https://blog.whatwg.org/newline-normalizations-in-form-submission

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes