### PR TITLE
Pass AppInfo to OpenXrDiscovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#790f50587d651fd865736cfd8c70cab0dea5dc7f"
+source = "git+https://github.com/servo/webxr#355dce2140012ac1535ff6f2cf87b60297556eb4"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#790f50587d651fd865736cfd8c70cab0dea5dc7f"
+source = "git+https://github.com/servo/webxr#355dce2140012ac1535ff6f2cf87b60297556eb4"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -20,7 +20,7 @@ use servo::Servo;
 use surfman::GLApi;
 use webxr::glwindow::GlWindowDiscovery;
 #[cfg(target_os = "windows")]
-use webxr::openxr::OpenXrDiscovery;
+use webxr::openxr::{AppInfo, OpenXrDiscovery};
 use winit::event::WindowEvent;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::WindowId;
@@ -163,7 +163,10 @@ impl App {
                     )))
                 } else if pref!(dom.webxr.openxr.enabled) && !opts::get().headless {
                     #[cfg(target_os = "windows")]
-                    let openxr = Some(XrDiscovery::OpenXr(OpenXrDiscovery::new(None)));
+                    let openxr = {
+                        let app_info = AppInfo::new("Servoshell", 0, "Servo", 0);
+                        Some(XrDiscovery::OpenXr(OpenXrDiscovery::new(None, app_info)))
+                    };
                     #[cfg(not(target_os = "windows"))]
                     let openxr = None;
 


### PR DESCRIPTION
This passes application info to OpenXrDiscovery, replacing the hardcoded values that were used for instance creation previously.