### PR TITLE
Replace the lazy_static crate with std::sync::LazyLock in components/net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4489,7 +4489,6 @@ dependencies = [
  "hyper_serde",
  "imsz",
  "ipc-channel",
- "lazy_static",
  "libflate",
  "log",
  "malloc_size_of",

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -36,7 +36,6 @@ hyper-rustls = { workspace = true }
 hyper_serde = { workspace = true }
 imsz = { workspace = true }
 ipc-channel = { workspace = true }
-lazy_static = { workspace = true }
 libflate = "0.1"
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-use lazy_static::lazy_static;
 use tokio::runtime::Runtime;
 
-lazy_static! {
-    pub static ref HANDLE: Mutex<Option<Runtime>> = Mutex::new(Some(Runtime::new().unwrap()));
-}
+pub static HANDLE: LazyLock<Mutex<Option<Runtime>>> =
+    LazyLock::new(|| Mutex::new(Some(Runtime::new().unwrap())));

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{self, BufReader, Seek, SeekFrom};
 use std::ops::Bound;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::{mem, str};
 
 use base64::engine::general_purpose;
@@ -19,7 +19,6 @@ use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt, Range};
 use http::header::{self, HeaderMap, HeaderName};
 use http::{Method, StatusCode};
 use ipc_channel::ipc::{self, IpcReceiver};
-use lazy_static::lazy_static;
 use log::{debug, warn};
 use mime::{self, Mime};
 use net_traits::blob_url_store::{parse_blob_url, BlobURLStoreError};
@@ -53,10 +52,8 @@ use crate::http_loader::{
 use crate::local_directory_listing;
 use crate::subresource_integrity::is_response_integrity_valid;
 
-lazy_static! {
-    static ref X_CONTENT_TYPE_OPTIONS: HeaderName =
-        HeaderName::from_static("x-content-type-options");
-}
+static X_CONTENT_TYPE_OPTIONS: LazyLock<HeaderName> =
+    LazyLock::new(|| HeaderName::from_static("x-content-type-options"));
 
 pub type Target<'a> = &'a mut (dyn FetchTaskTarget + Send);
 

--- a/components/net/hosts.rs
+++ b/components/net/hosts.rs
@@ -8,13 +8,10 @@ use std::env;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::net::{IpAddr, Ipv4Addr};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref HOST_TABLE: Mutex<Option<HashMap<String, IpAddr>>> = Mutex::new(create_host_table());
-}
+static HOST_TABLE: LazyLock<Mutex<Option<HashMap<String, IpAddr>>>> =
+    LazyLock::new(|| Mutex::new(create_host_table()));
 
 fn create_host_table() -> Option<HashMap<String, IpAddr>> {
     let path = env::var_os("HOST_FILE")?;

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -23,7 +23,7 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::net::TcpListener as StdTcpListener;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, LazyLock, Mutex, Weak};
 
 use crossbeam_channel::{unbounded, Sender};
 use devtools_traits::DevtoolsControlMsg;
@@ -34,7 +34,6 @@ use hyper::server::conn::Http;
 use hyper::server::Server as HyperServer;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse};
-use lazy_static::lazy_static;
 use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{self, CancellationListener, FetchContext};
 use net::filemanager_thread::FileManager;
@@ -54,15 +53,15 @@ use tokio_rustls::{self, TlsAcceptor};
 use tokio_stream::wrappers::TcpListenerStream;
 use tokio_test::block_on;
 
-lazy_static! {
-    pub static ref HANDLE: Mutex<Runtime> = Mutex::new(
+pub static HANDLE: LazyLock<Mutex<Runtime>> = LazyLock::new(|| {
+    Mutex::new(
         Builder::new_multi_thread()
             .enable_io()
             .worker_threads(10)
             .build()
-            .unwrap()
-    );
-}
+            .unwrap(),
+    )
+});
 
 const DEFAULT_USER_AGENT: &'static str = "Such Browser. Very Layout. Wow.";
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace the `lazy_static` crate with `std::sync::LazyLock` in components/net

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because `lazy_static` and `LazyLock` behave in the same way.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
