### PR TITLE
Fix debugmozjs compilation error

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -835,7 +835,7 @@ unsafe extern "C" fn servo_build_id(build_id: *mut BuildIdCharVector) -> bool {
 #[allow(unsafe_code)]
 #[cfg(feature = "debugmozjs")]
 unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
-    use js::jsapi::{JS_SetGCZeal, JS_DEFAULT_ZEAL_FREQ};
+    use js::jsapi::SetGCZeal;
 
     let level = match pref!(js.mem.gc.zeal.level) {
         level @ 0..=14 => level as u8,
@@ -843,9 +843,10 @@ unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
     };
     let frequency = match pref!(js.mem.gc.zeal.frequency) {
         frequency if frequency >= 0 => frequency as u32,
-        _ => JS_DEFAULT_ZEAL_FREQ,
+        // https://searchfox.org/mozilla-esr128/source/js/public/GCAPI.h#1392
+        _ => 5000,
     };
-    JS_SetGCZeal(cx, level, frequency);
+    SetGCZeal(cx, level, frequency);
 }
 
 #[allow(unsafe_code)]


### PR DESCRIPTION
Reported by @jschwe on zulip: https://servo.zulipchat.com/#narrow/stream/263398-general/topic/Build.20issues/near/454781548, caused by #32769.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] I manually tested that it compiles now with `--features debugmozjs`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
