### PR TITLE
mach: Add support for paths with spaces on Windows

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -215,8 +215,8 @@ def bootstrap(topdir):
     topdir = os.path.abspath(topdir)
 
     # We don't support paths with spaces for now
-    # https://github.com/servo/servo/issues/9442
-    if ' ' in topdir:
+    # https://github.com/servo/servo/issues/9616
+    if ' ' in topdir and (not _is_windows()):
         print('Cannot run mach in a path with spaces.')
         print('Current path:', topdir)
         sys.exit(1)


### PR DESCRIPTION
The default user name in Windows installations is of the form "FirstName LastName", so it seems likely that there will be spaces in the user's path. Based on my testing on Windows 11,  only Servo's bootstrap script has trouble dealing with spaces in paths. This patch fixes that by quoting such paths correctly. Our direct and indirect dependencies seem to handle these without issue and Servo does build and run correctly with this patch.

In this patch, the logic for gstreamer bootstrap now uses powershell instead of directly invoking msiexec.exe via cmd.exe as I was unable to get the installer to run correctly, even with quoting. Some extra hacks were necessary to propagate the exit code correctly to mach.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only modify bootstrap logic.
