### PR TITLE
bindings: Convert certain Exceptions into Promise rejections

### DIFF
--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -137,9 +137,9 @@ pub mod module {
     pub use crate::dom::bindings::utils::{
         callargs_is_constructing, enumerate_global, exception_to_promise, generic_getter,
         generic_lenient_getter, generic_lenient_setter, generic_method, generic_setter,
-        get_array_index_from_id, get_property_on_prototype, has_property_on_prototype,
-        resolve_global, trace_global, AsVoidPtr, DOMClass, DOMJSClass, ProtoOrIfaceArray,
-        DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, JSCLASS_DOM_GLOBAL,
+        generic_static_promise_method, get_array_index_from_id, get_property_on_prototype,
+        has_property_on_prototype, resolve_global, trace_global, AsVoidPtr, DOMClass, DOMJSClass,
+        ProtoOrIfaceArray, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, JSCLASS_DOM_GLOBAL,
     };
     pub use crate::dom::bindings::weakref::{WeakReferenceable, DOM_WEAK_SLOT};
     pub use crate::dom::types::{AnalyserNode, AudioNode, BaseAudioContext, EventTarget};

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -135,11 +135,11 @@ pub mod module {
     pub use crate::dom::bindings::root::{Dom, DomSlice, MaybeUnreflectedDom, Root};
     pub use crate::dom::bindings::trace::JSTraceable;
     pub use crate::dom::bindings::utils::{
-        callargs_is_constructing, enumerate_global, generic_getter, generic_lenient_getter,
-        generic_lenient_setter, generic_method, generic_setter, get_array_index_from_id,
-        get_property_on_prototype, has_property_on_prototype, resolve_global, trace_global,
-        AsVoidPtr, DOMClass, DOMJSClass, ProtoOrIfaceArray, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT,
-        JSCLASS_DOM_GLOBAL,
+        callargs_is_constructing, enumerate_global, exception_to_promise, generic_getter,
+        generic_lenient_getter, generic_lenient_setter, generic_method, generic_setter,
+        get_array_index_from_id, get_property_on_prototype, has_property_on_prototype,
+        resolve_global, trace_global, AsVoidPtr, DOMClass, DOMJSClass, ProtoOrIfaceArray,
+        DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, JSCLASS_DOM_GLOBAL,
     };
     pub use crate::dom::bindings::weakref::{WeakReferenceable, DOM_WEAK_SLOT};
     pub use crate::dom::types::{AnalyserNode, AudioNode, BaseAudioContext, EventTarget};

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -6,6 +6,7 @@
 
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
+use std::ptr::NonNull;
 use std::{ptr, slice, str};
 
 use js::conversions::ToJSValConvertible;
@@ -14,17 +15,19 @@ use js::glue::{
     UnwrapObjectDynamic, UnwrapObjectStatic, RUST_FUNCTION_VALUE_TO_JITINFO,
 };
 use js::jsapi::{
-    AtomToLinearString, CallArgs, DOMCallbacks, GetLinearStringCharAt, GetLinearStringLength,
-    GetNonCCWObjectGlobal, HandleId as RawHandleId, HandleObject as RawHandleObject, Heap, JSAtom,
-    JSContext, JSJitInfo, JSObject, JSTracer, JS_DeprecatedStringHasLatin1Chars,
-    JS_EnumerateStandardClasses, JS_FreezeObject, JS_GetLatin1StringCharsAndLength,
-    JS_IsExceptionPending, JS_IsGlobalObject, JS_ResolveStandardClass,
-    MutableHandleIdVector as RawMutableHandleIdVector, ObjectOpResult, StringIsArrayIndex,
+    AtomToLinearString, CallArgs, DOMCallbacks, ExceptionStackBehavior, GetLinearStringCharAt,
+    GetLinearStringLength, GetNonCCWObjectGlobal, HandleId as RawHandleId,
+    HandleObject as RawHandleObject, Heap, JSAtom, JSContext, JSJitInfo, JSObject, JSTracer,
+    JS_ClearPendingException, JS_DeprecatedStringHasLatin1Chars, JS_EnumerateStandardClasses,
+    JS_FreezeObject, JS_GetLatin1StringCharsAndLength, JS_IsExceptionPending, JS_IsGlobalObject,
+    JS_ResolveStandardClass, MutableHandleIdVector as RawMutableHandleIdVector,
+    MutableHandleValue as RawMutableHandleValue, ObjectOpResult, StringIsArrayIndex,
 };
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::wrappers::{
-    JS_DeletePropertyById, JS_ForwardGetPropertyTo, JS_GetProperty, JS_GetPrototype,
-    JS_HasProperty, JS_HasPropertyById, JS_SetProperty,
+    CallOriginalPromiseReject, JS_DeletePropertyById, JS_ForwardGetPropertyTo,
+    JS_GetPendingException, JS_GetProperty, JS_GetPrototype, JS_HasProperty, JS_HasPropertyById,
+    JS_SetPendingException, JS_SetProperty,
 };
 use js::rust::{
     get_object_class, is_dom_class, GCMethods, Handle, HandleId, HandleObject, HandleValue,
@@ -625,4 +628,23 @@ impl AsCCharPtrPtr for [u8] {
 
 pub unsafe fn callargs_is_constructing(args: &CallArgs) -> bool {
     (*args.argv_.offset(-1)).is_magic()
+}
+
+/// Coverts exception to promise rejection
+///
+/// https://searchfox.org/mozilla-central/rev/b220e40ff2ee3d10ce68e07d8a8a577d5558e2a2/dom/bindings/BindingUtils.cpp#3315
+pub unsafe fn exception_to_promise(cx: *mut JSContext, rval: RawMutableHandleValue) -> bool {
+    rooted!(in(cx) let mut exception = UndefinedValue());
+    if !JS_GetPendingException(cx, exception.handle_mut()) {
+        return false;
+    }
+    JS_ClearPendingException(cx);
+    if let Some(promise) = NonNull::new(CallOriginalPromiseReject(cx, exception.handle())) {
+        promise.to_jsval(cx, MutableHandleValue::from_raw(rval));
+        true
+    } else {
+        // We just give up.  Put the exception back.
+        JS_SetPendingException(cx, exception.handle(), ExceptionStackBehavior::Capture);
+        false
+    }
 }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -1084,6 +1084,29 @@ impl TestBindingMethods for TestBinding {
             stringMember: Some(s2),
         }
     }
+
+    fn MethodThrowToRejectPromise(&self) -> Fallible<Rc<Promise>> {
+        Err(Error::Type("test".to_string()))
+    }
+
+    fn GetGetterThrowToRejectPromise(&self) -> Fallible<Rc<Promise>> {
+        Err(Error::Type("test".to_string()))
+    }
+
+    fn MethodInternalThrowToRejectPromise(&self, _arg: u64) -> Rc<Promise> {
+        unreachable!("Method should already throw")
+    }
+}
+
+#[allow(non_snake_case)]
+impl TestBinding {
+    pub fn StaticThrowToRejectPromise(_: &GlobalScope) -> Fallible<Rc<Promise>> {
+        Err(Error::Type("test".to_string()))
+    }
+
+    pub fn StaticInternalThrowToRejectPromise(_: &GlobalScope, _arg: u64) -> Rc<Promise> {
+        unreachable!("Method should already throw")
+    }
 }
 
 #[allow(non_snake_case)]

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -574,6 +574,16 @@ interface TestBinding {
   undefined promiseRejectWithTypeError(Promise<any> p, USVString message);
   undefined resolvePromiseDelayed(Promise<any> p, DOMString value, unsigned long long ms);
 
+  [Throws]
+  static Promise<any> staticThrowToRejectPromise();
+  [Throws]
+  Promise<any> methodThrowToRejectPromise();
+  [Throws]
+  readonly attribute Promise<any> getterThrowToRejectPromise;
+
+  static Promise<any> staticInternalThrowToRejectPromise([EnforceRange] unsigned long long arg);
+  Promise<any> methodInternalThrowToRejectPromise([EnforceRange] unsigned long long arg);
+
   undefined panic();
 
   GlobalScope entryGlobal();

--- a/tests/wpt/meta-legacy-layout/fetch/api/idlharness.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/fetch/api/idlharness.any.js.ini
@@ -72,7 +72,6 @@
     expected: FAIL
 
   [Window interface: calling fetch(RequestInfo, optional RequestInit) on window with too few arguments must throw TypeError]
-    expected: FAIL
 
   [Window interface: operation fetch(RequestInfo, optional RequestInit)]
     expected: FAIL
@@ -170,7 +169,6 @@
     expected: FAIL
 
   [WorkerGlobalScope interface: calling fetch(RequestInfo, optional RequestInit) on self with too few arguments must throw TypeError]
-    expected: FAIL
 
   [WorkerGlobalScope interface: operation fetch(RequestInfo, optional RequestInit)]
     expected: FAIL

--- a/tests/wpt/meta/fetch/api/idlharness.any.js.ini
+++ b/tests/wpt/meta/fetch/api/idlharness.any.js.ini
@@ -69,7 +69,6 @@
     expected: FAIL
 
   [WorkerGlobalScope interface: calling fetch(RequestInfo, optional RequestInit) on self with too few arguments must throw TypeError]
-    expected: FAIL
 
   [Request interface: operation bytes()]
     expected: FAIL
@@ -158,7 +157,6 @@
     expected: FAIL
 
   [Window interface: calling fetch(RequestInfo, optional RequestInit) on window with too few arguments must throw TypeError]
-    expected: FAIL
 
   [Request interface: operation bytes()]
     expected: FAIL

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/exceptionToRejection.any.js.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/exceptionToRejection.any.js.ini
@@ -1,0 +1,7 @@
+[exceptionToRejection.any.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]
+
+[exceptionToRejection.any.worker.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13130,6 +13130,31 @@
       {}
      ]
     ],
+    "exceptionToRejection.any.js": [
+     "738a8bedbcfe83a6f110bc6e6d133e31f80ea9ad",
+     [
+      "mozilla/exceptionToRejection.any.html",
+      {
+       "script_metadata": [
+        [
+         "title",
+         "Test that promise exception are converted to rejections"
+        ]
+       ]
+      }
+     ],
+     [
+      "mozilla/exceptionToRejection.any.worker.html",
+      {
+       "script_metadata": [
+        [
+         "title",
+         "Test that promise exception are converted to rejections"
+        ]
+       ]
+      }
+     ]
+    ],
     "fetch_cannot_overwhelm_system.window.js": [
      "989231e9caedd099f5212bd2f9d377c83f929a22",
      [

--- a/tests/wpt/mozilla/meta/mozilla/exceptionToRejection.any.js.ini
+++ b/tests/wpt/mozilla/meta/mozilla/exceptionToRejection.any.js.ini
@@ -1,0 +1,7 @@
+[exceptionToRejection.any.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]
+
+[exceptionToRejection.any.worker.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/exceptionToRejection.any.js
+++ b/tests/wpt/mozilla/tests/mozilla/exceptionToRejection.any.js
@@ -1,0 +1,32 @@
+// META: title=Test that promise exception are converted to rejections
+
+var binding = new TestBinding();
+
+/*
+  static Promise<any> staticThrowToRejectPromise();
+  Promise<any> methodThrowToRejectPromise();
+  readonly attribute Promise<any> getterThrowToRejectPromise;
+
+  static Promise<any> staticInternalThrowToRejectPromise([EnforceRange] unsigned long long arg);
+  Promise<any> methodInternalThrowToRejectPromise([EnforceRange] unsigned long long arg);
+*/
+
+promise_test((t) => {
+    return promise_rejects_js(t, TypeError, TestBinding.staticThrowToRejectPromise());
+}, "staticThrowToRejectPromise");
+
+promise_test((t) => {
+    return promise_rejects_js(t, TypeError, binding.methodThrowToRejectPromise());
+}, "methodThrowToRejectPromise");
+
+promise_test((t) => {
+    return promise_rejects_js(t, TypeError, binding.getterThrowToRejectPromise);
+}, "getterThrowToRejectPromise");
+
+promise_test((t) => {
+    return promise_rejects_js(t, TypeError, TestBinding.staticInternalThrowToRejectPromise(Number.MAX_SAFE_INTEGER + 1));
+}, "staticInternalThrowToRejectPromise");
+
+promise_test((t) => {
+    return promise_rejects_js(t, TypeError, binding.methodInternalThrowToRejectPromise(Number.MAX_SAFE_INTEGER + 1));
+}, "methodInternalThrowToRejectPromise");


### PR DESCRIPTION
try run: https://github.com/sagudev/servo/actions/runs/10226975306/job/28298538636

Also works for my WIP webgpu stuff: https://gpuweb.github.io/cts/standalone/?q=webgpu:api,operation,adapter,requestDevice:limit,out_of_range:*

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32816
- [x] There are tests for these changes in 2df6f7eb414541d47c7ab2b265b4ceef8641ff0a

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
