### PR TITLE
ohos: Fix x86_64-unknown-linux-ohos

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: ['aarch64-unknown-linux-ohos']
+        arch: ['aarch64-unknown-linux-ohos', 'x86_64-unknown-linux-ohos']
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -28,6 +28,6 @@ lazy_static = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = "0.4"
 
-[target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64"))))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos"))))'.dependencies]
 nix = { version = "0.29", features = ["signal"] }
 unwind-sys = "0.1.4"

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -98,12 +98,15 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
         let sampler = crate::sampler_mac::MacOsSampler::new_boxed();
         #[cfg(all(
             target_os = "linux",
-            not(any(target_arch = "arm", target_arch = "aarch64"))
+            not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos")),
         ))]
         let sampler = crate::sampler_linux::LinuxSampler::new_boxed();
         #[cfg(any(
             target_os = "android",
-            all(target_os = "linux", any(target_arch = "arm", target_arch = "aarch64"))
+            all(
+                target_os = "linux",
+                any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos")
+            )
         ))]
         let sampler = crate::sampler::DummySampler::new_boxed();
 

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -8,7 +8,7 @@ pub mod background_hang_monitor;
 mod sampler;
 #[cfg(all(
     target_os = "linux",
-    not(any(target_arch = "arm", target_arch = "aarch64"))
+    not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos"))
 ))]
 mod sampler_linux;
 #[cfg(target_os = "macos")]

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -748,8 +748,8 @@ class CommandBase(object):
         env['TARGET_STRIP'] = to_sdk_llvm_bin("llvm-strip")
 
         rust_target_triple = str(self.cross_compile_target).replace('-', '_')
-        ndk_clang = to_sdk_llvm_bin("clang")
-        ndk_clangxx = to_sdk_llvm_bin("clang++")
+        ndk_clang = to_sdk_llvm_bin(f"{self.cross_compile_target}-clang")
+        ndk_clangxx = to_sdk_llvm_bin(f"{self.cross_compile_target}-clang++")
         env[f'CC_{rust_target_triple}'] = ndk_clang
         env[f'CXX_{rust_target_triple}'] = ndk_clangxx
         # The clang target name is different from the LLVM target name


### PR DESCRIPTION
* Fix compilation for `x86_64-unknown-linux-ohos` and test that in CI
* Fix a wrong symbol name for `x86_64-unknown-linux-ohos`, causing relocation failure

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix servo on `x86_64-unknown-linux-ohos`

