### PR TITLE
webrender_traits: update closure in with_front_buffer to FnOnce

### DIFF
--- a/components/shared/webrender/rendering_context.rs
+++ b/components/shared/webrender/rendering_context.rs
@@ -169,7 +169,7 @@ impl RenderingContext {
 
     /// Invoke a closure with the surface associated with the current front buffer.
     /// This can be used to create a surfman::SurfaceTexture to blit elsewhere.
-    pub fn with_front_buffer<F: FnMut(&Device, Surface) -> Surface>(&self, mut f: F) {
+    pub fn with_front_buffer<F: FnOnce(&Device, Surface) -> Surface>(&self, f: F) {
         let device = &mut self.0.device.borrow_mut();
         let context = &mut self.0.context.borrow_mut();
         let surface = device


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The closure is called only once. This should be a `FnOnce` closure. Otherwise, swapping the surface will need `Rc`/`RefCell`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [x] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
