### PR TITLE
Nix: Bump nixpkgs

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -5,7 +5,7 @@
   buildAndroid ? false
 }:
 with import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/63d37ccd2d178d54e7fb691d7ec76000740ea24a.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/d04953086551086b44b6f3c6b7eeb26294f207da.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {


### PR DESCRIPTION
Servoshell seems to be broken on the latest NixOS version with the same `IncompatibleNativeWidget` error as #31054. This comes from `surfman`, probably due to compiling it with an old library. Bumping nixpkgs to the tip of nixos-unstable (NixOS/nixpkgs@d04953086551086b44b6f3c6b7eeb26294f207da) seems to resolve the issue.

<details>
<summary>Stack trace</summary>

```
Failed to create connection: IncompatibleNativeWidget (thread main, at ports/servoshell/desktop/headed_window.rs:123)
   0: servoshell::backtrace::print
             at /persist/home/eri/Code/servo/ports/servoshell/backtrace.rs:18:5
   1: servoshell::panic_hook::panic_hook
             at /persist/home/eri/Code/servo/ports/servoshell/panic_hook.rs:38:17
   2: core::ops::function::Fn::call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:79:5
   3: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/alloc/src/boxed.rs:2034:9
      std::panicking::rust_panic_with_hook
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:783:13
   4: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:657:13
   5: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys_common/backtrace.rs:171:18
   6: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   7: core::panicking::panic_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:72:14
   8: core::result::unwrap_failed
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/result.rs:1654:5
   9: core::result::Result<T,E>::expect
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/result.rs:1034:23
  10: servoshell::desktop::headed_window::Window::new
             at /persist/home/eri/Code/servo/ports/servoshell/desktop/headed_window.rs:123:13
  11: servoshell::desktop::app::App::run
             at /persist/home/eri/Code/servo/ports/servoshell/desktop/app.rs:81:21
  12: servoshell::desktop::cli::main
             at /persist/home/eri/Code/servo/ports/servoshell/desktop/cli.rs:96:5
  13: servoshell::main
             at /persist/home/eri/Code/servo/ports/servoshell/lib.rs:39:5
  14: servo::main
             at /persist/home/eri/Code/servo/ports/servoshell/main.rs:26:13
  15: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
  16: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/sys_common/backtrace.rs:155:18
  17: std::rt::lang_start::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/rt.rs:166:18
  18: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:284:13
      std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
      std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
      std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/rt.rs:148:48
      std::panicking::try::do_call
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:552:40
      std::panicking::try
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:516:19
      std::panic::catch_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panic.rs:146:14
      std::rt::lang_start_internal
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/rt.rs:148:20
  19: std::rt::lang_start
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/rt.rs:165:17
  20: main
  21: __libc_start_call_main
  22: __libc_start_main@@GLIBC_2.34
  23: _start
Servo exited with non-zero status 101
```

</details>

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it is a version bump
