### PR TITLE
Update WebXR WPT expectations

### DIFF
--- a/tests/wpt/meta/webxr/__dir__.ini
+++ b/tests/wpt/meta/webxr/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom.webxr.test: true]

--- a/tests/wpt/meta/webxr/ar-module/xrDevice_isSessionSupported_immersive-ar.https.html.ini
+++ b/tests/wpt/meta/webxr/ar-module/xrDevice_isSessionSupported_immersive-ar.https.html.ini
@@ -1,6 +1,0 @@
-[xrDevice_isSessionSupported_immersive-ar.https.html]
-  [isSessionSupported resolves to true for immersive-ar on a supported device]
-    expected: FAIL
-
-  [isSessionSupported resolves to false for immersive-ar on an unsupported device]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/ar-module/xrDevice_requestSession_immersive-ar.https.html.ini
+++ b/tests/wpt/meta/webxr/ar-module/xrDevice_requestSession_immersive-ar.https.html.ini
@@ -4,9 +4,3 @@
 
   [Tests requestSession accepts immersive-ar mode - webgl2]
     expected: FAIL
-
-  [Tests requestSession accepts immersive-ar mode - webgl]
-    expected: FAIL
-
-  [Tests requestSession rejects immersive-ar mode when unsupported]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/ar-module/xrSession_environmentBlendMode.https.html.ini
+++ b/tests/wpt/meta/webxr/ar-module/xrSession_environmentBlendMode.https.html.ini
@@ -13,6 +13,3 @@
 
   [Tests environmentBlendMode for a VR device - webgl2]
     expected: FAIL
-
-  [Tests environmentBlendMode for a VR device - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/ar-module/xrSession_interactionMode.https.html.ini
+++ b/tests/wpt/meta/webxr/ar-module/xrSession_interactionMode.https.html.ini
@@ -14,12 +14,6 @@
   [Tests interactionMode for an VR_HMD_DEVICE]
     expected: FAIL
 
-  [Tests interactionMode for an AR_HMD_DEVICE - webgl]
-    expected: FAIL
-
-  [Tests interactionMode for an VR_HMD_DEVICE - webgl]
-    expected: FAIL
-
   [Tests interactionMode for a INLINE_SCREEN_DEVICE - webgl]
     expected: FAIL
 
@@ -43,4 +37,3 @@
 
   [Tests interactionMode for an VR_HMD_DEVICE - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/dom-overlay/ar_dom_overlay.https.html.ini
+++ b/tests/wpt/meta/webxr/dom-overlay/ar_dom_overlay.https.html.ini
@@ -1,4 +1,5 @@
 [ar_dom_overlay.https.html]
+  expected: ERROR
   [Ensures DOM Overlay input deduplication works]
     expected: FAIL
 
@@ -17,3 +18,32 @@
   [Ensures DOM Overlay interactions on cross origin iframe are ignored]
     expected: FAIL
 
+  [Ensures DOM Overlay feature works for immersive-ar, body element - webgl]
+    expected: FAIL
+
+  [Ensures DOM Overlay feature works for immersive-ar, body element - webgl2]
+    expected: FAIL
+
+  [Ensures DOM Overlay feature works for immersive-ar, div element - webgl]
+    expected: FAIL
+
+  [Ensures DOM Overlay feature works for immersive-ar, div element - webgl2]
+    expected: FAIL
+
+  [Ensures DOM Overlay input deduplication works - webgl]
+    expected: TIMEOUT
+
+  [Ensures DOM Overlay input deduplication works - webgl2]
+    expected: NOTRUN
+
+  [Ensures DOM Overlay Fullscreen API doesn't change DOM overlay - webgl]
+    expected: NOTRUN
+
+  [Ensures DOM Overlay Fullscreen API doesn't change DOM overlay - webgl2]
+    expected: NOTRUN
+
+  [Ensures DOM Overlay interactions on cross origin iframe are ignored - webgl]
+    expected: NOTRUN
+
+  [Ensures DOM Overlay interactions on cross origin iframe are ignored - webgl2]
+    expected: NOTRUN

--- a/tests/wpt/meta/webxr/dom-overlay/ar_dom_overlay_hit_test.https.html.ini
+++ b/tests/wpt/meta/webxr/dom-overlay/ar_dom_overlay_hit_test.https.html.ini
@@ -1,0 +1,6 @@
+[ar_dom_overlay_hit_test.https.html]
+  [Ensures DOM Overlay interactions on cross origin iframe do not cause hit test results to come up - webgl]
+    expected: FAIL
+
+  [Ensures DOM Overlay interactions on cross origin iframe do not cause hit test results to come up - webgl2]
+    expected: FAIL

--- a/tests/wpt/meta/webxr/dom-overlay/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/dom-overlay/idlharness.https.window.js.ini
@@ -1,0 +1,27 @@
+[idlharness.https.window.html]
+  [XRSession interface: attribute domOverlayState]
+    expected: FAIL
+
+  [HTMLElement interface: attribute onbeforexrselect]
+    expected: FAIL
+
+  [HTMLElement interface: document.body must inherit property "onbeforexrselect" with the proper type]
+    expected: FAIL
+
+  [Window interface: attribute onbeforexrselect]
+    expected: FAIL
+
+  [Window interface: window must inherit property "onbeforexrselect" with the proper type]
+    expected: FAIL
+
+  [Document interface: attribute onbeforexrselect]
+    expected: FAIL
+
+  [Document interface: document must inherit property "onbeforexrselect" with the proper type]
+    expected: FAIL
+
+  [SVGElement interface: attribute onbeforexrselect]
+    expected: FAIL
+
+  [SVGElement interface: svgElement must inherit property "onbeforexrselect" with the proper type]
+    expected: FAIL

--- a/tests/wpt/meta/webxr/events_session_select.https.html.ini
+++ b/tests/wpt/meta/webxr/events_session_select.https.html.ini
@@ -1,4 +1,5 @@
 [events_session_select.https.html]
+  expected: TIMEOUT
   [XRInputSources primary input presses properly fires off the right events]
     expected: FAIL
 
@@ -7,4 +8,3 @@
 
   [XRInputSources primary input presses properly fires off the right events - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/events_session_select.https.html.ini
+++ b/tests/wpt/meta/webxr/events_session_select.https.html.ini
@@ -1,5 +1,4 @@
 [events_session_select.https.html]
-  expected: TIMEOUT
   [XRInputSources primary input presses properly fires off the right events]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/getViewerPose_emulatedPosition.https.html.ini
+++ b/tests/wpt/meta/webxr/getViewerPose_emulatedPosition.https.html.ini
@@ -1,5 +1,4 @@
 [getViewerPose_emulatedPosition.https.html]
-  expected: TIMEOUT
   [XRFrame getViewerPose has emulatedPosition set properly. - webgl2]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/getViewerPose_emulatedPosition.https.html.ini
+++ b/tests/wpt/meta/webxr/getViewerPose_emulatedPosition.https.html.ini
@@ -1,7 +1,7 @@
 [getViewerPose_emulatedPosition.https.html]
+  expected: TIMEOUT
   [XRFrame getViewerPose has emulatedPosition set properly. - webgl2]
     expected: FAIL
 
   [XRFrame getViewerPose has emulatedPosition set properly. - webgl]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -5,8 +5,6 @@
   [XRSession interface: calling requestReferenceSpace(XRReferenceSpaceType) on xrSession with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRSystem interface: operation isSessionSupported(XRSessionMode)]
-
   [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's @@unscopables property]
     expected: FAIL
 
@@ -72,8 +70,6 @@
 
   [WebGLRenderingContext includes WebGLRenderingContextOverloads: member names are unique]
     expected: FAIL
-
-  [XRSystem interface: operation requestSession(XRSessionMode, optional XRSessionInit)]
 
   [XRReferenceSpaceEvent interface object name]
     expected: FAIL
@@ -210,8 +206,6 @@
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "framebufferHeight" with the proper type]
     expected: FAIL
 
-  [XRSession interface: operation requestReferenceSpace(XRReferenceSpaceType)]
-
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "framebufferWidth" with the proper type]
     expected: FAIL
 
@@ -259,8 +253,6 @@
 
   [Stringification of xrInputSourceArray]
     expected: FAIL
-
-  [XRSession interface: operation end()]
 
   [XRSession interface: xrSession must inherit property "cancelAnimationFrame(unsigned long)" with the proper type]
     expected: FAIL
@@ -316,8 +308,6 @@
   [XRFrame interface: attribute predictedDisplayTime]
     expected: FAIL
 
-  [WebGLRenderingContext interface: operation makeXRCompatible()]
-
   [XRSession interface: attribute enabledFeatures]
     expected: FAIL
 
@@ -328,33 +318,6 @@
     expected: FAIL
 
   [XRSession interface: xrSession must inherit property "isSystemKeyboardSupported" with the proper type]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: existence and properties of interface object]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface object length]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface object name]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: attribute session]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: attribute added]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: attribute removed]
     expected: FAIL
 
   [XRInputSource interface: attribute skipRendering]

--- a/tests/wpt/meta/webxr/webxr_permissions_policy.https.html.ini
+++ b/tests/wpt/meta/webxr/webxr_permissions_policy.https.html.ini
@@ -7,4 +7,4 @@
     expected: FAIL
 
   [Validate xr compatibility requests without xr-spatial-tracking policy]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/webxr/xrDevice_disconnect_ends.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_disconnect_ends.https.html.ini
@@ -1,4 +1,5 @@
 [xrDevice_disconnect_ends.https.html]
+  expected: TIMEOUT
   [Immersive session ends when device is disconnected]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/xrDevice_disconnect_ends.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_disconnect_ends.https.html.ini
@@ -1,10 +1,10 @@
 [xrDevice_disconnect_ends.https.html]
   expected: TIMEOUT
   [Immersive session ends when device is disconnected]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Immersive session ends when device is disconnected - webgl2]
-    expected: FAIL
+    expected: NOTRUN
 
   [Immersive session ends when device is disconnected - webgl]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/webxr/xrDevice_isSessionSupported_immersive.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_isSessionSupported_immersive.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_isSessionSupported_immersive.https.html]
-  [isSessionSupported resolves to true when immersive options supported]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_isSessionSupported_immersive_unsupported.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_isSessionSupported_immersive_unsupported.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_isSessionSupported_immersive_unsupported.https.html]
-  [isSessionSupported resolves to false when options not supported]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_isSessionSupported_inline.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_isSessionSupported_inline.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_isSessionSupported_inline.https.html]
-  [isSessionSupported resolves to true when inline options supported]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_immersive.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_immersive.https.html.ini
@@ -1,4 +1,5 @@
 [xrDevice_requestSession_immersive.https.html]
+  expected: TIMEOUT
   [Tests requestSession ignores unknown optionalFeatures]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_immersive.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_immersive.https.html.ini
@@ -1,12 +1,8 @@
 [xrDevice_requestSession_immersive.https.html]
-  expected: TIMEOUT
   [Tests requestSession ignores unknown optionalFeatures]
     expected: FAIL
 
   [Tests requestSession accepts XRSessionInit dictionary]
-    expected: FAIL
-
-  [Tests requestSession resolves when supported]
     expected: FAIL
 
   [Tests requestSession accepts XRSessionInit dictionary - webgl2]
@@ -16,13 +12,4 @@
     expected: FAIL
 
   [Tests requestSession ignores unknown optionalFeatures - webgl2]
-    expected: FAIL
-
-  [Tests requestSession resolves when supported - webgl]
-    expected: FAIL
-
-  [Tests requestSession accepts XRSessionInit dictionary - webgl]
-    expected: FAIL
-
-  [Tests requestSession ignores unknown optionalFeatures - webgl]
     expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_immersive_no_gesture.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_immersive_no_gesture.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_requestSession_immersive_no_gesture.https.html]
-  [Requesting immersive session outside of a user gesture rejects]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_immersive_unsupported.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_immersive_unsupported.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_requestSession_immersive_unsupported.https.html]
-  [Requesting an immersive session when unsupported rejects]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_no_mode.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_no_mode.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_requestSession_no_mode.https.html]
-  [Requesting a session with no mode rejects]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_non_immersive_no_gesture.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_non_immersive_no_gesture.https.html.ini
@@ -1,3 +1,0 @@
-[xrDevice_requestSession_non_immersive_no_gesture.https.html]
-  [Requesting non-immersive session outside of a user gesture succeeds]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrDevice_requestSession_optionalFeatures.https.html.ini
+++ b/tests/wpt/meta/webxr/xrDevice_requestSession_optionalFeatures.https.html.ini
@@ -22,15 +22,3 @@
 
   [Tests requestSession ignores unknown objects in optionalFeatures - webgl2]
     expected: FAIL
-
-  [Tests requestSession accepts XRSessionInit dictionary - webgl]
-    expected: FAIL
-
-  [Tests requestSession accepts XRSessionInit dictionary with empty feature lists - webgl]
-    expected: FAIL
-
-  [Tests requestSession ignores unknown strings in optionalFeatures - webgl]
-    expected: FAIL
-
-  [Tests requestSession ignores unknown objects in optionalFeatures - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrFrame_getPose.https.html.ini
+++ b/tests/wpt/meta/webxr/xrFrame_getPose.https.html.ini
@@ -1,4 +1,5 @@
 [xrFrame_getPose.https.html]
+  expected: TIMEOUT
   [XRFrame.getPose works for immersive sessions]
     expected: FAIL
 
@@ -16,4 +17,3 @@
 
   [XRFrame.getPose works for non-immersive sessions - webgl]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/xrFrame_getPose.https.html.ini
+++ b/tests/wpt/meta/webxr/xrFrame_getPose.https.html.ini
@@ -1,5 +1,4 @@
 [xrFrame_getPose.https.html]
-  expected: TIMEOUT
   [XRFrame.getPose works for immersive sessions]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/xrFrame_getViewerPose_getPose.https.html.ini
+++ b/tests/wpt/meta/webxr/xrFrame_getViewerPose_getPose.https.html.ini
@@ -4,6 +4,3 @@
 
   [XRFrame getViewerPose(refSpace) matches getPose(viewer, refSpace). - webgl2]
     expected: FAIL
-
-  [XRFrame getViewerPose(refSpace) matches getPose(viewer, refSpace). - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrFrame_lifetime.https.html.ini
+++ b/tests/wpt/meta/webxr/xrFrame_lifetime.https.html.ini
@@ -10,9 +10,3 @@
 
   [XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions - webgl2]
     expected: FAIL
-
-  [XRFrame methods throw exceptions outside of the requestAnimationFrame callback for immersive sessions - webgl]
-    expected: FAIL
-
-  [XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrInputSource_emulatedPosition.https.html.ini
+++ b/tests/wpt/meta/webxr/xrInputSource_emulatedPosition.https.html.ini
@@ -1,7 +1,7 @@
 [xrInputSource_emulatedPosition.https.html]
+  expected: TIMEOUT
   [Poses from XRInputSource.gripSpace have emulatedPosition set properly - webgl]
     expected: FAIL
 
   [Poses from XRInputSource.gripSpace have emulatedPosition set properly - webgl2]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/xrInputSource_emulatedPosition.https.html.ini
+++ b/tests/wpt/meta/webxr/xrInputSource_emulatedPosition.https.html.ini
@@ -1,5 +1,4 @@
 [xrInputSource_emulatedPosition.https.html]
-  expected: TIMEOUT
   [Poses from XRInputSource.gripSpace have emulatedPosition set properly - webgl]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/xrSession_cancelAnimationFrame.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_cancelAnimationFrame.https.html.ini
@@ -10,9 +10,3 @@
 
   [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for immersive sessions - webgl2]
     expected: FAIL
-
-  [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for immersive sessions - webgl]
-    expected: FAIL
-
-  [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for non-immersive sessions - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_cancelAnimationFrame_invalidhandle.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_cancelAnimationFrame_invalidhandle.https.html.ini
@@ -1,4 +1,5 @@
 [xrSession_cancelAnimationFrame_invalidhandle.https.html]
+  expected: TIMEOUT
   [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession]
     expected: FAIL
 
@@ -6,13 +7,13 @@
     expected: FAIL
 
   [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on non-immersive testSession - webgl2]
-    expected: FAIL
+    expected: NOTRUN
 
   [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on non-immersive testSession - webgl]
-    expected: FAIL
+    expected: NOTRUN
 
   [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession - webgl2]
-    expected: FAIL
+    expected: NOTRUN
 
   [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession - webgl]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/webxr/xrSession_end.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_end.https.html.ini
@@ -10,9 +10,3 @@
 
   [end event fires when immersive session ends - webgl2]
     expected: FAIL
-
-  [end event fires when immersive session ends - webgl]
-    expected: FAIL
-
-  [end event fires when non-immersive session ends - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_features_deviceSupport.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_features_deviceSupport.https.html.ini
@@ -1,3 +1,0 @@
-[xrSession_features_deviceSupport.https.html]
-  [Immersive XRSession requests with no supported device should reject]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_prevent_multiple_exclusive.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_prevent_multiple_exclusive.https.html.ini
@@ -1,3 +1,0 @@
-[xrSession_prevent_multiple_exclusive.https.html]
-  [Test prevention of multiple simultaneous immersive sessions]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_requestAnimationFrame_callback_calls.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_requestAnimationFrame_callback_calls.https.html.ini
@@ -10,9 +10,3 @@
 
   [XRSession requestAnimationFrame calls the provided callback a non-immersive session - webgl2]
     expected: FAIL
-
-  [XRSession requestAnimationFrame calls the provided callback for an immersive session - webgl]
-    expected: FAIL
-
-  [XRSession requestAnimationFrame calls the provided callback a non-immersive session - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_requestAnimationFrame_data_valid.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_requestAnimationFrame_data_valid.https.html.ini
@@ -4,6 +4,3 @@
 
   [RequestAnimationFrame resolves with good data - webgl2]
     expected: FAIL
-
-  [RequestAnimationFrame resolves with good data - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_requestAnimationFrame_getViewerPose.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_requestAnimationFrame_getViewerPose.https.html.ini
@@ -10,9 +10,3 @@
 
   [XRFrame getViewerPose updates on the next frame for immersive sessions - webgl2]
     expected: FAIL
-
-  [XRFrame getViewerPose updates on the next frame for non-immersive sessions - webgl]
-    expected: FAIL
-
-  [XRFrame getViewerPose updates on the next frame for immersive sessions - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_requestReferenceSpace.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_requestReferenceSpace.https.html.ini
@@ -2,12 +2,5 @@
   [Immersive XRSession requestReferenceSpace returns expected objects - webgl2]
     expected: FAIL
 
-  [Immersive XRSession requestReferenceSpace returns expected objects - webgl]
-    expected: FAIL
-
   [Non-immersive XRSession requestReferenceSpace returns expected objects - webgl2]
     expected: FAIL
-
-  [Non-immersive XRSession requestReferenceSpace returns expected objects - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta/webxr/xrSession_requestReferenceSpace_features.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_requestReferenceSpace_features.https.html.ini
@@ -70,39 +70,3 @@
 
   [Non-immersive session supports local space when required - webgl2]
     expected: FAIL
-
-  [Non-immersive session supports viewer space by default - webgl]
-    expected: FAIL
-
-  [Immersive session supports viewer space by default - webgl]
-    expected: FAIL
-
-  [Immersive session supports local space by default - webgl]
-    expected: FAIL
-
-  [Non-immersive session supports local space when required - webgl]
-    expected: FAIL
-
-  [Non-immersive session supports local space when optional - webgl]
-    expected: FAIL
-
-  [Non-immersive session supports local-floor space when required - webgl]
-    expected: FAIL
-
-  [Immersive session supports local-floor space when required - webgl]
-    expected: FAIL
-
-  [Immersive session supports local-floor space when optional - webgl]
-    expected: FAIL
-
-  [Non-immersive session rejects bounded-floor space even when requested - webgl]
-    expected: FAIL
-
-  [Non-immersive session rejects unbounded space even when requested - webgl]
-    expected: FAIL
-
-  [Non-immersive session rejects local space if not requested - webgl]
-    expected: FAIL
-
-  [Immersive session rejects local-floor space if not requested - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrSession_requestSessionDuringEnd.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_requestSessionDuringEnd.https.html.ini
@@ -8,12 +8,8 @@
   [Create mew session in end promise - webgl2]
     expected: FAIL
 
-  [Create mew session in end promise - webgl]
-    expected: FAIL
-
   [Create new session in OnSessionEnded event - webgl2]
     expected: FAIL
 
   [Create new session in OnSessionEnded event - webgl]
     expected: FAIL
-

--- a/tests/wpt/meta/webxr/xrSession_viewer_referenceSpace.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_viewer_referenceSpace.https.html.ini
@@ -10,9 +10,3 @@
 
   [Identity reference space provides correct poses for immersive sessions - webgl2]
     expected: FAIL
-
-  [Identity reference space provides correct poses for inline sessions - webgl]
-    expected: FAIL
-
-  [Identity reference space provides correct poses for immersive sessions - webgl]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrViewerPose_secondaryViews.https.html.ini
+++ b/tests/wpt/meta/webxr/xrViewerPose_secondaryViews.https.html.ini
@@ -1,17 +1,8 @@
 [xrViewerPose_secondaryViews.https.html]
-  [Only primary views are returned if secondary views are not requested for non-immersive - webgl]
-    expected: FAIL
-
   [Only primary views are returned if secondary views are not requested for non-immersive - webgl2]
     expected: FAIL
 
-  [Only primary views are returned if secondary views are not requested for immersive - webgl]
-    expected: FAIL
-
   [Only primary views are returned if secondary views are not requested for immersive - webgl2]
-    expected: FAIL
-
-  [Requesting secondary views only returns primary views for non-immersive - webgl]
     expected: FAIL
 
   [Requesting secondary views only returns primary views for non-immersive - webgl2]


### PR DESCRIPTION
The layout 2020 tests were not running with the `dom.webxr.test` pref set, meaning many tests were failing that should have been passing.