### PR TITLE
layout: Initial implementation of `flex-direction: column` and `column-reverse`

### DIFF
--- a/components/layout_2020/flexbox/geom.rs
+++ b/components/layout_2020/flexbox/geom.rs
@@ -67,7 +67,7 @@ impl<T> FlexRelativeSides<T> {
 
 /// One of the two bits set by the `flex-direction` property
 /// (The other is "forward" v.s. reverse.)
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum FlexAxis {
     /// The main axis is the inline axis of the container (not necessarily of flex items!),
     /// cross is block.

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -2389,6 +2389,7 @@ impl<'a> ContentSizesComputation<'a> {
                 let outer = atomic.outer_inline_content_sizes(
                     self.layout_context,
                     self.containing_block_writing_mode,
+                    Au::zero,
                 );
 
                 if !inline_formatting_context

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -366,7 +366,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
             BlockLevelBox::OutOfFlowFloatBox(ref mut float_box) => {
                 let size = float_box
                     .contents
-                    .outer_inline_content_sizes(layout_context, writing_mode)
+                    .outer_inline_content_sizes(layout_context, writing_mode, Au::zero)
                     .max(ContentSizes::zero());
                 let style_box = &float_box.contents.style().get_box();
                 Some((size, style_box.float, style_box.clear))
@@ -374,9 +374,12 @@ fn calculate_inline_content_size_for_block_level_boxes(
             BlockLevelBox::SameFormattingContextBlock {
                 style, contents, ..
             } => {
-                let size = sizing::outer_inline(style, writing_mode, || {
-                    contents.inline_content_sizes(layout_context, style.writing_mode)
-                })
+                let size = sizing::outer_inline(
+                    style,
+                    writing_mode,
+                    || contents.inline_content_sizes(layout_context, style.writing_mode),
+                    Au::zero,
+                )
                 .max(ContentSizes::zero());
                 // A block in the same BFC can overlap floats, it's not moved next to them,
                 // so we shouldn't add its size to the size of the floats.
@@ -385,7 +388,7 @@ fn calculate_inline_content_size_for_block_level_boxes(
             },
             BlockLevelBox::Independent(ref mut independent) => {
                 let size = independent
-                    .outer_inline_content_sizes(layout_context, writing_mode)
+                    .outer_inline_content_sizes(layout_context, writing_mode, Au::zero)
                     .max(ContentSizes::zero());
                 Some((size, Float::None, independent.style().get_box().clear))
             },

--- a/tests/wpt/meta/css/css-align/self-alignment/self-align-safe-unsafe-flex-003.html.ini
+++ b/tests/wpt/meta/css/css-align/self-alignment/self-align-safe-unsafe-flex-003.html.ini
@@ -1,0 +1,2 @@
+[self-align-safe-unsafe-flex-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/align-content-wrap-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-content-wrap-002.html.ini
@@ -1,9 +1,0 @@
-[align-content-wrap-002.html]
-  [.flex-horizontal, .flex-vertical 4]
-    expected: FAIL
-
-  [.flex-horizontal, .flex-vertical 5]
-    expected: FAIL
-
-  [.flex-horizontal, .flex-vertical 6]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/align-items-009.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-items-009.html.ini
@@ -1,2 +1,0 @@
-[align-items-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/align-self-015.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/align-self-015.html.ini
@@ -1,2 +1,0 @@
-[align-self-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-001.html.ini
@@ -13,6 +13,3 @@
 
   [#target > div 6]
     expected: FAIL
-
-  [#target > div 4]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-006.html.ini
@@ -1,3 +1,9 @@
 [flex-align-baseline-006.html]
   [#target > div 3]
     expected: FAIL
+
+  [#target > div 1]
+    expected: FAIL
+
+  [#target > div 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-007.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-007.html.ini
@@ -1,3 +1,9 @@
 [flex-align-baseline-007.html]
   [#target > div 3]
     expected: FAIL
+
+  [#target > div 1]
+    expected: FAIL
+
+  [#target > div 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
@@ -49,3 +49,9 @@
 
   [.target > * 25]
     expected: FAIL
+
+  [.target > * 43]
+    expected: FAIL
+
+  [.target > * 47]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/auto-height-column-with-border-and-padding.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/auto-height-column-with-border-and-padding.html.ini
@@ -1,0 +1,2 @@
+[auto-height-column-with-border-and-padding.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/box-sizing-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/box-sizing-001.html.ini
@@ -1,9 +1,3 @@
 [box-sizing-001.html]
-  [.flexbox 10]
-    expected: FAIL
-
-  [.flexbox 8]
-    expected: FAIL
-
-  [.flexbox 9]
+  [.flexbox 7]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/box-sizing-min-max-sizes-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/box-sizing-min-max-sizes-001.html.ini
@@ -1,0 +1,3 @@
+[box-sizing-min-max-sizes-001.html]
+  [.flexbox 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/change-column-flex-width.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/change-column-flex-width.html.ini
@@ -1,0 +1,3 @@
+[change-column-flex-width.html]
+  [#container 1]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/column-flex-child-with-overflow-scroll.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/column-flex-child-with-overflow-scroll.html.ini
@@ -1,0 +1,6 @@
+[column-flex-child-with-overflow-scroll.html]
+  [.flexbox 1]
+    expected: FAIL
+
+  [.flexbox 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/columns-height-set-via-top-bottom.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/columns-height-set-via-top-bottom.html.ini
@@ -1,7 +1,3 @@
 [columns-height-set-via-top-bottom.html]
-  [.flexbox 1]
-    expected: FAIL
-
   [.flexbox 2]
     expected: FAIL
-

--- a/tests/wpt/meta/css/css-flexbox/fieldset-as-container-justify-center.tentative.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/fieldset-as-container-justify-center.tentative.html.ini
@@ -1,3 +1,0 @@
-[fieldset-as-container-justify-center.tentative.html]
-  [.item 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-001.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-004.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-basis-010.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-basis-010.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-basis-011.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-basis-011.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-basis-intrinsics-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-basis-intrinsics-001.html.ini
@@ -25,3 +25,6 @@
 
   [.flex-item 11]
     expected: FAIL
+
+  [.flex-item 12]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-column-relayout-assert.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-column-relayout-assert.html.ini
@@ -1,0 +1,3 @@
+[flex-column-relayout-assert.html]
+  [.flexbox 1]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-direction-column-overlap-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-direction-column-overlap-001.html.ini
@@ -1,0 +1,3 @@
+[flex-direction-column-overlap-001.html]
+  [#container 1]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-factor-less-than-one.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-factor-less-than-one.html.ini
@@ -2,16 +2,7 @@
   [.flexbox 5]
     expected: FAIL
 
-  [.flexbox 7]
-    expected: FAIL
-
-  [.flexbox 3]
-    expected: FAIL
-
   [.flexbox 8]
-    expected: FAIL
-
-  [.flexbox 16]
     expected: FAIL
 
   [.flexbox 17]
@@ -20,5 +11,14 @@
   [.flexbox 14]
     expected: FAIL
 
-  [.flexbox 12]
+  [.flexbox 4]
+    expected: FAIL
+
+  [.flexbox 9]
+    expected: FAIL
+
+  [.flexbox 13]
+    expected: FAIL
+
+  [.flexbox 18]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-007.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-007.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-008.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-008.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-009.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-009.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-010.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-010.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-011.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-011.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-012.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-012.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-flow-013.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-flow-013.html.ini
@@ -8,12 +8,6 @@
   [.flexbox 4]
     expected: FAIL
 
-  [.flexbox 5]
-    expected: FAIL
-
-  [.flexbox 6]
-    expected: FAIL
-
   [.flexbox 7]
     expected: FAIL
 
@@ -27,4 +21,10 @@
     expected: FAIL
 
   [.flexbox 3]
+    expected: FAIL
+
+  [.flexbox 9]
+    expected: FAIL
+
+  [.flexbox 10]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-height-min-content.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-height-min-content.html.ini
@@ -1,0 +1,2 @@
+[flex-height-min-content.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-item-compressible-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-item-compressible-002.html.ini
@@ -23,18 +23,6 @@
   [.flexbox 5]
     expected: FAIL
 
-  [.flexbox 6]
-    expected: FAIL
-
-  [.flexbox 7]
-    expected: FAIL
-
-  [.flexbox 1]
-    expected: FAIL
-
-  [.flexbox 2]
-    expected: FAIL
-
   [.flexbox 3]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-flexbox/flex-item-contains-strict.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-item-contains-strict.html.ini
@@ -1,12 +1,18 @@
 [flex-item-contains-strict.html]
-  [.inline-flex 1]
-    expected: FAIL
-
   [.inline-flex 2]
     expected: FAIL
 
-  [.inline-flex 5]
+  [.inline-flex 6]
     expected: FAIL
 
-  [.inline-flex 6]
+  [.inline-flex 3]
+    expected: FAIL
+
+  [.inline-flex 7]
+    expected: FAIL
+
+  [.inline-flex 1]
+    expected: FAIL
+
+  [.inline-flex 5]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-margin-no-collapse.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-margin-no-collapse.html.ini
@@ -1,2 +1,0 @@
-[flex-margin-no-collapse.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-002.xht.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-002.xht.ini
@@ -1,0 +1,2 @@
+[flex-minimum-height-flex-items-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-004.xht.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-004.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-007.xht.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-007.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-008.xht.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-008.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-012.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-012.html.ini
@@ -1,4 +1,0 @@
-[flex-minimum-height-flex-items-012.html]
-  [.flexbox 1]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-014.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-014.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-019.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-019.html.ini
@@ -1,0 +1,2 @@
+[flex-minimum-height-flex-items-019.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-022.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-022.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-022.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-024.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-024.html.ini
@@ -1,0 +1,2 @@
+[flex-minimum-height-flex-items-024.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-026.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-026.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-026.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-028.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-028.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-028.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-030.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-030.html.ini
@@ -1,0 +1,2 @@
+[flex-minimum-height-flex-items-030.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-size-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-size-001.html.ini
@@ -1,3 +1,6 @@
 [flex-minimum-size-001.html]
   [.flexbox, .inline-flexbox 2]
     expected: FAIL
+
+  [.flexbox, .inline-flexbox 3]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-width-flex-items-015.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-width-flex-items-015.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-one-sets-flex-basis-to-zero-px.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-one-sets-flex-basis-to-zero-px.html.ini
@@ -1,7 +1,4 @@
 [flex-one-sets-flex-basis-to-zero-px.html]
-  [.flexbox 3]
-    expected: FAIL
-
   [.flexbox 4]
     expected: FAIL
 
@@ -9,4 +6,10 @@
     expected: FAIL
 
   [.flexbox 6]
+    expected: FAIL
+
+  [.flexbox 1]
+    expected: FAIL
+
+  [.flexbox 2]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-outer-flexbox-column-recalculate-height-on-resize-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-outer-flexbox-column-recalculate-height-on-resize-001.html.ini
@@ -1,0 +1,3 @@
+[flex-outer-flexbox-column-recalculate-height-on-resize-001.html]
+  [.OuterFlexbox 1]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-wrap-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-wrap-002.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-stretch-vert-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-stretch-vert-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-stretch-vert-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-break-request-vert-002a.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-break-request-vert-002a.html.ini
@@ -1,2 +1,0 @@
-[flexbox-break-request-vert-002a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-break-request-vert-002b.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-break-request-vert-002b.html.ini
@@ -1,2 +1,0 @@
-[flexbox-break-request-vert-002b.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-definite-sizes-005.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-definite-sizes-005.html.ini
@@ -1,2 +1,0 @@
-[flexbox-definite-sizes-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-definite-sizes-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-definite-sizes-006.html.ini
@@ -1,0 +1,2 @@
+[flexbox-definite-sizes-006.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-basis-content-004a.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-basis-content-004a.html.ini
@@ -1,0 +1,2 @@
+[flexbox-flex-basis-content-004a.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-basis-content-004b.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-basis-content-004b.html.ini
@@ -1,0 +1,2 @@
+[flexbox-flex-basis-content-004b.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column-percentage-ignored.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column-percentage-ignored.html.ini
@@ -1,0 +1,2 @@
+[flexbox-flex-direction-column-percentage-ignored.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column-reverse.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column-reverse.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-direction-column-reverse.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column.htm.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column.htm.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-direction-column.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-flow-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-flow-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-flow-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-flow-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-flow-002.html.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-flow-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-overflow-vert-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-002.html.ini
@@ -1,2 +1,0 @@
-[flexbox-overflow-vert-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-003.html.ini
@@ -1,2 +1,0 @@
-[flexbox-overflow-vert-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-overflow-vert-004.html.ini
@@ -1,2 +1,0 @@
-[flexbox-overflow-vert-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-writing-mode-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-writing-mode-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-writing-mode-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_flow-column-reverse-wrap-reverse.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_flow-column-reverse-wrap-reverse.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flow-column-reverse-wrap-reverse.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_flow-column-reverse-wrap.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_flow-column-reverse-wrap.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flow-column-reverse-wrap.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_order.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_order.html.ini
@@ -1,2 +1,0 @@
-[flexbox_order.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-002-lr.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-002-lr.html.ini
@@ -1,2 +1,0 @@
-[gap-002-lr.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-002-ltr.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-002-ltr.html.ini
@@ -1,2 +1,0 @@
-[gap-002-ltr.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-002-rl.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-002-rl.html.ini
@@ -1,2 +1,0 @@
-[gap-002-rl.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-002-rtl.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-002-rtl.html.ini
@@ -1,2 +1,0 @@
-[gap-002-rtl.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-003-lr.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-003-lr.html.ini
@@ -1,2 +1,0 @@
-[gap-003-lr.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-003-rl.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-003-rl.html.ini
@@ -1,2 +1,0 @@
-[gap-003-rl.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-005-lr.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-005-lr.html.ini
@@ -1,2 +1,0 @@
-[gap-005-lr.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-005-ltr.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-005-ltr.html.ini
@@ -1,2 +1,0 @@
-[gap-005-ltr.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-005-rl.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-005-rl.html.ini
@@ -1,2 +1,0 @@
-[gap-005-rl.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/gap-005-rtl.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/gap-005-rtl.html.ini
@@ -1,2 +1,0 @@
-[gap-005-rtl.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-002.html.ini
@@ -8,11 +8,26 @@
   [.flexbox > img 10]
     expected: FAIL
 
-  [.flexbox > img 7]
+  [.flexbox > img 1]
     expected: FAIL
 
-  [.flexbox > img 6]
+  [.flexbox > img 2]
     expected: FAIL
 
-  [.flexbox > img 3]
+  [.flexbox > img 5]
+    expected: FAIL
+
+  [.flexbox > img 8]
+    expected: FAIL
+
+  [.flexbox > img 9]
+    expected: FAIL
+
+  [.flexbox > img 12]
+    expected: FAIL
+
+  [.flexbox > img 13]
+    expected: FAIL
+
+  [.flexbox > img 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-002v.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-002v.html.ini
@@ -8,11 +8,26 @@
   [.flexbox > img 10]
     expected: FAIL
 
-  [.flexbox > img 7]
+  [.flexbox > img 1]
     expected: FAIL
 
-  [.flexbox > img 6]
+  [.flexbox > img 2]
     expected: FAIL
 
-  [.flexbox > img 3]
+  [.flexbox > img 5]
+    expected: FAIL
+
+  [.flexbox > img 8]
+    expected: FAIL
+
+  [.flexbox > img 9]
+    expected: FAIL
+
+  [.flexbox > img 12]
+    expected: FAIL
+
+  [.flexbox > img 13]
+    expected: FAIL
+
+  [.flexbox > img 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-004.html.ini
@@ -1,7 +1,4 @@
 [image-as-flexitem-size-004.html]
-  [.flexbox > img 15]
-    expected: FAIL
-
   [.flexbox > img 10]
     expected: FAIL
 
@@ -14,9 +11,6 @@
   [.flexbox > img 5]
     expected: FAIL
 
-  [.flexbox > img 4]
-    expected: FAIL
-
   [.flexbox > img 7]
     expected: FAIL
 
@@ -26,20 +20,17 @@
   [.flexbox > img 1]
     expected: FAIL
 
-  [.flexbox > img 3]
-    expected: FAIL
-
-  [.flexbox > img 14]
-    expected: FAIL
-
   [.flexbox > img 12]
-    expected: FAIL
-
-  [.flexbox > img 18]
     expected: FAIL
 
   [.flexbox > img 9]
     expected: FAIL
 
   [.flexbox > img 2]
+    expected: FAIL
+
+  [.flexbox > img 11]
+    expected: FAIL
+
+  [.flexbox > img 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-004v.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-004v.html.ini
@@ -1,7 +1,4 @@
 [image-as-flexitem-size-004v.html]
-  [.flexbox > img 15]
-    expected: FAIL
-
   [.flexbox > img 10]
     expected: FAIL
 
@@ -14,9 +11,6 @@
   [.flexbox > img 5]
     expected: FAIL
 
-  [.flexbox > img 4]
-    expected: FAIL
-
   [.flexbox > img 7]
     expected: FAIL
 
@@ -26,20 +20,17 @@
   [.flexbox > img 1]
     expected: FAIL
 
-  [.flexbox > img 3]
-    expected: FAIL
-
-  [.flexbox > img 14]
-    expected: FAIL
-
   [.flexbox > img 12]
-    expected: FAIL
-
-  [.flexbox > img 18]
     expected: FAIL
 
   [.flexbox > img 9]
     expected: FAIL
 
   [.flexbox > img 2]
+    expected: FAIL
+
+  [.flexbox > img 11]
+    expected: FAIL
+
+  [.flexbox > img 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-006.html.ini
@@ -2,21 +2,6 @@
   [.flexbox > img 15]
     expected: FAIL
 
-  [.flexbox > img 14]
-    expected: FAIL
-
-  [.flexbox > img 17]
-    expected: FAIL
-
-  [.flexbox > img 12]
-    expected: FAIL
-
-  [.flexbox > img 18]
-    expected: FAIL
-
-  [.flexbox > img 9]
-    expected: FAIL
-
   [.flexbox > img 8]
     expected: FAIL
 
@@ -36,19 +21,4 @@
     expected: FAIL
 
   [.flexbox > img 3]
-    expected: FAIL
-
-  [.flexbox > img 2]
-    expected: FAIL
-
-  [.flexbox > img 16]
-    expected: FAIL
-
-  [.flexbox > img 11]
-    expected: FAIL
-
-  [.flexbox > img 10]
-    expected: FAIL
-
-  [.flexbox > img 13]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-006v.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/image-as-flexitem-size-006v.html.ini
@@ -1,32 +1,5 @@
 [image-as-flexitem-size-006v.html]
-  [.flexbox > img 10]
-    expected: FAIL
-
-  [.flexbox > img 11]
-    expected: FAIL
-
-  [.flexbox > img 13]
-    expected: FAIL
-
-  [.flexbox > img 10]
-    expected: FAIL
-
   [.flexbox > img 15]
-    expected: FAIL
-
-  [.flexbox > img 14]
-    expected: FAIL
-
-  [.flexbox > img 17]
-    expected: FAIL
-
-  [.flexbox > img 12]
-    expected: FAIL
-
-  [.flexbox > img 18]
-    expected: FAIL
-
-  [.flexbox > img 9]
     expected: FAIL
 
   [.flexbox > img 8]
@@ -48,10 +21,4 @@
     expected: FAIL
 
   [.flexbox > img 3]
-    expected: FAIL
-
-  [.flexbox > img 2]
-    expected: FAIL
-
-  [.flexbox > img 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/intrinsic-size/col-wrap-009.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/intrinsic-size/col-wrap-009.html.ini
@@ -1,0 +1,2 @@
+[col-wrap-009.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/item-with-max-height-and-scrollbar.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/item-with-max-height-and-scrollbar.html.ini
@@ -1,0 +1,2 @@
+[item-with-max-height-and-scrollbar.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/justify-content-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/justify-content-006.html.ini
@@ -1,4 +1,0 @@
-[justify-content-006.html]
-  [.middle > div 1]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-flexbox/layout-algorithm_algo-cross-line-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/layout-algorithm_algo-cross-line-002.html.ini
@@ -1,2 +1,0 @@
-[layout-algorithm_algo-cross-line-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/orthogonal-writing-modes-and-intrinsic-sizing.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/orthogonal-writing-modes-and-intrinsic-sizing.html.ini
@@ -1,0 +1,3 @@
+[orthogonal-writing-modes-and-intrinsic-sizing.html]
+  [.flexbox 2]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/overflow-auto-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/overflow-auto-006.html.ini
@@ -1,0 +1,12 @@
+[overflow-auto-006.html]
+  [.flexbox, .inline-flexbox 7]
+    expected: FAIL
+
+  [.flexbox, .inline-flexbox 8]
+    expected: FAIL
+
+  [.flexbox, .inline-flexbox 9]
+    expected: FAIL
+
+  [.flexbox, .inline-flexbox 10]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/overflow-auto-008.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/overflow-auto-008.html.ini
@@ -1,0 +1,3 @@
+[overflow-auto-008.html]
+  [hbox dimensions]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-000.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-000.html.ini
@@ -7,12 +7,3 @@
 
   [.flexbox 6]
     expected: FAIL
-
-  [.flexbox 1]
-    expected: FAIL
-
-  [.flexbox 2]
-    expected: FAIL
-
-  [.flexbox 3]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-002.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-003.html.ini
@@ -1,6 +1,3 @@
 [percentage-heights-003.html]
-  [.flexbox 2]
-    expected: FAIL
-
-  [.flexbox 3]
+  [.flexbox 6]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-004.html.ini
@@ -1,0 +1,2 @@
+[percentage-heights-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-005.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-005.html.ini
@@ -1,0 +1,2 @@
+[percentage-heights-005.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-006.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-007.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-007.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-008.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-008.html.ini
@@ -1,0 +1,2 @@
+[percentage-heights-008.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-016.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-016.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-017.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-017.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-017.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-018.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-018.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-018.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-019.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-019.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-019.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-margins-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-margins-001.html.ini
@@ -1,4 +1,0 @@
-[percentage-margins-001.html]
-  [.flexbox 1]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-flexbox/percentage-max-height-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-max-height-004.html.ini
@@ -1,0 +1,2 @@
+[percentage-max-height-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-max-width-cross-axis.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-max-width-cross-axis.html.ini
@@ -1,3 +1,0 @@
-[percentage-max-width-cross-axis.html]
-  [.flexbox 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-size-quirks.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-size-quirks.html.ini
@@ -1,6 +1,0 @@
-[percentage-size-quirks.html]
-  [.flexbox 8]
-    expected: FAIL
-
-  [.flexbox 3]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-size.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-size.html.ini
@@ -1,6 +1,0 @@
-[percentage-size.html]
-  [.flexbox 8]
-    expected: FAIL
-
-  [.flexbox 3]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-001.html.ini
@@ -1,0 +1,2 @@
+[stretch-obeys-min-max-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-003.html.ini
@@ -1,0 +1,2 @@
+[stretch-obeys-min-max-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/stretched-child-shrink-on-relayout.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/stretched-child-shrink-on-relayout.html.ini
@@ -1,9 +1,0 @@
-[stretched-child-shrink-on-relayout.html]
-  [.flexbox 4]
-    expected: FAIL
-
-  [.flexbox 6]
-    expected: FAIL
-
-  [.flexbox 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-change-cell.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-change-cell.html.ini
@@ -1,0 +1,2 @@
+[table-as-item-change-cell.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/table-as-item-specified-height.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/table-as-item-specified-height.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-specified-height.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/column-flex-child-with-max-width.html
+++ b/tests/wpt/tests/css/css-flexbox/column-flex-child-with-max-width.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Item in column flex container with max-width</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-direction-property">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#flex-items">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#align-items-property">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="Contents of a flex item with max-width should be laid out within the decreased containing block.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 100px; height: 100px; background: red">
+  <div style="display: flex; flex-direction: column; width: 200px; height: 100px">
+    <div style="align-self: start; max-width: 100px">
+      <div style="display: flow-root; background: green">
+        <div style="float: left; width: 100px; height: 50px"></div>
+        <div style="float: left; width: 100px; height: 50px"></div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This change removes restrictions on using the column layout mode of
flexbox and adds an initial implementation of sizing for that flex
direction. There's a lot of missing pieces still, but in some cases this
does render column flexbox.

In particular, there are now two code paths for preferred widths
(intrinsic size) calcuation: one in the main axis (row) and one in
the cross axis (column) corresponding to the flex direciton with
horizontal writing modes.

In addition, `FlexItemBox::inline_content_sizes` is removed in favor of
making `sizing::outer_inline` /
`IndependentFormattingContext::outer_inline_content_sizes` generic
enough to handle using a different value for auto minimum sizes, which
flexbox needs.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
