### PR TITLE
Add support for structured logging with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4612,6 +4612,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4844,6 +4854,12 @@ name = "ordermap"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -6225,6 +6241,8 @@ dependencies = [
  "sig",
  "surfman",
  "tinyfiledialogs",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "vergen",
  "webxr",
@@ -6253,6 +6271,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -6836,6 +6863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7146,6 +7183,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7331,6 +7394,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,8 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.18"
-source = "git+https://github.com/rust-lang/libz-sys.git?rev=f76b7a24ed0a71ef1b8bdac1895e8535cb2cb9c0#f76b7a24ed0a71ef1b8bdac1895e8535cb2cb9c0"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
 dependencies = [
  "cc",
  "libc",
@@ -4162,6 +4163,15 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -5405,7 +5415,16 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.7",
- "regex-syntax",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5425,8 +5444,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7203,10 +7228,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -8673,3 +8702,8 @@ checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "libz-sys"
+version = "1.1.18"
+source = "git+https://github.com/rust-lang/libz-sys.git?rev=f76b7a24ed0a71ef1b8bdac1895e8535cb2cb9c0#f76b7a24ed0a71ef1b8bdac1895e8535cb2cb9c0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,8 @@ time_03 = { package = "time", version = "0.3", features = ["serde"] }
 to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 tokio = "1"
 tokio-rustls = "0.24"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 tungstenite = "0.20"
 uluru = "3.0"
 unicode-bidi = "0.3.15"

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /// Log an event from constellation at trace level.
-/// - To disable tracing: RUST_LOG='compositor<constellation@=off'
-/// - To enable tracing: RUST_LOG='compositor<constellation@'
+/// - To disable tracing: RUST_LOG='compositor-from-constellation:=off'
+/// - To enable tracing: RUST_LOG='compositor-from-constellation:'
 macro_rules! trace_msg_from_constellation {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -23,7 +23,7 @@ mod from_constellation {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("compositor<constellation@", $($name),+)
+            concat!("compositor-from-constellation:", $($name),+)
         };
     }
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -3,12 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /// Log an event from compositor at trace level.
-/// - To disable tracing: RUST_LOG='constellation<compositor@=off'
-/// - To enable tracing: RUST_LOG='constellation<compositor@'
+/// - To disable tracing: RUST_LOG='constellation-from-compositor:=off'
+/// - To enable tracing: RUST_LOG='constellation-from-compositor:'
 /// - Recommended filters when tracing is enabled:
-///   - constellation<compositor@ForwardEvent(MouseMoveEvent)=off
-///   - constellation<compositor@LogEntry=off
-///   - constellation<compositor@ReadyToPresent=off
+///   - constellation-from-compositor:ForwardEvent:MouseMoveEvent=off
+///   - constellation-from-compositor:LogEntry=off
+///   - constellation-from-compositor:ReadyToPresent=off
 macro_rules! trace_msg_from_compositor {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -18,10 +18,10 @@ macro_rules! trace_msg_from_compositor {
 }
 
 /// Log an event from script at trace level.
-/// - To disable tracing: RUST_LOG='constellation<script@=off'
-/// - To enable tracing: RUST_LOG='constellation<script@'
+/// - To disable tracing: RUST_LOG='constellation-from-script:=off'
+/// - To enable tracing: RUST_LOG='constellation-from-script:'
 /// - Recommended filters when tracing is enabled:
-///   - constellation<script@LogEntry=off
+///   - constellation-from-script:LogEntry=off
 macro_rules! trace_script_msg {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -31,8 +31,8 @@ macro_rules! trace_script_msg {
 }
 
 /// Log an event from layout at trace level.
-/// - To disable tracing: RUST_LOG='constellation<layout@=off'
-/// - To enable tracing: RUST_LOG='constellation<layout@'
+/// - To disable tracing: RUST_LOG='constellation-from-layout:=off'
+/// - To enable tracing: RUST_LOG='constellation-from-layout:'
 macro_rules! trace_layout_msg {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -51,7 +51,7 @@ mod from_compositor {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("constellation<compositor@", $($name),+)
+            concat!("constellation-from-compositor:", $($name),+)
         };
     }
 
@@ -99,7 +99,7 @@ mod from_compositor {
         fn log_target(&self) -> &'static str {
             macro_rules! target_variant {
                 ($name:literal) => {
-                    target!("ForwardEvent(" $name ")")
+                    target!("ForwardEvent:" $name)
                 };
             }
             match self {
@@ -122,7 +122,7 @@ mod from_script {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("constellation<script@", $($name),+)
+            concat!("constellation-from-script:", $($name),+)
         };
     }
 
@@ -196,7 +196,7 @@ mod from_script {
         fn log_target(&self) -> &'static str {
             macro_rules! target_variant {
                 ($name:literal) => {
-                    target!("ForwardToEmbedder(" $name ")")
+                    target!("ForwardToEmbedder:" $name)
                 };
             }
             match self {
@@ -249,7 +249,7 @@ mod from_layout {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("constellation<layout@", $($name),+)
+            concat!("constellation-from-layout:", $($name),+)
         };
     }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1185,6 +1185,9 @@ where
     }
 }
 
+/// Copy script process logs to the constellation, for crash detection.
+///
+/// Only used in multiprocess mode (-M, --multiprocess).
 pub fn set_logger(script_to_constellation_chan: ScriptToConstellationChan) {
     let con_logger = FromScriptLogger::new(script_to_constellation_chan);
     let env = env_logger::Env::default();
@@ -1193,7 +1196,8 @@ pub fn set_logger(script_to_constellation_chan: ScriptToConstellationChan) {
     let filter = max(env_logger.filter(), con_logger.filter());
     let logger = BothLogger(env_logger, con_logger);
 
-    log::set_boxed_logger(Box::new(logger)).expect("Failed to set logger.");
+    // FIXME: now fails because tracing-subscriber has already set a logger
+    log::set_boxed_logger(Box::new(logger)).ok();
     log::set_max_level(filter);
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -920,7 +920,8 @@ where
         let filter = max(env_logger.filter(), con_logger.filter());
         let logger = BothLogger(env_logger, con_logger);
 
-        log::set_boxed_logger(Box::new(logger)).expect("Failed to set logger.");
+        // FIXME: now fails because tracing-subscriber has already set a logger
+        log::set_boxed_logger(Box::new(logger)).ok();
         log::set_max_level(filter);
     }
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -105,6 +105,8 @@ raw-window-handle = "0.6"
 shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
 winit = "0.29.10"
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -106,7 +106,7 @@ shellwords = "1.0.0"
 surfman = { workspace = true, features = ["sm-x11", "sm-raw-window-handle-06"] }
 tinyfiledialogs = "3.0"
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
 winit = "0.29.10"
 

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -15,6 +15,8 @@ use crate::panic_hook;
 pub fn main() {
     crate::crash_handler::install();
 
+    tracing_subscriber::fmt::init();
+
     crate::resources::init();
 
     // Parse the command line options and store them globally

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -23,8 +23,6 @@ pub fn main() {
     // compositor-to-constellation and script-to-constellation logging.
     // <https://tokio.rs/tokio/topics/tracing>
     // <https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/fmt/index.html#composing-layers>
-    // FIXME: our event tracing log targets are considered “invalid filter directive”
-    // <https://book.servo.org/hacking/debugging.html#event-tracing>
     let env_filter_layer = EnvFilter::from_default_env();
     let fmt_layer = tracing_subscriber::fmt::layer();
     tracing_subscriber::registry()

--- a/ports/servoshell/desktop/tracing.rs
+++ b/ports/servoshell/desktop/tracing.rs
@@ -3,17 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /// Log an event from winit ([winit::event::Event]) at trace level.
-/// - To disable tracing: RUST_LOG='servoshell<winit@=off'
-/// - To enable tracing: RUST_LOG='servoshell<winit@'
+/// - To disable tracing: RUST_LOG='servoshell-from-winit:=off'
+/// - To enable tracing: RUST_LOG='servoshell-from-winit:'
 /// - Recommended filters when tracing is enabled:
-///   - servoshell<winit@DeviceEvent=off
-///   - servoshell<winit@MainEventsCleared=off
-///   - servoshell<winit@NewEvents(WaitCancelled)=off
-///   - servoshell<winit@RedrawEventsCleared=off
-///   - servoshell<winit@RedrawRequested=off
-///   - servoshell<winit@UserEvent(WakerEvent)=off
-///   - servoshell<winit@WindowEvent(AxisMotion)=off
-///   - servoshell<winit@WindowEvent(CursorMoved)=off
+///   - servoshell-from-winit:DeviceEvent=off
+///   - servoshell-from-winit:MainEventsCleared=off
+///   - servoshell-from-winit:NewEvents:WaitCancelled=off
+///   - servoshell-from-winit:RedrawEventsCleared=off
+///   - servoshell-from-winit:RedrawRequested=off
+///   - servoshell-from-winit:UserEvent:WakerEvent=off
+///   - servoshell-from-winit:WindowEvent:AxisMotion=off
+///   - servoshell-from-winit:WindowEvent:CursorMoved=off
 macro_rules! trace_winit_event {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -23,11 +23,11 @@ macro_rules! trace_winit_event {
 }
 
 /// Log an event from servo ([servo::embedder_traits::EmbedderMsg]) at trace level.
-/// - To disable tracing: RUST_LOG='servoshell<servo@=off'
-/// - To enable tracing: RUST_LOG='servoshell<servo@'
+/// - To disable tracing: RUST_LOG='servoshell-from-servo:=off'
+/// - To enable tracing: RUST_LOG='servoshell-from-servo:'
 /// - Recommended filters when tracing is enabled:
-///   - servoshell<servo@EventDelivered=off
-///   - servoshell<servo@ReadyToPresent=off
+///   - servoshell-from-servo:EventDelivered=off
+///   - servoshell-from-servo:ReadyToPresent=off
 macro_rules! trace_embedder_msg {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -37,11 +37,11 @@ macro_rules! trace_embedder_msg {
 }
 
 /// Log an event to servo ([servo::compositing::windowing::EmbedderEvent]) at trace level.
-/// - To disable tracing: RUST_LOG='servoshell>servo@=off'
-/// - To enable tracing: RUST_LOG='servoshell>servo@'
+/// - To disable tracing: RUST_LOG='servoshell-to-servo:=off'
+/// - To enable tracing: RUST_LOG='servoshell-to-servo:'
 /// - Recommended filters when tracing is enabled:
-///   - servoshell>servo@Idle=off
-///   - servoshell>servo@MouseWindowMoveEventClass=off
+///   - servoshell-to-servo:Idle=off
+///   - servoshell-to-servo:MouseWindowMoveEventClass=off
 macro_rules! trace_embedder_event {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -63,7 +63,7 @@ mod from_winit {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("servoshell<winit@", $($name),+)
+            concat!("servoshell-from-winit:", $($name),+)
         };
     }
 
@@ -72,14 +72,14 @@ mod from_winit {
             use winit::event::StartCause;
             match self {
                 Self::NewEvents(start_cause) => match start_cause {
-                    StartCause::ResumeTimeReached { .. } => target!("NewEvents(ResumeTimeReached)"),
-                    StartCause::WaitCancelled { .. } => target!("NewEvents(WaitCancelled)"),
-                    StartCause::Poll => target!("NewEvents(Poll)"),
-                    StartCause::Init => target!("NewEvents(Init)"),
+                    StartCause::ResumeTimeReached { .. } => target!("NewEvents:ResumeTimeReached"),
+                    StartCause::WaitCancelled { .. } => target!("NewEvents:WaitCancelled"),
+                    StartCause::Poll => target!("NewEvents:Poll"),
+                    StartCause::Init => target!("NewEvents:Init"),
                 },
                 Self::WindowEvent { event, .. } => event.log_target(),
                 Self::DeviceEvent { .. } => target!("DeviceEvent"),
-                Self::UserEvent(WakerEvent) => target!("UserEvent(WakerEvent)"),
+                Self::UserEvent(WakerEvent) => target!("UserEvent:WakerEvent"),
                 Self::Suspended => target!("Suspended"),
                 Self::Resumed => target!("Resumed"),
                 Self::AboutToWait => target!("AboutToWait"),
@@ -93,7 +93,7 @@ mod from_winit {
         fn log_target(&self) -> &'static str {
             macro_rules! target_variant {
                 ($name:literal) => {
-                    target!("WindowEvent(" $name ")")
+                    target!("WindowEvent:" $name)
                 };
             }
             match self {
@@ -134,7 +134,7 @@ mod from_servo {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("servoshell<servo@", $($name),+)
+            concat!("servoshell-from-servo:", $($name),+)
         };
     }
 
@@ -188,7 +188,7 @@ mod to_servo {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("servoshell>servo@", $($name),+)
+            concat!("servoshell-to-servo:", $($name),+)
         };
     }
 

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -65,7 +65,16 @@ packages = [
     "phf_shared",
 
     # icu (from mozjs) uses old version
+    # tracing-subscriber (tokio-rs/tracing#3033) uses old version
+    # regex -> regex-automata 0.4.7
+    # icu_list -> regex-automata 0.2.0
+    # tracing-subscriber -> matchers -> regex-automata 0.1.0
     "regex-automata",
+
+    # tracing-subscriber (tokio-rs/tracing#3033) uses old version
+    # regex [-> regex-automata 0.4.7] -> regex-syntax 0.8.4
+    # tracing-subscriber -> matchers -> regex-automata 0.1.0 -> regex-syntax 0.6.29
+    "regex-syntax",
 ]
 # Files that are ignored for all tidy and lint checks.
 files = [


### PR DESCRIPTION
Previously handled by [env_logger](https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/filter/struct.EnvFilter.html), RUST_LOG is now handled by the tracing [EnvFilter](https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/filter/struct.EnvFilter.html), whose syntax is more restrictive. In particular, the target name in a filter directive can only contain characters in the class `[\w:-]`, which breaks our [event tracing filters](https://book.servo.org/hacking/debugging.html). This patch renames those event tracing targets as follows:

- `<` → `-from-`
- `>` → `-to-`
- `@` → `:`
- `(Foo)` → `:Foo`

For example, `servoshell<winit@NewEvents(WaitCancelled)` is now `servoshell-from-winit:NewEvents:WaitCancelled`. I’ve updated the book’s [docs about this](https://book.servo.org/hacking/debugging.html#event-tracing) in servo/book#17.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
