### PR TITLE
Update Rust to 1.80.1

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -10,7 +10,7 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/8b81b8ed00b20fd57b24adcb390bd96ea81ecd90.tar.gz";
+      url = "https://github.com/oxalica/rust-overlay/archive/65e3dc0fe079fe8df087cd38f1fe6836a0373aad.tar.gz";
     }))
   ];
   config = {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Be sure to update etc/shell.nix when bumping this!
-channel = "1.80.0"
+channel = "1.80.1"
 
 components = [
     # For support/crown


### PR DESCRIPTION
This is interesting: https://blog.rust-lang.org/2024/08/08/Rust-1.80.1.html#false-positives-in-the-dead_code-lint


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because only rustc upgrade

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
