### PR TITLE
layout: Non-auto `z-index` should always make stacking contexts for flex items

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -31,7 +31,7 @@ use super::{FlexContainer, FlexItemBox, FlexLevelBox};
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext, IndependentLayout};
-use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment};
+use crate::fragment_tree::{BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags};
 use crate::geom::{AuOrAuto, LogicalRect, LogicalSides, LogicalVec2};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::sizing::ContentSizes;
@@ -1522,9 +1522,12 @@ impl InitialFlexLineLayout<'_> {
                     all_baselines.last = Some(item_baseline);
                 }
 
+                let mut fragment_info = item.box_.base_fragment_info();
+                fragment_info.flags.insert(FragmentFlags::IS_FLEX_ITEM);
+
                 (
                     BoxFragment::new(
-                        item.box_.base_fragment_info(),
+                        fragment_info,
                         item.box_.style().clone(),
                         item_layout_result.fragments,
                         content_rect,

--- a/components/layout_2020/fragment_tree/base_fragment.rs
+++ b/components/layout_2020/fragment_tree/base_fragment.rs
@@ -88,20 +88,22 @@ bitflags! {
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 1 << 0;
         /// Whether or not the node that created this Fragment is a `<br>` element.
         const IS_BR_ELEMENT = 1 << 1;
-        /// Whether or not the node that created was a `<table>`, `<th>` or
-        /// `<td>` element. Note that this does *not* include elements with
-        /// `display: table` or `display: table-cell`.
-        const IS_TABLE_TH_OR_TD_ELEMENT = 1 << 2;
+        /// Whether or not this Fragment is a flex item.
+        const IS_FLEX_ITEM = 1 << 2;
         /// Whether or not this Fragment was created to contain a replaced element or is
         /// a replaced element.
         const IS_REPLACED = 1 << 3;
+        /// Whether or not the node that created was a `<table>`, `<th>` or
+        /// `<td>` element. Note that this does *not* include elements with
+        /// `display: table` or `display: table-cell`.
+        const IS_TABLE_TH_OR_TD_ELEMENT = 1 << 4;
         /// Whether or not this Fragment was created to contain a list item marker
         /// with a used value of `list-style-position: outside`.
-        const IS_OUTSIDE_LIST_ITEM_MARKER = 1 << 4;
+        const IS_OUTSIDE_LIST_ITEM_MARKER = 1 << 5;
         /// Avoid painting the borders, backgrounds, and drop shadow for this fragment, this is used
         /// for empty table cells when 'empty-cells' is 'hide' and also table wrappers.  This flag
         /// doesn't avoid hit-testing nor does it prevent the painting outlines.
-        const DO_NOT_PAINT = 1 << 5;
+        const DO_NOT_PAINT = 1 << 6;
     }
 }
 

--- a/tests/wpt/meta/css/css-flexbox/flex-item-z-ordering-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-item-z-ordering-001.html.ini
@@ -1,2 +1,0 @@
-[flex-item-z-ordering-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-items-as-stacking-contexts-001.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-items-as-stacking-contexts-001.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-items-as-stacking-contexts-001.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-paint-ordering-002.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-paint-ordering-002.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-paint-ordering-002.xhtml]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/flex-item-z-ordering-002.html
+++ b/tests/wpt/tests/css/css-flexbox/flex-item-z-ordering-002.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>Flex painting order with z-index</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#painting">
+<meta name="assert"
+  content="z-index works on flex items even though they do not have `position: relative`" />
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+
+<style>
+    #flex {
+        display: flex;
+        width: 100px;
+        height: 100px;
+    }
+
+    #flex > div {
+        width: 0px;
+        height: 0px;
+    }
+    #flex > div > div {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.
+</p>
+
+<div id="flex">
+    <div><div style="background: green"></div></div>
+    <div style="z-index: -10"><div style="background: red;"></div></div>
+</div>


### PR DESCRIPTION
Fixes #32756.
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
