### PR TITLE
webgpu: Use wgpu's instead of string errors and update limits handling

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -718,7 +718,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                                                 isMember="Sequence",
                                                 isAutoRooted=isAutoRooted)
         declType = wrapInNativeContainerType(type, innerInfo.declType)
-        config = getConversionConfigForType(type, isEnforceRange, isClamp, treatNullAs)
+        config = getConversionConfigForType(type, innerContainerType(type).hasEnforceRange(), isClamp, treatNullAs)
 
         if type.nullable():
             declType = CGWrapper(declType, pre="Option<", post=" >")

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -7,9 +7,11 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
+use webgpu::wgc::instance::RequestDeviceError;
 use webgpu::wgt::MemoryHints;
 use webgpu::{wgt, WebGPU, WebGPUAdapter, WebGPURequest, WebGPUResponse};
 
+use super::bindings::codegen::Bindings::WebGPUBinding::GPUDeviceLostReason;
 use super::gpusupportedfeatures::GPUSupportedFeatures;
 use super::types::{GPUAdapterInfo, GPUSupportedLimits};
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
@@ -267,8 +269,7 @@ impl GPUAdapterMethods for GPUAdapter {
 impl AsyncWGPUListener for GPUAdapter {
     fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>) {
         match response {
-            WebGPUResponse::Device(Ok(device)) => {
-                let descriptor = device.descriptor;
+            WebGPUResponse::Device((device_id, queue_id, Ok(descriptor))) => {
                 let device = GPUDevice::new(
                     &self.global(),
                     self.channel.clone(),
@@ -276,16 +277,37 @@ impl AsyncWGPUListener for GPUAdapter {
                     Heap::default(),
                     descriptor.required_features,
                     descriptor.required_limits,
-                    device.device_id,
-                    device.queue_id,
+                    device_id,
+                    queue_id,
                     descriptor.label.unwrap_or_default(),
                 );
                 self.global().add_gpu_device(&device);
                 promise.resolve_native(&device);
             },
-            WebGPUResponse::Device(Err(e)) => {
-                warn!("Could not get GPUDevice({:?})", e);
-                promise.reject_error(Error::Operation);
+            WebGPUResponse::Device((_, _, Err(RequestDeviceError::UnsupportedFeature(f)))) => {
+                promise.reject_error(Error::Type(
+                    RequestDeviceError::UnsupportedFeature(f).to_string(),
+                ))
+            },
+            WebGPUResponse::Device((
+                _,
+                _,
+                Err(RequestDeviceError::LimitsExceeded(_) | RequestDeviceError::InvalidAdapter),
+            )) => promise.reject_error(Error::Operation),
+            WebGPUResponse::Device((device_id, queue_id, Err(e))) => {
+                let device = GPUDevice::new(
+                    &self.global(),
+                    self.channel.clone(),
+                    self,
+                    Heap::default(),
+                    wgt::Features::default(),
+                    wgt::Limits::default(),
+                    device_id,
+                    queue_id,
+                    String::new(),
+                );
+                device.lose(GPUDeviceLostReason::Unknown, e.to_string());
+                promise.resolve_native(&device);
             },
             WebGPUResponse::None => unreachable!("Failed to get a response for RequestDevice"),
             _ => unreachable!("GPUAdapter received wrong WebGPUResponse"),

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -21,7 +21,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension3D;
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
-    //readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
+    readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
     readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
@@ -39,9 +39,9 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
     readonly attribute unsigned long maxInterStageShaderComponents;
-    //readonly attribute unsigned long maxInterStageShaderVariables;
-    //readonly attribute unsigned long maxColorAttachments;
-    //readonly attribute unsigned long maxColorAttachmentBytesPerSample;
+    readonly attribute unsigned long maxInterStageShaderVariables;
+    readonly attribute unsigned long maxColorAttachments;
+    readonly attribute unsigned long maxColorAttachmentBytesPerSample;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
     readonly attribute unsigned long maxComputeWorkgroupSizeX;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2427,8 +2427,9 @@ impl ScriptThread {
                 pipeline_id,
             } => {
                 self.gpu_id_hub.free_device_id(device_id);
-                let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                global.remove_gpu_device(WebGPUDevice(device_id));
+                if let Some(global) = self.documents.borrow().find_global(pipeline_id) {
+                    global.remove_gpu_device(WebGPUDevice(device_id));
+                } // page can already be destroyed
             },
             WebGPUMsg::FreeBuffer(id) => self.gpu_id_hub.free_buffer_id(id),
             WebGPUMsg::FreePipelineLayout(id) => self.gpu_id_hub.free_pipeline_layout_id(id),

--- a/components/webgpu/ipc_messages/to_dom.rs
+++ b/components/webgpu/ipc_messages/to_dom.rs
@@ -66,19 +66,18 @@ pub struct Adapter {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct Device {
-    pub device_id: WebGPUDevice,
-    pub queue_id: WebGPUQueue,
-    pub descriptor: wgt::DeviceDescriptor<Option<String>>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum WebGPUResponse {
     /// WebGPU is disabled
     None,
     Adapter(Result<Adapter, RequestAdapterError>),
-    Device(Result<Device, RequestDeviceError>),
+    Device(
+        (
+            WebGPUDevice,
+            WebGPUQueue,
+            Result<wgt::DeviceDescriptor<Option<String>>, RequestDeviceError>,
+        ),
+    ),
     BufferMapAsync(Result<IpcSharedMemory, BufferAccessError>),
     SubmittedWorkDone,
     PoppedErrorScope(Result<Option<Error>, PopError>),

--- a/components/webgpu/ipc_messages/to_dom.rs
+++ b/components/webgpu/ipc_messages/to_dom.rs
@@ -7,6 +7,8 @@
 use ipc_channel::ipc::IpcSharedMemory;
 use serde::{Deserialize, Serialize};
 use wgc::pipeline::CreateShaderModuleError;
+use wgpu_core::instance::{RequestAdapterError, RequestDeviceError};
+use wgpu_core::resource::BufferAccessError;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
 use crate::identity::*;
@@ -75,10 +77,9 @@ pub struct Device {
 pub enum WebGPUResponse {
     /// WebGPU is disabled
     None,
-    // TODO: use wgpu errors
-    Adapter(Result<Adapter, String>),
-    Device(Result<Device, String>),
-    BufferMapAsync(Result<IpcSharedMemory, String>),
+    Adapter(Result<Adapter, RequestAdapterError>),
+    Device(Result<Device, RequestDeviceError>),
+    BufferMapAsync(Result<IpcSharedMemory, BufferAccessError>),
     SubmittedWorkDone,
     PoppedErrorScope(Result<Option<Error>, PopError>),
     CompilationInfo(Option<ShaderCompilationInfo>),


### PR DESCRIPTION
This one has been backing for a long time, as there were so many issue that came with it to debug (I just wanted for out of limits to get reject with TypeError), but I asked for too much as servo did not convert exceptions to rejection (done in #32923) and `EnforceRange` was not working right on `u64`  aka. `unsigned long long` in webidl (done in #32905). And off course some things are wrong in wgpu as well: https://github.com/gfx-rs/wgpu/pull/6074, https://github.com/gfx-rs/wgpu/issues/6075.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
