### PR TITLE
Upgrade font-kit, raqote, and stop using `dirs-next`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,16 +1178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68523903c8ae5aacfa32a0d9ae60cadeb764e1da14ee0d26b1f3089f13a54636"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "ctor"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1414,6 +1413,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1825,16 +1836,16 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-kit"
-version = "0.13.2"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2845a73bbd781e691ab7c2a028c579727cd254942e8ced57ff73e0eafd60de87"
+checksum = "b64b34f4efd515f905952d91bc185039863705592c0c53ae6d979805dd154520"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
  "core-foundation",
  "core-graphics",
  "core-text",
- "dirs-next",
+ "dirs",
  "dwrote",
  "float-ord",
  "freetype-sys",
@@ -4787,6 +4798,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "option-operations"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,9 +5270,8 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "raqote"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3061d5dcf59093c811d645c517be6eb7c26a0110d146730418950139496f84"
+version = "0.8.5"
+source = "git+https://github.com/jrmuizel/raqote?rev=64716c8#64716c8d68436451ca151bb0c70ba300fd964f42"
 dependencies = [
  "euclid",
  "font-kit",
@@ -6086,7 +6102,7 @@ dependencies = [
 name = "servo_config"
 version = "0.0.1"
 dependencies = [
- "dirs-next",
+ "dirs",
  "embedder_traits",
  "euclid",
  "getopts",
@@ -8439,11 +8455,10 @@ dependencies = [
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb6b23999a8b1a997bf47c7bb4d19ad4029c3327bb3386ebe0a5ff584b33c7a"
+checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
 dependencies = [
- "cstr",
  "dlib",
  "once_cell",
  "pkg-config",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -21,7 +21,7 @@ canvas_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }
 euclid = { workspace = true }
-font-kit = { version = "0.13" }
+font-kit = { version = "0.14" }
 fnv = { workspace = true }
 fonts = { path = "../fonts" }
 half = "2"
@@ -34,7 +34,7 @@ parking_lot = { workspace = true }
 pathfinder_geometry = "0.5"
 pixels = { path = "../pixels" }
 range = { path = "../range" }
-raqote = "0.8.4"
+raqote = { git = "https://github.com/jrmuizel/raqote", rev = "64716c8" }
 servo_arc = { workspace = true }
 sparkle = { workspace = true }
 style = { workspace = true }

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -25,4 +25,4 @@ style_config = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-dirs-next = "2.0"
+dirs = "5.0"

--- a/components/config/basedir.rs
+++ b/components/config/basedir.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
     not(target_os = "android")
 ))]
 pub fn default_config_dir() -> Option<PathBuf> {
-    let mut config_dir = ::dirs_next::config_dir().unwrap();
+    let mut config_dir = ::dirs::config_dir().unwrap();
     config_dir.push("servo");
     config_dir.push("default");
     Some(config_dir)
@@ -30,14 +30,14 @@ pub fn default_config_dir() -> Option<PathBuf> {
 pub fn default_config_dir() -> Option<PathBuf> {
     // FIXME: use `config_dir()` ($HOME/Library/Preferences)
     // instead of `data_dir()` ($HOME/Library/Application Support) ?
-    let mut config_dir = ::dirs_next::data_dir().unwrap();
+    let mut config_dir = ::dirs::data_dir().unwrap();
     config_dir.push("Servo");
     Some(config_dir)
 }
 
 #[cfg(target_os = "windows")]
 pub fn default_config_dir() -> Option<PathBuf> {
-    let mut config_dir = ::dirs_next::config_dir().unwrap();
+    let mut config_dir = ::dirs::config_dir().unwrap();
     config_dir.push("Servo");
     Some(config_dir)
 }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -63,7 +63,7 @@ freetype-sys = { workspace = true }
 servo_allocator = { path = "../allocator" }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
-fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "5" }
+fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 xml-rs = "0.8"


### PR DESCRIPTION
`dirs-next` is still used by the version of the `term` crate we are
using, but this also remoes a version of `cstr` so our dependency count
does not change.

A new version of `raqote` hasn't been released, so this depends on the
upstream repository directly. It's been almost 4 months since the
release has been ready -- so it's unclear when it will happen.

Fixes #32801.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
