### PR TITLE
shaping: Don't assume there's a space glyph when rendering tabs

### DIFF
--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -351,6 +351,10 @@ impl PlatformFontMethods for PlatformFont {
             .glyph_index('\u{6C34}')
             .and_then(|idx| self.glyph_h_advance(idx))
             .map(Au::from_f64_px);
+        let space_advance = self
+            .glyph_index(' ')
+            .and_then(|idx| self.glyph_h_advance(idx))
+            .unwrap_or(average_advance);
 
         FontMetrics {
             underline_size: Au::from_f64_px(underline_size),
@@ -367,6 +371,7 @@ impl PlatformFontMethods for PlatformFont {
             line_gap: Au::from_f64_px(line_height),
             zero_horizontal_advance,
             ic_horizontal_advance,
+            space_advance: Au::from_f64_px(space_advance),
         }
     }
 

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -272,11 +272,17 @@ impl PlatformFontMethods for PlatformFont {
             .glyph_index('0')
             .and_then(|idx| self.glyph_h_advance(idx))
             .map(Au::from_f64_px);
+        let average_advance = zero_horizontal_advance.unwrap_or(max_advance);
+
         let ic_horizontal_advance = self
             .glyph_index('\u{6C34}')
             .and_then(|idx| self.glyph_h_advance(idx))
             .map(Au::from_f64_px);
-        let average_advance = zero_horizontal_advance.unwrap_or(max_advance);
+        let space_advance = self
+            .glyph_index(' ')
+            .and_then(|index| self.glyph_h_advance(index))
+            .map(Au::from_f64_px)
+            .unwrap_or(average_advance);
 
         let metrics = FontMetrics {
             underline_size: Au::from_f64_au(underline_thickness),
@@ -301,6 +307,7 @@ impl PlatformFontMethods for PlatformFont {
             line_gap: Au::from_f64_px(line_gap),
             zero_horizontal_advance,
             ic_horizontal_advance,
+            space_advance,
         };
         debug!(
             "Font metrics (@{} pt): {:?}",

--- a/components/fonts/shaper.rs
+++ b/components/fonts/shaper.rs
@@ -545,20 +545,27 @@ impl Shaper {
                 let character = text[byte_range.clone()].chars().next().unwrap();
                 if is_bidi_control(character) {
                     // Don't add any glyphs for bidi control chars
-                } else if character == '\t' {
-                    // Treat tabs in pre-formatted text as a fixed number of spaces.
-                    //
-                    // TODO: Proper tab stops.
-                    const TAB_COLS: i32 = 8;
-                    let (space_glyph_id, space_advance) = glyph_space_advance(self.font);
-                    let advance = Au::from_f64_px(space_advance) * TAB_COLS;
-                    let data =
-                        GlyphData::new(space_glyph_id, advance, Default::default(), true, true);
-                    glyphs.add_glyph_for_byte_index(byte_idx, character, &data);
                 } else {
-                    let shape = glyph_data.entry_for_glyph(glyph_span.start, &mut y_pos);
-                    let advance = self.advance_for_shaped_glyph(shape.advance, character, options);
-                    let data = GlyphData::new(shape.codepoint, advance, shape.offset, true, true);
+                    let (glyph_id, advance, offset) = if character == '\t' {
+                        // Treat tabs in pre-formatted text as a fixed number of spaces. The glyph id does
+                        // not matter here as Servo doesn't render any glyphs for whitespace.
+                        //
+                        // TODO: Proper tab stops. This should happen in layout and be based on the
+                        // size of the space character of the inline formatting context.
+                        let font = unsafe { &(*self.font) };
+                        (
+                            font.glyph_index(' ').unwrap_or(0) as hb_codepoint_t,
+                            font.metrics.space_advance * 8,
+                            Default::default(),
+                        )
+                    } else {
+                        let shape = glyph_data.entry_for_glyph(glyph_span.start, &mut y_pos);
+                        let advance =
+                            self.advance_for_shaped_glyph(shape.advance, character, options);
+                        (shape.codepoint, advance, shape.offset)
+                    };
+
+                    let data = GlyphData::new(glyph_id, advance, offset, true, true);
                     glyphs.add_glyph_for_byte_index(byte_idx, character, &data);
                 }
             } else {
@@ -707,16 +714,6 @@ extern "C" fn glyph_h_advance_func(
         let advance = (*font).glyph_h_advance(glyph as GlyphId);
         Shaper::float_to_fixed(advance)
     }
-}
-
-fn glyph_space_advance(font: *const Font) -> (hb_codepoint_t, f64) {
-    let space_unicode = ' ';
-    let space_glyph: hb_codepoint_t = match unsafe { (*font).glyph_index(space_unicode) } {
-        Some(g) => g as hb_codepoint_t,
-        None => panic!("No space info"),
-    };
-    let space_advance = unsafe { (*font).glyph_h_advance(space_glyph as GlyphId) };
-    (space_glyph, space_advance)
 }
 
 // Callback to get a font table out of a font.

--- a/tests/wpt/meta-legacy-layout/css/css-text/tab-size/tab-size-integer-005.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-text/tab-size/tab-size-integer-005.html.ini
@@ -1,2 +1,2 @@
 [tab-size-integer-005.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-005.html.ini
+++ b/tests/wpt/meta/css/css-text/tab-size/tab-size-integer-005.html.ini
@@ -1,2 +1,2 @@
 [tab-size-integer-005.html]
-  expected: CRASH
+  expected: FAIL


### PR DESCRIPTION
Previously if a font didn't have a space advance and it was needed to
make advances for tabs, Servo would try to read the advance from the
font. If the font didn't have a space glyph, Servo would panic. This
fixes that issue by making the space advance part of the `FontMetrics`
of a font (like Gecko) and falling back properly if that glyph doesn't
exist. The rendered glyph is still the "space" glyph, but we make
sure to select a font that supports that glyph explicitly.

This prevents a crash, but tabs still aren't handled properly. In
reality, tab stops should be calculated in layout and the size of
the space character of the current font shouldn't come into play.
The addition of the space advance metric will make this easier.


Fixes #32970.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
