### PR TITLE
webxr: Update XRFrame to latest spec

### DIFF
--- a/components/script/dom/webidls/XRFrame.webidl
+++ b/components/script/dom/webidls/XRFrame.webidl
@@ -6,10 +6,11 @@
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRFrame {
-  readonly attribute XRSession session;
+  [SameObject] readonly attribute XRSession session;
+  readonly attribute DOMHighResTimeStamp predictedDisplayTime;
 
   [Throws] XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
-  [Throws] XRPose? getPose(XRSpace space, XRSpace relativeTo);
+  [Throws] XRPose? getPose(XRSpace space, XRSpace baseSpace);
 
   // WebXR Hand Input
   [Pref="dom.webxr.hands.enabled", Throws]

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -12,6 +12,7 @@ use webxr_api::{Frame, LayerId, SubImages};
 use crate::dom::bindings::codegen::Bindings::XRFrameBinding::XRFrameMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
@@ -79,6 +80,11 @@ impl XRFrameMethods for XRFrame {
         DomRoot::from_ref(&self.session)
     }
 
+    /// <https://www.w3.org/TR/webxr/#dom-xrframe-predicteddisplaytime>
+    fn PredictedDisplayTime(&self) -> Finite<f64> {
+        todo!()
+    }
+
     /// <https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose>
     fn GetViewerPose(
         &self,
@@ -114,9 +120,9 @@ impl XRFrameMethods for XRFrame {
     fn GetPose(
         &self,
         space: &XRSpace,
-        relative_to: &XRSpace,
+        base_space: &XRSpace,
     ) -> Result<Option<DomRoot<XRPose>>, Error> {
-        if self.session != space.session() || self.session != relative_to.session() {
+        if self.session != space.session() || self.session != base_space.session() {
             return Err(Error::InvalidState);
         }
         if !self.active.get() {
@@ -127,12 +133,12 @@ impl XRFrameMethods for XRFrame {
         } else {
             return Ok(None);
         };
-        let relative_to = if let Some(r) = self.get_pose(relative_to) {
+        let base_space = if let Some(r) = self.get_pose(base_space) {
             r
         } else {
             return Ok(None);
         };
-        let pose = space.then(&relative_to.inverse());
+        let pose = space.then(&base_space.inverse());
         Ok(Some(XRPose::new(&self.global(), pose)))
     }
 
@@ -140,10 +146,10 @@ impl XRFrameMethods for XRFrame {
     fn GetJointPose(
         &self,
         space: &XRJointSpace,
-        relative_to: &XRSpace,
+        base_space: &XRSpace,
     ) -> Result<Option<DomRoot<XRJointPose>>, Error> {
         if self.session != space.upcast::<XRSpace>().session() ||
-            self.session != relative_to.session()
+            self.session != base_space.session()
         {
             return Err(Error::InvalidState);
         }
@@ -155,12 +161,12 @@ impl XRFrameMethods for XRFrame {
         } else {
             return Ok(None);
         };
-        let relative_to = if let Some(r) = self.get_pose(relative_to) {
+        let base_space = if let Some(r) = self.get_pose(base_space) {
             r
         } else {
             return Ok(None);
         };
-        let pose = joint_frame.pose.then(&relative_to.inverse());
+        let pose = joint_frame.pose.then(&base_space.inverse());
         Ok(Some(XRJointPose::new(
             &self.global(),
             pose.cast_unit(),

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -82,7 +82,9 @@ impl XRFrameMethods for XRFrame {
 
     /// <https://www.w3.org/TR/webxr/#dom-xrframe-predicteddisplaytime>
     fn PredictedDisplayTime(&self) -> Finite<f64> {
-        todo!()
+        // TODO: If inline, return rAF callback time instead
+        Finite::new(self.data.predicted_display_time)
+            .expect("Failed to create predictedDisplayTime")
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose>

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -82,7 +82,8 @@ impl XRFrameMethods for XRFrame {
 
     /// <https://www.w3.org/TR/webxr/#dom-xrframe-predicteddisplaytime>
     fn PredictedDisplayTime(&self) -> Finite<f64> {
-        // TODO: If inline, return rAF callback time instead
+        // TODO: If inline, return the same value
+        // as the timestamp passed to XRFrameRequestCallback
         Finite::new(self.data.predicted_display_time)
             .expect("Failed to create predictedDisplayTime")
     }

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -350,9 +350,6 @@
   [XRSession interface: xrSession must inherit property "onframeratechange" with the proper type]
     expected: FAIL
 
-  [XRFrame interface: attribute predictedDisplayTime]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "enabledFeatures" with the proper type]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -293,9 +293,6 @@
   [XRSession interface: xrSession must inherit property "onframeratechange" with the proper type]
     expected: FAIL
 
-  [XRFrame interface: attribute predictedDisplayTime]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "enabledFeatures" with the proper type]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This updates XRFrame to account for a new `predictedDisplayTime` member, as well as updating some param names and marking session as [SameObject]

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
