### PR TITLE
Add exception to rejection logic in `generic_call`

### DIFF
--- a/components/script/dom/webidls/PromiseRejectionEvent.webidl
+++ b/components/script/dom/webidls/PromiseRejectionEvent.webidl
@@ -7,11 +7,11 @@
 [Exposed=(Window,Worker)]
 interface PromiseRejectionEvent : Event {
   [Throws] constructor(DOMString type, PromiseRejectionEventInit eventInitDict);
-  readonly attribute Promise<any> promise;
+  readonly attribute object promise;
   readonly attribute any reason;
 };
 
 dictionary PromiseRejectionEventInit : EventInit {
-  required Promise<any> promise;
+  required object promise;
   any reason;
 };

--- a/tests/wpt/meta/FileAPI/idlharness.any.js.ini
+++ b/tests/wpt/meta/FileAPI/idlharness.any.js.ini
@@ -1,9 +1,7 @@
 [idlharness.any.html]
   [Blob interface: operation text()]
-    expected: FAIL
 
   [Blob interface: operation arrayBuffer()]
-    expected: FAIL
 
   [FileReader interface: operation readAsBinaryString(Blob)]
     expected: FAIL
@@ -26,10 +24,8 @@
 
 [idlharness.any.worker.html]
   [Blob interface: operation text()]
-    expected: FAIL
 
   [Blob interface: operation arrayBuffer()]
-    expected: FAIL
 
   [FileReader interface: operation readAsBinaryString(Blob)]
     expected: FAIL

--- a/tests/wpt/meta/FileAPI/idlharness.html.ini
+++ b/tests/wpt/meta/FileAPI/idlharness.html.ini
@@ -1,9 +1,7 @@
 [idlharness.html]
   [Blob interface: operation text()]
-    expected: FAIL
 
   [Blob interface: operation arrayBuffer()]
-    expected: FAIL
 
   [FileReader interface: operation readAsBinaryString(Blob)]
     expected: FAIL

--- a/tests/wpt/meta/FileAPI/idlharness.worker.js.ini
+++ b/tests/wpt/meta/FileAPI/idlharness.worker.js.ini
@@ -1,9 +1,7 @@
 [idlharness.worker.html]
   [Blob interface: operation text()]
-    expected: FAIL
 
   [Blob interface: operation arrayBuffer()]
-    expected: FAIL
 
   [FileReader interface: operation readAsBinaryString(Blob)]
     expected: FAIL

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -686,7 +686,6 @@
     expected: FAIL
 
   [Document interface: operation exitFullscreen()]
-    expected: FAIL
 
   [Document interface: attribute fullscreenElement]
     expected: FAIL
@@ -695,7 +694,6 @@
     expected: FAIL
 
   [Element interface: operation requestFullscreen(optional FullscreenOptions)]
-    expected: FAIL
 
   [Element interface: attribute onfullscreenchange]
     expected: FAIL

--- a/tests/wpt/meta/fetch/api/idlharness.any.js.ini
+++ b/tests/wpt/meta/fetch/api/idlharness.any.js.ini
@@ -15,19 +15,14 @@
     expected: FAIL
 
   [Request interface: operation arrayBuffer()]
-    expected: FAIL
 
   [Request interface: operation blob()]
-    expected: FAIL
 
   [Request interface: operation formData()]
-    expected: FAIL
 
   [Request interface: operation json()]
-    expected: FAIL
 
   [Request interface: operation text()]
-    expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "keepalive" with the proper type]
     expected: FAIL
@@ -48,25 +43,19 @@
     expected: FAIL
 
   [Response interface: operation arrayBuffer()]
-    expected: FAIL
 
   [Response interface: operation blob()]
-    expected: FAIL
 
   [Response interface: operation formData()]
-    expected: FAIL
 
   [Response interface: operation json()]
-    expected: FAIL
 
   [Response interface: operation text()]
-    expected: FAIL
 
   [Response interface: calling json(any, optional ResponseInit) on new Response() with too few arguments must throw TypeError]
     expected: FAIL
 
   [WorkerGlobalScope interface: operation fetch(RequestInfo, optional RequestInit)]
-    expected: FAIL
 
   [WorkerGlobalScope interface: calling fetch(RequestInfo, optional RequestInit) on self with too few arguments must throw TypeError]
 
@@ -103,19 +92,14 @@
     expected: FAIL
 
   [Request interface: operation arrayBuffer()]
-    expected: FAIL
 
   [Request interface: operation blob()]
-    expected: FAIL
 
   [Request interface: operation formData()]
-    expected: FAIL
 
   [Request interface: operation json()]
-    expected: FAIL
 
   [Request interface: operation text()]
-    expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "keepalive" with the proper type]
     expected: FAIL
@@ -136,25 +120,19 @@
     expected: FAIL
 
   [Response interface: operation arrayBuffer()]
-    expected: FAIL
 
   [Response interface: operation blob()]
-    expected: FAIL
 
   [Response interface: operation formData()]
-    expected: FAIL
 
   [Response interface: operation json()]
-    expected: FAIL
 
   [Response interface: operation text()]
-    expected: FAIL
 
   [Response interface: calling json(any, optional ResponseInit) on new Response() with too few arguments must throw TypeError]
     expected: FAIL
 
   [Window interface: operation fetch(RequestInfo, optional RequestInit)]
-    expected: FAIL
 
   [Window interface: calling fetch(RequestInfo, optional RequestInit) on window with too few arguments must throw TypeError]
 

--- a/tests/wpt/meta/fullscreen/idlharness.window.js.ini
+++ b/tests/wpt/meta/fullscreen/idlharness.window.js.ini
@@ -6,7 +6,6 @@
     expected: FAIL
 
   [Document interface: operation exitFullscreen()]
-    expected: FAIL
 
   [Document interface: attribute fullscreenElement]
     expected: FAIL
@@ -15,7 +14,6 @@
     expected: FAIL
 
   [Element interface: operation requestFullscreen(optional FullscreenOptions)]
-    expected: FAIL
 
   [Element interface: attribute onfullscreenchange]
     expected: FAIL

--- a/tests/wpt/meta/gamepad/idlharness.window.js.ini
+++ b/tests/wpt/meta/gamepad/idlharness.window.js.ini
@@ -1,9 +1,7 @@
 [idlharness.window.html]
   [GamepadHapticActuator interface: operation playEffect(GamepadHapticEffectType, optional GamepadEffectParameters)]
-    expected: FAIL
 
   [GamepadHapticActuator interface: operation reset()]
-    expected: FAIL
 
   [GamepadEvent must be primary interface of new GamepadEvent("gamepad")]
     expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -780,7 +780,6 @@
     expected: FAIL
 
   [CustomElementRegistry interface: operation whenDefined(DOMString)]
-    expected: FAIL
 
   [DragEvent interface: existence and properties of interface object]
     expected: FAIL
@@ -2950,7 +2949,6 @@
     expected: FAIL
 
   [HTMLMediaElement interface: operation play()]
-    expected: FAIL
 
   [HTMLMarqueeElement interface: document.createElement("marquee") must inherit property "hspace" with the proper type]
     expected: FAIL
@@ -3196,7 +3194,6 @@
     expected: FAIL
 
   [HTMLImageElement interface: operation decode()]
-    expected: FAIL
 
   [HTMLTableRowElement interface: document.createElement("tr") must inherit property "vAlign" with the proper type]
     expected: FAIL

--- a/tests/wpt/meta/webxr/hit-test/idlharness.https.html.ini
+++ b/tests/wpt/meta/webxr/hit-test/idlharness.https.html.ini
@@ -6,7 +6,6 @@
     expected: FAIL
 
   [XRSession interface: operation requestHitTestSource(XRHitTestOptionsInit)]
-    expected: FAIL
 
   [XRTransientInputHitTestResult interface: existence and properties of interface prototype object]
     expected: FAIL

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -6,7 +6,6 @@
     expected: FAIL
 
   [XRSystem interface: operation isSessionSupported(XRSessionMode)]
-    expected: FAIL
 
   [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's @@unscopables property]
     expected: FAIL
@@ -75,7 +74,6 @@
     expected: FAIL
 
   [XRSystem interface: operation requestSession(XRSessionMode, optional XRSessionInit)]
-    expected: FAIL
 
   [XRReferenceSpaceEvent interface object name]
     expected: FAIL
@@ -213,7 +211,6 @@
     expected: FAIL
 
   [XRSession interface: operation requestReferenceSpace(XRReferenceSpaceType)]
-    expected: FAIL
 
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "framebufferWidth" with the proper type]
     expected: FAIL
@@ -264,7 +261,6 @@
     expected: FAIL
 
   [XRSession interface: operation end()]
-    expected: FAIL
 
   [XRSession interface: xrSession must inherit property "cancelAnimationFrame(unsigned long)" with the proper type]
     expected: FAIL
@@ -321,7 +317,6 @@
     expected: FAIL
 
   [WebGLRenderingContext interface: operation makeXRCompatible()]
-    expected: FAIL
 
   [XRSession interface: attribute enabledFeatures]
     expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13131,7 +13131,7 @@
      ]
     ],
     "exceptionToRejection.any.js": [
-     "738a8bedbcfe83a6f110bc6e6d133e31f80ea9ad",
+     "5d892832c29a4075751b313b3ba5c57d51cc19f3",
      [
       "mozilla/exceptionToRejection.any.html",
       {

--- a/tests/wpt/mozilla/tests/mozilla/exceptionToRejection.any.js
+++ b/tests/wpt/mozilla/tests/mozilla/exceptionToRejection.any.js
@@ -30,3 +30,9 @@ promise_test((t) => {
 promise_test((t) => {
     return promise_rejects_js(t, TypeError, binding.methodInternalThrowToRejectPromise(Number.MAX_SAFE_INTEGER + 1));
 }, "methodInternalThrowToRejectPromise");
+
+promise_test((t) => {
+    return promise_rejects_js(t, TypeError, new Promise(() => {
+        throw new TypeError();
+      }));
+}, "exception in JS Promise");


### PR DESCRIPTION
Relevant code in mozilla uses templates (see `ExceptionPolicy`), but we can use const generic to achieve same effect.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32816
- [x] There are tests for these changes in WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
