### PR TITLE
Replace lazy_static with std::sync::LazyLock in components/fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,7 +1878,6 @@ dependencies = [
  "freetype-sys",
  "harfbuzz-sys",
  "ipc-channel",
- "lazy_static",
  "libc",
  "log",
  "malloc_size_of",

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -25,7 +25,6 @@ fontsan = { git = "https://github.com/servo/fontsan" }
 fonts_traits = { workspace = true }
 harfbuzz-sys = "0.6.1"
 ipc-channel = { workspace = true }
-lazy_static = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -5,6 +5,7 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use base::text::{is_cjk, UnicodeBlock, UnicodeBlockMethod};
 use log::warn;
@@ -21,9 +22,7 @@ use crate::{
     FallbackFontSelectionOptions, FontTemplate, FontTemplateDescriptor, LowercaseFontFamilyName,
 };
 
-lazy_static::lazy_static! {
-    static ref FONT_LIST: FontList = FontList::new();
-}
+static FONT_LIST: LazyLock<FontList> = LazyLock::new(|| FontList::new());
 
 /// An identifier for a local font on Android systems.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use std::{fs, io};
 
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
@@ -25,9 +26,7 @@ use crate::{
     FontTemplateDescriptor, LowercaseFontFamilyName,
 };
 
-lazy_static::lazy_static! {
-    static ref FONT_LIST: FontList = FontList::new();
-}
+static FONT_LIST: LazyLock<FontList> = LazyLock::new(|| FontList::new());
 
 /// When testing the ohos font code on linux, we can pass the fonts directory of the SDK
 /// via an environment variable.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace the `lazy_static` crate with `std::sync::LazyLock` in components/fonts

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because `lazy_static` and `LazyLock` behave in the same way.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
