### PR TITLE
Update ipc-channel to use new windows 0.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,8 +3506,7 @@ dependencies = [
 [[package]]
 name = "ipc-channel"
 version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46231d1db8ea8f874012b1b87efb9e968f763c577220372a9c7caadce1448da"
+source = "git+https://github.com/sagudev/ipc-channel?branch=update-windows#7ba3edf3a165041c1cb1980c7547443f10c85ea2"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -3519,7 +3518,7 @@ dependencies = [
  "serde",
  "tempfile",
  "uuid",
- "windows 0.48.0",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,4 @@ strip = true
 #
 # [patch."https://github.com/servo/<repository>"]
 # <crate> = { path = "/path/to/local/checkout" }
+ipc-channel = { git = "https://github.com/sagudev/ipc-channel", branch = "update-windows" }


### PR DESCRIPTION
Companion to https://github.com/servo/ipc-channel/pull/346.

Try run: https://github.com/sagudev/servo/actions/runs/10438942256


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
