### PR TITLE
 ohos: Fix log filtering

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -340,12 +340,11 @@ fn initialize_logging_once() {
             "compositing::compositor",
             "constellation::constellation",
         ];
-        let mut filter_builder = env_filter::Builder::new();
         for &module in &filters {
-            filter_builder.filter_module(module, log::LevelFilter::Debug);
+            builder.filter_module(module, log::LevelFilter::Debug);
         }
 
-        builder.filter_level(LevelFilter::Debug).init();
+        builder.filter_level(LevelFilter::Warn).init();
 
         info!("Servo Register callback called!");
 


### PR DESCRIPTION
Adjust the default filtering of log messages on OpenHarmony to:
 * Increase default filtering to warn
 * fix module filtering (filter_builder was never used)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
