### PR TITLE
layout: Convert the FragmentTree to physical geometry

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -1178,11 +1178,9 @@ impl BoxFragment {
 
         let padding_rect = self
             .padding_rect()
-            .to_physical(self.style.writing_mode, &containing_block.rect)
             .translate(containing_block.rect.origin.to_vector());
         let content_rect = self
             .content_rect
-            .to_physical(self.style.writing_mode, &containing_block.rect)
             .translate(containing_block.rect.origin.to_vector());
 
         let for_absolute_descendants = ContainingBlock::new(
@@ -1246,9 +1244,7 @@ impl BoxFragment {
             _ => return None,
         };
 
-        let border_rect = self
-            .border_rect()
-            .to_physical(self.style.writing_mode, containing_block_rect);
+        let border_rect = self.border_rect();
         let clip_rect = clip_rect
             .for_border_rect(border_rect)
             .translate(containing_block_rect.origin.to_vector())
@@ -1306,7 +1302,6 @@ impl BoxFragment {
 
         let padding_rect = self
             .padding_rect()
-            .to_physical(self.style.writing_mode, containing_block_rect)
             .translate(containing_block_rect.origin.to_vector())
             .to_webrender();
 
@@ -1314,8 +1309,7 @@ impl BoxFragment {
             parent_scroll_node_id,
             parent_clip_id,
             external_id,
-            self.scrollable_overflow(containing_block_rect)
-                .to_webrender(),
+            self.scrollable_overflow().to_webrender(),
             padding_rect,
             sensitivity,
         );
@@ -1380,7 +1374,6 @@ impl BoxFragment {
 
         let frame_rect = self
             .border_rect()
-            .to_physical(self.style.writing_mode, containing_block_rect)
             .translate(containing_block_rect.origin.to_vector())
             .to_webrender();
 
@@ -1426,9 +1419,7 @@ impl BoxFragment {
             return None;
         }
 
-        let relative_border_rect = self
-            .border_rect()
-            .to_physical(self.style.writing_mode, containing_block_rect);
+        let relative_border_rect = self.border_rect();
         let border_rect = relative_border_rect.translate(containing_block_rect.origin.to_vector());
         let untyped_border_rect = border_rect.to_untyped();
 
@@ -1560,7 +1551,6 @@ impl PositioningFragment {
     ) {
         let rect = self
             .rect
-            .to_physical(self.writing_mode, &containing_block.rect)
             .translate(containing_block.rect.origin.to_vector());
         let new_containing_block = containing_block.new_replacing_rect(&rect);
         let new_containing_block_info =

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -29,7 +29,9 @@ use crate::formatting_contexts::{
 use crate::fragment_tree::{
     BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment, FragmentFlags,
 };
-use crate::geom::{AuOrAuto, LogicalRect, LogicalSides, LogicalVec2};
+use crate::geom::{
+    AuOrAuto, LogicalRect, LogicalSides, LogicalVec2, PhysicalRect, PhysicalSides, ToLogical,
+};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::replaced::ReplacedContent;
 use crate::sizing::{self, ContentSizes};
@@ -225,9 +227,10 @@ impl OutsideMarker {
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
     ) -> Fragment {
+        let containing_block_writing_mode = containing_block.style.writing_mode;
         let content_sizes = self
             .block_container
-            .inline_content_sizes(layout_context, containing_block.style.writing_mode);
+            .inline_content_sizes(layout_context, containing_block_writing_mode);
         let containing_block_for_children = ContainingBlock {
             inline_size: content_sizes.max_content,
             block_size: AuOrAuto::auto(),
@@ -241,22 +244,29 @@ impl OutsideMarker {
             sequential_layout_state,
             collapsible_with_parent_start_margin.unwrap_or(CollapsibleWithParentStartMargin(false)),
         );
-        let max_inline_size = flow_layout.fragments.iter().fold(
-            Length::zero(),
-            |current_max, fragment| match fragment {
-                Fragment::Text(text) => current_max.max(text.rect.max_inline_position().into()),
-                Fragment::Image(image) => current_max.max(image.rect.max_inline_position().into()),
-                Fragment::Positioning(positioning) => {
-                    current_max.max(positioning.rect.max_inline_position().into())
-                },
-                Fragment::Box(_) |
-                Fragment::Float(_) |
-                Fragment::AbsoluteOrFixedPositioned(_) |
-                Fragment::IFrame(_) => {
-                    unreachable!("Found unexpected fragment type in outside list marker!");
-                },
-            },
-        );
+        let max_inline_size =
+            flow_layout
+                .fragments
+                .iter()
+                .fold(Au::zero(), |current_max, fragment| {
+                    current_max.max(
+                        match fragment {
+                            Fragment::Text(text) => text.rect,
+                            Fragment::Image(image) => image.rect,
+                            Fragment::Positioning(positioning) => positioning.rect,
+                            Fragment::Box(_) |
+                            Fragment::Float(_) |
+                            Fragment::AbsoluteOrFixedPositioned(_) |
+                            Fragment::IFrame(_) => {
+                                unreachable!(
+                                    "Found unexpected fragment type in outside list marker!"
+                                );
+                            },
+                        }
+                        .to_logical(containing_block_writing_mode)
+                        .max_inline_position(),
+                    )
+                });
 
         // Position the marker beyond the inline start of the border box list item. This needs to
         // take into account the border and padding of the item.
@@ -269,13 +279,12 @@ impl OutsideMarker {
             start_corner: LogicalVec2 {
                 inline: -max_inline_size -
                     (pbm_of_list_item.border.inline_start +
-                        pbm_of_list_item.padding.inline_start)
-                        .into(),
+                        pbm_of_list_item.padding.inline_start),
                 block: Zero::zero(),
             },
             size: LogicalVec2 {
                 inline: max_inline_size,
-                block: flow_layout.content_block_size,
+                block: flow_layout.content_block_size.into(),
             },
         };
 
@@ -286,10 +295,10 @@ impl OutsideMarker {
             base_fragment_info,
             self.marker_style.clone(),
             flow_layout.fragments,
-            content_rect.into(),
-            LogicalSides::zero(),
-            LogicalSides::zero(),
-            LogicalSides::zero(),
+            content_rect.to_physical(containing_block_writing_mode),
+            PhysicalSides::zero(),
+            PhysicalSides::zero(),
+            PhysicalSides::zero(),
             None,
             CollapsedBlockMargins::zero(),
         ))
@@ -567,6 +576,7 @@ fn layout_block_level_children_in_parallel(
             placement_state.place_fragment_and_update_baseline(&mut fragment, None);
             child_positioning_context.adjust_static_position_of_hoisted_fragments(
                 &fragment,
+                containing_block.style.writing_mode,
                 PositioningContextLength::zero(),
             );
             positioning_context.append(child_positioning_context);
@@ -604,6 +614,7 @@ fn layout_block_level_children_sequentially(
                 .place_fragment_and_update_baseline(&mut fragment, Some(sequential_layout_state));
             positioning_context.adjust_static_position_of_hoisted_fragments(
                 &fragment,
+                containing_block.style.writing_mode,
                 positioning_context_length_before_layout,
             );
 
@@ -906,14 +917,15 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         },
     };
 
+    let containing_block_writing_mode = containing_block.style.writing_mode;
     BoxFragment::new(
         base_fragment_info,
         style.clone(),
         flow_layout.fragments,
-        content_rect,
-        pbm.padding,
-        pbm.border,
-        margin,
+        content_rect.to_physical(containing_block_writing_mode),
+        pbm.padding.to_physical(containing_block_writing_mode),
+        pbm.border.to_physical(containing_block_writing_mode),
+        margin.to_physical(containing_block_writing_mode),
         clearance,
         block_margins_collapsed_with_children,
     )
@@ -991,15 +1003,15 @@ impl NonReplacedFormattingContext {
         };
 
         let block_margins_collapsed_with_children = CollapsedBlockMargins::from_margin(&margin);
-
+        let containing_block_writing_mode = containing_block.style.writing_mode;
         BoxFragment::new(
             self.base_fragment_info,
             self.style.clone(),
             layout.fragments,
-            content_rect,
-            pbm.padding,
-            pbm.border,
-            margin,
+            content_rect.to_physical(containing_block_writing_mode),
+            pbm.padding.to_physical(containing_block_writing_mode),
+            pbm.border.to_physical(containing_block_writing_mode),
+            margin.to_physical(containing_block_writing_mode),
             None, /* clearance */
             block_margins_collapsed_with_children,
         )
@@ -1242,14 +1254,15 @@ impl NonReplacedFormattingContext {
         };
         let block_margins_collapsed_with_children = CollapsedBlockMargins::from_margin(&margin);
 
+        let containing_block_writing_mode = containing_block.style.writing_mode;
         BoxFragment::new(
             self.base_fragment_info,
             self.style.clone(),
             layout.fragments,
-            content_rect,
-            pbm.padding,
-            pbm.border,
-            margin,
+            content_rect.to_physical(containing_block_writing_mode),
+            pbm.padding.to_physical(containing_block_writing_mode),
+            pbm.border.to_physical(containing_block_writing_mode),
+            margin.to_physical(containing_block_writing_mode),
             clearance,
             block_margins_collapsed_with_children,
         )
@@ -1274,7 +1287,10 @@ fn layout_in_flow_replaced_block_level(
     let margin_inline_end;
     let effective_margin_inline_start;
     let (margin_block_start, margin_block_end) = solve_block_margins_for_in_flow_block_level(&pbm);
-    let fragments = replaced.make_fragments(style, content_size);
+
+    let containing_block_writing_mode = containing_block.style.writing_mode;
+    let physical_content_size = content_size.to_physical_size(containing_block_writing_mode);
+    let fragments = replaced.make_fragments(style, physical_content_size);
 
     let clearance;
     if let Some(ref mut sequential_layout_state) = sequential_layout_state {
@@ -1341,10 +1357,10 @@ fn layout_in_flow_replaced_block_level(
         inline: pbm.padding.inline_start + pbm.border.inline_start + effective_margin_inline_start,
     };
 
-    let content_rect = LogicalRect {
-        start_corner,
-        size: content_size,
-    };
+    let content_rect = PhysicalRect::new(
+        start_corner.to_physical_point(containing_block_writing_mode),
+        physical_content_size,
+    );
     let block_margins_collapsed_with_children = CollapsedBlockMargins::from_margin(&margin);
 
     BoxFragment::new(
@@ -1352,9 +1368,9 @@ fn layout_in_flow_replaced_block_level(
         style.clone(),
         fragments,
         content_rect,
-        pbm.padding,
-        pbm.border,
-        margin,
+        pbm.padding.to_physical(containing_block_writing_mode),
+        pbm.border.to_physical(containing_block_writing_mode),
+        margin.to_physical(containing_block_writing_mode),
         clearance,
         block_margins_collapsed_with_children,
     )
@@ -1618,6 +1634,9 @@ struct PlacementState {
     /// least as tall as the marker size -- even though the marker doesn't advance the block
     /// position of the placement.
     marker_block_size: Option<Au>,
+
+    /// The [`WritingMode`] of the containing fragment where these fragments are being laid out.
+    writing_mode: WritingMode,
 }
 
 impl PlacementState {
@@ -1637,6 +1656,7 @@ impl PlacementState {
             inflow_baselines: Baselines::default(),
             is_inline_block_context,
             marker_block_size: None,
+            writing_mode: containing_block_style.writing_mode,
         }
     }
 
@@ -1662,11 +1682,16 @@ impl PlacementState {
             return;
         }
 
-        let box_block_offset = box_fragment.content_rect.start_corner.block;
-        if let (None, Some(first)) = (self.inflow_baselines.first, box_fragment.baselines.first) {
+        let box_block_offset = box_fragment
+            .content_rect
+            .origin
+            .to_logical(self.writing_mode)
+            .block;
+        let box_fragment_baselines = box_fragment.baselines(self.writing_mode);
+        if let (None, Some(first)) = (self.inflow_baselines.first, box_fragment_baselines.first) {
             self.inflow_baselines.first = Some(first + box_block_offset);
         }
-        if let Some(last) = box_fragment.baselines.last {
+        if let Some(last) = box_fragment_baselines.last {
             self.inflow_baselines.last = Some(last + box_block_offset);
         }
     }
@@ -1694,14 +1719,22 @@ impl PlacementState {
                     .contains(FragmentFlags::IS_OUTSIDE_LIST_ITEM_MARKER);
                 if is_outside_marker {
                     assert!(self.marker_block_size.is_none());
-                    self.marker_block_size = Some(fragment.content_rect.size.block);
+                    self.marker_block_size = Some(
+                        fragment
+                            .content_rect
+                            .size
+                            .to_logical(self.writing_mode)
+                            .block,
+                    );
                     return;
                 }
 
                 let fragment_block_margins = &fragment.block_margins_collapsed_with_children;
-                let mut fragment_block_size = fragment.padding.block_sum() +
-                    fragment.border.block_sum() +
-                    fragment.content_rect.size.block;
+                let mut fragment_block_size = fragment
+                    .border_rect()
+                    .to_logical(self.writing_mode)
+                    .size
+                    .block;
 
                 // We use `last_in_flow_margin_collapses_with_parent_end_margin` to implement
                 // this quote from https://drafts.csswg.org/css2/#collapsing-margins
@@ -1737,8 +1770,12 @@ impl PlacementState {
                     self.current_margin
                         .adjoin_assign(&fragment_block_margins.start);
                 }
-                fragment.content_rect.start_corner.block +=
-                    self.current_margin.solve() + self.current_block_direction_position;
+
+                fragment.content_rect.origin += LogicalVec2 {
+                    inline: Au::zero(),
+                    block: self.current_margin.solve() + self.current_block_direction_position,
+                }
+                .to_physical_size(self.writing_mode);
 
                 if fragment_block_margins.collapsed_through {
                     // `fragment_block_size` is typically zero when collapsing through,
@@ -1766,6 +1803,7 @@ impl PlacementState {
                     self.current_block_direction_position + self.current_margin.solve();
                 sequential_layout_state.place_float_fragment(
                     box_fragment,
+                    self.writing_mode,
                     self.start_margin,
                     block_offset_from_containing_block_top,
                 );

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -353,9 +353,7 @@ impl BoxTree {
         let scrollable_overflow = root_fragments
             .iter()
             .fold(PhysicalRect::zero(), |acc, child| {
-                let child_overflow = child
-                    .borrow()
-                    .scrollable_overflow(&physical_containing_block);
+                let child_overflow = child.borrow().scrollable_overflow();
 
                 // https://drafts.csswg.org/css-overflow/#scrolling-direction
                 // We want to clip scrollable overflow on box-start and inline-start

--- a/components/layout_2020/fragment_tree/fragment_tree.rs
+++ b/components/layout_2020/fragment_tree/fragment_tree.rs
@@ -110,15 +110,9 @@ impl FragmentTree {
             }
 
             let fragment_relative_rect = match fragment {
-                Fragment::Box(fragment) | Fragment::Float(fragment) => fragment
-                    .border_rect()
-                    .to_physical(fragment.style.writing_mode, containing_block),
-                Fragment::Positioning(fragment) => fragment
-                    .rect
-                    .to_physical(fragment.writing_mode, containing_block),
-                Fragment::Text(fragment) => fragment
-                    .rect
-                    .to_physical(fragment.parent_style.writing_mode, containing_block),
+                Fragment::Box(fragment) | Fragment::Float(fragment) => fragment.border_rect(),
+                Fragment::Positioning(fragment) => fragment.rect,
+                Fragment::Text(fragment) => fragment.rect,
                 Fragment::AbsoluteOrFixedPositioned(_) |
                 Fragment::Image(_) |
                 Fragment::IFrame(_) => return None,
@@ -134,7 +128,7 @@ impl FragmentTree {
 
     pub fn get_border_dimensions_for_node(&self, requested_node: OpaqueNode) -> Rect<i32> {
         let tag_to_find = Tag::new(requested_node);
-        self.find(|fragment, _, containing_block| {
+        self.find(|fragment, _, _containing_block| {
             if fragment.tag() != Some(tag_to_find) {
                 return None;
             }
@@ -151,18 +145,13 @@ impl FragmentTree {
                     }
 
                     let border = fragment.style.get_border();
-                    let padding_rect = fragment
-                        .padding_rect()
-                        .to_physical(fragment.style.writing_mode, containing_block);
+                    let padding_rect = fragment.padding_rect();
                     Rect::new(
                         Point2D::new(border.border_left_width, border.border_top_width),
                         Size2D::new(padding_rect.size.width, padding_rect.size.height),
                     )
                 },
-                Fragment::Positioning(fragment) => fragment
-                    .rect
-                    .to_physical(fragment.writing_mode, containing_block)
-                    .cast_unit(),
+                Fragment::Positioning(fragment) => fragment.rect.cast_unit(),
                 _ => return None,
             };
 

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -198,21 +198,13 @@ pub fn process_resolved_style_request<'dom>(
                             _ => {},
                         }
                     }
-                    let content_rect = box_fragment
-                        .content_rect
-                        .to_physical(box_fragment.style.writing_mode, containing_block);
-                    let margins = box_fragment
-                        .margin
-                        .to_physical(box_fragment.style.writing_mode);
-                    let padding = box_fragment
-                        .padding
-                        .to_physical(box_fragment.style.writing_mode);
+                    let content_rect = box_fragment.content_rect;
+                    let margins = box_fragment.margin;
+                    let padding = box_fragment.padding;
                     (content_rect, margins, padding)
                 },
                 Fragment::Positioning(positioning_fragment) => {
-                    let content_rect = positioning_fragment
-                        .rect
-                        .to_physical(positioning_fragment.writing_mode, containing_block);
+                    let content_rect = positioning_fragment.rect;
                     (content_rect, SideOffsets2D::zero(), SideOffsets2D::zero())
                 },
                 _ => return None,
@@ -370,15 +362,9 @@ fn process_offset_parent_query_inner(
             //
             // [1]: https://github.com/w3c/csswg-drafts/issues/4541
             let fragment_relative_rect = match fragment {
-                Fragment::Box(fragment) | Fragment::Float(fragment) => fragment
-                    .border_rect()
-                    .to_physical(fragment.style.writing_mode, containing_block),
-                Fragment::Text(fragment) => fragment
-                    .rect
-                    .to_physical(fragment.parent_style.writing_mode, containing_block),
-                Fragment::Positioning(fragment) => fragment
-                    .rect
-                    .to_physical(fragment.writing_mode, containing_block),
+                Fragment::Box(fragment) | Fragment::Float(fragment) => fragment.border_rect(),
+                Fragment::Text(fragment) => fragment.rect,
+                Fragment::Positioning(fragment) => fragment.rect,
                 Fragment::AbsoluteOrFixedPositioned(_) |
                 Fragment::Image(_) |
                 Fragment::IFrame(_) => unreachable!(),
@@ -461,12 +447,9 @@ fn process_offset_parent_query_inner(
                         Fragment::Box(fragment) | Fragment::Float(fragment) => {
                             if fragment.base.tag == Some(offset_parent_node_tag) {
                                 // Again, take the *first* associated CSS layout box.
-                                let padding_box_corner = fragment
-                                    .padding_rect()
-                                    .to_physical(fragment.style.writing_mode, containing_block)
-                                    .origin
-                                    .to_vector() +
-                                    containing_block.origin.to_vector();
+                                let padding_box_corner =
+                                    fragment.padding_rect().origin.to_vector() +
+                                        containing_block.origin.to_vector();
                                 let padding_box_corner = padding_box_corner.to_untyped();
                                 Some(padding_box_corner)
                             } else {

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -27,7 +27,7 @@ use webrender_api::ImageKey;
 use crate::context::LayoutContext;
 use crate::dom::NodeExt;
 use crate::fragment_tree::{BaseFragmentInfo, Fragment, IFrameFragment, ImageFragment};
-use crate::geom::{LogicalRect, LogicalVec2, PhysicalSize};
+use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize};
 use crate::sizing::ContentSizes;
 use crate::style_ext::{Clamp, ComputedValuesExt, PaddingBorderMargin};
 use crate::{AuOrAuto, ContainingBlock};
@@ -268,8 +268,9 @@ impl ReplacedContent {
     pub fn make_fragments(
         &self,
         style: &ServoArc<ComputedValues>,
-        size: LogicalVec2<Au>,
+        size: PhysicalSize<Au>,
     ) -> Vec<Fragment> {
+        let rect = PhysicalRect::new(PhysicalPoint::origin(), size);
         match &self.kind {
             ReplacedContentKind::Image(image) => image
                 .as_ref()
@@ -278,10 +279,7 @@ impl ReplacedContent {
                     Fragment::Image(ImageFragment {
                         base: self.base_fragment_info.into(),
                         style: style.clone(),
-                        rect: LogicalRect {
-                            start_corner: LogicalVec2::zero(),
-                            size,
-                        },
+                        rect,
                         image_key,
                     })
                 })
@@ -290,10 +288,7 @@ impl ReplacedContent {
             ReplacedContentKind::Video(video) => vec![Fragment::Image(ImageFragment {
                 base: self.base_fragment_info.into(),
                 style: style.clone(),
-                rect: LogicalRect {
-                    start_corner: LogicalVec2::zero(),
-                    size,
-                },
+                rect,
                 image_key: video.image_key,
             })],
             ReplacedContentKind::IFrame(iframe) => {
@@ -302,10 +297,7 @@ impl ReplacedContent {
                     style: style.clone(),
                     pipeline_id: iframe.pipeline_id,
                     browsing_context_id: iframe.browsing_context_id,
-                    rect: LogicalRect {
-                        start_corner: LogicalVec2::zero(),
-                        size,
-                    },
+                    rect,
                 })]
             },
             ReplacedContentKind::Canvas(canvas_info) => {
@@ -336,10 +328,7 @@ impl ReplacedContent {
                 vec![Fragment::Image(ImageFragment {
                     base: self.base_fragment_info.into(),
                     style: style.clone(),
-                    rect: LogicalRect {
-                        start_corner: LogicalVec2::zero(),
-                        size,
-                    },
+                    rect,
                     image_key,
                 })]
             },


### PR DESCRIPTION
This converts all geometry in the FragmentTree into physical geometry,
doing conversions ahead of time instead of when traversing the fragment
tree. This is necessary to properly implement BiDi in Servo as we need
to know what side borders are on in mixed RTL and LTR contexts.

In addition, fragments are laid out in a particular context and only
that context knows its writing mode. There were issues where were using
one writing mode to lay out and another to convert to phyisical
coordinates. This isn't an issue now since we only use the default
writing mode, but starts to be an issue with BiDi text.

Closes #25564.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they shouldn't change behavior
      when we don't support any non-default writing modes at all.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
