### PR TITLE
Print reason when tests are skipped.

### DIFF
--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -170,6 +170,9 @@ class ServoHandler(mozlog.reader.LogHandler):
         test_path = data["test"]
         del self.running_tests[data['thread']]
 
+        if test_status == "SKIP":
+            print(data["message"])
+
         had_expected_test_result = self.data_was_for_expected_result(data)
         subtest_failures = self.subtest_failures.pop(test_path, [])
         if had_expected_test_result and not subtest_failures:

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -170,9 +170,6 @@ class ServoHandler(mozlog.reader.LogHandler):
         test_path = data["test"]
         del self.running_tests[data['thread']]
 
-        if test_status == "SKIP":
-            print(data["message"])
-
         had_expected_test_result = self.data_was_for_expected_result(data)
         subtest_failures = self.subtest_failures.pop(test_path, [])
         if had_expected_test_result and not subtest_failures:
@@ -233,6 +230,7 @@ class ServoFormatter(mozlog.formatters.base.BaseFormatter, ServoHandler):
         ServoHandler.__init__(self)
         self.current_display = ""
         self.interactive = os.isatty(sys.stdout.fileno())
+        self.number_skipped = 0
 
         if self.interactive:
             self.line_width = os.get_terminal_size().columns
@@ -299,16 +297,23 @@ class ServoFormatter(mozlog.formatters.base.BaseFormatter, ServoHandler):
 
     def test_end(self, data):
         unexpected_result = ServoHandler.test_end(self, data)
-        if not unexpected_result:
-            if self.interactive:
-                return self.generate_output(new_display=self.build_status_line())
-            else:
-                return self.generate_output(text="%s%s\n" % (self.test_counter(), data["test"]))
+        if unexpected_result:
+            # Surround test output by newlines so that it is easier to read.
+            output_for_unexpected_test = f"{unexpected_result}\n"
+            return self.generate_output(text=output_for_unexpected_test,
+                                        new_display=self.build_status_line())
 
-        # Surround test output by newlines so that it is easier to read.
-        output_for_unexpected_test = f"{unexpected_result}\n"
-        return self.generate_output(text=output_for_unexpected_test,
-                                    new_display=self.build_status_line())
+        # Print reason that tests are skipped.
+        if data["status"] == "SKIP":
+            self.number_skipped += 1
+            lines = [f"SKIP {data['test']}", f"{data['message']}\n"]
+            output_for_skipped_test = UnexpectedResult.wrap_and_indent_lines(lines, indent="  ")
+            return self.generate_output(text=output_for_skipped_test, new_display=self.build_status_line())
+
+        if self.interactive:
+            return self.generate_output(new_display=self.build_status_line())
+        else:
+            return self.generate_output(text="%s%s\n" % (self.test_counter(), data["test"]))
 
     def test_status(self, data):
         ServoHandler.test_status(self, data)
@@ -322,8 +327,9 @@ class ServoFormatter(mozlog.formatters.base.BaseFormatter, ServoHandler):
 
         output += u"Ran %i tests finished in %.1f seconds.\n" % (
             self.completed_tests, (data["time"] - self.suite_start_time) / 1000)
-        output += u"  \u2022 %i ran as expected. %i tests skipped.\n" % (
-            sum(self.expected.values()), self.expected['SKIP'])
+        output += f"  \u2022 {len(self.expected.values())} ran as expected.\n"
+        if self.number_skipped:
+            output += f"    \u2022 {self.number_skipped} skipped.\n"
 
         def text_for_unexpected_list(text, section):
             tests = self.unexpected_tests[section]


### PR DESCRIPTION
Before:
```
 0:01.43 SUITE_START: web-platform-test - running 1 tests
 0:01.43 TEST_START: /cookies/attributes/max-age.html
 0:01.43 TEST_END: SKIP
 0:01.43 INFO Using 1 child processes
 0:01.43 INFO No more tests
 0:01.43 SUITE_END

web-platform-test
~~~~~~~~~~~~~~~~~
Ran 1 checks (1 tests)
Expected results: 0
Skipped: 1 tests
Unexpected results: 0
OK
```

After:
```
0:01.36 SUITE_START: web-platform-test - running 1 tests
 0:01.36 TEST_START: /cookies/attributes/max-age.html
 0:01.36 TEST_END: SKIP
 0:01.36 INFO Using 1 child processes
 0:01.36 INFO STDOUT: Executor does not support testdriver.js
 0:01.36 INFO No more tests
 0:01.36 SUITE_END

web-platform-test
~~~~~~~~~~~~~~~~~
Ran 1 checks (1 tests)
Expected results: 0
Skipped: 1 tests
Unexpected results: 0
OK
```