### PR TITLE
layout: Fix display of new text in `textarea` elements

### DIFF
--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-textarea-001.tentative.html.ini
@@ -5,5 +5,5 @@
   [.target > * 1]
     expected: FAIL
 
-  [.target > * 5]
+  [.target > * 11]
     expected: FAIL

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir_auto-textarea-script-N-EN.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir_auto-textarea-script-N-EN.html.ini
@@ -1,2 +1,0 @@
-[dir_auto-textarea-script-N-EN.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html.ini
@@ -1,2 +1,0 @@
-[multiline-placeholder-cr.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-crlf.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-crlf.html.ini
@@ -1,2 +1,0 @@
-[multiline-placeholder-crlf.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder.html.ini
@@ -1,2 +1,0 @@
-[multiline-placeholder.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/placeholder-white-space.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/placeholder-white-space.tentative.html.ini
@@ -1,2 +1,0 @@
-[placeholder-white-space.tentative.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/textarea_placeholder.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/textarea_placeholder.html.ini
@@ -1,2 +1,0 @@
-[textarea_placeholder.html]
-  expected: FAIL


### PR DESCRIPTION
Previously `<textarea>` was just displaying node contents, which is the
original text content, not the one updated by later typing. This change
fixes that issue.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
