### PR TITLE
Ensure parsers initiated from DOMParser always complete.

### DIFF
--- a/tests/wpt/meta/xhr/responsexml-non-well-formed.htm.ini
+++ b/tests/wpt/meta/xhr/responsexml-non-well-formed.htm.ini
@@ -1,4 +1,7 @@
 [responsexml-non-well-formed.htm]
+  [XMLHttpRequest: responseXML non well-formed tests]
+    expected: FAIL
+
   [XMLHttpRequest: responseXML non well-formed tests 1]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12625,6 +12625,13 @@
       }
      ]
     ],
+    "DOMParser-parseFromString.html": [
+     "38715db5d923e4f153e2c4a2679f644fe1e6d14d",
+     [
+      null,
+      {}
+     ]
+    ],
     "DOMParser.html": [
      "f386a3e0191af2c70dcb05790ce7db15dd5ccbf1",
      [

--- a/tests/wpt/mozilla/meta/mozilla/DOMParser-parseFromString.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/DOMParser-parseFromString.html.ini
@@ -1,0 +1,2 @@
+[DOMParser-parseFromString.html]
+  prefs: ["dom.servoparser.async_html_tokenizer.enabled:true"]

--- a/tests/wpt/mozilla/tests/mozilla/DOMParser-parseFromString.html
+++ b/tests/wpt/mozilla/tests/mozilla/DOMParser-parseFromString.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<head>
+<title>Verify that parseFromString does not panic</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe src="missing"></iframe>
+<script>
+  test(() => {
+    {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString("", "text/html");
+      assert_equals(doc.URL, document.URL);
+    }
+  });
+</script>


### PR DESCRIPTION
This fixes a panic exposed by https://github.com/servo/servo/pull/32820#discussion_r1713451553. We used to run automated tests with the async tokenizer in the pre-Github CI setup, but that was never ported over. This PR adds one new test for this particular case that runs with the async parser.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33055
- [x] There are tests for these changes