### PR TITLE
Make string formatting more consistent in `CodegenRust.py`

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -661,12 +661,6 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                     '%s' % (firstCap(sourceDescription), exceptionCode))),
             post="\n")
 
-    def onFailureInvalidEnumValue(failureCode, passedVarName):
-        return CGGeneric(
-            failureCode
-            or ('throw_type_error(*cx, &format!("\'{}\' is not a valid enum value for enumeration \'%s\'.", %s)); %s'
-                % (type.name, passedVarName, exceptionCode)))
-
     def onFailureNotCallable(failureCode):
         return CGGeneric(
             failureCode

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2643,7 +2643,7 @@ class Argument():
     def declare(self):
         mut = 'mut ' if self.mutable else ''
         argType = f': {self.argType}' if self.argType else ''
-        string =  f"{mut}self.name{argType}"
+        string =  f"{mut}{self.name}{argType}"
         # XXXjdm Support default arguments somehow :/
         # if self.default is not None:
         #     string += " = " + self.default
@@ -4881,7 +4881,7 @@ class CGUnionStruct(CGThing):
         templateVars = [(getUnionTypeTemplateVars(t, self.descriptorProvider),
                          getTypeWrapper(t)) for t in self.type.flatMemberTypes]
         enumValues = [
-            f"    {v['name']}({wrapper}<{v['typeName']}>)" if wrapper else f"    {v['name']}({v['typeName']})"
+            f"    {v['name']}({wrapper}<{v['typeName']}>)," if wrapper else f"    {v['name']}({v['typeName']}),"
             for (v, wrapper) in templateVars
         ]
         enumConversions = [
@@ -4891,13 +4891,13 @@ class CGUnionStruct(CGThing):
         return f"""\
 #[derive(JSTraceable)]
 pub enum {self.type} {{
-{"\n".join(enumValues)}
+{'\n'.join(enumValues)}
 }}
 
 impl ToJSValConvertible for {self.type} {{
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {{
         match *self {{
-{"\n".join(enumConversions)}
+{'\n'.join(enumConversions)}
         }}
     }}
 }}
@@ -6907,12 +6907,12 @@ class CGRegisterProxyHandlers(CGThing):
             CGGeneric(
                 "#[allow(non_upper_case_globals)]\n"
                 "pub mod proxy_handlers {\n"
-                "".join(
+                f'{"".join(
                     f"    pub static {desc.name}: std::sync::atomic::AtomicPtr<libc::c_void> =\n"
                     "        std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());\n"
                     for desc in descriptors
-                )
-                + "}\n"
+                )}'
+                "}\n"
             ),
             CGRegisterProxyHandlersMethod(descriptors),
         ], "\n")


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR is to integrate various string formatting styles in `CodegenRust.py` into f-string.

The key changes in this PR are
- Replace string concatenations using `+` operator with f-string
- Replace `string.Template.substitute` with f-string
- Replace %formatting with f-string

This PR does **NOT** include the following changes
- Remove template strings that are used more than once
- Refactor formatting-related util functions (e.g. `fill` function, `instantiateJSToNativeConversionTemplate` function)

notes:
- I deleted an unused function `onFailureInvalidEnumValue`
- Inside f-string, we need to double curly braces `{{` `}}` to escape them (see https://docs.python.org/3/reference/lexical_analysis.html#f-strings )
- We cannot use backslash`\` inside curly braces. For example, `f"{'\n'.join(arr)}"` is invalid. (On my local Mac, `./mach test-tidy` doesn't report it. Linux build on CI fails. I feel it would be better to have a way to check tidiness as strictly as CI locally.)
- IMO, using ternary operators inside f-string sometimes makes it hard to read, so I avoid that kind of usage

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #31846 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a code style fix

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
