### PR TITLE
webxr: Add missing IDL members from AR Module

### DIFF
--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -16,18 +16,21 @@ enum XRVisibilityState {
   "hidden",
 };
 
+enum XRInteractionMode {
+  "screen-space",
+  "world-space",
+};
+
 callback XRFrameRequestCallback = undefined (DOMHighResTimeStamp time, XRFrame frame);
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRSession : EventTarget {
-  // // Attributes
-  readonly attribute XREnvironmentBlendMode environmentBlendMode;
-
+  // Attributes
   readonly attribute XRVisibilityState visibilityState;
   [SameObject] readonly attribute XRRenderState renderState;
   [SameObject] readonly attribute XRInputSourceArray inputSources;
 
-  // // Methods
+  // Methods
   [Throws] undefined updateRenderState(optional XRRenderStateInit state = {});
   Promise<XRReferenceSpace> requestReferenceSpace(XRReferenceSpaceType type);
 
@@ -36,10 +39,7 @@ interface XRSession : EventTarget {
 
   Promise<undefined> end();
 
-  // hit test module
-  Promise<XRHitTestSource> requestHitTestSource(XRHitTestOptionsInit options);
-
-  // // Events
+  // Events
   attribute EventHandler onend;
   attribute EventHandler onselect;
   attribute EventHandler onsqueeze;
@@ -49,4 +49,13 @@ interface XRSession : EventTarget {
   attribute EventHandler onsqueezestart;
   attribute EventHandler onsqueezeend;
   attribute EventHandler onvisibilitychange;
+
+  // AR Module
+  // Attributes
+  readonly attribute XREnvironmentBlendMode environmentBlendMode;
+  readonly attribute XRInteractionMode interactionMode;
+
+  // Hit Test Module
+  // Methods
+  Promise<XRHitTestSource> requestHitTestSource(XRHitTestOptionsInit options);
 };

--- a/components/script/dom/webidls/XRView.webidl
+++ b/components/script/dom/webidls/XRView.webidl
@@ -15,4 +15,7 @@ interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
   readonly attribute XRRigidTransform transform;
+
+  // AR Module
+  readonly attribute boolean isFirstPersonObserver;
 };

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -33,7 +33,7 @@ use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::{
     XRRenderStateInit, XRRenderStateMethods,
 };
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::{
-    XREnvironmentBlendMode, XRFrameRequestCallback, XRSessionMethods, XRVisibilityState,
+    XREnvironmentBlendMode, XRFrameRequestCallback, XRInteractionMode, XRSessionMethods, XRVisibilityState,
 };
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionMode;
 use crate::dom::bindings::error::{Error, ErrorResult};
@@ -872,6 +872,13 @@ impl XRSessionMethods for XRSession {
         self.session.borrow().request_hit_test(source);
 
         p
+    }
+
+    /// <https://www.w3.org/TR/webxr-ar-module-1/#dom-xrsession-interactionmode>
+    fn InteractionMode(&self) -> XRInteractionMode {
+        // Until Servo supports WebXR sessions on mobile phones or similar non-XR devices,
+        // this should always be world space
+        XRInteractionMode::World_space
     }
 }
 

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -33,7 +33,8 @@ use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::{
     XRRenderStateInit, XRRenderStateMethods,
 };
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::{
-    XREnvironmentBlendMode, XRFrameRequestCallback, XRInteractionMode, XRSessionMethods, XRVisibilityState,
+    XREnvironmentBlendMode, XRFrameRequestCallback, XRInteractionMode, XRSessionMethods,
+    XRVisibilityState,
 };
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionMode;
 use crate::dom::bindings::error::{Error, ErrorResult};

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -106,4 +106,10 @@ impl XRViewMethods for XRView {
     fn Transform(&self) -> DomRoot<XRRigidTransform> {
         DomRoot::from_ref(&self.transform)
     }
+
+    /// <https://www.w3.org/TR/webxr-ar-module-1/#dom-xrview-isfirstpersonobserver>
+    fn IsFirstPersonObserver(&self) -> bool {
+        // Servo is not currently supported anywhere that supports this, so return false
+        false
+    }
 }

--- a/tests/wpt/meta-legacy-layout/webxr/ar-module/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/ar-module/idlharness.https.window.js.ini
@@ -1,7 +1,4 @@
 [idlharness.https.window.html]
-  [XRSession interface: attribute interactionMode]
-    expected: FAIL
-
   [idl_test setup]
     expected: FAIL
 
@@ -10,7 +7,3 @@
 
   [XRSession interface: xrSession must inherit property "interactionMode" with the proper type]
     expected: FAIL
-
-  [XRView interface: attribute isFirstPersonObserver]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/webxr/ar-module/xrSession_interactionMode.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/ar-module/xrSession_interactionMode.https.html.ini
@@ -8,12 +8,6 @@
   [Tests interactionMode for an AR_SCREEN_DEVICE]
     expected: FAIL
 
-  [Tests interactionMode for an AR_HMD_DEVICE]
-    expected: FAIL
-
-  [Tests interactionMode for an VR_HMD_DEVICE]
-    expected: FAIL
-
   [Tests interactionMode for an AR_HMD_DEVICE - webgl]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/ar-module/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/ar-module/idlharness.https.window.js.ini
@@ -1,7 +1,4 @@
 [idlharness.https.window.html]
-  [XRSession interface: attribute interactionMode]
-    expected: FAIL
-
   [idl_test setup]
     expected: FAIL
 
@@ -10,7 +7,3 @@
 
   [XRSession interface: xrSession must inherit property "interactionMode" with the proper type]
     expected: FAIL
-
-  [XRView interface: attribute isFirstPersonObserver]
-    expected: FAIL
-


### PR DESCRIPTION
This adds a couple of missing IDL members, `XRSession.interactionMode` and `XRView.isFirstPersonObserver`, from the WebXR AR Module

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
