### PR TITLE
Update mozjs to fix enforcerange for 64bit numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#3720f6d208b45fb968961a8d5c97f64010ae3d81"
+source = "git+https://github.com/servo/mozjs#dbffebd0937c14d3c73ce9be4798da15cb2f369d"
 dependencies = [
  "bindgen",
  "cc",
@@ -4345,13 +4345,12 @@ dependencies = [
  "libc",
  "log",
  "mozjs_sys",
- "num-traits",
 ]
 
 [[package]]
 name = "mozjs_sys"
 version = "0.128.0-4"
-source = "git+https://github.com/servo/mozjs#3720f6d208b45fb968961a8d5c97f64010ae3d81"
+source = "git+https://github.com/servo/mozjs#dbffebd0937c14d3c73ce9be4798da15cb2f369d"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Relevant mozjs PR: https://github.com/servo/mozjs/pull/489


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
