### PR TITLE
layout: Properly handle subpixel units when dividing space between flex lines

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12462,6 +12462,13 @@
       {}
      ]
     ],
+    "flex_align_content_stretch_subpixel.html": [
+     "0a08f2540b6cc736d274c7f0b48f2f6123dd1862",
+     [
+      null,
+      {}
+     ]
+    ],
     "float-abspos.html": [
      "f691c1756f0dd5b6744952e1516950bacaaf4d33",
      [

--- a/tests/wpt/mozilla/meta/css/flex_align_content_stretch_subpixel.html.ini
+++ b/tests/wpt/mozilla/meta/css/flex_align_content_stretch_subpixel.html.ini
@@ -1,0 +1,2 @@
+[flex_align_content_stretch_subpixel.html]
+  prefs: ["layout.flexbox.enabled:true"]

--- a/tests/wpt/mozilla/tests/css/flex_align_content_stretch_subpixel.html
+++ b/tests/wpt/mozilla/tests/css/flex_align_content_stretch_subpixel.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Flex: align-content:stretch with subpixel amounts</title>
+<style>
+  #flex {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: stretch;
+    height: 5px;
+    border: solid;
+  }
+  #flex > div {
+    width: 100%;
+    outline: 1px solid lime;
+  }
+</style>
+<div id="flex"></div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+/* The flex container is 5px tall. Assuming that 1px are 60 app units,
+   that's 300 app units. Since we have 600 lines, half of them should
+   get 1 app unit, and the others should get 0. This way we ensure that
+   the container gets filled completely. */
+let flex = document.getElementById("flex");
+let item = document.createElement("div");
+for (let i = 0; i < 600; ++i) {
+  flex.appendChild(item.cloneNode());
+}
+test(() => {
+  let filled_space = flex.lastElementChild.getBoundingClientRect().bottom
+                     - flex.firstElementChild.getBoundingClientRect().top;
+  assert_approx_equals(filled_space, 5, 0.01);
+}, "Flex items fill the container entirely");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
