### PR TITLE
Fix panic in webstorage/symbol-props.window.js

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5563,6 +5563,22 @@ class CGProxyNamedDeleter(CGProxyNamedOperation):
     def __init__(self, descriptor):
         CGProxySpecialOperation.__init__(self, descriptor, 'NamedDeleter')
 
+    def define(self):
+        # Our first argument is the id we're getting.
+        argName = self.arguments[0].identifier.name
+        return ("if !id.is_symbol() {\n"
+                f'    let {argName} = match jsid_to_string(*cx, Handle::from_raw(id)) {{\n'
+                "        Some(val) => val,\n"
+                "        None => {\n"
+                "            throw_type_error(*cx, \"Not a string-convertible JSID\");\n"
+                "            return false;\n"
+                "        }\n"
+                "    };\n"
+                "    let this = UnwrapProxy(proxy);\n"
+                "    let this = &*this;\n"
+                f"    {CGProxySpecialOperation.define(self)}"
+                "}\n")
+
 
 class CGProxyUnwrap(CGAbstractMethod):
     def __init__(self, descriptor):

--- a/tests/wpt/meta/webstorage/symbol-props.window.js.ini
+++ b/tests/wpt/meta/webstorage/symbol-props.window.js.ini
@@ -1,2 +1,6 @@
 [symbol-props.window.html]
-  expected: CRASH
+  [localStorage: defineProperty not configurable]
+    expected: FAIL
+
+  [sessionStorage: defineProperty not configurable]
+    expected: FAIL


### PR DESCRIPTION

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32987

<!-- Either: -->
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
