### PR TITLE
Fix warnings after latest rust upgrade

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1059,7 +1059,6 @@ where
                 .map(|threads| threads.pipeline()),
             webxr_registry: self.webxr_registry.clone(),
             player_context: self.player_context.clone(),
-            event_loop_waker: None,
             user_agent: self.user_agent.clone(),
         });
 

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -21,7 +21,6 @@ use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::{CompositionPipeline, CompositorMsg, CompositorProxy};
 use crossbeam_channel::{unbounded, Sender};
 use devtools_traits::{DevtoolsControlMsg, ScriptToDevtoolsControlMsg};
-use embedder_traits::EventLoopWaker;
 use fonts::FontCacheThread;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -201,9 +200,6 @@ pub struct InitialPipelineState {
 
     /// Application window's GL Context for Media player
     pub player_context: WindowGLContext,
-
-    /// Mechanism to force the compositor to process events.
-    pub event_loop_waker: Option<Box<dyn EventLoopWaker>>,
 
     /// User agent string to report in network requests.
     pub user_agent: Cow<'static, str>,

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -11,7 +11,7 @@ use crate::StreamId;
 
 pub struct ObjectActor {
     pub name: String,
-    pub uuid: String,
+    pub _uuid: String,
 }
 
 impl Actor for ObjectActor {
@@ -37,7 +37,7 @@ impl ObjectActor {
             let name = registry.new_name("object");
             let actor = ObjectActor {
                 name: name.clone(),
-                uuid: uuid.clone(),
+                _uuid: uuid.clone(),
             };
 
             registry.register_script_actor(uuid, name.clone());

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -2675,7 +2675,6 @@ pub struct ISizeConstraintInput {
     pub inline_end_margin: MaybeAuto,
     pub inline_start: MaybeAuto,
     pub inline_end: MaybeAuto,
-    pub text_align: TextAlign,
     pub available_inline_size: Au,
 }
 
@@ -2686,7 +2685,6 @@ impl ISizeConstraintInput {
         inline_end_margin: MaybeAuto,
         inline_start: MaybeAuto,
         inline_end: MaybeAuto,
-        text_align: TextAlign,
         available_inline_size: Au,
     ) -> ISizeConstraintInput {
         ISizeConstraintInput {
@@ -2695,7 +2693,6 @@ impl ISizeConstraintInput {
             inline_end_margin,
             inline_start,
             inline_end,
-            text_align,
             available_inline_size,
         }
     }
@@ -2793,7 +2790,6 @@ pub trait ISizeAndMarginsComputer {
             MaybeAuto::from_style(margin.inline_end, containing_block_inline_size),
             MaybeAuto::from_style(position.inline_start, containing_block_inline_size),
             MaybeAuto::from_style(position.inline_end, containing_block_inline_size),
-            style.get_inherited_text().text_align,
             available_inline_size,
         )
     }

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -31,8 +31,6 @@ pub struct BackgroundPlacement {
     pub clip_rect: Rect<Au>,
     /// Rounded corners for the clip_rect.
     pub clip_radii: BorderRadius,
-    /// Whether or not the background is fixed to the viewport.
-    pub fixed: bool,
 }
 
 /// Access element at index modulo the array length.
@@ -170,17 +168,13 @@ pub fn placement(
         border_radii,
     );
 
-    let mut fixed = false;
     let mut bounds = match bg_attachment {
         BackgroundAttachment::Scroll => match bg_origin {
             BackgroundOrigin::BorderBox => absolute_bounds,
             BackgroundOrigin::PaddingBox => absolute_bounds.inner_rect(border),
             BackgroundOrigin::ContentBox => absolute_bounds.inner_rect(border_padding),
         },
-        BackgroundAttachment::Fixed => {
-            fixed = true;
-            Rect::new(Point2D::origin(), viewport_size)
-        },
+        BackgroundAttachment::Fixed => Rect::new(Point2D::origin(), viewport_size),
     };
 
     let mut tile_size = compute_background_image_size(bg_size, bounds.size, intrinsic_size);
@@ -223,7 +217,6 @@ pub fn placement(
         tile_spacing,
         clip_rect,
         clip_radii,
-        fixed,
     })
 }
 

--- a/components/net/decoder.rs
+++ b/components/net/decoder.rs
@@ -45,6 +45,7 @@ use libflate::non_blocking::gzip;
 use crate::connector::BUF_SIZE;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     Io(io::Error),
     Hyper(hyper::Error),

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -49,11 +49,11 @@ use crate::script_runtime::JSContext as SafeJSContext;
 #[derive(Clone, Copy)]
 pub struct NonCallbackInterfaceObjectClass {
     /// The SpiderMonkey class structure.
-    pub class: JSClass,
+    pub _class: JSClass,
     /// The prototype id of that interface, used in the hasInstance hook.
-    pub proto_id: PrototypeList::ID,
+    pub _proto_id: PrototypeList::ID,
     /// The prototype depth of that interface, used in the hasInstance hook.
-    pub proto_depth: u16,
+    pub _proto_depth: u16,
     /// The string representation of the object.
     pub representation: &'static [u8],
 }
@@ -69,7 +69,7 @@ impl NonCallbackInterfaceObjectClass {
         proto_depth: u16,
     ) -> NonCallbackInterfaceObjectClass {
         NonCallbackInterfaceObjectClass {
-            class: JSClass {
+            _class: JSClass {
                 name: c"Function".as_ptr(),
                 flags: 0,
                 cOps: &constructor_behavior.0,
@@ -77,8 +77,8 @@ impl NonCallbackInterfaceObjectClass {
                 ext: 0 as *const _,
                 oOps: &OBJECT_OPS,
             },
-            proto_id,
-            proto_depth,
+            _proto_id: proto_id,
+            _proto_depth: proto_depth,
             representation: string_rep,
         }
     }

--- a/components/script/dom/iirfilternode.rs
+++ b/components/script/dom/iirfilternode.rs
@@ -36,7 +36,7 @@ pub struct IIRFilterNode {
 impl IIRFilterNode {
     #[allow(crown::unrooted_must_root)]
     pub fn new_inherited(
-        window: &Window,
+        _window: &Window,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
     ) -> Fallible<IIRFilterNode> {

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -22,8 +22,8 @@ use crate::dom::document::Document;
 use crate::dom::eventtarget::EventTarget;
 
 pub enum MediaQueryListMatchState {
-    Same(bool),
-    Changed(bool),
+    Same,
+    Changed,
 }
 
 #[dom_struct]
@@ -59,12 +59,12 @@ impl MediaQueryList {
 
         let result = if let Some(old_matches) = self.last_match_state.get() {
             if old_matches == matches {
-                MediaQueryListMatchState::Same(matches)
+                MediaQueryListMatchState::Same
             } else {
-                MediaQueryListMatchState::Changed(matches)
+                MediaQueryListMatchState::Changed
             }
         } else {
-            MediaQueryListMatchState::Changed(matches)
+            MediaQueryListMatchState::Changed
         };
 
         self.last_match_state.set(Some(matches));

--- a/components/script/dom/webgl_validations/tex_image_2d.rs
+++ b/components/script/dom/webgl_validations/tex_image_2d.rs
@@ -59,8 +59,8 @@ impl fmt::Display for TexImageValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::TexImageValidationError::*;
         let description = match *self {
-            InvalidTextureTarget(_) => "Invalid texture target",
-            TextureTargetNotBound(_) => "Texture was not bound",
+            InvalidTextureTarget(texture_id) => &format!("Invalid texture target ({texture_id})"),
+            TextureTargetNotBound(texture_id) => &format!("Texture was not bound {texture_id}"),
             InvalidCubicTextureDimensions => {
                 "Invalid dimensions were given for a cubic texture target"
             },

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2460,7 +2460,7 @@ impl Window {
     pub fn evaluate_media_queries_and_report_changes(&self) {
         rooted_vec!(let mut mql_list);
         self.media_query_lists.for_each(|mql| {
-            if let MediaQueryListMatchState::Changed(_) = mql.evaluate_changes() {
+            if let MediaQueryListMatchState::Changed = mql.evaluate_changes() {
                 // Recording list of changed Media Queries
                 mql_list.push(Dom::from_ref(&*mql));
             }


### PR DESCRIPTION
This fixes various unused code warnings after the recent rust upgrade.
Some of the dead code is maintained, as it is quite likely that it will
be used in future changes.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
