### PR TITLE
Replace the lazy_static crate whth `std::sync::LazyLock` in components/script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5615,7 +5615,6 @@ dependencies = [
  "itertools 0.13.0",
  "jstraceable_derive",
  "keyboard-types",
- "lazy_static",
  "libc",
  "log",
  "malloc_size_of",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -66,7 +66,6 @@ itertools = { workspace = true }
 js = { package = "mozjs", git = "https://github.com/servo/mozjs", features = ["streams"] }
 jstraceable_derive = { path = "../jstraceable_derive" }
 keyboard-types = { workspace = true }
-lazy_static = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -9,13 +9,13 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
+use std::sync::LazyLock;
 use std::{fmt, ops, str};
 
 use chrono::prelude::{Utc, Weekday};
 use chrono::{Datelike, TimeZone};
 use cssparser::CowRcStr;
 use html5ever::{LocalName, Namespace};
-use lazy_static::lazy_static;
 use num_traits::Zero;
 use regex::Regex;
 use servo_atoms::Atom;
@@ -430,10 +430,10 @@ impl DOMString {
 
     /// <https://html.spec.whatwg.org/multipage/#valid-floating-point-number>
     pub fn is_valid_floating_point_number_string(&self) -> bool {
-        lazy_static! {
-            static ref RE: Regex =
-                Regex::new(r"^-?(?:\d+\.\d+|\d+|\.\d+)(?:(e|E)(\+|\-)?\d+)?$").unwrap();
-        }
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^-?(?:\d+\.\d+|\d+|\.\d+)(?:(e|E)(\+|\-)?\d+)?$").unwrap()
+        });
+
         RE.is_match(&self.0) && self.parse_floating_point_number().is_some()
     }
 
@@ -537,13 +537,14 @@ impl DOMString {
 
     /// <https://html.spec.whatwg.org/multipage/#valid-e-mail-address>
     pub fn is_valid_email_address_string(&self) -> bool {
-        lazy_static! {
-            static ref RE: Regex = Regex::new(concat!(
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(concat!(
                 r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?",
                 r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
             ))
-            .unwrap();
-        }
+            .unwrap()
+        });
+
         RE.is_match(&self.0)
     }
 

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
@@ -146,8 +147,8 @@ impl HTMLMetaElement {
         }
 
         // 2-11
-        lazy_static::lazy_static! {
-            static ref REFRESH_REGEX: Regex = Regex::new(
+        static REFRESH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(
                 r#"(?x)
                 ^
                 \s* # 3
@@ -169,8 +170,9 @@ impl HTMLMetaElement {
                 $
             "#,
             )
-            .unwrap();
-        }
+            .unwrap()
+        });
+
         let mut url_record = document.url();
         let captures = if let Some(captures) = REFRESH_REGEX.captures(content.as_bytes()) {
             captures

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -4,10 +4,10 @@
 
 use std::cell::Cell;
 use std::convert::TryInto;
+use std::sync::LazyLock;
 
 use dom_struct::dom_struct;
 use js::jsval::JSVal;
-use lazy_static::lazy_static;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
@@ -32,9 +32,8 @@ use crate::dom::xrsystem::XRSystem;
 use crate::script_runtime::JSContext;
 
 pub(super) fn hardware_concurrency() -> u64 {
-    lazy_static! {
-        static ref CPUS: u64 = num_cpus::get().try_into().unwrap_or(1);
-    }
+    static CPUS: LazyLock<u64> = LazyLock::new(|| num_cpus::get().try_into().unwrap_or(1));
+
     *CPUS
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -14,7 +14,7 @@ use std::io::{stdout, Write};
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use std::{fmt, os, ptr, thread};
 
@@ -47,7 +47,6 @@ use js::rust::{
     describe_scripted_caller, Handle, HandleObject as RustHandleObject, IntoHandle, JSEngine,
     JSEngineHandle, ParentRuntime, Runtime as RustRuntime,
 };
-use lazy_static::lazy_static;
 use malloc_size_of::MallocSizeOfOps;
 use profile_traits::mem::{Report, ReportKind, ReportsChan};
 use profile_traits::path;
@@ -487,9 +486,7 @@ impl Drop for JSEngineSetup {
     }
 }
 
-lazy_static! {
-    static ref JS_ENGINE: Mutex<Option<JSEngineHandle>> = Mutex::new(None);
-}
+static JS_ENGINE: LazyLock<Mutex<Option<JSEngineHandle>>> = LazyLock::new(|| Mutex::new(None));
 
 #[allow(unsafe_code)]
 pub unsafe fn new_child_runtime(

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -14,7 +14,7 @@ use std::io::{stdout, Write};
 use std::ops::Deref;
 use std::os::raw::c_void;
 use std::rc::Rc;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{fmt, os, ptr, thread};
 
@@ -486,7 +486,7 @@ impl Drop for JSEngineSetup {
     }
 }
 
-static JS_ENGINE: LazyLock<Mutex<Option<JSEngineHandle>>> = LazyLock::new(|| Mutex::new(None));
+static JS_ENGINE: Mutex<Option<JSEngineHandle>> = Mutex::new(None);
 
 #[allow(unsafe_code)]
 pub unsafe fn new_child_runtime(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace the lazy_static crate whth `std::sync::LazyLock` in components/script.

I removed lazy_static In `script_runtime.rs` because it uses only `Mutex::new` which can be used in const statements.
This part is initialized at compile time instead of on first access.
The other parts do not change behavior.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
