### PR TITLE
DevTools: Allow modification of attributes

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -86,10 +86,11 @@ impl Actor for InspectorActor {
                 self.script_chan.send(GetRootNode(pipeline, tx)).unwrap();
                 let root_info = rx.recv().unwrap().ok_or(())?;
 
-                let name = match self.walker.borrow().as_ref() {
-                    Some(walker) => walker.clone(),
-                    None => registry.new_name("walker"),
-                };
+                let name = self
+                    .walker
+                    .borrow()
+                    .clone()
+                    .unwrap_or_else(|| registry.new_name("walker"));
 
                 let root = root_info.encode(
                     registry,

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -104,7 +104,7 @@ impl Actor for NodeActor {
             "modifyAttributes" => {
                 let target = msg.get("to").ok_or(())?.as_str().ok_or(())?;
                 let mods = msg.get("modifications").ok_or(())?.as_array().ok_or(())?;
-                let modifications = mods
+                let modifications: Vec<_> = mods
                     .iter()
                     .filter_map(|json_mod| {
                         serde_json::from_str(&serde_json::to_string(json_mod).ok()?).ok()

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -180,7 +180,7 @@ impl NodeInfoToProtocol for NodeInfo {
                 name: name.clone(),
                 script_chan: script_chan.clone(),
                 pipeline,
-                walker,
+                walker: walker.clone(),
             };
             actors.register_script_actor(self.unique_id, name.clone());
             actors.register_later(Box::new(node_actor));
@@ -206,7 +206,7 @@ impl NodeInfoToProtocol for NodeInfo {
             let mut children = rx.recv().ok()??;
 
             let child = children.pop()?;
-            let msg = child.encode(actors, true, script_chan.clone(), pipeline);
+            let msg = child.encode(actors, true, script_chan.clone(), pipeline, walker);
 
             // If the node child is not a text node, do not represent it inline.
             if msg.node_type != TEXT_NODE {

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -273,7 +273,7 @@ impl WalkerActor {
         &self,
         stream: &mut TcpStream,
         target: &str,
-        modifications: &Vec<Modification>,
+        modifications: &[Modification],
     ) {
         {
             let mut mutations = self.mutations.borrow_mut();

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -4,11 +4,12 @@
 
 //! The walker actor is responsible for traversing the DOM tree in various ways to create new nodes
 
+use std::cell::RefCell;
 use std::net::TcpStream;
 
 use base::id::PipelineId;
-use devtools_traits::DevtoolScriptControlMsg;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement};
+use devtools_traits::{DevtoolScriptControlMsg, Modification};
 use ipc_channel::ipc::{self, IpcSender};
 use serde::Serialize;
 use serde_json::{self, Map, Value};
@@ -30,6 +31,7 @@ pub struct WalkerActor {
     pub script_chan: IpcSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub root_node: NodeActorMsg,
+    pub mutations: RefCell<Vec<(Modification, String)>>,
 }
 
 #[derive(Serialize)]
@@ -70,9 +72,32 @@ struct WatchRootNodeReply {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MutationMsg {
+    attribute_name: String,
+    new_value: Option<String>,
+    target: String,
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Serialize)]
+struct GetMutationsReply {
+    from: String,
+    mutations: Vec<MutationMsg>,
+}
+
+#[derive(Serialize)]
 struct GetOffsetParentReply {
     from: String,
     node: Option<()>,
+}
+
+#[derive(Serialize)]
+struct NewMutationsReply {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
 }
 
 impl Actor for WalkerActor {
@@ -89,6 +114,8 @@ impl Actor for WalkerActor {
     /// - `documentElement`: Returns the base document element node
     ///
     /// - `getLayoutInspector`: Returns the Layout inspector actor, placeholder
+    ///
+    /// - `getMutations`: Returns the list of attribute changes since it was last called
     ///
     /// - `getOffsetParent`: Placeholder
     ///
@@ -121,7 +148,13 @@ impl Actor for WalkerActor {
                     nodes: children
                         .into_iter()
                         .map(|child| {
-                            child.encode(registry, true, self.script_chan.clone(), self.pipeline)
+                            child.encode(
+                                registry,
+                                true,
+                                self.script_chan.clone(),
+                                self.pipeline,
+                                self.name(),
+                            )
                         })
                         .collect(),
                     from: self.name(),
@@ -140,8 +173,13 @@ impl Actor for WalkerActor {
                     .send(GetDocumentElement(self.pipeline, tx))
                     .map_err(|_| ())?;
                 let doc_elem_info = rx.recv().map_err(|_| ())?.ok_or(())?;
-                let node =
-                    doc_elem_info.encode(registry, true, self.script_chan.clone(), self.pipeline);
+                let node = doc_elem_info.encode(
+                    registry,
+                    true,
+                    self.script_chan.clone(),
+                    self.pipeline,
+                    self.name(),
+                );
 
                 let msg = DocumentElementReply {
                     from: self.name(),
@@ -163,6 +201,24 @@ impl Actor for WalkerActor {
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed
             },
+            "getMutations" => {
+                let msg = GetMutationsReply {
+                    from: self.name(),
+                    mutations: self
+                        .mutations
+                        .borrow_mut()
+                        .drain(..)
+                        .map(|(mutation, target)| MutationMsg {
+                            attribute_name: mutation.attribute_name,
+                            new_value: mutation.new_value,
+                            target,
+                            type_: "attributes".into(),
+                        })
+                        .collect(),
+                };
+                let _ = stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            },
             "getOffsetParent" => {
                 let msg = GetOffsetParentReply {
                     from: self.name(),
@@ -177,6 +233,7 @@ impl Actor for WalkerActor {
                 let mut hierarchy = find_child(
                     &self.script_chan,
                     self.pipeline,
+                    &self.name,
                     registry,
                     selector,
                     node,
@@ -211,11 +268,30 @@ impl Actor for WalkerActor {
     }
 }
 
+impl WalkerActor {
+    pub(crate) fn new_mutations(
+        &self,
+        stream: &mut TcpStream,
+        target: &str,
+        modifications: &Vec<Modification>,
+    ) {
+        {
+            let mut mutations = self.mutations.borrow_mut();
+            mutations.extend(modifications.iter().cloned().map(|m| (m, target.into())));
+        }
+        let _ = stream.write_json_packet(&NewMutationsReply {
+            from: self.name(),
+            type_: "newMutations".into(),
+        });
+    }
+}
+
 /// Recursively searches for a child with the specified selector
 /// If it is found, returns a list with the child and all of its ancestors.
 fn find_child(
     script_chan: &IpcSender<DevtoolScriptControlMsg>,
     pipeline: PipelineId,
+    name: &str,
     registry: &ActorRegistry,
     selector: &str,
     node: &str,
@@ -232,7 +308,7 @@ fn find_child(
     let children = rx.recv().unwrap().ok_or(vec![])?;
 
     for child in children {
-        let msg = child.encode(registry, true, script_chan.clone(), pipeline);
+        let msg = child.encode(registry, true, script_chan.clone(), pipeline, name.into());
         if msg.display_name == selector {
             hierarchy.push(msg);
             return Ok(hierarchy);
@@ -245,6 +321,7 @@ fn find_child(
         match find_child(
             script_chan,
             pipeline,
+            name,
             registry,
             selector,
             &msg.actor,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -235,6 +235,11 @@ pub fn handle_modify_attribute(
     node_id: String,
     modifications: Vec<Modification>,
 ) {
+    let Some(document) = documents.find_document(pipeline) else {
+        return warn!("document for pipeline id {} is not found", &pipeline);
+    };
+    let _realm = enter_realm(document.window());
+
     let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
         None => {
             return warn!(

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -222,7 +222,7 @@ pub enum DevtoolScriptControlMsg {
     Reload(PipelineId),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Modification {
     pub attribute_name: String,


### PR DESCRIPTION
This PR fixes the handling of attributes in the inspector. Now it is possible to add, remove and modify attributes of HTML nodes. There were two issues with it:

- Servo crashed when updating the values (#32885). This was because it was not properly entering a realm before making DOM modifications.
- The messages have changed. Now after receiving a `modifyAttributes` message, the node has to inform the walker that there have been mutations on the DOM. The walker then sends `newMutations` (which is part of the event messages that are not directly responding to another message, see `browsing_context` for more examples), which then triggers the DevTools client to ask for `getMutations`. Here we send a list of all of the changes to the attributes that we made.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32885 and are a part of #32404
- [x] These changes do not require tests because there are no tests yet for DevTools