### PR TITLE
Fix incorrect target_os value.

### DIFF
--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -454,7 +454,7 @@ where
             .otherwise(|| self.platform_handle_key(key_event));
     }
 
-    #[cfg(not(target_os = "win"))]
+    #[cfg(not(target_os = "windows"))]
     fn platform_handle_key(&mut self, key_event: KeyboardEvent) {
         if let Some(id) = self.focused_webview_id {
             if let Some(event) = ShortcutMatcher::from_event(key_event.clone())
@@ -471,7 +471,7 @@ where
         }
     }
 
-    #[cfg(target_os = "win")]
+    #[cfg(target_os = "windows")]
     fn platform_handle_key(&mut self, _key_event: KeyboardEvent) {}
 
     /// Handle key events after they have been handled by Servo.


### PR DESCRIPTION
This showed up in the new rustc cfg warnings:
```
warning: unexpected `cfg` condition value: `win`
   --> ports/servoshell/desktop/webview.rs:457:15
    |
457 |     #[cfg(not(target_os = "win"))]
    |               ^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, and `windows` and 2 more
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition value: `win`
   --> ports/servoshell/desktop/webview.rs:474:11
    |
474 |     #[cfg(target_os = "win")]
    |           ^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, and `windows` and 2 more
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```