### PR TITLE
Set the cfg properly for the production-stripped profile

### DIFF
--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -49,6 +49,9 @@ webrender_api = { workspace = true }
 webrender_traits = { workspace = true }
 xi-unicode = { workspace = true }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ohos_mock)'] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 byteorder = { workspace = true }
 core-foundation = "0.9"

--- a/components/shared/embedder/build.rs
+++ b/components/shared/embedder/build.rs
@@ -6,14 +6,21 @@ use std::error::Error;
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo::rustc-check-cfg=cfg(servo_production)");
+    println!("cargo::rustc-check-cfg=cfg(servo_do_not_use_in_production)");
     // Cargo does not expose the profile name to crates or their build scripts,
     // but we can extract it from OUT_DIR and set a custom cfg() ourselves.
     let out = std::env::var("OUT_DIR")?;
     let out = Path::new(&out);
     let krate = out.parent().unwrap();
     let build = krate.parent().unwrap();
-    let profile = build.parent().unwrap();
-    if profile.file_name().unwrap() == "production" {
+    let profile = build
+        .parent()
+        .unwrap()
+        .file_name()
+        .unwrap()
+        .to_string_lossy();
+    if profile == "production" || profile.starts_with("production-") {
         println!("cargo:rustc-cfg=servo_production");
     } else {
         println!("cargo:rustc-cfg=servo_do_not_use_in_production");

--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -21,14 +21,21 @@ fn generate_egl_bindings(out_dir: &Path) {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo::rustc-check-cfg=cfg(servo_production)");
+    println!("cargo::rustc-check-cfg=cfg(servo_do_not_use_in_production)");
     // Cargo does not expose the profile name to crates or their build scripts,
     // but we can extract it from OUT_DIR and set a custom cfg() ourselves.
     let out = std::env::var("OUT_DIR")?;
     let out = Path::new(&out);
     let krate = out.parent().unwrap();
     let build = krate.parent().unwrap();
-    let profile = build.parent().unwrap();
-    if profile.file_name().unwrap() == "production" {
+    let profile = build
+        .parent()
+        .unwrap()
+        .file_name()
+        .unwrap()
+        .to_string_lossy();
+    if profile == "production" || profile.starts_with("production-") {
         println!("cargo:rustc-cfg=servo_production");
     } else {
         println!("cargo:rustc-cfg=servo_do_not_use_in_production");


### PR DESCRIPTION
When building with `./mach build --profile production-stripped`, the `servo_production` cfg was not set properly because the check only considered the `production` build profile. This PR set the right cfg for both `production` and any `production-xyz` build profile.

Also added the required cargo output for the ` ohos_mock` cfg in fonts.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because no relevant test is needed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
