### PR TITLE
clippy: Fix various clippy warnings throughout the code 

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1085,7 +1085,8 @@ impl WebGLImpl {
                 state.restore_depth_invariant(gl);
             },
             WebGLCommand::DepthRange(near, far) => {
-gl.depth_range(near.max(0.).min(1.) as f64, far.max(0.).min(1.) as f64)            },
+                gl.depth_range(near.max(0.).min(1.) as f64, far.max(0.).min(1.) as f64)
+            },
             WebGLCommand::Disable(cap) => match cap {
                 gl::SCISSOR_TEST => {
                     state.scissor_test_enabled = false;

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1046,7 +1046,7 @@ impl WebGLImpl {
                 gl.clear_color(r, g, b, a);
             },
             WebGLCommand::ClearDepth(depth) => {
-                let value = depth.clamp(0., 1.) as f64;
+                let value = depth.max(0.).min(1.) as f64;
                 state.depth_clear_value = value;
                 gl.clear_depth(value)
             },
@@ -1085,8 +1085,7 @@ impl WebGLImpl {
                 state.restore_depth_invariant(gl);
             },
             WebGLCommand::DepthRange(near, far) => {
-                gl.depth_range(near.clamp(0., 1.) as f64, far.clamp(0., 1.) as f64)
-            },
+gl.depth_range(near.max(0.).min(1.) as f64, far.max(0.).min(1.) as f64)            },
             WebGLCommand::Disable(cap) => match cap {
                 gl::SCISSOR_TEST => {
                     state.scissor_test_enabled = false;

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1046,7 +1046,7 @@ impl WebGLImpl {
                 gl.clear_color(r, g, b, a);
             },
             WebGLCommand::ClearDepth(depth) => {
-                let value = depth.max(0.).min(1.) as f64;
+                let value = depth.clamp(0., 1.) as f64;
                 state.depth_clear_value = value;
                 gl.clear_depth(value)
             },
@@ -1085,7 +1085,7 @@ impl WebGLImpl {
                 state.restore_depth_invariant(gl);
             },
             WebGLCommand::DepthRange(near, far) => {
-                gl.depth_range(near.max(0.).min(1.) as f64, far.max(0.).min(1.) as f64)
+                gl.depth_range(near.clamp(0., 1.) as f64, far.clamp(0., 1.) as f64)
             },
             WebGLCommand::Disable(cap) => match cap {
                 gl::SCISSOR_TEST => {
@@ -2878,8 +2878,8 @@ fn flip_pixels_y(
 
 // Clamp a size to the current GL context's max viewport
 fn clamp_viewport(gl: &Gl, size: Size2D<u32>) -> Size2D<u32> {
-    let mut max_viewport = [i32::max_value(), i32::max_value()];
-    let mut max_renderbuffer = [i32::max_value()];
+    let mut max_viewport = [i32::MAX, i32::MAX];
+    let mut max_renderbuffer = [i32::MAX];
     #[allow(unsafe_code)]
     unsafe {
         gl.get_integer_v(gl::MAX_VIEWPORT_DIMS, &mut max_viewport);

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1921,8 +1921,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             return;
         }
 
-        self.page_zoom =
-            Scale::new((self.page_zoom.get() * magnification).clamp(MIN_ZOOM, MAX_ZOOM));
+        self.page_zoom = Scale::new(
+            (self.page_zoom.get() * magnification)
+                .max(MIN_ZOOM)
+                .min(MAX_ZOOM),
+        );
         self.update_after_zoom_or_hidpi_change();
     }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1921,9 +1921,8 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             return;
         }
 
-        self.page_zoom = Scale::new(
-            (self.page_zoom.get() * magnification).clamp(MIN_ZOOM, MAX_ZOOM)
-        );
+        self.page_zoom =
+            Scale::new((self.page_zoom.get() * magnification).clamp(MIN_ZOOM, MAX_ZOOM));
         self.update_after_zoom_or_hidpi_change();
     }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1922,9 +1922,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         }
 
         self.page_zoom = Scale::new(
-            (self.page_zoom.get() * magnification)
-                .max(MIN_ZOOM)
-                .min(MAX_ZOOM),
+            (self.page_zoom.get() * magnification).clamp(MIN_ZOOM, MAX_ZOOM)
         );
         self.update_after_zoom_or_hidpi_change();
     }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1824,9 +1824,9 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             if previous_pipeline_id.replace(pipeline_id) != Some(pipeline_id) {
                 let scroll_result = self
                     .pipeline_details
-                    .get_mut(&pipeline_id)?
+                    .get_mut(pipeline_id)?
                     .scroll_tree
-                    .scroll_node_or_ancestor(&scroll_tree_node, scroll_location);
+                    .scroll_node_or_ancestor(scroll_tree_node, scroll_location);
                 if let Some((external_id, offset)) = scroll_result {
                     return Some((*pipeline_id, external_id, offset));
                 }

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -72,7 +72,7 @@ impl Actor for AccessibilityActor {
     /// - `getTraits`: Informs the DevTools client about the configuration of the accessibility actor
     ///
     /// - `getWalker`: Returns a new AccessibleWalker actor (not to be confused with the general
-    /// inspector Walker actor)
+    ///   inspector Walker actor)
     fn handle_message(
         &self,
         registry: &ActorRegistry,

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -42,7 +42,7 @@ impl Actor for CssPropertiesActor {
     /// The css properties actor can handle the following messages:
     ///
     /// - `getCSSDatabase`: Returns a big list of every supported css property so that the
-    /// inspector can show the available options
+    ///   inspector can show the available options
     fn handle_message(
         &self,
         _registry: &ActorRegistry,

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -89,7 +89,7 @@ impl Actor for NodeActor {
     /// The node actor can handle the following messages:
     ///
     /// - `modifyAttributes`: Asks the script to change a value in the attribute of the
-    /// corresponding node
+    ///   corresponding node
     ///
     /// - `getUniqueSelector`: Returns the display name of this node
     fn handle_message(

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -120,7 +120,7 @@ impl Actor for WalkerActor {
     /// - `getOffsetParent`: Placeholder
     ///
     /// - `querySelector`: Recursively looks for the specified selector in the tree, reutrning the
-    /// node and its ascendents
+    ///   node and its ascendents
     fn handle_message(
         &self,
         registry: &ActorRegistry,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -77,7 +77,7 @@ impl Actor for TabDescriptorActor {
     /// - `getFavicon`: Should return the tab favicon, but it is not yet supported.
     ///
     /// - `getWatcher`: Returns a `WatcherActor` linked to the tab's `BrowsingContext`. It is used
-    /// to describe the debugging capabilities of this tab.
+    ///   to describe the debugging capabilities of this tab.
     fn handle_message(
         &self,
         registry: &ActorRegistry,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -160,17 +160,17 @@ impl Actor for WatcherActor {
     /// The watcher actor can handle the following messages:
     ///
     /// - `watchTargets`: Returns a list of objects to debug. Since we only support web views, it
-    /// returns the associated `BrowsingContextActor`. Every target sent creates a
-    /// `target-available-form` event.
+    ///   returns the associated `BrowsingContextActor`. Every target sent creates a
+    ///   `target-available-form` event.
     ///
     /// - `watchResources`: Start watching certain resource types. This sends
-    /// `resource-available-form` events.
+    ///   `resource-available-form` events.
     ///
     /// - `getNetworkParentActor`: Returns the network parent actor. It doesn't seem to do much at
-    /// the moment.
+    ///   the moment.
     ///
     /// - `getTargetConfigurationActor`: Returns the configuration actor for a specific target, so
-    /// that the server can update its settings.
+    ///   that the server can update its settings.
     ///
     /// - `getThreadConfigurationActor`: The same but with the configuration actor for the thread
     fn handle_message(

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -5,7 +5,7 @@
 use std::cmp::{Ordering, PartialOrd};
 use std::sync::Arc;
 use std::vec::Vec;
-use std::{fmt, mem, u16};
+use std::{fmt, mem};
 
 use app_units::Au;
 use euclid::default::Point2D;

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -5,7 +5,7 @@
 use std::cmp::max;
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::{fmt, i32, isize, mem};
+use std::{fmt, mem};
 
 use app_units::{Au, MIN_AU};
 use base::print_tree::PrintTree;

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -1006,7 +1006,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             repeat_vertical: border_image_repeat.1.to_webrender(),
         });
         builder.wr().push_border(
-            &common,
+            common,
             border_image_area.to_box2d(),
             border_image_widths,
             details,

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1262,7 +1262,7 @@ impl InitialFlexLineLayout<'_> {
         let mut max_ascent = Au::zero();
         let mut max_descent = Au::zero();
         let mut max_outer_hypothetical_cross_size = Au::zero();
-        for (item_result, item) in item_layout_results.iter().zip(&items) {
+        for (item_result, item) in item_layout_results.iter().zip(items) {
             // TODO: check inline-axis is parallel to main axis, check no auto cross margins
             if matches!(
                 item.align_self.0.value(),

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1262,7 +1262,7 @@ impl InitialFlexLineLayout<'_> {
         let mut max_ascent = Au::zero();
         let mut max_descent = Au::zero();
         let mut max_outer_hypothetical_cross_size = Au::zero();
-        for (item_result, item) in item_layout_results.iter().zip(&*items) {
+        for (item_result, item) in item_layout_results.iter().zip(&items) {
             // TODO: check inline-axis is parallel to main axis, check no auto cross margins
             if matches!(
                 item.align_self.0.value(),

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -220,7 +220,7 @@ impl FlexContainer {
         let mut item_infos = vec![];
 
         let container_is_horizontal = self.style.writing_mode.is_horizontal();
-        let flex_direction = used_flex_direction(&*self.style);
+        let flex_direction = used_flex_direction(&self.style);
         let flex_axis = FlexAxis::from(flex_direction);
         let flex_wrap = self.style.get_position().flex_wrap;
         let flex_wrap_reverse = match flex_wrap {

--- a/components/layout_2020/fragment_tree/containing_block.rs
+++ b/components/layout_2020/fragment_tree/containing_block.rs
@@ -28,7 +28,8 @@ pub(crate) struct ContainingBlockManager<'a, T> {
     ///      element is split across multiple lines, the containing block is
     ///      undefined.
     ///   2. Otherwise, the containing block is formed by the padding edge of the
-    ///      ancestor."
+    ///      ancestor.
+    ///
     /// <https://www.w3.org/TR/CSS2/visudet.html#containing-block-details>
     /// If the ancestor forms a containing block for all descendants (see below),
     /// this value will be None and absolute descendants will use the containing

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -81,10 +81,10 @@ struct MeasurableCachedResource {
 impl MallocSizeOf for CachedResource {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         // TODO: self.request_headers.unconditional_size_of(ops) +
-        self.body.unconditional_size_of(ops)
-            + self.aborted.unconditional_size_of(ops)
-            + self.awaiting_body.unconditional_size_of(ops)
-            + self.data.size_of(ops)
+        self.body.unconditional_size_of(ops) +
+            self.aborted.unconditional_size_of(ops) +
+            self.awaiting_body.unconditional_size_of(ops) +
+            self.data.size_of(ops)
     }
 }
 
@@ -148,9 +148,9 @@ fn response_is_cacheable(metadata: &Metadata) -> bool {
     // 2. check for absence of the Authorization header field.
     let mut is_cacheable = false;
     let headers = metadata.headers.as_ref().unwrap();
-    if headers.contains_key(header::EXPIRES)
-        || headers.contains_key(header::LAST_MODIFIED)
-        || headers.contains_key(header::ETAG)
+    if headers.contains_key(header::EXPIRES) ||
+        headers.contains_key(header::LAST_MODIFIED) ||
+        headers.contains_key(header::ETAG)
     {
         is_cacheable = true;
     }
@@ -158,10 +158,10 @@ fn response_is_cacheable(metadata: &Metadata) -> bool {
         if directive.no_store() {
             return false;
         }
-        if directive.public()
-            || directive.s_max_age().is_some()
-            || directive.max_age().is_some()
-            || directive.no_cache()
+        if directive.public() ||
+            directive.s_max_age().is_some() ||
+            directive.max_age().is_some() ||
+            directive.no_cache()
         {
             is_cacheable = true;
         }
@@ -862,8 +862,8 @@ impl HttpCache {
             Ok(FetchMetadata::Filtered {
                 filtered: _,
                 unsafe_: metadata,
-            })
-            | Ok(FetchMetadata::Unfiltered(metadata)) => metadata,
+            }) |
+            Ok(FetchMetadata::Unfiltered(metadata)) => metadata,
             _ => return,
         };
         if !response_is_cacheable(&metadata) {

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -9,8 +9,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::Path;
+use std::thread;
 use std::time::Duration;
-use std::{f64, thread, u32, u64};
 
 use ipc_channel::ipc::{self, IpcReceiver};
 use profile_traits::time::{

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -5,7 +5,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Mutex;
-use std::u64;
 
 use lazy_static::lazy_static;
 use log::trace;

--- a/components/shared/webrender/rendering_context.rs
+++ b/components/shared/webrender/rendering_context.rs
@@ -97,7 +97,7 @@ impl RenderingContext {
         let device = &mut self.0.device.borrow_mut();
         let context = &self.0.context.borrow();
         let surface_access = SurfaceAccess::GPUOnly;
-        device.create_surface(&context, surface_access, surface_type)
+        device.create_surface(context, surface_access, surface_type)
     }
 
     pub fn destroy_surface(&self, mut surface: Surface) -> Result<(), Error> {


### PR DESCRIPTION
Overall formatting with clippy. However I did change one thing in 74004c8, I assumed that the values were swapped.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #31500
- [x] These changes do not require tests because they are just formatting
