### PR TITLE
Use correct feature name for JS backtraces.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -1044,7 +1044,7 @@ class CommandBase(object):
             if self.config["build"]["webgl-backtrace"]:
                 features.append("webgl-backtrace")
             if self.config["build"]["dom-backtrace"]:
-                features.append("dom-backtrace")
+                features.append("js_backtrace")
             args += ["--features", " ".join(features)]
 
         if with_debug_assertions or self.config["build"]["debug-assertions"]:


### PR DESCRIPTION
This has been wrong since I first added it in 06bca43aeef990da8f02cd8b814329f7607365dd, but I remember using it before. Mysterious!

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a build feature.