### PR TITLE
CI: wpt-tests-to-run -> wpt-args

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -8,7 +8,7 @@ on:
       profile:
         required: true
         type: string
-      wpt-tests-to-run:
+      wpt-args:
         required: true
         type: string
       wpt-layout:
@@ -37,7 +37,7 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-layout: ${{ inputs.wpt-layout }}
       unit-tests: ${{ inputs.unit-tests }}
-      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+      wpt-args: ${{ inputs.wpt-args }}
 
   linux:
     if: ${{ inputs.workflow == 'linux' }}
@@ -48,7 +48,7 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-layout: ${{ inputs.wpt-layout }}
       unit-tests: ${{ inputs.unit-tests }}
-      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+      wpt-args: ${{ inputs.wpt-args }}
 
   android:
     if: ${{ inputs.workflow == 'android' }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -5,7 +5,7 @@ on:
       profile:
         required: true
         type: string
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -67,13 +67,13 @@ jobs:
           python3 ./mach test-wpt \
             $WPT_LAYOUT_ARG \
             $WPT_ALWAYS_SUCCEED_ARG \
-            ${{ inputs.wpt-tests-to-run }} \
             --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux-${{ inputs.wpt-layout }}/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux-${{ inputs.wpt-layout }}/wptreport/${{ matrix.chunk_id }}.json \
             --log-raw-unexpected wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
-            --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
+            --filter-intermittents wpt-filtered-logs/linux-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json \
+            ${{ inputs.wpt-args }}
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Archive results (filtered)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ on:
         required: false
         default: "release"
         type: string
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -35,7 +35,7 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -161,7 +161,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+      wpt-args: ${{ inputs.wpt-args }}
       profile: ${{ inputs.profile }}
       wpt-sync-from-upstream: ${{ inputs.wpt-sync-from-upstream }}
       wpt-layout: "layout-2020"
@@ -173,7 +173,7 @@ jobs:
     needs: ["build"]
     uses: ./.github/workflows/linux-wpt.yml
     with:
-      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+      wpt-args: ${{ inputs.wpt-args }}
       profile: ${{ inputs.profile }}
       wpt-sync-from-upstream: ${{ inputs.wpt-sync-from-upstream }}
       wpt-layout: "layout-2013"

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -3,7 +3,7 @@ name: Mac WPT Tests
 on:
   workflow_call:
     inputs:
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -52,12 +52,13 @@ jobs:
         run: |
           mkdir -p wpt-filtered-logs/macos-${{ inputs.wpt-layout }}
           mkdir -p wpt-full-logs/macos-${{ inputs.wpt-layout }}
-          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG ${{ inputs.wpt-tests-to-run }} \
+          python3 ./mach test-wpt $WPT_COMMAND_LINE_ARG \
             --${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --log-raw-unexpected wpt-filtered-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/macos-${{ inputs.wpt-layout }}/${{ matrix.chunk_id }}.json
+            ${{ inputs.wpt-args }}
       - name: Archive results (filtered)
         uses: actions/upload-artifact@v4
         if: ${{ always() }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: "release"
         type: string
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -32,7 +32,7 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -158,7 +158,7 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       wpt-layout: "layout-2020"
-      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+      wpt-args: ${{ inputs.wpt-args }}
     secrets: inherit
 
   wpt-2013:
@@ -169,5 +169,5 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       wpt-layout: "layout-2013"
-      wpt-tests-to-run: ${{ inputs.wpt-tests-to-run }}
+      wpt-args: ${{ inputs.wpt-args }}
     secrets: inherit

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -136,7 +136,7 @@ jobs:
       wpt-layout: ${{ matrix.wpt_layout }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
-      wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
+      wpt-args: ${{ matrix.wpt_args }}
 
   results:
     name: Results

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -10,7 +10,7 @@ on:
         default: "release"
         type: choice
         options: ["release", "debug", "production"]
-      wpt-tests-to-run:
+      wpt-args:
         default: ""
         required: false
         type: string
@@ -75,7 +75,7 @@ jobs:
             if (context.eventName == "workflow_dispatch") {
               // WPT-related overrides only affect Linux currently, as tests don't run by default on other platforms.
               configuration.matrix[0].wpt_layout = "${{ inputs.wpt-layout }}" || "none";
-              configuration.matrix[0].wpt_tests_to_run = "${{ inputs.wpt-tests-to-run }}" || "";
+              configuration.matrix[0].wpt_args = "${{ inputs.wpt-args }}" || "";
 
               let unit_tests = Boolean(${{ inputs.unit-tests }});
               let profile = '${{ inputs.profile }}';
@@ -103,7 +103,7 @@ jobs:
       wpt-layout: ${{ matrix.wpt_layout }}
       profile: ${{ matrix.profile }}
       unit-tests: ${{ matrix.unit_tests }}
-      wpt-tests-to-run: ${{ matrix.wpt_tests_to_run }}
+      wpt-args: ${{ matrix.wpt_args }}
 
   build-result:
     name: Result

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -56,10 +56,10 @@ class JobConfig(object):
     wpt_layout: Layout = Layout.none
     profile: str = "release"
     unit_tests: bool = False
-    wpt_tests_to_run: str = ""
+    wpt_args: str = ""
     # These are the fields that must match in between two JobConfigs for them to be able to be
     # merged. If you modify any of the fields above, make sure to update this line as well.
-    merge_compatibility_fields: ClassVar[List[str]] = ['workflow', 'profile', 'wpt_tests_to_run']
+    merge_compatibility_fields: ClassVar[List[str]] = ['workflow', 'profile', 'wpt_args']
 
     def merge(self, other: JobConfig) -> bool:
         """Try to merge another job with this job. Returns True if merging is successful
@@ -101,7 +101,7 @@ def handle_preset(s: str) -> Optional[JobConfig]:
     elif s == "webgpu":
         return JobConfig("WebGPU CTS", Workflow.LINUX,
                          wpt_layout=Layout.layout2020,  # reftests are mode for new layout
-                         wpt_tests_to_run="_webgpu",  # run only webgpu cts
+                         wpt_args="_webgpu",  # run only webgpu cts
                          profile="production",  # WebGPU works to slow with debug assert
                          unit_tests=False)  # production profile does not work with unit-tests
     else:
@@ -176,7 +176,7 @@ class TestParser(unittest.TestCase):
                                   'unit_tests': True,
                                   'workflow': 'linux',
                                   'wpt_layout': 'none',
-                                  'wpt_tests_to_run': ''
+                                  'wpt_args': ''
                               }]
                               })
 
@@ -189,7 +189,7 @@ class TestParser(unittest.TestCase):
                                   "wpt_layout": "all",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  "wpt_tests_to_run": ""
+                                  "wpt_args": ""
                               },
                               {
                                   "name": "MacOS",
@@ -197,7 +197,7 @@ class TestParser(unittest.TestCase):
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  "wpt_tests_to_run": ""
+                                  "wpt_args": ""
                               },
                               {
                                   "name": "Windows",
@@ -205,7 +205,7 @@ class TestParser(unittest.TestCase):
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": True,
-                                  "wpt_tests_to_run": ""
+                                  "wpt_args": ""
                               },
                               {
                                   "name": "Android",
@@ -213,7 +213,7 @@ class TestParser(unittest.TestCase):
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": False,
-                                  "wpt_tests_to_run": ""
+                                  "wpt_args": ""
                               },
                               {
                                   "name": "OpenHarmony",
@@ -221,7 +221,7 @@ class TestParser(unittest.TestCase):
                                   "wpt_layout": "none",
                                   "profile": "release",
                                   "unit_tests": False,
-                                  "wpt_tests_to_run": ""
+                                  "wpt_args": ""
                               }
                               ]})
 
@@ -234,7 +234,7 @@ class TestParser(unittest.TestCase):
                                   'unit_tests': False,
                                   'workflow': 'linux',
                                   'wpt_layout': 'all',
-                                  'wpt_tests_to_run': ''
+                                  'wpt_args': ''
                               }]
                               })
 
@@ -254,7 +254,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 
         a = JobConfig("Linux", Workflow.LINUX, unit_tests=True)
-        b = JobConfig("Linux", Workflow.LINUX, unit_tests=True, wpt_tests_to_run="/css")
+        b = JobConfig("Linux", Workflow.LINUX, unit_tests=True, wpt_args="/css")
         self.assertFalse(a.merge(b), "Should not merge jobs that run different WPT tests.")
         self.assertEqual(a, JobConfig("Linux", Workflow.LINUX, unit_tests=True))
 


### PR DESCRIPTION
This is a step towards generalization of wpt workflow. This variable must be last so it can override already provided options (ex: processes).

Extracted from #33009

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are CI changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
