### PR TITLE
ci: allow android builds on forks to skip keystore configuration

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Setup Key Store for APK Signing
         env:
           KEYSTORE_BASE64: ${{ secrets.APK_KEYSTORE_BASE64 }}
+        if: ${{ env.KEYSTORE_BASE64 != '' }}
         run: |
           APK_SIGNING_KEY_STORE_PATH="${PWD}/servo_keystore.jks"
           echo "${KEYSTORE_BASE64}" | base64 -d > "${APK_SIGNING_KEY_STORE_PATH}"


### PR DESCRIPTION
Our build.gradle configuration already defaults to using the debug
keystore when the keystore is not configured so only the CI needs this
fix.

Fixes #32922

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32922
- [x] These changes do not require tests because they only change the ci workflow
