### PR TITLE
Update data-url to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,12 +1255,9 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "data-url"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
-dependencies = [
- "matches",
-]
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "dbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
 cssparser = { version = "0.34", features = ["serde"] }
 darling = { version = "0.20", default-features = false }
-data-url = "0.1.0"
+data-url = "0.3"
 devtools_traits = { path = "components/shared/devtools" }
 embedder_traits = { path = "components/shared/embedder" }
 encoding_rs = "0.8"


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

