### PR TITLE
Remove unused constant from `components/net/fetch/methods.rs`

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{self, BufReader, Seek, SeekFrom};
 use std::ops::Bound;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 use std::{mem, str};
 
 use base64::engine::general_purpose;
@@ -51,9 +51,6 @@ use crate::http_loader::{
 };
 use crate::local_directory_listing;
 use crate::subresource_integrity::is_response_integrity_valid;
-
-static X_CONTENT_TYPE_OPTIONS: LazyLock<HeaderName> =
-    LazyLock::new(|| HeaderName::from_static("x-content-type-options"));
 
 pub type Target<'a> = &'a mut (dyn FetchTaskTarget + Send);
 


### PR DESCRIPTION
This was revealed by the recent switch to `LazyLock`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this should not change any behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
