### PR TITLE
layout: Simple port of legacy innerText getter

### DIFF
--- a/tests/wpt/meta/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.html.ini
+++ b/tests/wpt/meta/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-stateful.html.ini
@@ -1,3 +1,0 @@
-[iso2022jp-encode-form-errors-stateful.html]
-  [Form submission using ISO-2022-JP correctly replaces unencodables]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/srcdoc-anchor.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/srcdoc-anchor.html.ini
@@ -1,3 +1,0 @@
-[srcdoc-anchor.html]
-  [Verify srcdoc content loads when src is about:srcdoc#foo.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/srcdoc-attribute-reset.html.ini
@@ -1,3 +1,0 @@
-[srcdoc-attribute-reset.html]
-  [Verify that the frame reloads with empty body after we remove srcdoc.]
-    expected: FAIL


### PR DESCRIPTION
Hey there,

I've ported the functions used by the innerText getter from layout2013 to 2020, since right now it just returns "" all the time. While it's not great, now it at least returns something closer to the content.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

There seem to be a lot of WPT tests already in html/dom/elements/the-innertext-and-outertext-properties, do these suffice, or do you prefer rust ones?
