### PR TITLE
build: Fix a print statement when repackaging GStreamer

### DIFF
--- a/python/servo/gstreamer.py
+++ b/python/servo/gstreamer.py
@@ -272,7 +272,7 @@ def package_gstreamer_dylibs(binary_path: str, library_target_directory: str, cr
         return True
 
     if os.path.exists(library_target_directory):
-        print(" • Packaged GStreamer is out of date. Rebuilding into {library_target_directory}")
+        print(f" • Packaged GStreamer is out of date. Rebuilding into {library_target_directory}")
         shutil.rmtree(library_target_directory)
     else:
         print(f" • Packaging GStreamer into {library_target_directory}")


### PR DESCRIPTION
I neglected to put make a string a formatted string, which means that
the variable won't be included in the output properly.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes do not require tests because this fixes a print statement during the build.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
