### PR TITLE
DevTools: Inspect node styles

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -230,9 +230,9 @@ impl BrowsingContextActor {
         let accessibility = AccessibilityActor::new(actors.new_name("accessibility"));
 
         let properties = (|| {
-            let (tx, rx) = ipc::channel().ok()?;
-            script_sender.send(GetCssDatabase(tx)).ok()?;
-            rx.recv().ok()
+            let (properties_sender, properties_receiver) = ipc::channel().ok()?;
+            script_sender.send(GetCssDatabase(properties_sender)).ok()?;
+            properties_receiver.recv().ok()
         })()
         .unwrap_or_default();
         let css_properties = CssPropertiesActor::new(actors.new_name("css-properties"), properties);

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -229,9 +229,12 @@ impl BrowsingContextActor {
 
         let accessibility = AccessibilityActor::new(actors.new_name("accessibility"));
 
-        let (tx, rx) = ipc::channel().unwrap();
-        script_sender.send(GetCssDatabase(tx)).unwrap();
-        let properties = rx.recv().unwrap();
+        let properties = (|| {
+            let (tx, rx) = ipc::channel().ok()?;
+            script_sender.send(GetCssDatabase(tx)).ok()?;
+            rx.recv().ok()
+        })()
+        .unwrap_or_default();
         let css_properties = CssPropertiesActor::new(actors.new_name("css-properties"), properties);
 
         let inspector = InspectorActor {

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -29,6 +29,7 @@ pub mod highlighter;
 pub mod layout;
 pub mod node;
 pub mod page_style;
+pub mod style_rule;
 pub mod walker;
 
 #[derive(Serialize)]

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -48,7 +48,6 @@ impl Actor for CssPropertiesActor {
             "getCSSDatabase" => {
                 let _ = stream.write_json_packet(&GetCssDatabaseReply {
                     from: self.name(),
-                    // TODO: Move this or reference or avoid clone
                     properties: &self.properties,
                 });
 

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -76,8 +76,8 @@ pub struct NodeActorMsg {
 
 pub struct NodeActor {
     name: String,
-    script_chan: IpcSender<DevtoolScriptControlMsg>,
-    pipeline: PipelineId,
+    pub script_chan: IpcSender<DevtoolScriptControlMsg>,
+    pub pipeline: PipelineId,
     pub walker: String,
 }
 
@@ -102,7 +102,6 @@ impl Actor for NodeActor {
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
             "modifyAttributes" => {
-                let target = msg.get("to").ok_or(())?.as_str().ok_or(())?;
                 let mods = msg.get("modifications").ok_or(())?.as_array().ok_or(())?;
                 let modifications: Vec<_> = mods
                     .iter()
@@ -117,7 +116,7 @@ impl Actor for NodeActor {
                 self.script_chan
                     .send(ModifyAttribute(
                         self.pipeline,
-                        registry.actor_to_script(target.to_owned()),
+                        registry.actor_to_script(self.name()),
                         modifications,
                     ))
                     .map_err(|_| ())?;

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -80,7 +80,7 @@ pub struct NodeActor {
     pub script_chan: IpcSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub walker: String,
-    pub style_rules: RefCell<HashMap<String, String>>,
+    pub style_rules: RefCell<HashMap<(String, usize), String>>,
 }
 
 impl Actor for NodeActor {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -34,13 +34,13 @@ struct GetUniqueSelectorReply {
     value: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Serialize)]
 struct AttrMsg {
     name: String,
     value: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeActorMsg {
     pub actor: String,

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -33,13 +33,13 @@ struct GetUniqueSelectorReply {
     value: String,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct AttrMsg {
     name: String,
     value: String,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeActorMsg {
     pub actor: String,
@@ -175,13 +175,14 @@ impl NodeInfoToProtocol for NodeInfo {
     ) -> NodeActorMsg {
         let actor = if !actors.script_actor_registered(self.unique_id.clone()) {
             let name = actors.new_name("node");
+            actors.register_script_actor(self.unique_id, name.clone());
+
             let node_actor = NodeActor {
                 name: name.clone(),
                 script_chan: script_chan.clone(),
                 pipeline,
                 walker: walker.clone(),
             };
-            actors.register_script_actor(self.unique_id, name.clone());
             actors.register_later(Box::new(node_actor));
             name
         } else {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -5,6 +5,7 @@
 //! This actor represents one DOM node. It is created by the Walker actor when it is traversing the
 //! document tree.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::net::TcpStream;
 
@@ -79,6 +80,7 @@ pub struct NodeActor {
     pub script_chan: IpcSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub walker: String,
+    pub style_rules: RefCell<HashMap<String, String>>,
 }
 
 impl Actor for NodeActor {
@@ -182,6 +184,7 @@ impl NodeInfoToProtocol for NodeInfo {
                 script_chan: script_chan.clone(),
                 pipeline,
                 walker: walker.clone(),
+                style_rules: RefCell::new(HashMap::new()),
             };
             actors.register_later(Box::new(node_actor));
             name

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -17,7 +17,6 @@ use serde_json::{self, Map, Value};
 
 use super::style_rule::StyleRuleActor;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
-use crate::actors::inspector::node::NodeInfoToProtocol;
 use crate::protocol::JsonPacketStream;
 use crate::StreamId;
 

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -9,14 +9,14 @@ use std::collections::HashMap;
 use std::net::TcpStream;
 
 use base::id::PipelineId;
-use devtools_traits::DevtoolScriptControlMsg::{GetAppliedStyle, GetDocumentElement, GetLayout};
+use devtools_traits::DevtoolScriptControlMsg::GetLayout;
 use devtools_traits::{ComputedNodeLayout, DevtoolScriptControlMsg};
 use ipc_channel::ipc::{self, IpcSender};
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
-use super::style_rule::StyleRuleActor;
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::actors::inspector::style_rule::{AppliedRule, StyleRuleActor};
 use crate::protocol::JsonPacketStream;
 use crate::StreamId;
 
@@ -35,42 +35,9 @@ struct GetComputedReply {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AppliedEntry {
-    rule: AppliedRule,
+    rule: Option<AppliedRule>,
     pseudo_element: Option<()>,
     is_system: bool,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AppliedRule {
-    actor: String,
-    ancestor_data: Vec<()>,
-    authored_text: String,
-    css_text: String,
-    declarations: Vec<AppliedDeclaration>,
-    href: String,
-    #[serde(rename = "type")]
-    type_: u32,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AppliedDeclaration {
-    pub colon_offsets: Vec<i32>,
-    pub is_name_valid: bool,
-    pub is_used: IsUsed,
-    pub is_valid: bool,
-    pub name: String,
-    pub offsets: Vec<i32>,
-    pub priority: String,
-    pub terminator: String,
-    pub value: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IsUsed {
-    pub used: bool,
 }
 
 #[derive(Serialize)]
@@ -151,52 +118,13 @@ impl Actor for PageStyleActor {
 
                 // TODO: This should be the same actor across different invocations of
                 // styles, save the result somewhere and check for changes
-                let actor = StyleRuleActor::new(registry.new_name("style-rule"));
+                let style_rule =
+                    StyleRuleActor::new(registry.new_name("style-rule"), target.into());
 
-                let (tx, rx) = ipc::channel().unwrap();
-                self.script_chan
-                    .send(GetDocumentElement(self.pipeline, tx))
-                    .unwrap();
-                let node = rx.recv().map_err(|_| ())?.ok_or(())?;
-
-                let (tx, rx) = ipc::channel().map_err(|_| ())?;
-                self.script_chan
-                    .send(GetAppliedStyle(
-                        self.pipeline,
-                        registry.actor_to_script(target.to_owned()),
-                        tx,
-                    ))
-                    .unwrap();
-                let styles = rx.recv().map_err(|_| ())?.ok_or(())?;
                 let entry = AppliedEntry {
-                    // TODO: Fill with real values
-                    rule: AppliedRule {
-                        // TODO: Separate rules based on selector and ancerstor and so on
-                        //       Each style rule actor should correspond to each set of rules
-                        actor: actor.name(),
-                        ancestor_data: vec![],
-                        authored_text: "TODO".into(),
-                        css_text: "TODO".into(),
-                        declarations: styles
-                            .iter()
-                            .filter_map(|style| {
-                                let mut decl = style.text.split(":");
-                                Some(AppliedDeclaration {
-                                    colon_offsets: vec![],
-                                    is_name_valid: true,
-                                    is_used: IsUsed { used: true },
-                                    is_valid: true,
-                                    name: decl.next()?.trim().into(),
-                                    offsets: vec![],
-                                    priority: "".into(),
-                                    terminator: "".into(),
-                                    value: decl.next()?.replace(";", "").trim().into(), // Is this ok?
-                                })
-                            })
-                            .collect(),
-                        href: node.base_uri.clone(),
-                        type_: 100,
-                    },
+                    // TODO: Separate rules based on selector and ancerstor and so on
+                    //       Each style rule actor should correspond to each set of rules
+                    rule: style_rule.rule(registry),
                     pseudo_element: None,
                     is_system: false,
                 };
@@ -207,12 +135,14 @@ impl Actor for PageStyleActor {
                 };
                 let _ = stream.write_json_packet(&msg);
 
-                registry.register_later(Box::new(actor));
+                registry.register_later(Box::new(style_rule));
                 ActorMessageStatus::Processed
             },
 
             "getComputed" => {
                 // TODO: Query script for relevant computed styles on node (msg.node)
+                //
+                // Where are these?
                 let msg = GetComputedReply {
                     computed: vec![],
                     from: self.name(),

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::net::TcpStream;
 
 use base::id::PipelineId;
-use devtools_traits::DevtoolScriptControlMsg::GetLayout;
+use devtools_traits::DevtoolScriptControlMsg::{GetLayout, GetSelectors};
 use devtools_traits::{ComputedNodeLayout, DevtoolScriptControlMsg};
 use ipc_channel::ipc::{self, IpcSender};
 use serde::Serialize;
@@ -136,6 +136,8 @@ impl Actor for PageStyleActor {
                 .into_iter()
                 .filter_map(|node| {
                     let inherited = (node.actor != target).then(|| node.actor.clone());
+
+                    // TODO: Query for all of the selectors and create a style rule for each
 
                     // TODO: This should be the same actor across different invocations of
                     // styles, save the result somewhere and check for changes

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -7,14 +7,65 @@
 
 use std::net::TcpStream;
 
+use devtools_traits::DevtoolScriptControlMsg::{GetAppliedStyle, GetDocumentElement, ModifyRule};
+use ipc_channel::ipc;
+use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::actors::inspector::node::NodeActor;
+use crate::actors::inspector::walker::WalkerActor;
 use crate::protocol::JsonPacketStream;
-use crate::{EmptyReplyMsg, StreamId};
+use crate::StreamId;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppliedRule {
+    actor: String,
+    ancestor_data: Vec<()>,
+    authored_text: String,
+    css_text: String,
+    declarations: Vec<AppliedDeclaration>,
+    href: String,
+    #[serde(rename = "type")]
+    type_: u32,
+    traits: StyleRuleActorTraits,
+}
+
+#[derive(Serialize)]
+pub struct IsUsed {
+    pub used: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppliedDeclaration {
+    colon_offsets: Vec<i32>,
+    is_name_valid: bool,
+    is_used: IsUsed,
+    is_valid: bool,
+    name: String,
+    offsets: Vec<i32>,
+    priority: String,
+    terminator: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StyleRuleActorTraits {
+    pub can_set_rule_text: bool,
+}
+
+#[derive(Serialize)]
+pub struct StyleRuleActorMsg {
+    from: String,
+    rule: Option<AppliedRule>,
+}
 
 pub struct StyleRuleActor {
     name: String,
+    node: String,
 }
 
 impl Actor for StyleRuleActor {
@@ -27,17 +78,40 @@ impl Actor for StyleRuleActor {
     /// -
     fn handle_message(
         &self,
-        _registry: &ActorRegistry,
+        registry: &ActorRegistry,
         msg_type: &str,
-        _msg: &Map<String, Value>,
+        msg: &Map<String, Value>,
         stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
-            "setRuleText" => {
-                // TODO: ...
-                let msg = EmptyReplyMsg { from: self.name() };
-                let _ = stream.write_json_packet(&msg);
+            "modifyProperties" | "setRuleText" => {
+                let mods = msg.get("modifications").ok_or(())?.as_array().ok_or(())?;
+                // TODO: Check this
+                let modifications: Vec<_> = mods
+                    .iter()
+                    .filter_map(|json_mod| {
+                        serde_json::from_str(&serde_json::to_string(json_mod).ok()?).ok()
+                    })
+                    .collect();
+
+                log::info!("{:?}", modifications);
+
+                let node = registry.find::<NodeActor>(&self.node);
+                let walker = registry.find::<WalkerActor>(&node.walker);
+                // TODO: Is this necessary?
+                // walker.new_mutations(stream, &self.node, &modifications);
+
+                walker
+                    .script_chan
+                    .send(ModifyRule(
+                        walker.pipeline,
+                        registry.actor_to_script(self.node.clone()),
+                        modifications,
+                    ))
+                    .map_err(|_| ())?;
+
+                let _ = stream.write_json_packet(&self.encodable(registry));
                 ActorMessageStatus::Processed
             },
             _ => ActorMessageStatus::Ignored,
@@ -46,7 +120,66 @@ impl Actor for StyleRuleActor {
 }
 
 impl StyleRuleActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn new(name: String, node: String) -> Self {
+        Self { name, node }
+    }
+
+    pub fn rule(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
+        let node = registry.find::<NodeActor>(&self.node);
+        let walker = registry.find::<WalkerActor>(&node.walker);
+
+        let (tx, rx) = ipc::channel().ok()?;
+        walker
+            .script_chan
+            .send(GetDocumentElement(walker.pipeline, tx))
+            .unwrap();
+        let node = rx.recv().ok()??;
+
+        let (tx, rx) = ipc::channel().ok()?;
+        walker
+            .script_chan
+            .send(GetAppliedStyle(
+                walker.pipeline,
+                registry.actor_to_script(self.node.clone()),
+                tx,
+            ))
+            .unwrap();
+        let style = rx.recv().ok()??;
+
+        // TODO: Fill with real values
+        Some(AppliedRule {
+            actor: self.name(),
+            ancestor_data: vec![],
+            authored_text: "TODO".into(),
+            css_text: "TODO".into(),
+            declarations: style
+                .into_iter()
+                .filter_map(|decl| {
+                    Some(AppliedDeclaration {
+                        colon_offsets: vec![],
+                        is_name_valid: true,
+                        is_used: IsUsed { used: true },
+                        is_valid: true,
+                        name: decl.name,
+                        offsets: vec![],
+                        priority: decl.priority,
+                        terminator: "".into(),
+                        value: decl.value,
+                    })
+                })
+                .collect(),
+            href: node.base_uri.clone(),
+            type_: 100, // Element style type, extract to constant
+            traits: StyleRuleActorTraits {
+                can_set_rule_text: true,
+            },
+        })
+    }
+
+    pub fn encodable(&self, registry: &ActorRegistry) -> StyleRuleActorMsg {
+        StyleRuleActorMsg {
+            from: self.name(),
+            rule: self.rule(registry),
+        }
     }
 }

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -5,10 +5,8 @@
 //! Liberally derived from <https://searchfox.org/mozilla-central/source/devtools/server/actors/thread-configuration.js>
 //! This actor represents one css rule from a node, allowing the inspector to view it and change it.
 
-use std::collections::HashMap;
 use std::net::TcpStream;
 
-use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
@@ -32,15 +30,16 @@ impl Actor for StyleRuleActor {
         _registry: &ActorRegistry,
         msg_type: &str,
         _msg: &Map<String, Value>,
-        _stream: &mut TcpStream,
+        stream: &mut TcpStream,
         _id: StreamId,
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
-            // TODO: "updateConfiguration" => {
-            //     let msg = EmptyReplyMsg { from: self.name() };
-            //     let _ = stream.write_json_packet(&msg);
-            //     ActorMessageStatus::Processed
-            // },
+            "setRuleText" => {
+                // TODO: ...
+                let msg = EmptyReplyMsg { from: self.name() };
+                let _ = stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            },
             _ => ActorMessageStatus::Ignored,
         })
     }

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Liberally derived from <https://searchfox.org/mozilla-central/source/devtools/server/actors/thread-configuration.js>
+//! This actor represents one css rule from a node, allowing the inspector to view it and change it.
+
+use std::collections::HashMap;
+use std::net::TcpStream;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::protocol::JsonPacketStream;
+use crate::{EmptyReplyMsg, StreamId};
+
+pub struct StyleRuleActor {
+    name: String,
+}
+
+impl Actor for StyleRuleActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// The style rule configuration actor can handle the following messages:
+    ///
+    /// -
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        _stream: &mut TcpStream,
+        _id: StreamId,
+    ) -> Result<ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            // TODO: "updateConfiguration" => {
+            //     let msg = EmptyReplyMsg { from: self.name() };
+            //     let _ = stream.write_json_packet(&msg);
+            //     ActorMessageStatus::Processed
+            // },
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+impl StyleRuleActor {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -28,7 +28,7 @@ pub struct AppliedRule {
     ancestor_data: Vec<()>,
     authored_text: String,
     css_text: String,
-    declarations: Vec<AppliedDeclaration>,
+    pub declarations: Vec<AppliedDeclaration>,
     href: String,
     #[serde(rename = "type")]
     type_: u32,
@@ -144,6 +144,7 @@ impl StyleRuleActor {
             .unwrap();
         let node = rx.recv().ok()??;
 
+        // TODO: Styles from stylesheets
         let (tx, rx) = ipc::channel().ok()?;
         walker
             .script_chan

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -9,7 +9,7 @@ use std::net::TcpStream;
 
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement};
-use devtools_traits::{DevtoolScriptControlMsg, Modification};
+use devtools_traits::{AttrModification, DevtoolScriptControlMsg};
 use ipc_channel::ipc::{self, IpcSender};
 use serde::Serialize;
 use serde_json::{self, Map, Value};
@@ -31,7 +31,7 @@ pub struct WalkerActor {
     pub script_chan: IpcSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub root_node: NodeActorMsg,
-    pub mutations: RefCell<Vec<(Modification, String)>>,
+    pub mutations: RefCell<Vec<(AttrModification, String)>>,
 }
 
 #[derive(Serialize)]
@@ -273,7 +273,7 @@ impl WalkerActor {
         &self,
         stream: &mut TcpStream,
         target: &str,
-        modifications: &[Modification],
+        modifications: &[AttrModification],
     ) {
         {
             let mut mutations = self.mutations.borrow_mut();

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -288,6 +288,7 @@ impl WalkerActor {
 
 /// Recursively searches for a child with the specified selector
 /// If it is found, returns a list with the child and all of its ancestors.
+/// TODO: Cache this to some extent, investigate all of the "checking node..."
 pub fn find_child(
     script_chan: &IpcSender<DevtoolScriptControlMsg>,
     pipeline: PipelineId,

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -288,7 +288,7 @@ impl WalkerActor {
 
 /// Recursively searches for a child with the specified selector
 /// If it is found, returns a list with the child and all of its ancestors.
-/// TODO: Cache this to some extent, investigate all of the "checking node..."
+/// TODO: Investigate how to cache this to some extent
 pub fn find_child(
     script_chan: &IpcSender<DevtoolScriptControlMsg>,
     pipeline: PipelineId,

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -288,7 +288,7 @@ impl WalkerActor {
 
 /// Recursively searches for a child with the specified selector
 /// If it is found, returns a list with the child and all of its ancestors.
-/// TODO: Investigate how to cache this to some extent
+/// TODO: Investigate how to cache this to some extent.
 pub fn find_child(
     script_chan: &IpcSender<DevtoolScriptControlMsg>,
     pipeline: PipelineId,
@@ -296,7 +296,7 @@ pub fn find_child(
     registry: &ActorRegistry,
     node: &str,
     mut hierarchy: Vec<NodeActorMsg>,
-    compare: impl Fn(&NodeActorMsg) -> bool + Clone,
+    compare_fn: impl Fn(&NodeActorMsg) -> bool + Clone,
 ) -> Result<Vec<NodeActorMsg>, Vec<NodeActorMsg>> {
     let (tx, rx) = ipc::channel().unwrap();
     script_chan
@@ -310,7 +310,7 @@ pub fn find_child(
 
     for child in children {
         let msg = child.encode(registry, true, script_chan.clone(), pipeline, name.into());
-        if compare(&msg) {
+        if compare_fn(&msg) {
             hierarchy.push(msg);
             return Ok(hierarchy);
         };
@@ -326,7 +326,7 @@ pub fn find_child(
             registry,
             &msg.actor,
             hierarchy,
-            compare.clone(),
+            compare_fn.clone(),
         ) {
             Ok(mut hierarchy) => {
                 hierarchy.push(msg);

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -59,7 +59,7 @@ impl SessionContext {
             // working propperly
             supported_resources: HashMap::from([
                 ("console-message", true),
-                ("css-change", false),
+                ("css-change", true),
                 ("css-message", false),
                 ("css-registered-properties", false),
                 ("document-event", false),

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -14,7 +14,6 @@ use devtools_traits::{
 use ipc_channel::ipc::IpcSender;
 use js::jsval::UndefinedValue;
 use js::rust::ToString;
-use style::properties::ShorthandId;
 use uuid::Uuid;
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -16,9 +16,11 @@ use js::jsval::UndefinedValue;
 use js::rust::ToString;
 use servo_arc::Arc;
 use style::properties::{ComputedValues, PropertyDeclaration, PropertyDeclarationBlock};
+use style::rule_tree::StyleSource;
 use style::shared_lock::Locked;
 use uuid::Uuid;
 
+use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding::CSSRuleList_Binding::CSSRuleListMethods;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -190,13 +192,13 @@ pub fn handle_get_applied_style(
             .downcast::<Element>()
             .expect("should be getting layout of element");
 
+        // This is only for style="..."
         #[allow(unsafe_code)]
-        let style = elem.style_attribute().try_borrow().ok()?;
-        log::warn!("borrow");
+        let style = elem.style_attribute().try_borrow().ok()?.clone()?;
 
-        let style = style.clone()?;
-        log::warn!("{:?}", style);
+        // This is mixing computed and applied
         let declarations: &Locked<PropertyDeclarationBlock> = style.borrow();
+        log::error!("{:?}", declarations);
 
         let document = documents.find_document(pipeline)?;
         {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -273,7 +273,11 @@ pub fn handle_get_selectors(
         .filter_map(|rule| {
             let style = rule.downcast::<CSSStyleRule>()?;
             let selector = style.SelectorText();
-            let _ = node.downcast::<Element>()?.Matches(selector.clone()).ok()?;
+            let _ = node
+                .downcast::<Element>()?
+                .Matches(selector.clone())
+                .ok()?
+                .then_some(())?;
             Some(selector.into())
         })
         .collect();

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -344,7 +344,7 @@ impl CSSStyleDeclaration {
     }
 }
 
-static ENABLED_LONGHAND_PROPERTIES: LazyLock<Vec<LonghandId>> = LazyLock::new(|| {
+pub static ENABLED_LONGHAND_PROPERTIES: LazyLock<Vec<LonghandId>> = LazyLock::new(|| {
     // The 'all' shorthand contains all the enabled longhands with 2 exceptions:
     // 'direction' and 'unicode-bidi', so these must be added afterward.
     let mut enabled_longhands: Vec<LonghandId> = ShorthandId::All.longhands().collect();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2534,6 +2534,9 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetAppliedStyle(id, node_id, reply) => {
                 devtools::handle_get_applied_style(&documents, id, node_id, reply)
             },
+            DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
+                devtools::handle_get_computed_style(&documents, id, node_id, reply)
+            },
             DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => {
                 devtools::handle_get_layout(&documents, id, node_id, reply)
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2534,9 +2534,15 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
                 devtools::handle_get_attribute_style(&documents, id, node_id, reply)
             },
-            DevtoolScriptControlMsg::GetStylesheetStyle(id, node_id, selector, reply) => {
-                devtools::handle_get_stylesheet_style(&documents, id, node_id, selector, reply)
-            },
+            DevtoolScriptControlMsg::GetStylesheetStyle(
+                id,
+                node_id,
+                selector,
+                stylesheet,
+                reply,
+            ) => devtools::handle_get_stylesheet_style(
+                &documents, id, node_id, selector, stylesheet, reply,
+            ),
             DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
                 devtools::handle_get_selectors(&documents, id, node_id, reply)
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2540,6 +2540,9 @@ impl ScriptThread {
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) => {
                 devtools::handle_modify_attribute(&documents, id, node_id, modifications)
             },
+            DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => {
+                devtools::handle_modify_rule(&documents, id, node_id, modifications)
+            },
             DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => match documents
                 .find_window(id)
             {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2559,6 +2559,9 @@ impl ScriptThread {
                 devtools::handle_request_animation_frame(&documents, id, name)
             },
             DevtoolScriptControlMsg::Reload(id) => devtools::handle_reload(&documents, id),
+            DevtoolScriptControlMsg::GetCssDatabase(reply) => {
+                devtools::handle_get_css_database(reply)
+            },
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1839,8 +1839,8 @@ impl ScriptThread {
                             // creator's origin. This must match the logic in the constellation
                             // when creating a new pipeline
                             let not_an_about_blank_and_about_srcdoc_load =
-                                new_layout_info.load_data.url.as_str() != "about:blank"
-                                    && new_layout_info.load_data.url.as_str() != "about:srcdoc";
+                                new_layout_info.load_data.url.as_str() != "about:blank" &&
+                                    new_layout_info.load_data.url.as_str() != "about:srcdoc";
                             let origin = if not_an_about_blank_and_about_srcdoc_load {
                                 MutableOrigin::new(new_layout_info.load_data.url.origin())
                             } else if let Some(parent) =
@@ -2380,13 +2380,13 @@ impl ScriptThread {
                     *self.webgpu_port.borrow_mut() = Some(p);
                 }
             },
-            msg @ ConstellationControlMsg::AttachLayout(..)
-            | msg @ ConstellationControlMsg::Viewport(..)
-            | msg @ ConstellationControlMsg::Resize(..)
-            | msg @ ConstellationControlMsg::ExitFullScreen(..)
-            | msg @ ConstellationControlMsg::SendEvent(..)
-            | msg @ ConstellationControlMsg::TickAllAnimations(..)
-            | msg @ ConstellationControlMsg::ExitScriptThread => {
+            msg @ ConstellationControlMsg::AttachLayout(..) |
+            msg @ ConstellationControlMsg::Viewport(..) |
+            msg @ ConstellationControlMsg::Resize(..) |
+            msg @ ConstellationControlMsg::ExitFullScreen(..) |
+            msg @ ConstellationControlMsg::SendEvent(..) |
+            msg @ ConstellationControlMsg::TickAllAnimations(..) |
+            msg @ ConstellationControlMsg::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
             ConstellationControlMsg::SetScrollStates(pipeline_id, scroll_states) => {
@@ -3676,8 +3676,8 @@ impl ScriptThread {
             },
 
             Some(ref mime)
-                if (mime.type_() == mime::TEXT && mime.subtype() == mime::XML)
-                    || (mime.type_() == mime::APPLICATION && mime.subtype() == mime::XML) =>
+                if (mime.type_() == mime::TEXT && mime.subtype() == mime::XML) ||
+                    (mime.type_() == mime::APPLICATION && mime.subtype() == mime::XML) =>
             {
                 IsHTMLDocument::NonHTMLDocument
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1839,8 +1839,8 @@ impl ScriptThread {
                             // creator's origin. This must match the logic in the constellation
                             // when creating a new pipeline
                             let not_an_about_blank_and_about_srcdoc_load =
-                                new_layout_info.load_data.url.as_str() != "about:blank" &&
-                                    new_layout_info.load_data.url.as_str() != "about:srcdoc";
+                                new_layout_info.load_data.url.as_str() != "about:blank"
+                                    && new_layout_info.load_data.url.as_str() != "about:srcdoc";
                             let origin = if not_an_about_blank_and_about_srcdoc_load {
                                 MutableOrigin::new(new_layout_info.load_data.url.origin())
                             } else if let Some(parent) =
@@ -2380,13 +2380,13 @@ impl ScriptThread {
                     *self.webgpu_port.borrow_mut() = Some(p);
                 }
             },
-            msg @ ConstellationControlMsg::AttachLayout(..) |
-            msg @ ConstellationControlMsg::Viewport(..) |
-            msg @ ConstellationControlMsg::Resize(..) |
-            msg @ ConstellationControlMsg::ExitFullScreen(..) |
-            msg @ ConstellationControlMsg::SendEvent(..) |
-            msg @ ConstellationControlMsg::TickAllAnimations(..) |
-            msg @ ConstellationControlMsg::ExitScriptThread => {
+            msg @ ConstellationControlMsg::AttachLayout(..)
+            | msg @ ConstellationControlMsg::Viewport(..)
+            | msg @ ConstellationControlMsg::Resize(..)
+            | msg @ ConstellationControlMsg::ExitFullScreen(..)
+            | msg @ ConstellationControlMsg::SendEvent(..)
+            | msg @ ConstellationControlMsg::TickAllAnimations(..)
+            | msg @ ConstellationControlMsg::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
             ConstellationControlMsg::SetScrollStates(pipeline_id, scroll_states) => {
@@ -2530,6 +2530,9 @@ impl ScriptThread {
             },
             DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
                 devtools::handle_get_children(&documents, id, node_id, reply)
+            },
+            DevtoolScriptControlMsg::GetAppliedStyle(id, node_id, reply) => {
+                devtools::handle_get_applied_style(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => {
                 devtools::handle_get_layout(&documents, id, node_id, reply)
@@ -3673,8 +3676,8 @@ impl ScriptThread {
             },
 
             Some(ref mime)
-                if (mime.type_() == mime::TEXT && mime.subtype() == mime::XML) ||
-                    (mime.type_() == mime::APPLICATION && mime.subtype() == mime::XML) =>
+                if (mime.type_() == mime::TEXT && mime.subtype() == mime::XML)
+                    || (mime.type_() == mime::APPLICATION && mime.subtype() == mime::XML) =>
             {
                 IsHTMLDocument::NonHTMLDocument
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2531,8 +2531,14 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
                 devtools::handle_get_children(&documents, id, node_id, reply)
             },
-            DevtoolScriptControlMsg::GetAppliedStyle(id, node_id, reply) => {
-                devtools::handle_get_applied_style(&documents, id, node_id, reply)
+            DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
+                devtools::handle_get_attribute_style(&documents, id, node_id, reply)
+            },
+            DevtoolScriptControlMsg::GetStylesheetStyle(id, node_id, selector, reply) => {
+                devtools::handle_get_stylesheet_style(&documents, id, node_id, selector, reply)
+            },
+            DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
+                devtools::handle_get_selectors(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
                 devtools::handle_get_computed_style(&documents, id, node_id, reply)

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -155,7 +155,7 @@ pub enum TimelineMarkerType {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AppliedNodeStyle {
+pub struct NodeStyle {
     pub name: String,
     pub value: String,
     pub priority: String,
@@ -211,7 +211,9 @@ pub enum DevtoolScriptControlMsg {
     /// Retrieve the details of the child nodes of the given node in the given pipeline.
     GetChildren(PipelineId, String, IpcSender<Option<Vec<NodeInfo>>>),
     /// Retrieve the applied css style properties for the given node.
-    GetAppliedStyle(PipelineId, String, IpcSender<Option<Vec<AppliedNodeStyle>>>),
+    GetAppliedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
+    /// Retrieve the computed css style properties for the given node.
+    GetComputedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.
     GetLayout(PipelineId, String, IpcSender<Option<ComputedNodeLayout>>),
     /// Update a given node's attributes with a list of modifications.

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -152,6 +152,12 @@ pub enum TimelineMarkerType {
     DOMEvent,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppliedNodeStyle {
+    pub text: String,
+}
+
 /// The properties of a DOM node as computed by layout.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -201,6 +207,8 @@ pub enum DevtoolScriptControlMsg {
     GetDocumentElement(PipelineId, IpcSender<Option<NodeInfo>>),
     /// Retrieve the details of the child nodes of the given node in the given pipeline.
     GetChildren(PipelineId, String, IpcSender<Option<Vec<NodeInfo>>>),
+    /// Retrieve the applied css style properties for the given node.
+    GetAppliedStyle(PipelineId, String, IpcSender<Option<Vec<AppliedNodeStyle>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.
     GetLayout(PipelineId, String, IpcSender<Option<ComputedNodeLayout>>),
     /// Update a given node's attributes with a list of modifications.

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -217,10 +217,11 @@ pub enum DevtoolScriptControlMsg {
         PipelineId,
         String,
         String,
+        usize,
         IpcSender<Option<Vec<NodeStyle>>>,
     ),
     /// Retrieves the css selectors for the given node in the current stylesheets.
-    GetSelectors(PipelineId, String, IpcSender<Option<Vec<String>>>),
+    GetSelectors(PipelineId, String, IpcSender<Option<Vec<(String, usize)>>>),
     /// Retrieve the computed css style properties for the given node.
     GetComputedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -155,7 +155,9 @@ pub enum TimelineMarkerType {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppliedNodeStyle {
-    pub text: String,
+    pub name: String,
+    pub value: String,
+    pub priority: String,
 }
 
 /// The properties of a DOM node as computed by layout.
@@ -212,7 +214,9 @@ pub enum DevtoolScriptControlMsg {
     /// Retrieve the computed layout properties of the given node in the given pipeline.
     GetLayout(PipelineId, String, IpcSender<Option<ComputedNodeLayout>>),
     /// Update a given node's attributes with a list of modifications.
-    ModifyAttribute(PipelineId, String, Vec<Modification>),
+    ModifyAttribute(PipelineId, String, Vec<AttrModification>),
+    /// Update a given node's style rules with a list of modifications.
+    ModifyRule(PipelineId, String, Vec<RuleModification>),
     /// Request live console messages for a given pipeline (true if desired, false otherwise).
     WantsLiveNotifications(PipelineId, bool),
     /// Request live notifications for a given set of timeline events for a given pipeline.
@@ -232,9 +236,20 @@ pub enum DevtoolScriptControlMsg {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Modification {
+pub struct AttrModification {
     pub attribute_name: String,
     pub new_value: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleModification {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub index: u32,
+    pub name: String,
+    pub value: String,
+    pub priority: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -210,8 +210,17 @@ pub enum DevtoolScriptControlMsg {
     GetDocumentElement(PipelineId, IpcSender<Option<NodeInfo>>),
     /// Retrieve the details of the child nodes of the given node in the given pipeline.
     GetChildren(PipelineId, String, IpcSender<Option<Vec<NodeInfo>>>),
-    /// Retrieve the applied css style properties for the given node.
-    GetAppliedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
+    /// Retrieve the css style properties defined in the attribute tag for the given node.
+    GetAttributeStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
+    /// Retrieve the css style properties defined in an stylesheet for the given selector.
+    GetStylesheetStyle(
+        PipelineId,
+        String,
+        String,
+        IpcSender<Option<Vec<NodeStyle>>>,
+    ),
+    /// Retrieves the css selectors for the given node in the current stylesheets.
+    GetSelectors(PipelineId, String, IpcSender<Option<Vec<String>>>),
     /// Retrieve the computed css style properties for the given node.
     GetComputedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -10,6 +10,7 @@
 #![crate_type = "rlib"]
 #![deny(unsafe_code)]
 
+use std::collections::HashMap;
 use std::net::TcpStream;
 use std::time::{Duration, SystemTime};
 
@@ -232,6 +233,8 @@ pub enum DevtoolScriptControlMsg {
     RequestAnimationFrame(PipelineId, String),
     /// Direct the given pipeline to reload the current page.
     Reload(PipelineId),
+    /// Gets the list of all allowed CSS rules and possible values.
+    GetCssDatabase(IpcSender<HashMap<String, CssDatabaseProperty>>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -387,3 +390,12 @@ impl PreciseTime {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct WorkerId(pub Uuid);
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CssDatabaseProperty {
+    pub is_inherited: bool,
+    pub values: Vec<String>,
+    pub supports: Vec<String>,
+    pub subproperties: Vec<String>,
+}

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -220,7 +220,8 @@ pub enum DevtoolScriptControlMsg {
         usize,
         IpcSender<Option<Vec<NodeStyle>>>,
     ),
-    /// Retrieves the css selectors for the given node in the current stylesheets.
+    /// Retrieves the css selectors for the given node. A selector is comprised of the text
+    /// of the selector and the id of the stylesheet that contains it.
     GetSelectors(PipelineId, String, IpcSender<Option<Vec<(String, usize)>>>),
     /// Retrieve the computed css style properties for the given node.
     GetComputedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -210,9 +210,9 @@ pub enum DevtoolScriptControlMsg {
     GetDocumentElement(PipelineId, IpcSender<Option<NodeInfo>>),
     /// Retrieve the details of the child nodes of the given node in the given pipeline.
     GetChildren(PipelineId, String, IpcSender<Option<Vec<NodeInfo>>>),
-    /// Retrieve the css style properties defined in the attribute tag for the given node.
+    /// Retrieve the CSS style properties defined in the attribute tag for the given node.
     GetAttributeStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
-    /// Retrieve the css style properties defined in an stylesheet for the given selector.
+    /// Retrieve the CSS style properties defined in an stylesheet for the given selector.
     GetStylesheetStyle(
         PipelineId,
         String,
@@ -220,10 +220,10 @@ pub enum DevtoolScriptControlMsg {
         usize,
         IpcSender<Option<Vec<NodeStyle>>>,
     ),
-    /// Retrieves the css selectors for the given node. A selector is comprised of the text
+    /// Retrieves the CSS selectors for the given node. A selector is comprised of the text
     /// of the selector and the id of the stylesheet that contains it.
     GetSelectors(PipelineId, String, IpcSender<Option<Vec<(String, usize)>>>),
-    /// Retrieve the computed css style properties for the given node.
+    /// Retrieve the computed CSS style properties for the given node.
     GetComputedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.
     GetLayout(PipelineId, String, IpcSender<Option<ComputedNodeLayout>>),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -12,6 +12,5 @@ components = [
     "rust-docs",
     # For formatting
     "rustfmt",
-    "rust-analyzer",
 ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -12,5 +12,6 @@ components = [
     "rust-docs",
     # For formatting
     "rustfmt",
+    "rust-analyzer",
 ]
 profile = "minimal"


### PR DESCRIPTION
This pr restores the element style inspector and the computed styles list.

**New features:**

- View the applied styles for a node (the ones defined explicitly). This includes the style attribute (for example `<p style="color: blue">`) and the styles defined in stylesheets (like `p { color: blue; }`)
- Modify the applied styles or add a new one. Preview the changes live.
- View the computed styles for a node (all of the calculated css properties).
- Show all of the supported CSS properties, mark the ones that are spelled wrongly and autocomplete names.

**Future work:**

- Disable properties with the checkbox (start with `getCompatibility` for the inspector actor)
- Handle pseudo elements (check `AppliedEntry::pseudo_element` in the page style actor)
- Improve the way it works with big websites, and add some type of caching

![image](https://github.com/user-attachments/assets/8f1b7341-8f8a-414c-b532-6681e6603750)

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are a part of #32404
- [x] These changes do not require tests because there are no tests yet for DevTools