### PR TITLE
[css-flexbox] Improve sizing in column layout

### DIFF
--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -67,7 +67,7 @@ impl<T> FlexRelativeSides<T> {
 
 /// One of the two bits set by the `flex-direction` property
 /// (The other is "forward" v.s. reverse.)
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum FlexAxis {
     /// The main axis is the inline axis of the container (not necessarily of flex items!),
     /// cross is block.

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2377,6 +2377,7 @@ impl<'a> ContentSizesComputation<'a> {
                 let outer = atomic.outer_inline_content_sizes(
                     self.layout_context,
                     self.containing_block_writing_mode,
+                    Au::zero,
                 );
 
                 if !inline_formatting_context

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -357,7 +357,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
             BlockLevelBox::OutOfFlowFloatBox(ref mut float_box) => {
                 let size = float_box
                     .contents
-                    .outer_inline_content_sizes(layout_context, writing_mode)
+                    .outer_inline_content_sizes(layout_context, writing_mode, Au::zero)
                     .max(ContentSizes::zero());
                 let style_box = &float_box.contents.style().get_box();
                 Some((size, style_box.float, style_box.clear))
@@ -365,9 +365,12 @@ fn calculate_inline_content_size_for_block_level_boxes(
             BlockLevelBox::SameFormattingContextBlock {
                 style, contents, ..
             } => {
-                let size = sizing::outer_inline(style, writing_mode, || {
-                    contents.inline_content_sizes(layout_context, style.writing_mode)
-                })
+                let size = sizing::outer_inline(
+                    style,
+                    writing_mode,
+                    || contents.inline_content_sizes(layout_context, style.writing_mode),
+                    Au::zero,
+                )
                 .max(ContentSizes::zero());
                 // A block in the same BFC can overlap floats, it's not moved next to them,
                 // so we shouldn't add its size to the size of the floats.
@@ -376,7 +379,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
             },
             BlockLevelBox::Independent(ref mut independent) => {
                 let size = independent
-                    .outer_inline_content_sizes(layout_context, writing_mode)
+                    .outer_inline_content_sizes(layout_context, writing_mode, Au::zero)
                     .max(ContentSizes::zero());
                 Some((size, Float::None, independent.style().get_box().clear))
             },

--- a/tests/wpt/meta/css/css-flexbox/align-content-wrap-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-content-wrap-002.html.ini
@@ -1,6 +1,0 @@
-[align-content-wrap-002.html]
-  [.flex-horizontal, .flex-vertical 5]
-    expected: FAIL
-
-  [.flex-horizontal, .flex-vertical 6]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/align-items-009.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-items-009.html.ini
@@ -1,2 +1,0 @@
-[align-items-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/align-self-014.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-self-014.html.ini
@@ -1,3 +1,0 @@
-[align-self-014.html]
-  [.content 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
@@ -50,47 +50,8 @@
   [.target > * 25]
     expected: FAIL
 
-  [.target > * 10]
-    expected: FAIL
-
-  [.target > * 12]
-    expected: FAIL
-
-  [.target > * 13]
-    expected: FAIL
-
-  [.target > * 14]
-    expected: FAIL
-
-  [.target > * 16]
-    expected: FAIL
-
   [.target > * 43]
     expected: FAIL
 
   [.target > * 47]
-    expected: FAIL
-
-  [.target > * 26]
-    expected: FAIL
-
-  [.target > * 28]
-    expected: FAIL
-
-  [.target > * 30]
-    expected: FAIL
-
-  [.target > * 32]
-    expected: FAIL
-
-  [.target > * 42]
-    expected: FAIL
-
-  [.target > * 44]
-    expected: FAIL
-
-  [.target > * 46]
-    expected: FAIL
-
-  [.target > * 48]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/fit-content-item-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/fit-content-item-001.html.ini
@@ -1,2 +1,0 @@
-[fit-content-item-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-item-contains-strict.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-item-contains-strict.html.ini
@@ -10,3 +10,9 @@
 
   [.inline-flex 7]
     expected: FAIL
+
+  [.inline-flex 1]
+    expected: FAIL
+
+  [.inline-flex 5]
+    expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/column-flex-child-with-max-width.html
+++ b/tests/wpt/tests/css/css-flexbox/column-flex-child-with-max-width.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Item in column flex container with max-width</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-direction-property">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-items">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#align-items-property">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Contents of a flex item with max-width should be laid out within the decreased containing block.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 100px; height: 100px; background: red">
+  <div style="display: flex; flex-direction: column; width: 200px; height: 100px">
+    <div style="align-self: start; max-width: 100px">
+      <div style="display: flow-root; background: green">
+        <div style="float: left; width: 100px; height: 50px"></div>
+        <div style="float: left; width: 100px; height: 50px"></div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This patch implements intrinsic sizing for column flex containers.

It also removes inline_content_sizes() from FlexItemBox, in favour of outer_inline_content_sizes() from IndependentFormattingContext, which now accepts a new parameter to resolve automatic minimum sizes.

Also some fixes during the layout of flex items in a column layout.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
