### PR TITLE
Replace `once_cell` crate with `std::sync::LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,6 @@ name = "crown"
 version = "0.0.1"
 dependencies = [
  "compiletest_rs",
- "once_cell",
 ]
 
 [[package]]

--- a/support/crown/Cargo.toml
+++ b/support/crown/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 # so it needs to make sense without the workspace manifest.
 [dev-dependencies]
 compiletest_rs = { version = "0.11", features = ["tmp"] }
-once_cell = "1"
 
 [features]
 default = ["unrooted_must_root_lint", "trace_in_no_trace_lint"]

--- a/support/crown/tests/compile_test.rs
+++ b/support/crown/tests/compile_test.rs
@@ -4,11 +4,11 @@
 
 use std::env;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use compiletest_rs as compiletest;
-use once_cell::sync::Lazy;
 
-static PROFILE_PATH: Lazy<PathBuf> = Lazy::new(|| {
+static PROFILE_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
     let current_exe_path = env::current_exe().unwrap();
     let deps_path = current_exe_path.parent().unwrap();
     let profile_path = deps_path.parent().unwrap();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace `once_cell::sync::Lazy` with `std::sync::LazyLock`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
<!-- Either: -->
- [x] These changes do not require tests because `once_cell::sync::Lazy` and `std::sync::LazyLock` is same behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
