### PR TITLE
Various borrow hazard fixes

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4287,15 +4287,15 @@ impl DocumentMethods for Document {
     // https://dom.spec.whatwg.org/#dom-document-getelementsbytagname
     fn GetElementsByTagName(&self, qualified_name: DOMString) -> DomRoot<HTMLCollection> {
         let qualified_name = LocalName::from(&*qualified_name);
-        match self.tag_map.borrow_mut().entry(qualified_name.clone()) {
-            Occupied(entry) => DomRoot::from_ref(entry.get()),
-            Vacant(entry) => {
-                let result =
-                    HTMLCollection::by_qualified_name(&self.window, self.upcast(), qualified_name);
-                entry.insert(Dom::from_ref(&*result));
-                result
-            },
+        if let Some(entry) = self.tag_map.borrow_mut().get(&qualified_name) {
+            return DomRoot::from_ref(entry);
         }
+        let result =
+            HTMLCollection::by_qualified_name(&self.window, self.upcast(), qualified_name.clone());
+        self.tag_map
+            .borrow_mut()
+            .insert(qualified_name, Dom::from_ref(&*result));
+        result
     }
 
     // https://dom.spec.whatwg.org/#dom-document-getelementsbytagnamens

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -175,6 +175,8 @@ impl FormDataMethods for FormData {
     #[allow(crown::unrooted_must_root)]
     // https://xhr.spec.whatwg.org/#dom-formdata-set
     fn Set_(&self, name: USVString, blob: &Blob, filename: Option<USVString>) {
+        let file = self.create_an_entry(blob, filename);
+
         let mut data = self.data.borrow_mut();
         let local_name = LocalName::from(name.0.clone());
 
@@ -185,9 +187,7 @@ impl FormDataMethods for FormData {
             FormDatum {
                 ty: DOMString::from("file"),
                 name: DOMString::from(name.0),
-                value: FormDatumValue::File(DomRoot::from_ref(
-                    &*self.create_an_entry(blob, filename),
-                )),
+                value: FormDatumValue::File(file),
             },
         ));
     }

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -466,7 +466,8 @@ impl Response {
         if let Some(body) = self.body_stream.get() {
             body.close_native();
         }
-        if let Some(stream_consumer) = self.stream_consumer.borrow_mut().take() {
+        let stream_consumer = self.stream_consumer.borrow_mut().take();
+        if let Some(stream_consumer) = stream_consumer {
             stream_consumer.stream_end();
         }
     }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -644,6 +644,9 @@ impl WindowProxy {
             // because we want to replace the wrapper's `ProxyTraps`, but we
             // don't want to update its identity.
             rooted!(in(*cx) let new_js_proxy = handler.new_window_proxy(&cx, window_jsobject));
+            // Explicitly set this slot to a null pointer in case a GC occurs before we
+            // are ready to set it to a real value.
+            SetProxyReservedSlot(new_js_proxy.get(), 0, &PrivateValue(ptr::null_mut()));
             debug!(
                 "Transplanting proxy from {:p} to {:p}.",
                 old_js_proxy.get(),


### PR DESCRIPTION
Extracted from #24069. These were all discovered by cranking up SpiderMonkey's GC zeal settings so that GC would occur much more frequently than normal.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix https://github.com/servo/servo/issues/24117 and fix https://github.com/servo/servo/issues/24118 and fix https://github.com/servo/servo/issues/24116 and fix https://github.com/servo/servo/issues/23959.
- [x] These changes do not require tests because they can't be triggered deterministically by tests in CI