### PR TITLE
Use `FontInstanceFlags::SUBPIXEL_POSITION` for font instances on Windows

### DIFF
--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -272,7 +272,7 @@ impl PlatformFontMethods for PlatformFont {
     }
 
     fn webrender_font_instance_flags(&self) -> FontInstanceFlags {
-        FontInstanceFlags::empty()
+        FontInstanceFlags::SUBPIXEL_POSITION
     }
 
     fn typographic_bounds(&self, glyph_id: GlyphId) -> Rect<f32> {


### PR DESCRIPTION
This fixes some text clipping issues on Windows. Without sub-pixel position flag the glyphs are slightly off position and depending on the font used the text can be clipped.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes partially address #32459.
- [x] These changes do not require tests because tests aren't run for Windows yet.

This is an example of text using Arial font that was clipped on the right side:
[text.webm](https://github.com/user-attachments/assets/64b3a0ef-5385-4987-ac3d-8d69aed27a7a)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
