### PR TITLE
ohos: Present on vsync signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4781,6 +4781,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2fd4c1b349c53cd06dfa959bb53076453960d793961caafd367e64c3bb5522"
 
 [[package]]
+name = "ohos-vsync"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5871e38034a33e8d43c711a40d39e24fd3500f43b61b9269b8586f608a70aec3"
+dependencies = [
+ "ohos-sys",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6207,6 +6216,7 @@ dependencies = [
  "net_traits",
  "nix",
  "ohos-sys",
+ "ohos-vsync",
  "raw-window-handle",
  "serde_json",
  "servo-media",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -81,6 +81,7 @@ hilog = "0.1.0"
 napi-derive-ohos = "0.0.9"
 napi-ohos = "0.1"
 ohos-sys = { version = "0.3.0", features = ["xcomponent"] }
+ohos-vsync = "0.1"
 
 [target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
 nix = { workspace = true, features = ["fs"] }

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -196,7 +196,11 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_performUpdates<'local>(
     _class: JClass<'local>,
 ) {
     debug!("performUpdates");
-    call(&mut env, |s| s.perform_updates());
+    call(&mut env, |s| {
+        s.perform_updates()?;
+        s.present_if_needed();
+        Ok(())
+    });
 }
 
 #[no_mangle]

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -39,7 +39,13 @@ pub trait HostTrait {
     /// Page animation state has changed. If animating, it's recommended
     /// that the embedder doesn't wait for the wake function to be called
     /// to call perform_updates. Usually, it means doing:
-    /// while true { servo.perform_updates() }. This will end up calling flush
+    /// ```rust
+    /// while true {
+    ///     servo.perform_updates();
+    ///     servo.present_if_needed();
+    /// }
+    /// ```
+    /// . This will end up calling flush
     /// which will call swap_buffer which will be blocking long enough to limit
     /// drawing at 60 FPS.
     /// If not animating, call perform_updates only when needed (when the embedder


### PR DESCRIPTION
Exposes `present` as a dedicated function, so it can be called synchronized with the vsync signal.
Swapping buffers based on the vsync signal makes scrolling more smooth.
Follow-up PRs will also use the vsync events to implement fling and potentially also trigger animation updates (instead of the currently hardcoded 16ms)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

