### PR TITLE
Replace `callargs_is_constructing` util func with `is_constructing` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#dae748dee6fb8c1db771364bd12101db1ed34614"
+source = "git+https://github.com/servo/mozjs#4f0724dd3b9b58120903ff6a1043e71e7c7b9eb1"
 dependencies = [
  "bindgen",
  "cc",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.0-8"
-source = "git+https://github.com/servo/mozjs#dae748dee6fb8c1db771364bd12101db1ed34614"
+source = "git+https://github.com/servo/mozjs#4f0724dd3b9b58120903ff6a1043e71e7c7b9eb1"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -6283,7 +6283,7 @@ let global = DomRoot::downcast::<dom::types::%s>(global).unwrap();
         else:
             ctorName = GetConstructorNameForReporting(self.descriptor, self.constructor)
             preamble += """
-if !callargs_is_constructing(&args) {
+if !args.is_constructing() {
   throw_constructor_without_new(*cx, "%s");
   return false;
 }

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -135,11 +135,11 @@ pub mod module {
     pub use crate::dom::bindings::root::{Dom, DomSlice, MaybeUnreflectedDom, Root};
     pub use crate::dom::bindings::trace::JSTraceable;
     pub use crate::dom::bindings::utils::{
-        callargs_is_constructing, enumerate_global, exception_to_promise, generic_getter,
-        generic_lenient_getter, generic_lenient_setter, generic_method, generic_setter,
-        generic_static_promise_method, get_array_index_from_id, get_property_on_prototype,
-        has_property_on_prototype, resolve_global, trace_global, AsVoidPtr, DOMClass, DOMJSClass,
-        ProtoOrIfaceArray, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, JSCLASS_DOM_GLOBAL,
+        enumerate_global, exception_to_promise, generic_getter, generic_lenient_getter,
+        generic_lenient_setter, generic_method, generic_setter, generic_static_promise_method,
+        get_array_index_from_id, get_property_on_prototype, has_property_on_prototype,
+        resolve_global, trace_global, AsVoidPtr, DOMClass, DOMJSClass, ProtoOrIfaceArray,
+        DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, JSCLASS_DOM_GLOBAL,
     };
     pub use crate::dom::bindings::weakref::{WeakReferenceable, DOM_WEAK_SLOT};
     pub use crate::dom::types::{AnalyserNode, AudioNode, BaseAudioContext, EventTarget};

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -40,8 +40,7 @@ use crate::dom::bindings::conversions::{get_dom_class, DOM_OBJECT_SLOT};
 use crate::dom::bindings::guard::Guard;
 use crate::dom::bindings::principals::ServoJSPrincipals;
 use crate::dom::bindings::utils::{
-    callargs_is_constructing, get_proto_or_iface_array, DOMJSClass, ProtoOrIfaceArray,
-    DOM_PROTOTYPE_SLOT, JSCLASS_DOM_GLOBAL,
+    get_proto_or_iface_array, DOMJSClass, ProtoOrIfaceArray, DOM_PROTOTYPE_SLOT, JSCLASS_DOM_GLOBAL,
 };
 use crate::script_runtime::JSContext as SafeJSContext;
 
@@ -611,7 +610,7 @@ pub fn get_desired_proto(
         // https://heycam.github.io/webidl/#internally-create-a-new-object-implementing-the-interface
         // step 3.
 
-        assert!(callargs_is_constructing(args));
+        assert!(args.is_constructing());
 
         // The desired prototype depends on the actual constructor that was invoked,
         // which is passed to us as the newTarget in the callargs.  We want to do

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -625,10 +625,6 @@ impl AsCCharPtrPtr for [u8] {
     }
 }
 
-pub unsafe fn callargs_is_constructing(args: &CallArgs) -> bool {
-    (*args.argv_.offset(-1)).is_magic()
-}
-
 /// https://searchfox.org/mozilla-central/rev/7279a1df13a819be254fd4649e07c4ff93e4bd45/dom/bindings/BindingUtils.cpp#3300
 pub unsafe extern "C" fn generic_static_promise_method(
     cx: *mut JSContext,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR is for refactoring `callargs_is_constructing` function.

We introduced a new method `is_constructing` on `JS::CallArgs` in https://github.com/servo/mozjs/pull/497, so now we can clean up `callargs_is_constructing` and use `is_constructing` instead.

This PR includes the following changes:

- Update `Cargo.lock` to point to the latest `mozjs` and `mozjs_sys`
- Replace `callargs_is_constructing` with [`is_constructing`](https://github.com/servo/mozjs/blob/4f0724dd3b9b58120903ff6a1043e71e7c7b9eb1/mozjs-sys/src/jsimpls.rs#L306-L309) method.
- Delete `callargs_is_constructing` since it's no longer used

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29821

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is a simple refactoring

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
