### PR TITLE
Enable WAV decoding

### DIFF
--- a/python/servo/gstreamer.py
+++ b/python/servo/gstreamer.py
@@ -73,6 +73,7 @@ GSTREAMER_PLUGIN_LIBS = [
     "gstrtpmanager",
     "gstvideofilter",
     "gstvpx",
+    "gstwavparse",
     # gst-plugins-bad
     "gstaudiobuffersplit",
     "gstdtls",


### PR DESCRIPTION
I was testing a game of mine and noticed that Servo on MacOS doesn't support WAV decoding, breaking my game. Adding gstwavparse to the gstreamer plugin list fixed that issue for me.


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

I didn't want to add new tests since for example /webaudio/the-audio-api/the-audiobuffersourcenode-interface/audiobuffersource-multi-channels.html fails on MacOS for me without these changes
