### PR TITLE
remove usage of legacy numeric operations in script/

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -422,7 +422,7 @@ impl Animations {
 
         let active_duration = match animation.iteration_state {
             KeyframesIterationState::Finite(_, max) => max * animation.duration,
-            KeyframesIterationState::Infinite(_) => std::f64::MAX,
+            KeyframesIterationState::Infinite(_) => f64::MAX,
         };
 
         // Calculate the `elapsed-time` property of the event and take the absolute

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -25,7 +25,7 @@ pub trait CollectionFilter: JSTraceable {
     fn filter<'a>(&self, elem: &'a Element, root: &'a Node) -> bool;
 }
 
-/// An optional u32, using maxint to represent None.
+/// An optional u32, using u32::MAX to represent None.
 /// It would be nicer just to use Option<u32> for this, but that would produce word
 /// alignment issues since Option<u32> uses 33 bits.
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
@@ -35,7 +35,7 @@ struct OptionU32 {
 
 impl OptionU32 {
     fn to_option(self) -> Option<u32> {
-        if self.bits == u32::max_value() {
+        if self.bits == u32::MAX {
             None
         } else {
             Some(self.bits)
@@ -43,14 +43,12 @@ impl OptionU32 {
     }
 
     fn some(bits: u32) -> OptionU32 {
-        assert_ne!(bits, u32::max_value());
+        assert_ne!(bits, u32::MAX);
         OptionU32 { bits }
     }
 
     fn none() -> OptionU32 {
-        OptionU32 {
-            bits: u32::max_value(),
-        }
+        OptionU32 { bits: u32::MAX }
     }
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -630,7 +630,7 @@ unsafe fn new_rt_and_cx_with_parent(
         if pref!(js.baseline_jit.unsafe_eager_compilation.enabled) {
             0
         } else {
-            u32::max_value()
+            u32::MAX
         },
     );
     JS_SetGlobalJitCompilerOption(
@@ -639,7 +639,7 @@ unsafe fn new_rt_and_cx_with_parent(
         if pref!(js.ion.unsafe_eager_compilation.enabled) {
             0
         } else {
-            u32::max_value()
+            u32::MAX
         },
     );
     // TODO: handle js.discard_system_source.enabled
@@ -652,7 +652,7 @@ unsafe fn new_rt_and_cx_with_parent(
         JSGCParamKey::JSGC_MAX_BYTES,
         in_range(pref!(js.mem.max), 1, 0x100)
             .map(|val| (val * 1024 * 1024) as u32)
-            .unwrap_or(u32::max_value()),
+            .unwrap_or(u32::MAX),
     );
     // NOTE: This is disabled above, so enabling it here will do nothing for now.
     JS_SetGCParameter(

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -8,7 +8,6 @@ use std::borrow::ToOwned;
 use std::cmp::min;
 use std::default::Default;
 use std::ops::{Add, AddAssign, Range};
-use std::usize;
 
 use keyboard_types::{Key, KeyState, Modifiers, ShortcutMatcher};
 use unicode_segmentation::UnicodeSegmentation;


### PR DESCRIPTION
These operations are deprecated and might be removed in a future rust version. Clippy's `legacy_numeric_constants` lint is also complaining about them.

For example, [`u32::max_value()`](https://doc.rust-lang.org/std/primitive.u32.html#method.max_value) should be [`u32::MAX`](https://doc.rust-lang.org/std/primitive.u32.html#associatedconstant.MAX)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

- [X] These changes do not require tests because they don't change behaviour


