### PR TITLE
Handle failed string conversions in console.log.

### DIFF
--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -221,6 +221,7 @@ impl FromJSValConvertible for DOMString {
 /// Convert the given `JSString` to a `DOMString`. Fails if the string does not
 /// contain valid UTF-16.
 pub unsafe fn jsstring_to_str(cx: *mut JSContext, s: *mut JSString) -> DOMString {
+    assert!(!s.is_null());
     let latin1 = JS_DeprecatedStringHasLatin1Chars(s);
     DOMString::from_string(if latin1 {
         latin1_to_string(cx, s)

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -73,6 +73,9 @@ where
 unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) -> DOMString {
     rooted!(in(cx) let mut js_string = std::ptr::null_mut::<jsapi::JSString>());
     js_string.set(JS_ValueToSource(cx, value));
+    if js_string.is_null() {
+        return "<error converting value to string>".into();
+    }
     jsstring_to_str(cx, *js_string)
 }
 


### PR DESCRIPTION
I hit this crash while trying to log some website object that was throwing an exception. I think it points at some missing complexity in our console logging stringification right now, but https://searchfox.org/mozilla-central/rev/2455e4d6388cbdeadb44b9633b971a65a98b504c/js/src/jsexn.cpp#794-797 shows that this is a more appropriate way to handle the current failure instead of crashing.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because I have no idea how to actually trigger the underlying issue right now.