### PR TITLE
Bump mozjs-sys to 128.0-6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#dbffebd0937c14d3c73ce9be4798da15cb2f369d"
+source = "git+https://github.com/servo/mozjs#c715ae4081e7cd25dfd1e21151289d12ea5e2e64"
 dependencies = [
  "bindgen",
  "cc",
@@ -4350,8 +4350,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.0-4"
-source = "git+https://github.com/servo/mozjs#dbffebd0937c14d3c73ce9be4798da15cb2f369d"
+version = "0.128.0-6"
+source = "git+https://github.com/servo/mozjs#c715ae4081e7cd25dfd1e21151289d12ea5e2e64"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Companion PR to https://github.com/servo/mozjs/pull/488

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes make assertion failures in spidermonkey on OpenHarmony appear in the `hilog` logging system.

