### PR TITLE
De-duplicate `syn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,13 +217,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "0.3.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.74",
+ "syn",
  "which",
 ]
 
@@ -573,7 +573,7 @@ checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1198,7 +1198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1237,7 +1237,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1248,7 +1248,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1280,7 +1280,7 @@ dependencies = [
 name = "deny_public_fields"
 version = "0.0.1"
 dependencies = [
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -1309,7 +1309,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -1321,7 +1321,7 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1386,7 +1386,7 @@ dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ dependencies = [
  "serde",
  "smallvec",
  "strck_ident",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1448,7 +1448,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1482,7 +1482,7 @@ name = "dom_struct"
 version = "0.0.1"
 dependencies = [
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1491,7 +1491,7 @@ version = "0.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -1645,26 +1645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0aac423d2d59cc8b22de1ebd0db7f8d07382b8189945c89ab882a1c659b5"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df9d0cef4b051baf3ef7f9b1674273dc78cd56e02cba60fa187f9c0ff4ff5e0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1977,7 +1957,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -2094,7 +2074,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -2313,7 +2293,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -2887,7 +2867,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -3391,7 +3371,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -3640,7 +3620,7 @@ name = "jstraceable_derive"
 version = "0.0.1"
 dependencies = [
  "proc-macro2",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -4138,7 +4118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44db74bde26fdf427af23f1d146c211aed857c59e3be750cf2617f6b0b05c94"
 dependencies = [
  "proc-macro2",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -4414,7 +4394,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -4428,7 +4408,7 @@ dependencies = [
  "napi-derive-backend-ohos",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -4645,7 +4625,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -4706,7 +4686,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -4918,7 +4898,7 @@ source = "git+https://github.com/servo/webrender?branch=0.65#c0bcdd024adac1297ce
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "synstructure",
  "unicode-xid",
 ]
@@ -4998,7 +4978,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -5036,7 +5016,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -5599,7 +5579,6 @@ dependencies = [
  "domobject_derive",
  "embedder_traits",
  "encoding_rs",
- "enum-iterator",
  "euclid",
  "fnv",
  "fonts",
@@ -5839,7 +5818,7 @@ checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -5906,7 +5885,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -5925,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -5938,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -5959,17 +5938,17 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -5983,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -6017,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -6027,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6041,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "glib",
  "gstreamer",
@@ -6056,7 +6035,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -6068,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -6077,12 +6056,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#adfb5467abadcc42a0c047fcfd043e5be10818e6"
+source = "git+https://github.com/servo/media#f6e6ee0528c8735e3ded8b9a9f68acfabefaf539"
 dependencies = [
  "lazy_static",
  "log",
@@ -6145,7 +6124,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -6579,7 +6558,7 @@ dependencies = [
  "derive_common",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -6677,17 +6656,6 @@ checksum = "e454d048db5527d000bfddb77bd072bbf3a1e2ae785f16d9bd116e07c2ab45eb"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
@@ -6705,7 +6673,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -6832,7 +6800,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -6983,7 +6951,7 @@ dependencies = [
  "derive_common",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -7011,7 +6979,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -7136,7 +7104,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -7454,7 +7422,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -7488,7 +7456,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7940,7 +7908,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7998,7 +7966,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -8009,7 +7977,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -8517,7 +8485,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -8539,7 +8507,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]
@@ -8559,7 +8527,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
  "synstructure",
 ]
 
@@ -8593,7 +8561,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn",
 ]
 
 [[package]]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 doctest = false
 
 [dependencies]
-async-recursion = "0.3.2"
+async-recursion = "1.1"
 async-tungstenite = { workspace = true }
 base = { workspace = true }
 base64 = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -49,7 +49,6 @@ dom_struct = { path = "../dom_struct" }
 domobject_derive = { path = "../domobject_derive" }
 embedder_traits = { workspace = true }
 encoding_rs = { workspace = true }
-enum-iterator = "0.3"
 euclid = { workspace = true }
 fnv = { workspace = true }
 fxhash = { workspace = true }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -413,7 +413,7 @@ impl Window {
     pub fn ignore_all_tasks(&self) {
         let mut ignore_flags = self.task_manager.task_cancellers.borrow_mut();
         for task_source_name in TaskSourceName::all() {
-            let flag = ignore_flags.entry(task_source_name).or_default();
+            let flag = ignore_flags.entry(*task_source_name).or_default();
             flag.store(true, Ordering::SeqCst);
         }
     }
@@ -1646,7 +1646,7 @@ impl Window {
     pub fn cancel_all_tasks(&self) {
         let mut ignore_flags = self.task_manager.task_cancellers.borrow_mut();
         for task_source_name in TaskSourceName::all() {
-            let flag = ignore_flags.entry(task_source_name).or_default();
+            let flag = ignore_flags.entry(*task_source_name).or_default();
             let cancelled = std::mem::take(&mut *flag);
             cancelled.store(true, Ordering::SeqCst);
         }

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -18,16 +18,16 @@ pub mod websocket;
 
 use std::result::Result;
 
-use enum_iterator::IntoEnumIterator;
-
 use crate::dom::globalscope::GlobalScope;
 use crate::task::{TaskCanceller, TaskOnce};
 
-// The names of all task sources, used to differentiate TaskCancellers.
-// Note: When adding a task source, update this enum.
-// Note: The HistoryTraversalTaskSource is not part of this,
-// because it doesn't implement TaskSource.
-#[derive(Clone, Eq, Hash, IntoEnumIterator, JSTraceable, PartialEq)]
+/// The names of all task sources, used to differentiate TaskCancellers. Note: When adding a task
+/// source, update this enum. Note: The HistoryTraversalTaskSource is not part of this, because it
+/// doesn't implement TaskSource.
+///
+/// Note: When adding or removing a [`TaskSourceName`], be sure to also update the return value of
+/// [`TaskSourceName::all`].
+#[derive(Clone, Copy, Eq, Hash, JSTraceable, PartialEq)]
 pub enum TaskSourceName {
     DOMManipulation,
     FileReading,
@@ -47,8 +47,22 @@ pub enum TaskSourceName {
 }
 
 impl TaskSourceName {
-    pub fn all() -> Vec<TaskSourceName> {
-        TaskSourceName::into_enum_iter().collect()
+    pub fn all() -> &'static [TaskSourceName] {
+        &[
+            TaskSourceName::DOMManipulation,
+            TaskSourceName::FileReading,
+            TaskSourceName::HistoryTraversal,
+            TaskSourceName::Networking,
+            TaskSourceName::PerformanceTimeline,
+            TaskSourceName::PortMessage,
+            TaskSourceName::UserInteraction,
+            TaskSourceName::RemoteEvent,
+            TaskSourceName::Rendering,
+            TaskSourceName::MediaElement,
+            TaskSourceName::Websocket,
+            TaskSourceName::Timer,
+            TaskSourceName::Gamepad,
+        ]
     }
 }
 

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -27,7 +27,6 @@ packages = [
     "hermit-abi",
     "redox_syscall",
     "libredox",
-    "syn",
     "time",
     "wasi",
     "wayland-sys",


### PR DESCRIPTION
This is the last step toward removing our use of `syn` version. 
It does three things:

1. Upgrades `async-recursion` to a newer version that uses `syn` 2.
2. Removes the use of `enum-iterator` that was only used to produce a
   trivial list of enum names. This reduces the number of crates we
   depend on by 2.
3. Upgrades `media` to a version which no longer uses `syn` 1

Fixes #33034.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this should not change any behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
