### PR TITLE
webrender_traits: add surface methods to RenderingContext

### DIFF
--- a/components/shared/webrender/rendering_context.rs
+++ b/components/shared/webrender/rendering_context.rs
@@ -90,6 +90,22 @@ impl RenderingContext {
         Ok(RenderingContext(Rc::new(data)))
     }
 
+    pub fn create_surface(
+        &self,
+        surface_type: SurfaceType<NativeWidget>,
+    ) -> Result<Surface, Error> {
+        let device = &mut self.0.device.borrow_mut();
+        let context = &self.0.context.borrow();
+        let surface_access = SurfaceAccess::GPUOnly;
+        device.create_surface(&context, surface_access, surface_type)
+    }
+
+    pub fn destroy_surface(&self, mut surface: Surface) -> Result<(), Error> {
+        let device = &self.0.device.borrow();
+        let context = &mut self.0.context.borrow_mut();
+        device.destroy_surface(context, &mut surface)
+    }
+
     pub fn create_surface_texture(&self, surface: Surface) -> Result<SurfaceTexture, Error> {
         let device = &self.0.device.borrow();
         let context = &mut self.0.context.borrow_mut();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
It would be great for `RenderingContext` to support multi-surface.
This PR adds two methods to create and destroy additional surfaces that are not bound to the context.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
