### PR TITLE
Remove lazy static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,7 +3712,6 @@ dependencies = [
  "icu_segmenter",
  "ipc-channel",
  "itertools 0.13.0",
- "lazy_static",
  "log",
  "net_traits",
  "parking_lot",
@@ -4150,7 +4149,6 @@ dependencies = [
  "euclid",
  "fnv",
  "ipc-channel",
- "lazy_static",
  "log",
  "serde",
  "servo-media",
@@ -6132,7 +6130,6 @@ dependencies = [
 name = "servo_rand"
 version = "0.0.1"
 dependencies = [
- "lazy_static",
  "log",
  "rand",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ itertools = "0.13"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
 keyboard-types = "0.7"
-lazy_static = "1.5"
 libc = "0.2"
 log = "0.4"
 malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2024-07-16", features = ["servo"] }

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -53,5 +53,4 @@ webrender_traits = { workspace = true }
 xi-unicode = { workspace = true }
 
 [dev-dependencies]
-lazy_static = { workspace = true }
 quickcheck = "1"

--- a/components/layout_2020/tests/floats.rs
+++ b/components/layout_2020/tests/floats.rs
@@ -17,13 +17,10 @@ use layout_2020::flow::float::{
     PlacementInfo,
 };
 use layout_2020::geom::{LogicalRect, LogicalVec2};
-use lazy_static::lazy_static;
 use quickcheck::{Arbitrary, Gen};
 use style::values::computed::Clear;
 
-lazy_static! {
-    static ref PANIC_HOOK_MUTEX: Mutex<()> = Mutex::new(());
-}
+static PANIC_HOOK_MUTEX: Mutex<()> = Mutex::new(());
 
 // Suppresses panic messages. Some tests need to fail and we don't want them to spam the console.
 // Note that, because the panic hook is process-wide, tests that are expected to fail might

--- a/components/media/Cargo.toml
+++ b/components/media/Cargo.toml
@@ -14,7 +14,6 @@ path = "lib.rs"
 euclid = { workspace = true }
 fnv = { workspace = true }
 ipc-channel = { workspace = true }
-lazy_static = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 servo-media = { workspace = true }

--- a/components/media/media_channel/mod.rs
+++ b/components/media/media_channel/mod.rs
@@ -9,15 +9,9 @@ mod mpsc;
 
 use std::fmt;
 
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use servo_config::opts;
 
 use crate::GLPlayerMsg;
-
-lazy_static! {
-    static ref IS_MULTIPROCESS: bool = opts::multiprocess();
-}
 
 #[derive(Deserialize, Serialize)]
 pub enum GLPlayerSender<T: Serialize> {

--- a/components/rand/Cargo.toml
+++ b/components/rand/Cargo.toml
@@ -11,7 +11,6 @@ name = "servo_rand"
 path = "lib.rs"
 
 [dependencies]
-lazy_static = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -6,7 +6,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Mutex;
 
-use lazy_static::lazy_static;
 use log::trace;
 /// A random number generator which shares one instance of an `OsRng`.
 ///
@@ -26,9 +25,7 @@ use rand_isaac::isaac::IsaacCore;
 use uuid::{Builder, Uuid};
 
 // The shared RNG which may hold on to a file descriptor
-lazy_static! {
-    static ref OS_RNG: Mutex<OsRng> = Mutex::new(OsRng);
-}
+static OS_RNG: Mutex<OsRng> = Mutex::new(OsRng);
 
 // Generate 32K of data between reseedings
 const RESEED_THRESHOLD: u64 = 32_768;

--- a/support/suppressed_leaks_for_asan.txt
+++ b/support/suppressed_leaks_for_asan.txt
@@ -1,5 +1,5 @@
 # intentional Box::leak, introduced here: https://github.com/servo/stylo/blob/f4cde5d89d03db92d111eaa4b4b34e622b6eecac/style/sharing/mod.rs#L481
 leak:style::sharing::SHARING_CACHE_KEY::__init
 
-# lazy_static never frees memory because it never runs destructors, see https://docs.rs/lazy_static/1.4.0/lazy_static/index.html#semantics
-leak:lazy_static::lazy::Lazy*::get
+# std::sync::LazyLock never frees memory because it never runs destructors, see https://doc.rust-lang.org/std/sync/struct.LazyLock.html#examples
+leak:std::sync::LazyLock


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
It removes the `lazy_static` crate from dependencies because all of `lazy_static` was replaced.

`Mutex` is need not lazy initialization.
`IS_MULTIPROCESS` would be removed because it is unused constant.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because this should not change any behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
