### PR TITLE
fonts: Enable fast text shaping on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,8 +1514,7 @@ dependencies = [
 [[package]]
 name = "dwrote"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+source = "git+https://github.com/servo/dwrote-rs?rev=f2f644d3de8dee9a71c90e0376fd44531e5c2eec#f2f644d3de8dee9a71c90e0376fd44531e5c2eec"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,8 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "dwrote"
-version = "0.11.0"
-source = "git+https://github.com/servo/dwrote-rs?rev=f2f644d3de8dee9a71c90e0376fd44531e5c2eec#f2f644d3de8dee9a71c90e0376fd44531e5c2eec"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da3498378ed373237bdef1eddcc64e7be2d3ba4841f4c22a998e81cadeea83c"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,3 @@ strip = true
 #
 # [patch."https://github.com/servo/<repository>"]
 # <crate> = { path = "/path/to/local/checkout" }
-
-# patch dwrote for https://github.com/servo/dwrote-rs/pull/55
-dwrote = { git = "https://github.com/servo/dwrote-rs", rev = "f2f644d3de8dee9a71c90e0376fd44531e5c2eec" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,3 +194,6 @@ strip = true
 #
 # [patch."https://github.com/servo/<repository>"]
 # <crate> = { path = "/path/to/local/checkout" }
+
+# patch dwrote for https://github.com/servo/dwrote-rs/pull/55
+dwrote = { git = "https://github.com/servo/dwrote-rs", rev = "f2f644d3de8dee9a71c90e0376fd44531e5c2eec" }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -74,5 +74,5 @@ harfbuzz-sys = { version = "0.6.1", features = ["bundled"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 harfbuzz-sys = { version = "0.6", features = ["bundled"] }
-dwrote = "0.11"
+dwrote = "0.11.1"
 truetype = { version = "0.47.3", features = ["ignore-invalid-language-ids"] }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 [lib]
 name = "fonts"
 path = "lib.rs"
-test = false
+test = true
 doctest = false
 
 [dependencies]

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -212,15 +212,15 @@ impl PlatformFontMethods for PlatformFont {
 
     /// Can this font do basic horizontal LTR shaping without Harfbuzz?
     fn can_do_fast_shaping(&self) -> bool {
-        // TODO copy CachedKernTable from the MacOS X implementation to
-        // somehwere global and use it here.  We could also implement the
-        // IDirectWriteFontFace1 interface and use the glyph kerning pair
-        // methods there.
-        false
+        self.face.has_kerning_pairs()
     }
 
-    fn glyph_h_kerning(&self, _: GlyphId, _: GlyphId) -> FractionalPixel {
-        0.0
+    fn glyph_h_kerning(&self, first_glyph: GlyphId, second_glyph: GlyphId) -> FractionalPixel {
+        let adjustment = self
+            .face
+            .get_glyph_pair_kerning_adjustment(first_glyph as u16, second_glyph as u16);
+
+        (adjustment as f32 * self.scaled_du_to_px) as FractionalPixel
     }
 
     fn metrics(&self) -> FontMetrics {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Use glyph pair kerning info provided by `IDWriteFontFace1` (via dwrote).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
