### PR TITLE
Dont use lazy static to construct mutexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,7 +6187,6 @@ dependencies = [
  "ipc-channel",
  "jni",
  "keyboard-types",
- "lazy_static",
  "libc",
  "libloading",
  "libservo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,6 @@ dependencies = [
  "base",
  "crossbeam-channel",
  "ipc-channel",
- "lazy_static",
  "libc",
  "log",
  "mach2",

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -22,9 +22,6 @@ libc = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
 
-[dev-dependencies]
-lazy_static = { workspace = true }
-
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = "0.4"
 

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -17,9 +17,7 @@ use background_hang_monitor_api::{
 use base::id::TEST_PIPELINE_ID;
 use ipc_channel::ipc;
 
-lazy_static::lazy_static! {
-    static ref SERIAL: Mutex<()> = Mutex::new(());
-}
+static SERIAL: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_hang_monitoring() {

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -56,7 +56,6 @@ libc = { workspace = true }
 libservo = { path = "../../components/servo" }
 cfg-if = { workspace = true }
 log = { workspace = true }
-lazy_static = { workspace = true }
 getopts = { workspace = true }
 url = { workspace = true }
 servo-media = { workspace = true }

--- a/ports/servoshell/resources.rs
+++ b/ports/servoshell/resources.rs
@@ -9,9 +9,7 @@ use std::{env, fs};
 use cfg_if::cfg_if;
 use servo::embedder_traits::resources::{self, Resource};
 
-lazy_static::lazy_static! {
-    static ref CMD_RESOURCE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
-}
+static CMD_RESOURCE_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 struct ResourceReader;
 


### PR DESCRIPTION
There are a few snippets of around the codebase that like this:

```rust
lazy_static::lazy_static! {
    static ref SERIAL: Mutex<()> = Mutex::new(());
}
```
Because `Mutex::new` is const (since rust `1.63.0`) we can instead initialize the Mutex at compile time like this:
```rust
static SERIAL: Mutex<()> = Mutex::new(());
```
This removes the dependency of `servoshell` and `background-hang-monitor` on `lazy-static`. There are (probably) more, but after these changes I noticed that @Hmikihiro is also working on removing `lazy-static` and I don't want to duplicate their work. 


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because *they are trivial, atomic replacements of code patterns*
