### PR TITLE
Free some space on android runners

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,6 +30,13 @@ jobs:
       matrix:
         arch: ['aarch64-linux-android', 'armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: false
+          large-packages: false
+          swap-storage: false
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:


### PR DESCRIPTION
Speculative fix for https://servo.zulipchat.com/#narrow/stream/263398-general/topic/Android.20CI.20builds.20are.20failing.20due.20to.20lack.20of.20disk.20space


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because CI changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
