### PR TITLE
Remove many explicit reflow calls

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2354,8 +2354,6 @@ impl Document {
                     // http://w3c.github.io/navigation-timing/#widl-PerformanceNavigationTiming-loadEventEnd
                     update_with_current_time_ms(&document.load_event_end);
 
-                    window.reflow(ReflowGoal::Full, ReflowReason::DocumentLoaded);
-
                     if let Some(fragment) = document.url().fragment() {
                         document.check_and_scroll_fragment(fragment);
                     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1352,9 +1352,6 @@ impl Document {
             self.commit_focus_transaction(FocusType::Element);
             self.maybe_fire_dblclick(client_point, node, pressed_mouse_buttons);
         }
-
-        self.window
-            .reflow(ReflowGoal::Full, ReflowReason::MouseEvent);
     }
 
     fn maybe_fire_dblclick(
@@ -1570,8 +1567,6 @@ impl Document {
         // If the target has changed then store the current mouse over target for next frame.
         if target_has_changed {
             prev_mouse_over_target.set(maybe_new_target.as_deref());
-            self.window
-                .reflow(ReflowGoal::Full, ReflowReason::MouseEvent);
         }
     }
 
@@ -1771,8 +1766,6 @@ impl Document {
         );
         let event = event.upcast::<Event>();
         let result = event.fire(&target);
-
-        window.reflow(ReflowGoal::Full, ReflowReason::MouseEvent);
 
         match result {
             EventStatus::Canceled => TouchEventResult::Processed(false),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1850,8 +1850,6 @@ impl Document {
                 }
             }
         }
-
-        self.window.reflow(ReflowGoal::Full, ReflowReason::KeyEvent);
     }
 
     pub fn ime_dismissed(&self) {

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -10,7 +10,6 @@ use dom_struct::dom_struct;
 use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
 use js::rust::HandleObject;
 use profile_traits::ipc as ProfiledIpc;
-use script_layout_interface::ReflowGoal;
 use script_traits::IFrameSandboxState::{IFrameSandboxed, IFrameUnsandboxed};
 use script_traits::{
     HistoryEntryReplacement, IFrameLoadInfo, IFrameLoadInfoWithData, JsEvalResult, LoadData,
@@ -40,7 +39,6 @@ use crate::dom::node::{
     document_from_node, window_from_node, BindContext, Node, NodeDamage, UnbindContext,
 };
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::dom::window::ReflowReason;
 use crate::dom::windowproxy::WindowProxy;
 use crate::script_thread::ScriptThread;
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -420,7 +420,7 @@ impl HTMLIFrameElement {
 
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
         let window = window_from_node(self);
-        window.reflow(ReflowGoal::Full, ReflowReason::FramedContentChanged);
+        window.add_pending_reflow();
     }
 
     fn new_inherited(

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -500,9 +500,6 @@ impl HTMLIFrameElement {
         LoadBlocker::terminate(&mut blocker);
 
         // TODO Step 5 - unset child document `mut iframe load` flag
-
-        let window = window_from_node(self);
-        window.reflow(ReflowGoal::Full, ReflowReason::IFrameLoadEvent);
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -167,7 +167,6 @@ pub enum ReflowReason {
     DOMContentLoaded,
     ElementStateChanged,
     FirstLoad,
-    IFrameLoadEvent,
     ImageLoaded,
     MissingExplicitReflow,
     PendingReflow,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -164,17 +164,14 @@ enum WindowState {
 #[derive(Debug, MallocSizeOf)]
 pub enum ReflowReason {
     CachedPageNeededReflow,
-    DOMContentLoaded,
     ElementStateChanged,
     FirstLoad,
-    ImageLoaded,
     MissingExplicitReflow,
     PendingReflow,
     Query,
     RefreshTick,
     RequestAnimationFrame,
     ScrollFromScript,
-    StylesheetLoaded,
     Viewport,
     WindowResize,
     WorkletLoaded,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -172,7 +172,6 @@ pub enum ReflowReason {
     ImageLoaded,
     KeyEvent,
     MissingExplicitReflow,
-    MouseEvent,
     PendingReflow,
     Query,
     RefreshTick,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -168,7 +168,6 @@ pub enum ReflowReason {
     DocumentLoaded,
     ElementStateChanged,
     FirstLoad,
-    FramedContentChanged,
     IFrameLoadEvent,
     ImageLoaded,
     KeyEvent,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -179,7 +179,6 @@ pub enum ReflowReason {
     RequestAnimationFrame,
     ScrollFromScript,
     StylesheetLoaded,
-    Timer,
     Viewport,
     WindowResize,
     WorkletLoaded,
@@ -2319,7 +2318,6 @@ impl Window {
 
     pub fn handle_fire_timer(&self, timer_id: TimerEventId) {
         self.upcast::<GlobalScope>().fire_timer(timer_id);
-        self.reflow(ReflowGoal::Full, ReflowReason::Timer);
     }
 
     pub fn set_window_size(&self, size: WindowSizeData) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -165,7 +165,6 @@ enum WindowState {
 pub enum ReflowReason {
     CachedPageNeededReflow,
     DOMContentLoaded,
-    DocumentLoaded,
     ElementStateChanged,
     FirstLoad,
     IFrameLoadEvent,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -170,7 +170,6 @@ pub enum ReflowReason {
     FirstLoad,
     IFrameLoadEvent,
     ImageLoaded,
-    KeyEvent,
     MissingExplicitReflow,
     PendingReflow,
     Query,


### PR DESCRIPTION
Most of these reflow calls were added back before we had a catch-all reflow mechanism. They should be unnecessary if there is not explicit dirtying present, while any code that explicitly dirties nodes can use the pending reflow mechanism instead.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33063
- [x] There are tests for these changes