### PR TITLE
Fix visual_studio.py to call vswhere with -utf8

### DIFF
--- a/python/servo/visual_studio.py
+++ b/python/servo/visual_studio.py
@@ -57,7 +57,8 @@ def find_compatible_msvc_with_vswhere() -> Generator[VisualStudioInstallation, N
         '-format', 'json',
         '-products', '*',
         '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
-        '-requires', 'Microsoft.VisualStudio.Component.Windows10SDK'
+        '-requires', 'Microsoft.VisualStudio.Component.Windows10SDK',
+        '-utf8'
     ]).decode(errors='ignore')
 
     for install in json.loads(output):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
In Japanese Windows, `./mach build` fails because `vswhere` puts cp932 string in default and fails to load json in Pyhton.
This fixes it by adding `-utf8` option

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it relates to `./mach build`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
