### PR TITLE
legacy-layout: Fix display list building after WebRender upgrade

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -931,8 +931,13 @@ impl LayoutThread {
                 self.epoch.set(epoch);
 
                 // TODO: Avoid the temporary conversion and build webrender sc/dl directly!
-                let (mut builder, compositor_info, is_contentful) =
-                    display_list.convert_to_webrender(self.id, viewport_size, epoch.into());
+                let (mut builder, compositor_info, is_contentful) = display_list
+                    .convert_to_webrender(
+                        self.id,
+                        viewport_size,
+                        epoch.into(),
+                        self.debug.dump_display_list,
+                    );
 
                 // Observe notifications about rendered frames if needed right before
                 // sending the display list to WebRender in order to set time related


### PR DESCRIPTION
The most recent version of WebRender tracks stacking context offsets in
a different way, which broke legacy layout. It's easier just to track
the stacking context offset in Servo and apply them to the items
manually like we do in non-legacy layout.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes, but they are not run on CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
