### PR TITLE
ci: Only export WPT test changes on the `main` branch

### DIFF
--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -2,6 +2,7 @@ name: WPT Export
 on:
   pull_request_target:
     types: ['opened', 'synchronize', 'reopened', 'edited', 'closed']
+    branches: ['main']
 
 jobs:
   upstream:


### PR DESCRIPTION
This ensures that the WPT export job only runs on chnages that target
the `main` branch. This makes it so changes to WPT tests in temporary
branches aren't upstreamed.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
