### PR TITLE
Fix incorrect documentation and add `track_caller` to DomRefCell methods

### DIFF
--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -35,6 +35,12 @@ impl<T> DomRefCell<T> {
     /// Unlike RefCell::borrow, this method is unsafe because it does not return a Ref, thus leaving
     /// the borrow flag untouched. Mutably borrowing the RefCell while the reference returned by
     /// this method is alive is undefined behaviour.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called from anywhere other than the layout thread
+    ///
+    /// Panics if the value is currently mutably borrowed.
     #[allow(unsafe_code)]
     pub unsafe fn borrow_for_layout(&self) -> &T {
         assert_in_layout();
@@ -50,6 +56,10 @@ impl<T> DomRefCell<T> {
     /// Unlike RefCell::borrow, this method is unsafe because it does not return a Ref, thus leaving
     /// the borrow flag untouched. Mutably borrowing the RefCell while the reference returned by
     /// this method is alive is undefined behaviour.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called from anywhere other than the script thread.
     #[allow(unsafe_code, clippy::mut_from_ref)]
     pub unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
         assert_in_script();
@@ -64,6 +74,10 @@ impl<T> DomRefCell<T> {
     /// Unlike RefCell::borrow, this method is unsafe because it does not return a Ref, thus leaving
     /// the borrow flag untouched. Mutably borrowing the RefCell while the reference returned by
     /// this method is alive is undefined behaviour.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called from anywhere other than the layout thread.
     #[allow(unsafe_code, clippy::mut_from_ref)]
     pub unsafe fn borrow_mut_for_layout(&self) -> &mut T {
         assert_in_layout();
@@ -88,8 +102,6 @@ impl<T> DomRefCell<T> {
     ///
     /// # Panics
     ///
-    /// Panics if this is called off the script thread.
-    ///
     /// Panics if the value is currently mutably borrowed.
     pub fn borrow(&self) -> Ref<T> {
         self.value.borrow()
@@ -101,8 +113,6 @@ impl<T> DomRefCell<T> {
     /// cannot be borrowed while this borrow is active.
     ///
     /// # Panics
-    ///
-    /// Panics if this is called off the script thread.
     ///
     /// Panics if the value is currently borrowed.
     pub fn borrow_mut(&self) -> RefMut<T> {

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -103,6 +103,7 @@ impl<T> DomRefCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed.
+    #[track_caller]
     pub fn borrow(&self) -> Ref<T> {
         self.value.borrow()
     }
@@ -115,6 +116,7 @@ impl<T> DomRefCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently borrowed.
+    #[track_caller]
     pub fn borrow_mut(&self) -> RefMut<T> {
         self.value.borrow_mut()
     }


### PR DESCRIPTION
Fixes the documentation as described in #33099 and, while we're at it, adds the `#[track_caller]` attribute to `DomRefCell::borrow/borrow_mut`, closing #27336.

`#[track_caller]` could arguably be applied in many more places (like `assert_in_script()` or `assert_in_layout()`). 
I didn't do that for now.


---

- [X] `./mach build -d` does not report any errors (only warnings that will be fixed by 33109)
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33099 
- [X] These changes fix #27336
- [X] These changes do not require tests because its just documentation/panic message formatting

