### PR TITLE
ReadableStream: implement Cancel and Locked

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -640,7 +640,7 @@ fn stream_handle_incoming(stream: &ReadableStream, bytes: Result<Vec<u8>, Error>
 
 /// Callback used to close streams as part of FileListener.
 fn stream_handle_eof(stream: &ReadableStream) {
-    stream.close_native();
+    stream.close();
 }
 
 impl FileListener {

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -181,7 +181,7 @@ impl ReadableStream {
             UnderlyingSourceType::Memory(bytes.len()),
         );
         stream.enqueue_native(bytes);
-        stream.close_native();
+        stream.close();
         stream
     }
 
@@ -251,15 +251,6 @@ impl ReadableStream {
         self.state.set(ReadableStreamState::Errored);
         match self.controller {
             ControllerType::Default(ref controller) => controller.error(),
-            _ => unreachable!("Native closing a stream with a non-default controller"),
-        }
-    }
-
-    /// <https://streams.spec.whatwg.org/#readable-stream-close>
-    /// Note: in other use cases this call happens via the controller.
-    pub fn close_native(&self) {
-        match self.controller {
-            ControllerType::Default(ref controller) => controller.close(),
             _ => unreachable!("Native closing a stream with a non-default controller"),
         }
     }
@@ -399,6 +390,39 @@ impl ReadableStream {
             ),
         }
     }
+
+    /// <https://streams.spec.whatwg.org/#readable-stream-close>
+    pub fn close(&self) {
+        self.state.set(ReadableStreamState::Closed);
+        match self.reader {
+            ReaderType::Default(ref reader) => {
+                if let Some(reader) = reader.get() {
+                    reader.close();
+                }
+            },
+            ReaderType::BYOB(ref reader) => todo!(),
+        }
+    }
+
+    /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
+    fn cancel(&self, promise: &Promise, reason: SafeHandleValue) {
+        self.disturbed.set(true);
+
+        if self.is_closed() {
+            return promise.resolve_native(&());
+        }
+
+        if self.is_errored() {
+            // TODO: resolve with stored_error.
+            return promise.reject_native(&());
+        }
+
+        self.close();
+
+        // TODO: run the bytes reader steps.
+
+        // TODO: react to sourceCancelPromise.
+    }
 }
 
 impl ReadableStreamMethods for ReadableStream {
@@ -408,9 +432,15 @@ impl ReadableStreamMethods for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>
-    fn Cancel(&self, _cx: SafeJSContext, _reason: SafeHandleValue) -> Rc<Promise> {
-        // TODO
-        Promise::new(&self.reflector_.global())
+    fn Cancel(&self, _cx: SafeJSContext, reason: SafeHandleValue) -> Rc<Promise> {
+        let promise = Promise::new(&self.reflector_.global());
+        if !self.is_locked() {
+            // TODO: reject with a TypeError exception.
+            promise.reject_native(&());
+        } else {
+            self.cancel(&promise, reason);
+        }
+        promise
     }
 
     /// <https://streams.spec.whatwg.org/#rs-get-reader>

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -332,6 +332,7 @@ impl ReadableStream {
         }
     }
 
+    /// <https://streams.spec.whatwg.org/#is-readable-stream-locked>
     pub fn is_locked(&self) -> bool {
         match self.reader {
             ReaderType::Default(ref reader) => reader.get().is_some(),
@@ -403,8 +404,7 @@ impl ReadableStream {
 impl ReadableStreamMethods for ReadableStream {
     /// <https://streams.spec.whatwg.org/#rs-locked>
     fn Locked(&self) -> bool {
-        // TODO
-        false
+        self.is_locked()
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -465,7 +465,7 @@ impl Response {
     #[allow(crown::unrooted_must_root)]
     pub fn finish(&self) {
         if let Some(body) = self.body_stream.get() {
-            body.close_native();
+            body.close();
         }
         if let Some(stream_consumer) = self.stream_consumer.borrow_mut().take() {
             stream_consumer.stream_end();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implement the remaining public JS methods of ReadableStream: `Closed` and `Cancel`. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
