### PR TITLE
webxr: Update XRSession to latest spec

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -117,7 +117,7 @@ DOMInterfaces = {
 },
 
 'XRSession': {
-    'inRealms': ['UpdateRenderState', 'RequestReferenceSpace'],
+    'inRealms': ['UpdateRenderState', 'RequestReferenceSpace', 'UpdateTargetFrameRate'],
 },
 
 'Bluetooth': {

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -27,11 +27,16 @@ callback XRFrameRequestCallback = undefined (DOMHighResTimeStamp time, XRFrame f
 interface XRSession : EventTarget {
   // Attributes
   readonly attribute XRVisibilityState visibilityState;
+  readonly attribute float? frameRate;
+  readonly attribute Float32Array? supportedFrameRates;
   [SameObject] readonly attribute XRRenderState renderState;
   [SameObject] readonly attribute XRInputSourceArray inputSources;
+  readonly attribute /*FrozenArray<DOMString>*/ any enabledFeatures;
+  readonly attribute boolean isSystemKeyboardSupported;
 
   // Methods
   [Throws] undefined updateRenderState(optional XRRenderStateInit state = {});
+  Promise<undefined> updateTargetFrameRate(float rate);
   Promise<XRReferenceSpace> requestReferenceSpace(XRReferenceSpaceType type);
 
   long requestAnimationFrame(XRFrameRequestCallback callback);
@@ -49,6 +54,7 @@ interface XRSession : EventTarget {
   attribute EventHandler onsqueezestart;
   attribute EventHandler onsqueezeend;
   attribute EventHandler onvisibilitychange;
+  attribute EventHandler onframeratechange;
 
   // AR Module
   // Attributes

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -12,6 +12,8 @@ use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Transform3D, Vector3D};
 use ipc_channel::ipc::IpcReceiver;
 use ipc_channel::router::ROUTER;
+use js::jsval::JSVal;
+use js::typedarray::Float32Array;
 use metrics::ToMs;
 use profile_traits::ipc;
 use webxr_api::{
@@ -39,9 +41,11 @@ use crate::dom::bindings::codegen::Bindings::XRSessionBinding::{
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionMode;
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot, MutDom, MutNullableDom};
+use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -56,6 +60,7 @@ use crate::dom::xrrenderstate::XRRenderState;
 use crate::dom::xrsessionevent::XRSessionEvent;
 use crate::dom::xrspace::XRSpace;
 use crate::realms::InRealm;
+use crate::script_runtime::JSContext;
 use crate::task_source::TaskSource;
 
 #[dom_struct]
@@ -581,6 +586,8 @@ impl XRSessionMethods for XRSession {
         SetOninputsourceschange
     );
 
+    event_handler!(frameratechange, GetOnframeratechange, SetOnframeratechange);
+
     // https://immersive-web.github.io/webxr/#dom-xrsession-renderstate
     fn RenderState(&self) -> DomRoot<XRRenderState> {
         self.active_render_state.get()
@@ -880,6 +887,30 @@ impl XRSessionMethods for XRSession {
         // Until Servo supports WebXR sessions on mobile phones or similar non-XR devices,
         // this should always be world space
         XRInteractionMode::World_space
+    }
+    
+    fn GetFrameRate(&self) -> Option<Finite<f32>> {
+        todo!()
+    }
+    
+    fn GetSupportedFrameRates(&self, cx: JSContext) -> Option<Float32Array> {
+        todo!()
+    }
+    
+    fn EnabledFeatures(&self, cx: JSContext) -> JSVal {
+        let session = self.session.borrow();
+        let features = session.granted_features();
+        to_frozen_array(features, cx)
+    }
+    
+    fn IsSystemKeyboardSupported(&self) -> bool {
+        // Support for this only exists on Meta headsets (no desktop support)
+        // so this will always be false until that changes
+        false
+    }
+    
+    fn UpdateTargetFrameRate(&self, rate: Finite<f32>) -> Rc<Promise> {
+        todo!()
     }
 }
 

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -612,6 +612,7 @@ impl XRSessionMethods for XRSession {
         SetOninputsourceschange
     );
 
+    // https://www.w3.org/TR/webxr/#dom-xrsession-onframeratechange
     event_handler!(frameratechange, GetOnframeratechange, SetOnframeratechange);
 
     // https://immersive-web.github.io/webxr/#dom-xrsession-renderstate

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -5,9 +5,8 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::f64::consts::{FRAC_PI_2, PI};
-use std::mem;
-use std::ptr;
 use std::rc::Rc;
+use std::{mem, ptr};
 
 use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Transform3D, Vector3D};
@@ -934,8 +933,10 @@ impl XRSessionMethods for XRSession {
         } else {
             let framerates = session.supported_frame_rates();
             rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
-            Some(create_buffer_source(cx, framerates, array.handle_mut())
-                .expect("Failed to construct supported frame rates array"))
+            Some(
+                create_buffer_source(cx, framerates, array.handle_mut())
+                    .expect("Failed to construct supported frame rates array"),
+            )
         }
     }
 
@@ -959,7 +960,10 @@ impl XRSessionMethods for XRSession {
         let supported_frame_rates = session.supported_frame_rates();
         let promise = Promise::new_in_current_realm(comp);
 
-        if self.mode == XRSessionMode::Inline || supported_frame_rates.is_empty() || self.ended.get() {
+        if self.mode == XRSessionMode::Inline ||
+            supported_frame_rates.is_empty() ||
+            self.ended.get()
+        {
             promise.reject_error(Error::InvalidState);
             return promise;
         }

--- a/tests/wpt/meta-legacy-layout/webxr/depth-sensing/depth_sensing_preferences.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/depth-sensing/depth_sensing_preferences.https.html.ini
@@ -1,16 +1,4 @@
 [depth_sensing_preferences.https.html]
-  [depthSensing - Required - Fully populated grants session]
-    expected: FAIL
-
-  [depthSensing - Required - Empty usage grants session]
-    expected: FAIL
-
-  [depthSensing - Required - Empty format grants session]
-    expected: FAIL
-
-  [depthSensing - Required - Empty usage and format grants session]
-    expected: FAIL
-
   [depthSensing - Required - Missing usage rejects session]
     expected: FAIL
 

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -335,18 +335,6 @@
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "fixedFoveation" with the proper type]
     expected: FAIL
 
-  [XRSession interface: attribute frameRate]
-    expected: FAIL
-
-  [XRSession interface: attribute supportedFrameRates]
-    expected: FAIL
-
-  [XRSession interface: operation updateTargetFrameRate(float)]
-    expected: FAIL
-
-  [XRSession interface: attribute onframeratechange]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "frameRate" with the proper type]
     expected: FAIL
 
@@ -365,13 +353,7 @@
   [XRFrame interface: attribute predictedDisplayTime]
     expected: FAIL
 
-  [XRSession interface: attribute enabledFeatures]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "enabledFeatures" with the proper type]
-    expected: FAIL
-
-  [XRSession interface: attribute isSystemKeyboardSupported]
     expected: FAIL
 
   [XRSession interface: xrSession must inherit property "isSystemKeyboardSupported" with the proper type]

--- a/tests/wpt/meta/webxr/depth-sensing/depth_sensing_preferences.https.html.ini
+++ b/tests/wpt/meta/webxr/depth-sensing/depth_sensing_preferences.https.html.ini
@@ -1,16 +1,4 @@
 [depth_sensing_preferences.https.html]
-  [depthSensing - Required - Fully populated grants session]
-    expected: FAIL
-
-  [depthSensing - Required - Empty usage grants session]
-    expected: FAIL
-
-  [depthSensing - Required - Empty format grants session]
-    expected: FAIL
-
-  [depthSensing - Required - Empty usage and format grants session]
-    expected: FAIL
-
   [depthSensing - Required - Missing usage rejects session]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -278,18 +278,6 @@
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "fixedFoveation" with the proper type]
     expected: FAIL
 
-  [XRSession interface: attribute frameRate]
-    expected: FAIL
-
-  [XRSession interface: attribute supportedFrameRates]
-    expected: FAIL
-
-  [XRSession interface: operation updateTargetFrameRate(float)]
-    expected: FAIL
-
-  [XRSession interface: attribute onframeratechange]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "frameRate" with the proper type]
     expected: FAIL
 
@@ -308,13 +296,7 @@
   [XRFrame interface: attribute predictedDisplayTime]
     expected: FAIL
 
-  [XRSession interface: attribute enabledFeatures]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "enabledFeatures" with the proper type]
-    expected: FAIL
-
-  [XRSession interface: attribute isSystemKeyboardSupported]
     expected: FAIL
 
   [XRSession interface: xrSession must inherit property "isSystemKeyboardSupported" with the proper type]


### PR DESCRIPTION
This updates XRSession to the latest spec, implementing new members for updating session framerate, getting enabled features, and checking for system keyboard support.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
