### PR TITLE
Refactor `GlyphStore::iter_glyphs_for_byte_range` without recursion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "freetype-sys",
  "harfbuzz-sys",
  "ipc-channel",
+ "itertools 0.13.0",
  "libc",
  "log",
  "malloc_size_of",

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -25,6 +25,7 @@ fontsan = { git = "https://github.com/servo/fontsan" }
 fonts_traits = { workspace = true }
 harfbuzz-sys = "0.6.1"
 ipc-channel = { workspace = true }
+itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/range/lib.rs
+++ b/components/range/lib.rs
@@ -193,6 +193,19 @@ impl<I: RangeIndex> Iterator for EachIndex<I> {
     }
 }
 
+impl<I: RangeIndex> DoubleEndedIterator for EachIndex<I> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.stop {
+            let next = self.stop - I::one();
+            self.stop = next;
+            Some(next)
+        } else {
+            None
+        }
+    }
+}
+
 impl<I: RangeIndex> Range<I> {
     /// Create a new range from beginning and length offsets. This could be
     /// denoted as `[begin, begin + length)`.

--- a/tests/wpt/meta-legacy-layout/css/css-fonts/crash-large-grapheme-cluster.html.ini
+++ b/tests/wpt/meta-legacy-layout/css/css-fonts/crash-large-grapheme-cluster.html.ini
@@ -1,4 +1,0 @@
-[crash-large-grapheme-cluster.html]
-  expected: CRASH
-  [Should not crash when there is an exceedingly large grapheme cluster]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/crash-large-grapheme-cluster.html.ini
+++ b/tests/wpt/meta/css/css-fonts/crash-large-grapheme-cluster.html.ini
@@ -1,4 +1,0 @@
-[crash-large-grapheme-cluster.html]
-  expected: CRASH
-  [Should not crash when there is an exceedingly large grapheme cluster]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Previous `GlyphStore::iter_glyphs_for_byte_range` implementation used recursion which caused stack overflow when trying to iterate over a very long grapheme cluster.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32969

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
