### PR TITLE
clippy: Fix missing indentation in comments and remove on unecessary cast

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -519,7 +519,7 @@ fn translate_including_floats(cur_b: &mut Au, delta: Au, floats: &mut Floats) {
 /// This is a traversal of an Absolute Flow tree.
 /// - Relatively positioned flows and the Root flow start new Absolute flow trees.
 /// - The kids of a flow in this tree will be the flows for which it is the
-/// absolute Containing Block.
+///   absolute Containing Block.
 /// - Thus, leaf nodes and inner non-root nodes are all Absolute Flows.
 ///
 /// A Flow tree can have several Absolute Flow trees (depending on the number

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -89,7 +89,7 @@ static DEFAULT_REPLACED_HEIGHT: i32 = 150;
 /// specification:
 ///
 /// * Several fragments may correspond to the same CSS box or DOM node. For example, a CSS text box
-/// broken across two lines is represented by two fragments.
+///   broken across two lines is represented by two fragments.
 ///
 /// * Some CSS fragments are not created at all, such as some anonymous block fragments induced by
 ///   inline fragments with block-level sibling fragments. In that case, Servo uses an `InlineFlow`

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1933,8 +1933,8 @@ impl GlobalScope {
     /// Promote non-Slice blob:
     /// 1. Memory-based: The bytes in data slice will be transferred to file manager thread.
     /// 2. File-based: If set_valid, then activate the FileID so it can serve as URL
-    /// Depending on set_valid, the returned FileID can be part of
-    /// valid or invalid Blob URL.
+    ///     Depending on set_valid, the returned FileID can be part of
+    ///     valid or invalid Blob URL.
     pub fn promote(&self, blob_info: &mut BlobInfo, set_valid: bool) -> Uuid {
         let mut bytes = vec![];
         let global_url = self.get_url();

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -107,8 +107,7 @@ impl XRInputSource {
                     .map_and_normalize_buttons(i as usize, *value as f64);
             });
         frame.axis_values.iter().enumerate().for_each(|(i, value)| {
-            self.gamepad
-                .map_and_normalize_axes(i, *value as f64);
+            self.gamepad.map_and_normalize_axes(i, *value as f64);
         });
     }
 }

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -108,7 +108,7 @@ impl XRInputSource {
             });
         frame.axis_values.iter().enumerate().for_each(|(i, value)| {
             self.gamepad
-                .map_and_normalize_axes(i as usize, *value as f64);
+                .map_and_normalize_axes(i, *value as f64);
         });
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fixing clippy warnings

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500
<!-- Either: -->
- [X] These changes do not require tests because don't change logic of code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->