### PR TITLE
Update to rust 1.80.0

### DIFF
--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -35,6 +35,9 @@ fn test_exit() {
     );
     resource_thread.send(CoreResourceMsg::Exit(sender)).unwrap();
     receiver.recv().unwrap();
+    // Workaround for https://github.com/servo/servo/issues/32912
+    #[cfg(windows)]
+    std::thread::sleep(std::time::Duration::from_millis(100));
 }
 
 #[test]

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -10,7 +10,7 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/7f0e3ef7b7fbed78e12e5100851175d28af4b7c6.tar.gz";
+      url = "https://github.com/oxalica/rust-overlay/archive/8b81b8ed00b20fd57b24adcb390bd96ea81ecd90.tar.gz";
     }))
   ];
   config = {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update etc/shell.nix when bumping this!
-channel = "1.78.0"
+channel = "1.80.0"
 
 components = [
     # For support/crown

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -48,22 +48,22 @@ pub fn in_derive_expn(span: Span) -> bool {
 
 #[macro_export]
 macro_rules! symbols {
-     ($($s: ident)+) => {
-         #[derive(Clone)]
-         #[allow(non_snake_case)]
-         pub(crate) struct Symbols {
-             $( $s: Symbol, )+
-         }
+    ($($s: ident)+) => {
+        #[derive(Clone)]
+        #[allow(non_snake_case)]
+        pub(crate) struct Symbols {
+            $( $s: Symbol, )+
+        }
 
-         impl Symbols {
-             fn new() -> Self {
-                 Symbols {
-                     $( $s: Symbol::intern(stringify!($s)), )+
-                 }
-             }
-         }
-     }
- }
+        impl Symbols {
+            fn new() -> Self {
+                Symbols {
+                    $( $s: Symbol::intern(stringify!($s)), )+
+                }
+            }
+        }
+    }
+}
 
 /*
 Stuff copied from clippy:

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -6,7 +6,7 @@ use rustc_ast::Mutability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::{ImplItemRef, ItemKind, Node, OwnerId, PrimTy, TraitItemRef};
-use rustc_infer::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
+use rustc_infer::infer::type_variable::TypeVariableOrigin;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::LateContext;
 use rustc_middle::ty::fast_reject::SimplifiedType;
@@ -49,22 +49,22 @@ pub fn in_derive_expn(span: Span) -> bool {
 
 #[macro_export]
 macro_rules! symbols {
-    ($($s: ident)+) => {
-        #[derive(Clone)]
-        #[allow(non_snake_case)]
-        pub(crate) struct Symbols {
-            $( $s: Symbol, )+
-        }
+     ($($s: ident)+) => {
+         #[derive(Clone)]
+         #[allow(non_snake_case)]
+         pub(crate) struct Symbols {
+             $( $s: Symbol, )+
+         }
 
-        impl Symbols {
-            fn new() -> Self {
-                Symbols {
-                    $( $s: Symbol::intern(stringify!($s)), )+
-                }
-            }
-        }
-    }
-}
+         impl Symbols {
+             fn new() -> Self {
+                 Symbols {
+                     $( $s: Symbol::intern(stringify!($s)), )+
+                 }
+             }
+         }
+     }
+ }
 
 /*
 Stuff copied from clippy:
@@ -339,7 +339,7 @@ pub fn implements_trait_with_env<'tcx>(
     }
     let infcx = tcx.infer_ctxt().build();
     let orig = TypeVariableOrigin {
-        kind: TypeVariableOriginKind::MiscVariable,
+        param_def_id: None,
         span: DUMMY_SP,
     };
     let ty_params = tcx.mk_args_from_iter(

--- a/support/crown/src/common.rs
+++ b/support/crown/src/common.rs
@@ -6,7 +6,6 @@ use rustc_ast::Mutability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::{ImplItemRef, ItemKind, Node, OwnerId, PrimTy, TraitItemRef};
-use rustc_infer::infer::type_variable::TypeVariableOrigin;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::LateContext;
 use rustc_middle::ty::fast_reject::SimplifiedType;
@@ -338,14 +337,10 @@ pub fn implements_trait_with_env<'tcx>(
         return false;
     }
     let infcx = tcx.infer_ctxt().build();
-    let orig = TypeVariableOrigin {
-        param_def_id: None,
-        span: DUMMY_SP,
-    };
     let ty_params = tcx.mk_args_from_iter(
         ty_params
             .into_iter()
-            .map(|arg| arg.unwrap_or_else(|| infcx.next_ty_var(orig).into())),
+            .map(|arg| arg.unwrap_or_else(|| infcx.next_ty_var(DUMMY_SP).into())),
     );
     infcx
         .type_implements_trait(

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -30,7 +30,7 @@ declare_tool_lint! {
 
 const EMPTY_TRACE_IN_NO_TRACE_MSG: &str =
     "must_not_have_traceable marked wrapper is not needed for types that implements \
-  empty Traceable (like primitive types). Consider removing the wrapper.";
+empty Traceable (like primitive types). Consider removing the wrapper.";
 
 pub fn register(lint_store: &mut LintStore) {
     let symbols = Symbols::new();

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -30,7 +30,7 @@ declare_tool_lint! {
 
 const EMPTY_TRACE_IN_NO_TRACE_MSG: &str =
     "must_not_have_traceable marked wrapper is not needed for types that implements \
-empty Traceable (like primitive types). Consider removing the wrapper.";
+  empty Traceable (like primitive types). Consider removing the wrapper.";
 
 pub fn register(lint_store: &mut LintStore) {
     let symbols = Symbols::new();
@@ -131,24 +131,18 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
                 {
                     let inner = substs.type_at(pos);
                     if inner.is_primitive_ty() {
-                        cx.lint(
-                            EMPTY_TRACE_IN_NO_TRACE,
-                            EMPTY_TRACE_IN_NO_TRACE_MSG,
-                            |lint| {
-                                lint.span(span);
-                            },
-                        )
+                        cx.lint(EMPTY_TRACE_IN_NO_TRACE, |lint| {
+                            lint.primary_message(EMPTY_TRACE_IN_NO_TRACE_MSG);
+                            lint.span(span);
+                        })
                     } else if is_jstraceable(cx, inner) {
-                        cx.lint(
-                            TRACE_IN_NO_TRACE,
-                            format!(
+                        cx.lint(TRACE_IN_NO_TRACE, |lint| {
+                            lint.primary_message(format!(
                                 "must_not_have_traceable marked wrapper must not have \
-jsmanaged inside on {pos}-th position. Consider removing the wrapper."
-                            ),
-                            |lint| {
-                                lint.span(span);
-                            },
-                        )
+ jsmanaged inside on {pos}-th position. Consider removing the wrapper."
+                            ));
+                            lint.span(span);
+                        })
                     }
                     false
                 } else {

--- a/support/crown/src/trace_in_no_trace.rs
+++ b/support/crown/src/trace_in_no_trace.rs
@@ -139,7 +139,7 @@ fn incorrect_no_trace<'tcx, I: Into<MultiSpan> + Copy>(
                         cx.lint(TRACE_IN_NO_TRACE, |lint| {
                             lint.primary_message(format!(
                                 "must_not_have_traceable marked wrapper must not have \
- jsmanaged inside on {pos}-th position. Consider removing the wrapper."
+jsmanaged inside on {pos}-th position. Consider removing the wrapper."
                             ));
                             lint.span(span);
                         })

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -187,14 +187,13 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
             for field in def.fields() {
                 let field_type = cx.tcx.type_of(field.def_id);
                 if is_unrooted_ty(&self.symbols, cx, field_type.skip_binder(), false) {
-                    cx.lint(
-                        UNROOTED_MUST_ROOT,
-                        "Type must be rooted, use #[crown::unrooted_must_root_lint::must_root] \
-                         on the struct definition to propagate",
-                        |lint| {
-                            lint.span(field.span);
-                        },
-                    )
+                    cx.lint(UNROOTED_MUST_ROOT, |lint| {
+                          lint.primary_message(
+                              "Type must be rooted, use #[crown::unrooted_must_root_lint::must_root] \
+                               on the struct definition to propagate"
+                              );
+                          lint.span(field.span);
+                      })
                 }
             }
         }
@@ -212,15 +211,14 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                     for field in fields {
                         let field_type = cx.tcx.type_of(field.def_id);
                         if is_unrooted_ty(&self.symbols, cx, field_type.skip_binder(), false) {
-                            cx.lint(
-                                UNROOTED_MUST_ROOT,
-                                "Type must be rooted, \
-                                use #[crown::unrooted_must_root_lint::must_root] \
-                                on the enum definition to propagate",
-                                |lint| {
-                                    lint.span(field.ty.span);
-                                },
-                            )
+                            cx.lint(UNROOTED_MUST_ROOT, |lint| {
+                                lint.primary_message(
+                                    "Type must be rooted, \
+                                      use #[crown::unrooted_must_root_lint::must_root] \
+                                      on the enum definition to propagate",
+                                );
+                                lint.span(field.ty.span);
+                            })
                         }
                     }
                 },
@@ -250,7 +248,8 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
 
             for (arg, ty) in decl.inputs.iter().zip(sig.inputs().skip_binder().iter()) {
                 if is_unrooted_ty(&self.symbols, cx, *ty, false) {
-                    cx.lint(UNROOTED_MUST_ROOT, "Type must be rooted", |lint| {
+                    cx.lint(UNROOTED_MUST_ROOT, |lint| {
+                        lint.primary_message("Type must be rooted");
                         lint.span(arg.span);
                     })
                 }
@@ -259,7 +258,8 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
             if !in_new_function &&
                 is_unrooted_ty(&self.symbols, cx, sig.output().skip_binder(), false)
             {
-                cx.lint(UNROOTED_MUST_ROOT, "Type must be rooted", |lint| {
+                cx.lint(UNROOTED_MUST_ROOT, |lint| {
+                    lint.primary_message("Type must be rooted");
                     lint.span(decl.output.span());
                 })
             }
@@ -289,13 +289,10 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for FnDefVisitor<'a, 'tcx> {
         let require_rooted = |cx: &LateContext, in_new_function: bool, subexpr: &hir::Expr| {
             let ty = cx.typeck_results().expr_ty(subexpr);
             if is_unrooted_ty(self.symbols, cx, ty, in_new_function) {
-                cx.lint(
-                    UNROOTED_MUST_ROOT,
-                    format!("Expression of type {:?} must be rooted", ty),
-                    |lint| {
-                        lint.span(subexpr.span);
-                    },
-                )
+                cx.lint(UNROOTED_MUST_ROOT, |lint| {
+                    lint.primary_message(format!("Expression of type {:?} must be rooted", ty));
+                    lint.span(subexpr.span);
+                })
             }
         };
 
@@ -333,13 +330,10 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for FnDefVisitor<'a, 'tcx> {
             hir::PatKind::Binding(hir::BindingMode::MUT, ..) => {
                 let ty = cx.typeck_results().pat_ty(pat);
                 if is_unrooted_ty(self.symbols, cx, ty, self.in_new_function) {
-                    cx.lint(
-                        UNROOTED_MUST_ROOT,
-                        format!("Expression of type {:?} must be rooted", ty),
-                        |lint| {
-                            lint.span(pat.span);
-                        },
-                    )
+                    cx.lint(UNROOTED_MUST_ROOT, |lint| {
+                        lint.primary_message(format!("Expression of type {:?} must be rooted", ty));
+                        lint.span(pat.span);
+                    })
                 }
             },
             _ => {},

--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -329,8 +329,8 @@ impl<'a, 'tcx> visit::Visitor<'tcx> for FnDefVisitor<'a, 'tcx> {
         // are implemented, the `Unannotated` case could cause false-positives.
         // These should be fixable by adding an explicit `ref`.
         match pat.kind {
-            hir::PatKind::Binding(hir::BindingAnnotation::NONE, ..) |
-            hir::PatKind::Binding(hir::BindingAnnotation::MUT, ..) => {
+            hir::PatKind::Binding(hir::BindingMode::NONE, ..) |
+            hir::PatKind::Binding(hir::BindingMode::MUT, ..) => {
                 let ty = cx.typeck_results().pat_ty(pat);
                 if is_unrooted_ty(self.symbols, cx, ty, self.in_new_function) {
                     cx.lint(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

 I would create a new pull request for commits failed in PR #32889 .

---
rustc library had some changes in 1.79 & 1.80.

`LazyLock` is part of standard library in 1.80
Rust1.80 can replace from `lazy_static` & `once_cell::sync::Lazy` to `std::LazyLock`.
I would suggest updating to rust1.80 as the first step, with replace to `LazyLock` later.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes (test-unit crown)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
