### PR TITLE
Fix panic in `htmlimageelement.rs` using `char_indices()` to iterate over characters

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1891,7 +1891,8 @@ pub fn collect_sequence_characters<F>(s: &str, predicate: F) -> (&str, &str)
 where
     F: Fn(&char) -> bool,
 {
-    for (i, ch) in s.chars().enumerate() {
+    let mut char_indices = s.char_indices();
+    while let Some((i, ch)) = char_indices.next() {
         if !predicate(&ch) {
             return (&s[0..i], &s[i..]);
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32976

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
