### PR TITLE
Select servo feature on servo_arc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2024-07-16", features = ["servo"] }
 servo_atoms = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 size_of_test = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 smallbitvec = "2.5.3"


### PR DESCRIPTION
to enable running `cargo test -p net --test main` without `--features servo_arc?/servo`. 

servo_url depends on servo_arc/servo feature but it has not got it enabled, hence it cannot be compiled standalone (except if some other crate enables servo_arc/servo).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's usability change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
