### PR TITLE
Start marking functions that can transitively trigger a GC

### DIFF
--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -97,7 +97,7 @@ impl AnalyserNode {
         context: &BaseAudioContext,
         options: &AnalyserOptions,
     ) -> Fallible<DomRoot<AnalyserNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -106,9 +106,10 @@ impl AnalyserNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<AnalyserNode>> {
         let (node, recv) = AnalyserNode::new_inherited(window, context, options)?;
-        let object = reflect_dom_object_with_proto(Box::new(node), window, proto, CanGc::note());
+        let object = reflect_dom_object_with_proto(Box::new(node), window, proto, can_gc);
         let (source, canceller) = window
             .task_manager()
             .dom_manipulation_task_source_with_canceller();
@@ -135,10 +136,11 @@ impl AnalyserNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &AnalyserOptions,
     ) -> Fallible<DomRoot<AnalyserNode>> {
-        AnalyserNode::new_with_proto(window, proto, context, options)
+        AnalyserNode::new_with_proto(window, proto, context, options, can_gc)
     }
 
     pub fn push_block(&self, block: Block) {

--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -26,6 +26,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 use crate::task_source::TaskSource;
 
 #[dom_struct]
@@ -107,7 +108,7 @@ impl AnalyserNode {
         options: &AnalyserOptions,
     ) -> Fallible<DomRoot<AnalyserNode>> {
         let (node, recv) = AnalyserNode::new_inherited(window, context, options)?;
-        let object = reflect_dom_object_with_proto(Box::new(node), window, proto);
+        let object = reflect_dom_object_with_proto(Box::new(node), window, proto, CanGc::note());
         let (source, canceller) = window
             .task_manager()
             .dom_manipulation_task_source_with_canceller();

--- a/components/script/dom/animationevent.rs
+++ b/components/script/dom/animationevent.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct AnimationEvent {
@@ -51,6 +52,7 @@ impl AnimationEvent {
             Box::new(AnimationEvent::new_inherited(init)),
             window,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/animationevent.rs
+++ b/components/script/dom/animationevent.rs
@@ -39,7 +39,7 @@ impl AnimationEvent {
     }
 
     pub fn new(window: &Window, type_: Atom, init: &AnimationEventInit) -> DomRoot<AnimationEvent> {
-        Self::new_with_proto(window, None, type_, init)
+        Self::new_with_proto(window, None, type_, init, CanGc::note())
     }
 
     fn new_with_proto(
@@ -47,12 +47,13 @@ impl AnimationEvent {
         proto: Option<HandleObject>,
         type_: Atom,
         init: &AnimationEventInit,
+        can_gc: CanGc,
     ) -> DomRoot<AnimationEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(AnimationEvent::new_inherited(init)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -65,10 +66,11 @@ impl AnimationEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &AnimationEventInit,
     ) -> DomRoot<AnimationEvent> {
-        AnimationEvent::new_with_proto(window, proto, Atom::from(type_), init)
+        AnimationEvent::new_with_proto(window, proto, Atom::from(type_), init, can_gc)
     }
 }
 

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -22,7 +22,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::realms::enter_realm;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // Spec mandates at least [8000, 96000], we use [8000, 192000] to match Firefox
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer
@@ -102,7 +102,7 @@ impl AudioBuffer {
         initial_data: Option<&[Vec<f32>]>,
     ) -> DomRoot<AudioBuffer> {
         let buffer = AudioBuffer::new_inherited(number_of_channels, length, sample_rate);
-        let buffer = reflect_dom_object_with_proto(Box::new(buffer), global, proto);
+        let buffer = reflect_dom_object_with_proto(Box::new(buffer), global, proto, CanGc::note());
         buffer.set_initial_data(initial_data);
         buffer
     }

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -89,6 +89,7 @@ impl AudioBuffer {
             length,
             sample_rate,
             initial_data,
+            CanGc::note(),
         )
     }
 
@@ -100,9 +101,10 @@ impl AudioBuffer {
         length: u32,
         sample_rate: f32,
         initial_data: Option<&[Vec<f32>]>,
+        can_gc: CanGc,
     ) -> DomRoot<AudioBuffer> {
         let buffer = AudioBuffer::new_inherited(number_of_channels, length, sample_rate);
-        let buffer = reflect_dom_object_with_proto(Box::new(buffer), global, proto, CanGc::note());
+        let buffer = reflect_dom_object_with_proto(Box::new(buffer), global, proto, can_gc);
         buffer.set_initial_data(initial_data);
         buffer
     }
@@ -112,6 +114,7 @@ impl AudioBuffer {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         options: &AudioBufferOptions,
     ) -> Fallible<DomRoot<AudioBuffer>> {
         if options.length == 0 ||
@@ -129,6 +132,7 @@ impl AudioBuffer {
             options.length,
             *options.sampleRate,
             None,
+            can_gc,
         ))
     }
 

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -101,7 +101,7 @@ impl AudioBufferSourceNode {
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -110,13 +110,14 @@ impl AudioBufferSourceNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
         let node = AudioBufferSourceNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -124,10 +125,11 @@ impl AudioBufferSourceNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &AudioBufferSourceOptions,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
-        AudioBufferSourceNode::new_with_proto(window, proto, context, options)
+        AudioBufferSourceNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -28,6 +28,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct AudioBufferSourceNode {
@@ -111,7 +112,12 @@ impl AudioBufferSourceNode {
         options: &AudioBufferSourceOptions,
     ) -> Fallible<DomRoot<AudioBufferSourceNode>> {
         let node = AudioBufferSourceNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -33,6 +33,7 @@ use crate::dom::mediastreamtrackaudiosourcenode::MediaStreamTrackAudioSourceNode
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::realms::InRealm;
+use crate::script_runtime::CanGc;
 use crate::task_source::TaskSource;
 
 #[dom_struct]
@@ -89,7 +90,8 @@ impl AudioContext {
     ) -> Fallible<DomRoot<AudioContext>> {
         let pipeline_id = window.pipeline_id();
         let context = AudioContext::new_inherited(options, pipeline_id)?;
-        let context = reflect_dom_object_with_proto(Box::new(context), window, proto);
+        let context =
+            reflect_dom_object_with_proto(Box::new(context), window, proto, CanGc::note());
         context.resume();
         Ok(context)
     }

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -87,11 +87,11 @@ impl AudioContext {
         window: &Window,
         proto: Option<HandleObject>,
         options: &AudioContextOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<AudioContext>> {
         let pipeline_id = window.pipeline_id();
         let context = AudioContext::new_inherited(options, pipeline_id)?;
-        let context =
-            reflect_dom_object_with_proto(Box::new(context), window, proto, CanGc::note());
+        let context = reflect_dom_object_with_proto(Box::new(context), window, proto, can_gc);
         context.resume();
         Ok(context)
     }
@@ -101,9 +101,10 @@ impl AudioContext {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         options: &AudioContextOptions,
     ) -> Fallible<DomRoot<AudioContext>> {
-        AudioContext::new(window, proto, options)
+        AudioContext::new(window, proto, options, can_gc)
     }
 
     fn resume(&self) {

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2889,7 +2889,8 @@ class CGWrapMethod(CGAbstractMethod):
         args = [Argument('SafeJSContext', 'cx'),
                 Argument('&GlobalScope', 'scope'),
                 Argument('Option<HandleObject>', 'given_proto'),
-                Argument(f"Box<{descriptor.concreteType}>", 'object')]
+                Argument(f"Box<{descriptor.concreteType}>", 'object'),
+                Argument('CanGc', '_can_gc')]
         retval = f'DomRoot<{descriptor.concreteType}>'
         CGAbstractMethod.__init__(self, descriptor, 'Wrap', retval, args,
                                   pub=True, unsafe=True)
@@ -3082,6 +3083,7 @@ impl DomObjectWrap for {name} {{
         &GlobalScope,
         Option<HandleObject>,
         Box<Self>,
+        CanGc,
     ) -> Root<Dom<Self>> = Wrap;
 }}
 """
@@ -3105,6 +3107,7 @@ impl DomObjectIteratorWrap for {name} {{
         &GlobalScope,
         Option<HandleObject>,
         Box<IterableIterator<Self>>,
+        CanGc,
     ) -> Root<Dom<IterableIterator<Self>>> = Wrap;
 }}
 """

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -6237,7 +6237,7 @@ if proto_result.is_err() {{
 """
             name = self.constructor.identifier.name
             nativeName = MakeNativeName(self.descriptor.binaryNameFor(name))
-            args = ["&global", "Some(desired_proto.handle())"]
+            args = ["&global", "Some(desired_proto.handle())", "CanGc::note()"]
             constructorCall = CGMethodCall(args, nativeName, True,
                                            self.descriptor, self.constructor)
         return CGList([CGGeneric(preamble), constructorCall])

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -145,4 +145,5 @@ pub mod module {
     pub use crate::dom::types::{AnalyserNode, AudioNode, BaseAudioContext, EventTarget};
     pub use crate::mem::malloc_size_of_including_raw_self;
     pub use crate::realms::{AlreadyInRealm, InRealm};
+    pub use crate::script_runtime::CanGc;
 }

--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::reflector::{
 use crate::dom::bindings::root::{Dom, DomRoot, Root};
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 /// The values that an iterator will iterate over.
 #[derive(JSTraceable, MallocSizeOf)]
@@ -126,6 +126,7 @@ impl<T: DomObjectIteratorWrap + JSTraceable + Iterable> DomObjectWrap for Iterab
         &GlobalScope,
         Option<HandleObject>,
         Box<Self>,
+        CanGc,
     ) -> Root<Dom<Self>> = T::ITER_WRAP;
 }
 

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, Root};
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::globalscope::GlobalScope;
 use crate::realms::AlreadyInRealm;
-use crate::script_runtime::{JSContext, CanGc};
+use crate::script_runtime::{CanGc, JSContext};
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
@@ -25,20 +25,29 @@ where
     U: DerivedFrom<GlobalScope>,
 {
     let global_scope = global.upcast();
-    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, None, obj, CanGc::note()) }
+    unsafe {
+        T::WRAP(
+            GlobalScope::get_cx(),
+            global_scope,
+            None,
+            obj,
+            CanGc::note(),
+        )
+    }
 }
 
 pub fn reflect_dom_object_with_proto<T, U>(
     obj: Box<T>,
     global: &U,
     proto: Option<HandleObject>,
+    can_gc: CanGc,
 ) -> DomRoot<T>
 where
     T: DomObject + DomObjectWrap,
     U: DerivedFrom<GlobalScope>,
 {
     let global_scope = global.upcast();
-    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, proto, obj, CanGc::note()) }
+    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, proto, obj, can_gc) }
 }
 
 /// A struct to store a reference to the reflector of a DOM object.

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, Root};
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::globalscope::GlobalScope;
 use crate::realms::AlreadyInRealm;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{JSContext, CanGc};
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
@@ -25,7 +25,7 @@ where
     U: DerivedFrom<GlobalScope>,
 {
     let global_scope = global.upcast();
-    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, None, obj) }
+    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, None, obj, CanGc::note()) }
 }
 
 pub fn reflect_dom_object_with_proto<T, U>(
@@ -38,7 +38,7 @@ where
     U: DerivedFrom<GlobalScope>,
 {
     let global_scope = global.upcast();
-    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, proto, obj) }
+    unsafe { T::WRAP(GlobalScope::get_cx(), global_scope, proto, obj, CanGc::note()) }
 }
 
 /// A struct to store a reference to the reflector of a DOM object.
@@ -131,6 +131,7 @@ pub trait DomObjectWrap: Sized + DomObject {
         &GlobalScope,
         Option<HandleObject>,
         Box<Self>,
+        CanGc,
     ) -> Root<Dom<Self>>;
 }
 
@@ -143,5 +144,6 @@ pub trait DomObjectIteratorWrap: DomObjectWrap + JSTraceable + Iterable {
         &GlobalScope,
         Option<HandleObject>,
         Box<IterableIterator<Self>>,
+        CanGc,
     ) -> Root<Dom<IterableIterator<Self>>>;
 }

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -118,7 +118,7 @@ impl BiquadFilterNode {
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -127,13 +127,14 @@ impl BiquadFilterNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
         let node = BiquadFilterNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -141,10 +142,11 @@ impl BiquadFilterNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &BiquadFilterOptions,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
-        BiquadFilterNode::new_with_proto(window, proto, context, options)
+        BiquadFilterNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -27,6 +27,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct BiquadFilterNode {
@@ -128,7 +129,12 @@ impl BiquadFilterNode {
         options: &BiquadFilterOptions,
     ) -> Fallible<DomRoot<BiquadFilterNode>> {
         let node = BiquadFilterNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -30,7 +30,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
 use crate::realms::{AlreadyInRealm, InRealm};
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // https://w3c.github.io/FileAPI/#blob
 #[dom_struct]
@@ -50,8 +50,12 @@ impl Blob {
         proto: Option<HandleObject>,
         blob_impl: BlobImpl,
     ) -> DomRoot<Blob> {
-        let dom_blob =
-            reflect_dom_object_with_proto(Box::new(Blob::new_inherited(&blob_impl)), global, proto);
+        let dom_blob = reflect_dom_object_with_proto(
+            Box::new(Blob::new_inherited(&blob_impl)),
+            global,
+            proto,
+            CanGc::note(),
+        );
         global.track_blob(&dom_blob, blob_impl);
         dom_blob
     }

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -42,19 +42,20 @@ pub struct Blob {
 
 impl Blob {
     pub fn new(global: &GlobalScope, blob_impl: BlobImpl) -> DomRoot<Blob> {
-        Self::new_with_proto(global, None, blob_impl)
+        Self::new_with_proto(global, None, blob_impl, CanGc::note())
     }
 
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         blob_impl: BlobImpl,
+        can_gc: CanGc,
     ) -> DomRoot<Blob> {
         let dom_blob = reflect_dom_object_with_proto(
             Box::new(Blob::new_inherited(&blob_impl)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         global.track_blob(&dom_blob, blob_impl);
         dom_blob
@@ -73,6 +74,7 @@ impl Blob {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         blobParts: Option<Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>>,
         blobPropertyBag: &BlobBinding::BlobPropertyBag,
     ) -> Fallible<DomRoot<Blob>> {
@@ -87,7 +89,7 @@ impl Blob {
         let type_string = normalize_type_string(blobPropertyBag.type_.as_ref());
         let blob_impl = BlobImpl::new_from_bytes(bytes, type_string);
 
-        Ok(Blob::new_with_proto(global, proto, blob_impl))
+        Ok(Blob::new_with_proto(global, proto, blob_impl, can_gc))
     }
 
     /// Get a slice to inner data, this might incur synchronous read and caching

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -63,6 +63,7 @@ impl BluetoothAdvertisingEvent {
         appearance: Option<u16>,
         txPower: Option<i8>,
         rssi: Option<i8>,
+        can_gc: CanGc,
     ) -> DomRoot<BluetoothAdvertisingEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(BluetoothAdvertisingEvent::new_inherited(
@@ -70,7 +71,7 @@ impl BluetoothAdvertisingEvent {
             )),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -83,6 +84,7 @@ impl BluetoothAdvertisingEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &BluetoothAdvertisingEventInit,
     ) -> Fallible<DomRoot<BluetoothAdvertisingEvent>> {
@@ -104,6 +106,7 @@ impl BluetoothAdvertisingEvent {
             appearance,
             txPower,
             rssi,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/bluetoothadvertisingevent.rs
+++ b/components/script/dom/bluetoothadvertisingevent.rs
@@ -19,6 +19,7 @@ use crate::dom::bluetoothdevice::BluetoothDevice;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothadvertisingevent
 #[dom_struct]
@@ -69,6 +70,7 @@ impl BluetoothAdvertisingEvent {
             )),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[dom_struct]
 pub struct BroadcastChannel {
@@ -48,6 +48,7 @@ impl BroadcastChannel {
             Box::new(BroadcastChannel::new_inherited(name)),
             global,
             proto,
+            CanGc::note(),
         );
         global.track_broadcast_channel(&channel);
         channel

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -34,21 +34,23 @@ impl BroadcastChannel {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         name: DOMString,
     ) -> DomRoot<BroadcastChannel> {
-        BroadcastChannel::new(global, proto, name)
+        BroadcastChannel::new(global, proto, name, can_gc)
     }
 
     fn new(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         name: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<BroadcastChannel> {
         let channel = reflect_dom_object_with_proto(
             Box::new(BroadcastChannel::new_inherited(name)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         global.track_broadcast_channel(&channel);
         channel

--- a/components/script/dom/channelmergernode.rs
+++ b/components/script/dom/channelmergernode.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct ChannelMergerNode {
@@ -70,7 +71,12 @@ impl ChannelMergerNode {
         options: &ChannelMergerOptions,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
         let node = ChannelMergerNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/channelmergernode.rs
+++ b/components/script/dom/channelmergernode.rs
@@ -60,7 +60,7 @@ impl ChannelMergerNode {
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -69,13 +69,14 @@ impl ChannelMergerNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
         let node = ChannelMergerNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -83,10 +84,11 @@ impl ChannelMergerNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &ChannelMergerOptions,
     ) -> Fallible<DomRoot<ChannelMergerNode>> {
-        ChannelMergerNode::new_with_proto(window, proto, context, options)
+        ChannelMergerNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/channelsplitternode.rs
+++ b/components/script/dom/channelsplitternode.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct ChannelSplitterNode {
@@ -72,7 +73,12 @@ impl ChannelSplitterNode {
         options: &ChannelSplitterOptions,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
         let node = ChannelSplitterNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/channelsplitternode.rs
+++ b/components/script/dom/channelsplitternode.rs
@@ -62,7 +62,7 @@ impl ChannelSplitterNode {
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -71,13 +71,14 @@ impl ChannelSplitterNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
         let node = ChannelSplitterNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -85,9 +86,10 @@ impl ChannelSplitterNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &ChannelSplitterOptions,
     ) -> Fallible<DomRoot<ChannelSplitterNode>> {
-        ChannelSplitterNode::new_with_proto(window, proto, context, options)
+        ChannelSplitterNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct CloseEvent {
@@ -62,7 +63,7 @@ impl CloseEvent {
         reason: DOMString,
     ) -> DomRoot<CloseEvent> {
         let event = Box::new(CloseEvent::new_inherited(wasClean, code, reason));
-        let ev = reflect_dom_object_with_proto(event, global, proto);
+        let ev = reflect_dom_object_with_proto(event, global, proto, CanGc::note());
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -47,7 +47,15 @@ impl CloseEvent {
         reason: DOMString,
     ) -> DomRoot<CloseEvent> {
         Self::new_with_proto(
-            global, None, type_, bubbles, cancelable, wasClean, code, reason,
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            wasClean,
+            code,
+            reason,
+            CanGc::note(),
         )
     }
 
@@ -61,9 +69,10 @@ impl CloseEvent {
         wasClean: bool,
         code: u16,
         reason: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<CloseEvent> {
         let event = Box::new(CloseEvent::new_inherited(wasClean, code, reason));
-        let ev = reflect_dom_object_with_proto(event, global, proto, CanGc::note());
+        let ev = reflect_dom_object_with_proto(event, global, proto, can_gc);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -74,6 +83,7 @@ impl CloseEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &CloseEventBinding::CloseEventInit,
     ) -> Fallible<DomRoot<CloseEvent>> {
@@ -88,6 +98,7 @@ impl CloseEvent {
             init.wasClean,
             init.code,
             init.reason.clone(),
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -13,6 +13,7 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 /// An HTML comment.
 #[dom_struct]
@@ -43,6 +44,7 @@ impl Comment {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        _can_gc: CanGc,
         data: DOMString,
     ) -> Fallible<DomRoot<Comment>> {
         let document = window.Document();

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -45,7 +45,15 @@ impl CompositionEvent {
         data: DOMString,
     ) -> DomRoot<CompositionEvent> {
         Self::new_with_proto(
-            window, None, type_, can_bubble, cancelable, view, detail, data,
+            window,
+            None,
+            type_,
+            can_bubble,
+            cancelable,
+            view,
+            detail,
+            data,
+            CanGc::note(),
         )
     }
 
@@ -59,6 +67,7 @@ impl CompositionEvent {
         view: Option<&Window>,
         detail: i32,
         data: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<CompositionEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(CompositionEvent {
@@ -67,7 +76,7 @@ impl CompositionEvent {
             }),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         ev.uievent
             .InitUIEvent(type_, can_bubble, cancelable, view, detail);
@@ -78,6 +87,7 @@ impl CompositionEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &CompositionEventBinding::CompositionEventInit,
     ) -> Fallible<DomRoot<CompositionEvent>> {
@@ -90,6 +100,7 @@ impl CompositionEvent {
             init.parent.view.as_deref(),
             init.parent.detail,
             init.data.clone(),
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct CompositionEvent {
@@ -66,6 +67,7 @@ impl CompositionEvent {
             }),
             window,
             proto,
+            CanGc::note(),
         );
         ev.uievent
             .InitUIEvent(type_, can_bubble, cancelable, view, detail);

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -68,7 +68,7 @@ impl ConstantSourceNode {
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -77,13 +77,14 @@ impl ConstantSourceNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
         let node = ConstantSourceNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -91,10 +92,11 @@ impl ConstantSourceNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &ConstantSourceOptions,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
-        ConstantSourceNode::new_with_proto(window, proto, context, options)
+        ConstantSourceNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -21,6 +21,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct ConstantSourceNode {
@@ -78,7 +79,12 @@ impl ConstantSourceNode {
         options: &ConstantSourceOptions,
     ) -> Fallible<DomRoot<ConstantSourceNode>> {
         let node = ConstantSourceNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -38,18 +38,19 @@ impl CustomEvent {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<CustomEvent> {
-        Self::new_uninitialized_with_proto(global, None)
+        Self::new_uninitialized_with_proto(global, None, CanGc::note())
     }
 
     fn new_uninitialized_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<CustomEvent> {
         reflect_dom_object_with_proto(
             Box::new(CustomEvent::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -60,8 +61,9 @@ impl CustomEvent {
         bubbles: bool,
         cancelable: bool,
         detail: HandleValue,
+        can_gc: CanGc,
     ) -> DomRoot<CustomEvent> {
-        let ev = CustomEvent::new_uninitialized_with_proto(global, proto);
+        let ev = CustomEvent::new_uninitialized_with_proto(global, proto, can_gc);
         ev.init_custom_event(type_, bubbles, cancelable, detail);
         ev
     }
@@ -70,6 +72,7 @@ impl CustomEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<CustomEventBinding::CustomEventInit>,
     ) -> Fallible<DomRoot<CustomEvent>> {
@@ -80,6 +83,7 @@ impl CustomEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             init.detail.handle(),
+            can_gc,
         ))
     }
 

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // https://dom.spec.whatwg.org/#interface-customevent
 #[dom_struct]
@@ -45,7 +45,12 @@ impl CustomEvent {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<CustomEvent> {
-        reflect_dom_object_with_proto(Box::new(CustomEvent::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(CustomEvent::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     fn new(

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3409,6 +3409,7 @@ impl Document {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<Document>> {
         let doc = window.Document();
         let docloader = DocumentLoader::new(&doc.loader());
@@ -3428,6 +3429,7 @@ impl Document {
             None,
             None,
             Default::default(),
+            can_gc,
         ))
     }
 
@@ -3464,6 +3466,7 @@ impl Document {
             referrer_policy,
             status_code,
             canceller,
+            CanGc::note(),
         )
     }
 
@@ -3484,6 +3487,7 @@ impl Document {
         referrer_policy: Option<ReferrerPolicy>,
         status_code: Option<u16>,
         canceller: FetchCanceller,
+        can_gc: CanGc,
     ) -> DomRoot<Document> {
         let document = reflect_dom_object_with_proto(
             Box::new(Document::new_inherited(
@@ -3504,7 +3508,7 @@ impl Document {
             )),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let node = document.upcast::<Node>();
@@ -4594,7 +4598,7 @@ impl DocumentMethods for Document {
 
     // https://dom.spec.whatwg.org/#dom-document-createrange
     fn CreateRange(&self) -> DomRoot<Range> {
-        Range::new_with_doc(self, None)
+        Range::new_with_doc(self, None, CanGc::note())
     }
 
     // https://dom.spec.whatwg.org/#dom-document-createnodeiteratorroot-whattoshow-filter

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -177,7 +177,7 @@ use crate::dom::window::{ReflowReason, Window};
 use crate::dom::windowproxy::WindowProxy;
 use crate::fetch::FetchCanceller;
 use crate::realms::{AlreadyInRealm, InRealm};
-use crate::script_runtime::{CommonScriptMsg, ScriptThreadEventCategory};
+use crate::script_runtime::{CanGc, CommonScriptMsg, ScriptThreadEventCategory};
 use crate::script_thread::{MainThreadScriptMsg, ScriptThread};
 use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::TaskBox;
@@ -3504,6 +3504,7 @@ impl Document {
             )),
             window,
             proto,
+            CanGc::note(),
         );
         {
             let node = document.upcast::<Node>();

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -21,6 +21,7 @@ use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::node::{window_from_node, Node};
 use crate::dom::nodelist::NodeList;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#documentfragment
 #[dom_struct]
@@ -58,6 +59,7 @@ impl DocumentFragment {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        _can_gc: CanGc,
     ) -> Fallible<DomRoot<DocumentFragment>> {
         let document = window.Document();
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::reflector::{
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[repr(u16)]
 #[derive(Clone, Copy, Debug, Eq, JSTraceable, MallocSizeOf, Ord, PartialEq, PartialOrd)]
@@ -157,6 +158,7 @@ impl DOMException {
             Box::new(DOMException::new_inherited(message, name)),
             global,
             proto,
+            CanGc::note(),
         ))
     }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -151,6 +151,7 @@ impl DOMException {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         message: DOMString,
         name: DOMString,
     ) -> Result<DomRoot<DOMException>, Error> {
@@ -158,7 +159,7 @@ impl DOMException {
             Box::new(DOMException::new_inherited(message, name)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -30,7 +30,7 @@ pub struct DOMMatrix {
 #[allow(non_snake_case)]
 impl DOMMatrix {
     pub fn new(global: &GlobalScope, is2D: bool, matrix: Transform3D<f64>) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, is2D, matrix)
+        Self::new_with_proto(global, None, is2D, matrix, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -39,9 +39,10 @@ impl DOMMatrix {
         proto: Option<HandleObject>,
         is2D: bool,
         matrix: Transform3D<f64>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::note())
+        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, can_gc)
     }
 
     pub fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {
@@ -54,6 +55,7 @@ impl DOMMatrix {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: Option<StringOrUnrestrictedDoubleSequence>,
     ) -> Fallible<DomRoot<Self>> {
         if init.is_none() {
@@ -62,6 +64,7 @@ impl DOMMatrix {
                 proto,
                 true,
                 Transform3D::identity(),
+                can_gc,
             ));
         }
         match init.unwrap() {
@@ -75,11 +78,11 @@ impl DOMMatrix {
                     return Ok(Self::new(global, true, Transform3D::identity()));
                 }
                 transform_to_matrix(s.to_string())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
                 entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
             },
         }
     }
@@ -102,6 +105,7 @@ impl DOMMatrix {
         DOMMatrix::Constructor(
             global,
             None,
+            CanGc::note(),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -115,6 +119,7 @@ impl DOMMatrix {
         DOMMatrix::Constructor(
             global,
             None,
+            CanGc::note(),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -20,6 +20,7 @@ use crate::dom::dommatrixreadonly::{
 };
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct DOMMatrix {
@@ -40,7 +41,7 @@ impl DOMMatrix {
         matrix: Transform3D<f64>,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto)
+        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::note())
     }
 
     pub fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -44,7 +44,7 @@ pub struct DOMMatrixReadOnly {
 #[allow(non_snake_case)]
 impl DOMMatrixReadOnly {
     pub fn new(global: &GlobalScope, is2D: bool, matrix: Transform3D<f64>) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, is2D, matrix)
+        Self::new_with_proto(global, None, is2D, matrix, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -53,9 +53,10 @@ impl DOMMatrixReadOnly {
         proto: Option<HandleObject>,
         is2D: bool,
         matrix: Transform3D<f64>,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::note())
+        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, can_gc)
     }
 
     pub fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {
@@ -70,6 +71,7 @@ impl DOMMatrixReadOnly {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: Option<StringOrUnrestrictedDoubleSequence>,
     ) -> Fallible<DomRoot<Self>> {
         if init.is_none() {
@@ -78,6 +80,7 @@ impl DOMMatrixReadOnly {
                 proto,
                 true,
                 Transform3D::identity(),
+                can_gc,
             ));
         }
         match init.unwrap() {
@@ -91,11 +94,11 @@ impl DOMMatrixReadOnly {
                     return Ok(Self::new(global, true, Transform3D::identity()));
                 }
                 transform_to_matrix(s.to_string())
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
             },
             StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(ref entries) => {
                 entries_to_matrix(&entries[..])
-                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix))
+                    .map(|(is2D, matrix)| Self::new_with_proto(global, proto, is2D, matrix, can_gc))
             },
         }
     }
@@ -411,6 +414,7 @@ impl DOMMatrixReadOnly {
         DOMMatrixReadOnly::Constructor(
             global,
             None,
+            CanGc::note(),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }
@@ -425,6 +429,7 @@ impl DOMMatrixReadOnly {
         DOMMatrixReadOnly::Constructor(
             global,
             None,
+            CanGc::note(),
             Some(StringOrUnrestrictedDoubleSequence::UnrestrictedDoubleSequence(vec)),
         )
     }

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -30,7 +30,7 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::dompoint::DOMPoint;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 #[allow(non_snake_case)]
@@ -55,7 +55,7 @@ impl DOMMatrixReadOnly {
         matrix: Transform3D<f64>,
     ) -> DomRoot<Self> {
         let dommatrix = Self::new_inherited(is2D, matrix);
-        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto)
+        reflect_dom_object_with_proto(Box::new(dommatrix), global, proto, CanGc::note())
     }
 
     pub fn new_inherited(is2D: bool, matrix: Transform3D<f64>) -> Self {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -37,12 +37,12 @@ impl DOMParser {
         }
     }
 
-    fn new(window: &Window, proto: Option<HandleObject>) -> DomRoot<DOMParser> {
+    fn new(window: &Window, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<DOMParser> {
         reflect_dom_object_with_proto(
             Box::new(DOMParser::new_inherited(window)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -50,8 +50,9 @@ impl DOMParser {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMParser>> {
-        Ok(DOMParser::new(window, proto))
+        Ok(DOMParser::new(window, proto, can_gc))
     }
 }
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -21,6 +21,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::servoparser::ServoParser;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct DOMParser {
@@ -37,7 +38,12 @@ impl DOMParser {
     }
 
     fn new(window: &Window, proto: Option<HandleObject>) -> DomRoot<DOMParser> {
-        reflect_dom_object_with_proto(Box::new(DOMParser::new_inherited(window)), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(DOMParser::new_inherited(window)),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -29,7 +29,7 @@ impl DOMPoint {
     }
 
     pub fn new(global: &GlobalScope, x: f64, y: f64, z: f64, w: f64) -> DomRoot<DOMPoint> {
-        Self::new_with_proto(global, None, x, y, z, w)
+        Self::new_with_proto(global, None, x, y, z, w, CanGc::note())
     }
 
     fn new_with_proto(
@@ -39,24 +39,26 @@ impl DOMPoint {
         y: f64,
         z: f64,
         w: f64,
+        can_gc: CanGc,
     ) -> DomRoot<DOMPoint> {
         reflect_dom_object_with_proto(
             Box::new(DOMPoint::new_inherited(x, y, z, w)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         x: f64,
         y: f64,
         z: f64,
         w: f64,
     ) -> Fallible<DomRoot<DOMPoint>> {
-        Ok(DOMPoint::new_with_proto(global, proto, x, y, z, w))
+        Ok(DOMPoint::new_with_proto(global, proto, x, y, z, w, can_gc))
     }
 
     // https://drafts.fxtf.org/geometry/#dom-dompoint-frompoint

--- a/components/script/dom/dompoint.rs
+++ b/components/script/dom/dompoint.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::dompointreadonly::{DOMPointReadOnly, DOMPointWriteMethods};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 // http://dev.w3.org/fxtf/geometry/Overview.html#dompoint
 #[dom_struct]
@@ -39,7 +40,12 @@ impl DOMPoint {
         z: f64,
         w: f64,
     ) -> DomRoot<DOMPoint> {
-        reflect_dom_object_with_proto(Box::new(DOMPoint::new_inherited(x, y, z, w)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(DOMPoint::new_inherited(x, y, z, w)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn Constructor(

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 // http://dev.w3.org/fxtf/geometry/Overview.html#dompointreadonly
 #[dom_struct]
@@ -52,6 +53,7 @@ impl DOMPointReadOnly {
             Box::new(DOMPointReadOnly::new_inherited(x, y, z, w)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -38,7 +38,7 @@ impl DOMPointReadOnly {
     }
 
     pub fn new(global: &GlobalScope, x: f64, y: f64, z: f64, w: f64) -> DomRoot<DOMPointReadOnly> {
-        Self::new_with_proto(global, None, x, y, z, w)
+        Self::new_with_proto(global, None, x, y, z, w, CanGc::note())
     }
 
     fn new_with_proto(
@@ -48,24 +48,28 @@ impl DOMPointReadOnly {
         y: f64,
         z: f64,
         w: f64,
+        can_gc: CanGc,
     ) -> DomRoot<DOMPointReadOnly> {
         reflect_dom_object_with_proto(
             Box::new(DOMPointReadOnly::new_inherited(x, y, z, w)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         x: f64,
         y: f64,
         z: f64,
         w: f64,
     ) -> Fallible<DomRoot<DOMPointReadOnly>> {
-        Ok(DOMPointReadOnly::new_with_proto(global, proto, x, y, z, w))
+        Ok(DOMPointReadOnly::new_with_proto(
+            global, proto, x, y, z, w, can_gc,
+        ))
     }
 
     // https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint

--- a/components/script/dom/domquad.rs
+++ b/components/script/dom/domquad.rs
@@ -45,7 +45,7 @@ impl DOMQuad {
         p3: &DOMPoint,
         p4: &DOMPoint,
     ) -> DomRoot<DOMQuad> {
-        Self::new_with_proto(global, None, p1, p2, p3, p4)
+        Self::new_with_proto(global, None, p1, p2, p3, p4, CanGc::note())
     }
 
     fn new_with_proto(
@@ -55,18 +55,20 @@ impl DOMQuad {
         p2: &DOMPoint,
         p3: &DOMPoint,
         p4: &DOMPoint,
+        can_gc: CanGc,
     ) -> DomRoot<DOMQuad> {
         reflect_dom_object_with_proto(
             Box::new(DOMQuad::new_inherited(p1, p2, p3, p4)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         p1: &DOMPointInit,
         p2: &DOMPointInit,
         p3: &DOMPointInit,
@@ -79,6 +81,7 @@ impl DOMQuad {
             &DOMPoint::new_from_init(global, p2),
             &DOMPoint::new_from_init(global, p3),
             &DOMPoint::new_from_init(global, p4),
+            can_gc,
         ))
     }
 

--- a/components/script/dom/domquad.rs
+++ b/components/script/dom/domquad.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::dompoint::DOMPoint;
 use crate::dom::domrect::DOMRect;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 // https://drafts.fxtf.org/geometry/#DOMQuad
 #[dom_struct]
@@ -59,6 +60,7 @@ impl DOMQuad {
             Box::new(DOMQuad::new_inherited(p1, p2, p3, p4)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::domrectreadonly::DOMRectReadOnly;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct DOMRect {
@@ -41,6 +42,7 @@ impl DOMRect {
             Box::new(DOMRect::new_inherited(x, y, width, height)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/domrect.rs
+++ b/components/script/dom/domrect.rs
@@ -27,7 +27,7 @@ impl DOMRect {
     }
 
     pub fn new(global: &GlobalScope, x: f64, y: f64, width: f64, height: f64) -> DomRoot<DOMRect> {
-        Self::new_with_proto(global, None, x, y, width, height)
+        Self::new_with_proto(global, None, x, y, width, height, CanGc::note())
     }
 
     fn new_with_proto(
@@ -37,12 +37,13 @@ impl DOMRect {
         y: f64,
         width: f64,
         height: f64,
+        can_gc: CanGc,
     ) -> DomRoot<DOMRect> {
         reflect_dom_object_with_proto(
             Box::new(DOMRect::new_inherited(x, y, width, height)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -50,12 +51,15 @@ impl DOMRect {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         x: f64,
         y: f64,
         width: f64,
         height: f64,
     ) -> Fallible<DomRoot<DOMRect>> {
-        Ok(DOMRect::new_with_proto(global, proto, x, y, width, height))
+        Ok(DOMRect::new_with_proto(
+            global, proto, x, y, width, height, can_gc,
+        ))
     }
 }
 

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct DOMRectReadOnly {
@@ -45,6 +46,7 @@ impl DOMRectReadOnly {
             Box::new(DOMRectReadOnly::new_inherited(x, y, width, height)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/domrectreadonly.rs
+++ b/components/script/dom/domrectreadonly.rs
@@ -41,12 +41,13 @@ impl DOMRectReadOnly {
         y: f64,
         width: f64,
         height: f64,
+        can_gc: CanGc,
     ) -> DomRoot<DOMRectReadOnly> {
         reflect_dom_object_with_proto(
             Box::new(DOMRectReadOnly::new_inherited(x, y, width, height)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -54,12 +55,15 @@ impl DOMRectReadOnly {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         x: f64,
         y: f64,
         width: f64,
         height: f64,
     ) -> Fallible<DomRoot<DOMRectReadOnly>> {
-        Ok(DOMRectReadOnly::new(global, proto, x, y, width, height))
+        Ok(DOMRectReadOnly::new(
+            global, proto, x, y, width, height, can_gc,
+        ))
     }
 
     pub fn set_x(&self, value: f64) {

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -22,7 +22,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct ErrorEvent {
@@ -48,7 +48,12 @@ impl ErrorEvent {
     }
 
     fn new_uninitialized(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<ErrorEvent> {
-        reflect_dom_object_with_proto(Box::new(ErrorEvent::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(ErrorEvent::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -47,13 +47,12 @@ impl ErrorEvent {
         }
     }
 
-    fn new_uninitialized(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<ErrorEvent> {
-        reflect_dom_object_with_proto(
-            Box::new(ErrorEvent::new_inherited()),
-            global,
-            proto,
-            CanGc::note(),
-        )
+    fn new_uninitialized(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<ErrorEvent> {
+        reflect_dom_object_with_proto(Box::new(ErrorEvent::new_inherited()), global, proto, can_gc)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -69,7 +68,17 @@ impl ErrorEvent {
         error: HandleValue,
     ) -> DomRoot<ErrorEvent> {
         Self::new_with_proto(
-            global, None, type_, bubbles, cancelable, message, filename, lineno, colno, error,
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            message,
+            filename,
+            lineno,
+            colno,
+            error,
+            CanGc::note(),
         )
     }
 
@@ -85,8 +94,9 @@ impl ErrorEvent {
         lineno: u32,
         colno: u32,
         error: HandleValue,
+        can_gc: CanGc,
     ) -> DomRoot<ErrorEvent> {
-        let ev = ErrorEvent::new_uninitialized(global, proto);
+        let ev = ErrorEvent::new_uninitialized(global, proto, can_gc);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -103,6 +113,7 @@ impl ErrorEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<ErrorEventBinding::ErrorEventInit>,
     ) -> Fallible<DomRoot<ErrorEvent>> {
@@ -135,6 +146,7 @@ impl ErrorEvent {
             line_num,
             col_num,
             init.error.handle(),
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -34,6 +34,7 @@ use crate::dom::node::{Node, ShadowIncluding};
 use crate::dom::performance::reduce_timing_resolution;
 use crate::dom::virtualmethods::vtable_for;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
 
 #[dom_struct]
@@ -83,7 +84,12 @@ impl Event {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<Event> {
-        reflect_dom_object_with_proto(Box::new(Event::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Event::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn new(

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -77,19 +77,15 @@ impl Event {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<Event> {
-        Self::new_uninitialized_with_proto(global, None)
+        Self::new_uninitialized_with_proto(global, None, CanGc::note())
     }
 
     pub fn new_uninitialized_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<Event> {
-        reflect_dom_object_with_proto(
-            Box::new(Event::new_inherited()),
-            global,
-            proto,
-            CanGc::note(),
-        )
+        reflect_dom_object_with_proto(Box::new(Event::new_inherited()), global, proto, can_gc)
     }
 
     pub fn new(
@@ -98,7 +94,7 @@ impl Event {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
     ) -> DomRoot<Event> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable)
+        Self::new_with_proto(global, None, type_, bubbles, cancelable, CanGc::note())
     }
 
     fn new_with_proto(
@@ -107,8 +103,9 @@ impl Event {
         type_: Atom,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
+        can_gc: CanGc,
     ) -> DomRoot<Event> {
-        let event = Event::new_uninitialized_with_proto(global, proto);
+        let event = Event::new_uninitialized_with_proto(global, proto, can_gc);
         event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
         event
     }
@@ -117,6 +114,7 @@ impl Event {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &EventBinding::EventInit,
     ) -> Fallible<DomRoot<Event>> {
@@ -128,6 +126,7 @@ impl Event {
             Atom::from(type_),
             bubbles,
             cancelable,
+            can_gc,
         ))
     }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -44,6 +44,7 @@ use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::fetch::{create_a_potential_cors_request, FetchCanceller};
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
 use crate::realms::enter_realm;
+use crate::script_runtime::CanGc;
 use crate::task_source::{TaskSource, TaskSourceName};
 use crate::timers::OneshotTimerCallback;
 
@@ -475,6 +476,7 @@ impl EventSource {
             Box::new(EventSource::new_inherited(url, with_credentials)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -471,12 +471,13 @@ impl EventSource {
         proto: Option<HandleObject>,
         url: ServoUrl,
         with_credentials: bool,
+        can_gc: CanGc,
     ) -> DomRoot<EventSource> {
         reflect_dom_object_with_proto(
             Box::new(EventSource::new_inherited(url, with_credentials)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -516,6 +517,7 @@ impl EventSource {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         url: DOMString,
         event_source_init: &EventSourceInit,
     ) -> Fallible<DomRoot<EventSource>> {
@@ -533,6 +535,7 @@ impl EventSource {
             proto,
             url_record.clone(),
             event_source_init.withCredentials,
+            can_gc,
         );
         global.track_event_source(&ev);
         // Steps 6-7

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -361,12 +361,16 @@ impl EventTarget {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<EventTarget> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<EventTarget> {
         reflect_dom_object_with_proto(
             Box::new(EventTarget::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -374,8 +378,9 @@ impl EventTarget {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<EventTarget>> {
-        Ok(EventTarget::new(global, proto))
+        Ok(EventTarget::new(global, proto, can_gc))
     }
 
     /// Determine if there are any listeners for a given event type.

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -55,6 +55,7 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::realms::{enter_realm, InRealm};
+use crate::script_runtime::CanGc;
 
 #[derive(Clone, JSTraceable, MallocSizeOf, PartialEq)]
 pub enum CommonEventHandler {
@@ -361,7 +362,12 @@ impl EventTarget {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<EventTarget> {
-        reflect_dom_object_with_proto(Box::new(EventTarget::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(EventTarget::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // https://w3c.github.io/ServiceWorker/#extendable-event
 #[dom_struct]
@@ -53,6 +53,7 @@ impl ExtendableEvent {
             Box::new(ExtendableEvent::new_inherited()),
             worker,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -39,7 +39,7 @@ impl ExtendableEvent {
         bubbles: bool,
         cancelable: bool,
     ) -> DomRoot<ExtendableEvent> {
-        Self::new_with_proto(worker, None, type_, bubbles, cancelable)
+        Self::new_with_proto(worker, None, type_, bubbles, cancelable, CanGc::note())
     }
 
     fn new_with_proto(
@@ -48,12 +48,13 @@ impl ExtendableEvent {
         type_: Atom,
         bubbles: bool,
         cancelable: bool,
+        can_gc: CanGc,
     ) -> DomRoot<ExtendableEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(ExtendableEvent::new_inherited()),
             worker,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -65,6 +66,7 @@ impl ExtendableEvent {
     pub fn Constructor(
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &ExtendableEventBinding::ExtendableEventInit,
     ) -> Fallible<DomRoot<ExtendableEvent>> {
@@ -74,6 +76,7 @@ impl ExtendableEvent {
             Atom::from(type_),
             init.parent.bubbles,
             init.parent.cancelable,
+            can_gc,
         ))
     }
 

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -24,7 +24,7 @@ use crate::dom::extendableevent::ExtendableEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 #[allow(non_snake_case)]
@@ -105,7 +105,7 @@ impl ExtendableMessageEvent {
             lastEventId,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto(ev, global, proto);
+        let ev = reflect_dom_object_with_proto(ev, global, proto, CanGc::note());
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -85,6 +85,7 @@ impl ExtendableMessageEvent {
             origin,
             lastEventId,
             ports,
+            CanGc::note(),
         )
     }
 
@@ -99,13 +100,14 @@ impl ExtendableMessageEvent {
         origin: DOMString,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) -> DomRoot<ExtendableMessageEvent> {
         let ev = Box::new(ExtendableMessageEvent::new_inherited(
             origin,
             lastEventId,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto(ev, global, proto, CanGc::note());
+        let ev = reflect_dom_object_with_proto(ev, global, proto, can_gc);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
@@ -118,6 +120,7 @@ impl ExtendableMessageEvent {
     pub fn Constructor(
         worker: &ServiceWorkerGlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<ExtendableMessageEventBinding::ExtendableMessageEventInit>,
     ) -> Fallible<DomRoot<ExtendableMessageEvent>> {
@@ -132,6 +135,7 @@ impl ExtendableMessageEvent {
             init.origin.clone(),
             init.lastEventId.clone(),
             vec![],
+            can_gc,
         );
         Ok(ev)
     }

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::{blob_parts_to_bytes, normalize_type_string, Blob};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct File {
@@ -64,6 +65,7 @@ impl File {
             Box::new(File::new_inherited(&blob_impl, name, modified)),
             global,
             proto,
+            CanGc::note(),
         );
         global.track_file(&file, blob_impl);
         file

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -50,7 +50,7 @@ impl File {
         name: DOMString,
         modified: Option<i64>,
     ) -> DomRoot<File> {
-        Self::new_with_proto(global, None, blob_impl, name, modified)
+        Self::new_with_proto(global, None, blob_impl, name, modified, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -60,12 +60,13 @@ impl File {
         blob_impl: BlobImpl,
         name: DOMString,
         modified: Option<i64>,
+        can_gc: CanGc,
     ) -> DomRoot<File> {
         let file = reflect_dom_object_with_proto(
             Box::new(File::new_inherited(&blob_impl, name, modified)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         global.track_file(&file, blob_impl);
         file
@@ -98,6 +99,7 @@ impl File {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         fileBits: Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>,
         filename: DOMString,
         filePropertyBag: &FileBinding::FilePropertyBag,
@@ -120,6 +122,7 @@ impl File {
             BlobImpl::new_from_bytes(bytes, type_string),
             replaced_filename,
             modified,
+            can_gc,
         ))
     }
 

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -35,7 +35,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::progressevent::ProgressEvent;
 use crate::realms::enter_realm;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 use crate::task_source::file_reading::FileReadingTask;
 use crate::task_source::{TaskSource, TaskSourceName};
 
@@ -154,7 +154,12 @@ impl FileReader {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<FileReader> {
-        reflect_dom_object_with_proto(Box::new(FileReader::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(FileReader::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -153,21 +153,21 @@ impl FileReader {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<FileReader> {
-        reflect_dom_object_with_proto(
-            Box::new(FileReader::new_inherited()),
-            global,
-            proto,
-            CanGc::note(),
-        )
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<FileReader> {
+        reflect_dom_object_with_proto(Box::new(FileReader::new_inherited()), global, proto, can_gc)
     }
 
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<FileReader>> {
-        Ok(FileReader::new(global, proto))
+        Ok(FileReader::new(global, proto, can_gc))
     }
 
     //https://w3c.github.io/FileAPI/#dfn-error-steps

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
 use crate::dom::filereader::FileReaderSharedFunctionality;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct FileReaderSync {
@@ -34,7 +34,12 @@ impl FileReaderSync {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<FileReaderSync> {
-        reflect_dom_object_with_proto(Box::new(FileReaderSync::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(FileReaderSync::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -33,12 +33,16 @@ impl FileReaderSync {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<FileReaderSync> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<FileReaderSync> {
         reflect_dom_object_with_proto(
             Box::new(FileReaderSync::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -46,8 +50,9 @@ impl FileReaderSync {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<FileReaderSync>> {
-        Ok(FileReaderSync::new(global, proto))
+        Ok(FileReaderSync::new(global, proto, can_gc))
     }
 
     fn get_blob_bytes(blob: &Blob) -> Result<Vec<u8>, Error> {

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -19,6 +19,7 @@ use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct FocusEvent {
@@ -42,7 +43,12 @@ impl FocusEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<FocusEvent> {
-        reflect_dom_object_with_proto(Box::new(FocusEvent::new_inherited()), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(FocusEvent::new_inherited()),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn new(

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -36,19 +36,15 @@ impl FocusEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<FocusEvent> {
-        Self::new_uninitialized_with_proto(window, None)
+        Self::new_uninitialized_with_proto(window, None, CanGc::note())
     }
 
     pub fn new_uninitialized_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
-        reflect_dom_object_with_proto(
-            Box::new(FocusEvent::new_inherited()),
-            window,
-            proto,
-            CanGc::note(),
-        )
+        reflect_dom_object_with_proto(Box::new(FocusEvent::new_inherited()), window, proto, can_gc)
     }
 
     pub fn new(
@@ -69,6 +65,7 @@ impl FocusEvent {
             view,
             detail,
             related_target,
+            CanGc::note(),
         )
     }
 
@@ -82,8 +79,9 @@ impl FocusEvent {
         view: Option<&Window>,
         detail: i32,
         related_target: Option<&EventTarget>,
+        can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
-        let ev = FocusEvent::new_uninitialized_with_proto(window, proto);
+        let ev = FocusEvent::new_uninitialized_with_proto(window, proto, can_gc);
         ev.upcast::<UIEvent>().InitUIEvent(
             type_,
             bool::from(can_bubble),
@@ -99,6 +97,7 @@ impl FocusEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &FocusEventBinding::FocusEventInit,
     ) -> Fallible<DomRoot<FocusEvent>> {
@@ -113,6 +112,7 @@ impl FocusEvent {
             init.parent.view.as_deref(),
             init.parent.detail,
             init.relatedTarget.as_deref(),
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/fontfaceset.rs
+++ b/components/script/dom/fontfaceset.rs
@@ -14,6 +14,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::realms::enter_realm;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct FontFaceSet {
@@ -31,7 +32,12 @@ impl FontFaceSet {
     }
 
     pub fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(FontFaceSet::new_inherited(global)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(FontFaceSet::new_inherited(global)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn fulfill_ready_promise_if_needed(&self) {

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -21,6 +21,7 @@ use crate::dom::blob::Blob;
 use crate::dom::file::File;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::{FormDatum, FormDatumValue, HTMLFormElement};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct FormData {
@@ -57,6 +58,7 @@ impl FormData {
             Box::new(FormData::new_inherited(form_datums)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -46,19 +46,20 @@ impl FormData {
     }
 
     pub fn new(form_datums: Option<Vec<FormDatum>>, global: &GlobalScope) -> DomRoot<FormData> {
-        Self::new_with_proto(form_datums, global, None)
+        Self::new_with_proto(form_datums, global, None, CanGc::note())
     }
 
     fn new_with_proto(
         form_datums: Option<Vec<FormDatum>>,
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<FormData> {
         reflect_dom_object_with_proto(
             Box::new(FormData::new_inherited(form_datums)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -67,16 +68,22 @@ impl FormData {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         form: Option<&HTMLFormElement>,
     ) -> Fallible<DomRoot<FormData>> {
         if let Some(opt_form) = form {
             return match opt_form.get_form_dataset(None, None) {
-                Some(form_datums) => Ok(FormData::new_with_proto(Some(form_datums), global, proto)),
+                Some(form_datums) => Ok(FormData::new_with_proto(
+                    Some(form_datums),
+                    global,
+                    proto,
+                    can_gc,
+                )),
                 None => Err(Error::InvalidState),
             };
         }
 
-        Ok(FormData::new_with_proto(None, global, proto))
+        Ok(FormData::new_with_proto(None, global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/formdataevent.rs
+++ b/components/script/dom/formdataevent.rs
@@ -34,7 +34,15 @@ impl FormDataEvent {
         cancelable: EventCancelable,
         form_data: &FormData,
     ) -> DomRoot<FormDataEvent> {
-        Self::new_with_proto(global, None, type_, can_bubble, cancelable, form_data)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            can_bubble,
+            cancelable,
+            form_data,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -44,6 +52,7 @@ impl FormDataEvent {
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         form_data: &FormData,
+        can_gc: CanGc,
     ) -> DomRoot<FormDataEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(FormDataEvent {
@@ -52,7 +61,7 @@ impl FormDataEvent {
             }),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
 
         {
@@ -66,6 +75,7 @@ impl FormDataEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &FormDataEventBinding::FormDataEventInit,
     ) -> Fallible<DomRoot<FormDataEvent>> {
@@ -79,6 +89,7 @@ impl FormDataEvent {
             bubbles,
             cancelable,
             &init.formData.clone(),
+            can_gc,
         );
 
         Ok(event)

--- a/components/script/dom/formdataevent.rs
+++ b/components/script/dom/formdataevent.rs
@@ -18,6 +18,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::formdata::FormData;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct FormDataEvent {
@@ -51,6 +52,7 @@ impl FormDataEvent {
             }),
             global,
             proto,
+            CanGc::note(),
         );
 
         {

--- a/components/script/dom/gainnode.rs
+++ b/components/script/dom/gainnode.rs
@@ -70,7 +70,7 @@ impl GainNode {
         context: &BaseAudioContext,
         options: &GainOptions,
     ) -> Fallible<DomRoot<GainNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -79,13 +79,14 @@ impl GainNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &GainOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<GainNode>> {
         let node = GainNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -93,10 +94,11 @@ impl GainNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &GainOptions,
     ) -> Fallible<DomRoot<GainNode>> {
-        GainNode::new_with_proto(window, proto, context, options)
+        GainNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/gainnode.rs
+++ b/components/script/dom/gainnode.rs
@@ -22,6 +22,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GainNode {
@@ -80,7 +81,12 @@ impl GainNode {
         options: &GainOptions,
     ) -> Fallible<DomRoot<GainNode>> {
         let node = GainNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -23,7 +23,7 @@ use crate::dom::gamepadevent::{GamepadEvent, GamepadEventType};
 use crate::dom::gamepadhapticactuator::GamepadHapticActuator;
 use crate::dom::gamepadpose::GamepadPose;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // This value is for determining when to consider a gamepad as having a user gesture
 // from an axis tilt. This matches the threshold in Chromium.
@@ -142,6 +142,7 @@ impl Gamepad {
             )),
             global,
             None,
+            CanGc::note(),
         );
         gamepad.init_axes();
         gamepad

--- a/components/script/dom/gamepadevent.rs
+++ b/components/script/dom/gamepadevent.rs
@@ -18,6 +18,7 @@ use crate::dom::event::Event;
 use crate::dom::gamepad::Gamepad;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GamepadEvent {
@@ -60,6 +61,7 @@ impl GamepadEvent {
             Box::new(GamepadEvent::new_inherited(gamepad)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/gamepadevent.rs
+++ b/components/script/dom/gamepadevent.rs
@@ -46,7 +46,15 @@ impl GamepadEvent {
         cancelable: bool,
         gamepad: &Gamepad,
     ) -> DomRoot<GamepadEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, gamepad)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            gamepad,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -56,12 +64,13 @@ impl GamepadEvent {
         bubbles: bool,
         cancelable: bool,
         gamepad: &Gamepad,
+        can_gc: CanGc,
     ) -> DomRoot<GamepadEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(GamepadEvent::new_inherited(gamepad)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -88,6 +97,7 @@ impl GamepadEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &GamepadEventBinding::GamepadEventInit,
     ) -> Fallible<DomRoot<GamepadEvent>> {
@@ -98,6 +108,7 @@ impl GamepadEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.gamepad,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepadhapticactuator.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::utils::to_frozen_array;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::realms::InRealm;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 use crate::task::TaskCanceller;
 use crate::task_source::gamepad::GamepadTaskSource;
 use crate::task_source::{TaskSource, TaskSourceName};
@@ -125,6 +125,7 @@ impl GamepadHapticActuator {
             )),
             global,
             None,
+            CanGc::note(),
         );
         haptic_actuator
     }

--- a/components/script/dom/gpucompilationinfo.rs
+++ b/components/script/dom/gpucompilationinfo.rs
@@ -13,7 +13,7 @@ use super::bindings::utils::to_frozen_array;
 use super::types::GPUCompilationMessage;
 use crate::dom::bindings::reflector::Reflector;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct GPUCompilationInfo {
@@ -32,7 +32,12 @@ impl GPUCompilationInfo {
 
     #[allow(dead_code)]
     pub fn new(global: &GlobalScope, msg: Vec<DomRoot<GPUCompilationMessage>>) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited(msg)), global, None)
+        reflect_dom_object_with_proto(
+            Box::new(Self::new_inherited(msg)),
+            global,
+            None,
+            CanGc::note(),
+        )
     }
 
     pub fn from(global: &GlobalScope, error: Option<ShaderCompilationInfo>) -> DomRoot<Self> {

--- a/components/script/dom/gpuerror.rs
+++ b/components/script/dom/gpuerror.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GPUError {
@@ -38,7 +39,12 @@ impl GPUError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(GPUError::new_inherited(message)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(GPUError::new_inherited(message)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn from_error(global: &GlobalScope, error: Error) -> DomRoot<Self> {

--- a/components/script/dom/gpuerror.rs
+++ b/components/script/dom/gpuerror.rs
@@ -53,16 +53,19 @@ impl GPUError {
                 global,
                 None,
                 DOMString::from_string(msg),
+                CanGc::note(),
             )),
             Error::OutOfMemory(msg) => DomRoot::upcast(GPUOutOfMemoryError::new_with_proto(
                 global,
                 None,
                 DOMString::from_string(msg),
+                CanGc::note(),
             )),
             Error::Internal(msg) => DomRoot::upcast(GPUInternalError::new_with_proto(
                 global,
                 None,
                 DOMString::from_string(msg),
+                CanGc::note(),
             )),
         }
     }

--- a/components/script/dom/gpuinternalerror.rs
+++ b/components/script/dom/gpuinternalerror.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GPUInternalError {
@@ -28,7 +29,12 @@ impl GPUInternalError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited(message)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Self::new_inherited(message)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-GPUInternalError-GPUInternalError>

--- a/components/script/dom/gpuinternalerror.rs
+++ b/components/script/dom/gpuinternalerror.rs
@@ -28,12 +28,13 @@ impl GPUInternalError {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
             Box::new(Self::new_inherited(message)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -42,8 +43,9 @@ impl GPUInternalError {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         message: DOMString,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message)
+        Self::new_with_proto(global, proto, message, can_gc)
     }
 }

--- a/components/script/dom/gpuoutofmemoryerror.rs
+++ b/components/script/dom/gpuoutofmemoryerror.rs
@@ -28,12 +28,13 @@ impl GPUOutOfMemoryError {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
             Box::new(Self::new_inherited(message)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -42,8 +43,9 @@ impl GPUOutOfMemoryError {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         message: DOMString,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message)
+        Self::new_with_proto(global, proto, message, can_gc)
     }
 }

--- a/components/script/dom/gpuoutofmemoryerror.rs
+++ b/components/script/dom/gpuoutofmemoryerror.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GPUOutOfMemoryError {
@@ -28,7 +29,12 @@ impl GPUOutOfMemoryError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited(message)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Self::new_inherited(message)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-GPUOutOfMemoryError-GPUOutOfMemoryError>

--- a/components/script/dom/gpupipelineerror.rs
+++ b/components/script/dom/gpupipelineerror.rs
@@ -35,12 +35,13 @@ impl GPUPipelineError {
         proto: Option<HandleObject>,
         message: DOMString,
         reason: GPUPipelineErrorReason,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
             Box::new(Self::new_inherited(message, reason)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -49,7 +50,7 @@ impl GPUPipelineError {
         message: DOMString,
         reason: GPUPipelineErrorReason,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, message, reason)
+        Self::new_with_proto(global, None, message, reason, CanGc::note())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-constructor>
@@ -57,10 +58,11 @@ impl GPUPipelineError {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         message: DOMString,
         options: &GPUPipelineErrorInit,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message, options.reason)
+        Self::new_with_proto(global, proto, message, options.reason, can_gc)
     }
 }
 

--- a/components/script/dom/gpupipelineerror.rs
+++ b/components/script/dom/gpupipelineerror.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::domexception::DOMException;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 /// <https://gpuweb.github.io/gpuweb/#gpupipelineerror>
 #[dom_struct]
@@ -39,6 +40,7 @@ impl GPUPipelineError {
             Box::new(Self::new_inherited(message, reason)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/gpusupportedfeatures.rs
+++ b/components/script/dom/gpusupportedfeatures.rs
@@ -22,6 +22,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 // manual hash derived
 // TODO: allow derivables in bindings.conf
@@ -102,6 +103,7 @@ impl GPUSupportedFeatures {
             }),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/gpuuncapturederrorevent.rs
+++ b/components/script/dom/gpuuncapturederrorevent.rs
@@ -38,7 +38,7 @@ impl GPUUncapturedErrorEvent {
         type_: DOMString,
         init: &GPUUncapturedErrorEventInit,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, type_, init)
+        Self::new_with_proto(global, None, type_, init, CanGc::note())
     }
 
     fn new_with_proto(
@@ -46,12 +46,13 @@ impl GPUUncapturedErrorEvent {
         proto: Option<HandleObject>,
         type_: DOMString,
         init: &GPUUncapturedErrorEventInit,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let ev = reflect_dom_object_with_proto(
             Box::new(GPUUncapturedErrorEvent::new_inherited(init)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         ev.event.init_event(
             Atom::from(type_),
@@ -66,10 +67,11 @@ impl GPUUncapturedErrorEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &GPUUncapturedErrorEventInit,
     ) -> DomRoot<Self> {
-        GPUUncapturedErrorEvent::new_with_proto(global, proto, type_, init)
+        GPUUncapturedErrorEvent::new_with_proto(global, proto, type_, init, can_gc)
     }
 }
 

--- a/components/script/dom/gpuuncapturederrorevent.rs
+++ b/components/script/dom/gpuuncapturederrorevent.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpuerror::GPUError;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GPUUncapturedErrorEvent {
@@ -50,6 +51,7 @@ impl GPUUncapturedErrorEvent {
             Box::new(GPUUncapturedErrorEvent::new_inherited(init)),
             global,
             proto,
+            CanGc::note(),
         );
         ev.event.init_event(
             Atom::from(type_),

--- a/components/script/dom/gpuvalidationerror.rs
+++ b/components/script/dom/gpuvalidationerror.rs
@@ -28,12 +28,13 @@ impl GPUValidationError {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         message: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
             Box::new(Self::new_inherited(message)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -42,8 +43,9 @@ impl GPUValidationError {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         message: DOMString,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, proto, message)
+        Self::new_with_proto(global, proto, message, can_gc)
     }
 }

--- a/components/script/dom/gpuvalidationerror.rs
+++ b/components/script/dom/gpuvalidationerror.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct GPUValidationError {
@@ -28,7 +29,12 @@ impl GPUValidationError {
         proto: Option<HandleObject>,
         message: DOMString,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited(message)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Self::new_inherited(message)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror>

--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -59,7 +59,16 @@ impl HashChangeEvent {
         old_url: String,
         new_url: String,
     ) -> DomRoot<HashChangeEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, old_url, new_url)
+        Self::new_with_proto(
+            window,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            old_url,
+            new_url,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -70,12 +79,13 @@ impl HashChangeEvent {
         cancelable: bool,
         old_url: String,
         new_url: String,
+        can_gc: CanGc,
     ) -> DomRoot<HashChangeEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(HashChangeEvent::new_inherited(old_url, new_url)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -88,6 +98,7 @@ impl HashChangeEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &HashChangeEventBinding::HashChangeEventInit,
     ) -> Fallible<DomRoot<HashChangeEvent>> {
@@ -99,6 +110,7 @@ impl HashChangeEvent {
             init.parent.cancelable,
             init.oldURL.0.clone(),
             init.newURL.0.clone(),
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::event::Event;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#hashchangeevent
 #[dom_struct]
@@ -46,6 +47,7 @@ impl HashChangeEvent {
             Box::new(HashChangeEvent::new_inherited(String::new(), String::new())),
             window,
             proto,
+            CanGc::note(),
         )
     }
 
@@ -73,6 +75,7 @@ impl HashChangeEvent {
             Box::new(HashChangeEvent::new_inherited(old_url, new_url)),
             window,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{is_token, ByteString};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct Headers {
@@ -54,7 +55,12 @@ impl Headers {
     }
 
     fn new_with_proto(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Headers> {
-        reflect_dom_object_with_proto(Box::new(Headers::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Headers::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     // https://fetch.spec.whatwg.org/#dom-headers

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -51,16 +51,15 @@ impl Headers {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<Headers> {
-        Self::new_with_proto(global, None)
+        Self::new_with_proto(global, None, CanGc::note())
     }
 
-    fn new_with_proto(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Headers> {
-        reflect_dom_object_with_proto(
-            Box::new(Headers::new_inherited()),
-            global,
-            proto,
-            CanGc::note(),
-        )
+    fn new_with_proto(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<Headers> {
+        reflect_dom_object_with_proto(Box::new(Headers::new_inherited()), global, proto, can_gc)
     }
 
     // https://fetch.spec.whatwg.org/#dom-headers
@@ -68,9 +67,10 @@ impl Headers {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: Option<HeadersInit>,
     ) -> Fallible<DomRoot<Headers>> {
-        let dom_headers_new = Headers::new_with_proto(global, proto);
+        let dom_headers_new = Headers::new_with_proto(global, proto, can_gc);
         dom_headers_new.fill(init)?;
         Ok(dom_headers_new)
     }

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -17,6 +17,7 @@ use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::htmlmediaelement::HTMLMediaElement;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLAudioElement {
@@ -55,6 +56,7 @@ impl HTMLAudioElement {
     pub fn Audio(
         window: &Window,
         proto: Option<HandleObject>,
+        _can_gc: CanGc,
         src: Option<DOMString>,
     ) -> Fallible<DomRoot<HTMLAudioElement>> {
         let element = Element::create(

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -96,6 +96,7 @@ use crate::image_listener::{generate_cache_listener_for_element, ImageCacheListe
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
 use crate::realms::enter_realm;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 use crate::task_source::TaskSource;
 
@@ -1327,6 +1328,7 @@ impl HTMLImageElement {
     pub fn Image(
         window: &Window,
         proto: Option<HandleObject>,
+        _can_gc: CanGc,
         width: Option<u32>,
         height: Option<u32>,
     ) -> Fallible<DomRoot<HTMLImageElement>> {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -35,6 +35,7 @@ use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLOptionElement {
@@ -86,6 +87,7 @@ impl HTMLOptionElement {
     pub fn Option(
         window: &Window,
         proto: Option<HandleObject>,
+        _can_gc: CanGc,
         text: DOMString,
         value: Option<DOMString>,
         default_selected: bool,

--- a/components/script/dom/iirfilternode.rs
+++ b/components/script/dom/iirfilternode.rs
@@ -25,6 +25,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct IIRFilterNode {
@@ -83,7 +84,12 @@ impl IIRFilterNode {
         options: &IIRFilterOptions,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
         let node = IIRFilterNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/iirfilternode.rs
+++ b/components/script/dom/iirfilternode.rs
@@ -73,7 +73,7 @@ impl IIRFilterNode {
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -82,13 +82,14 @@ impl IIRFilterNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
         let node = IIRFilterNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -96,10 +97,11 @@ impl IIRFilterNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &IIRFilterOptions,
     ) -> Fallible<DomRoot<IIRFilterNode>> {
-        IIRFilterNode::new_with_proto(window, proto, context, options)
+        IIRFilterNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct ImageData {
@@ -101,7 +101,12 @@ impl ImageData {
             data: heap_typed_array,
         });
 
-        Ok(reflect_dom_object_with_proto(imagedata, global, proto))
+        Ok(reflect_dom_object_with_proto(
+            imagedata,
+            global,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     fn new_without_jsobject(
@@ -131,7 +136,12 @@ impl ImageData {
             data: heap_typed_array,
         });
 
-        Ok(reflect_dom_object_with_proto(imagedata, global, proto))
+        Ok(reflect_dom_object_with_proto(
+            imagedata,
+            global,
+            proto,
+            CanGc::note(),
+        ))
     }
     /// <https://html.spec.whatwg.org/multipage/#pixel-manipulation:dom-imagedata-3>
     #[allow(non_snake_case)]

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -48,9 +48,16 @@ impl ImageData {
                 d.resize(len as usize, 0);
                 let data = CreateWith::Slice(&d[..]);
                 Uint8ClampedArray::create(*cx, data, js_object.handle_mut()).unwrap();
-                Self::new_with_jsobject(global, None, width, Some(height), js_object.get())
+                Self::new_with_jsobject(
+                    global,
+                    None,
+                    width,
+                    Some(height),
+                    js_object.get(),
+                    CanGc::note(),
+                )
             } else {
-                Self::new_without_jsobject(global, None, width, height)
+                Self::new_without_jsobject(global, None, width, height, CanGc::note())
             }
         }
     }
@@ -62,6 +69,7 @@ impl ImageData {
         width: u32,
         opt_height: Option<u32>,
         jsobject: *mut JSObject,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         let heap_typed_array = match new_initialized_heap_buffer_source::<ClampedU8>(
             HeapTypedArrayInit::Buffer(BufferSource::Uint8ClampedArray(Heap::boxed(jsobject))),
@@ -102,10 +110,7 @@ impl ImageData {
         });
 
         Ok(reflect_dom_object_with_proto(
-            imagedata,
-            global,
-            proto,
-            CanGc::note(),
+            imagedata, global, proto, can_gc,
         ))
     }
 
@@ -114,6 +119,7 @@ impl ImageData {
         proto: Option<HandleObject>,
         width: u32,
         height: u32,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         if width == 0 || height == 0 {
             return Err(Error::IndexSize);
@@ -137,10 +143,7 @@ impl ImageData {
         });
 
         Ok(reflect_dom_object_with_proto(
-            imagedata,
-            global,
-            proto,
-            CanGc::note(),
+            imagedata, global, proto, can_gc,
         ))
     }
     /// <https://html.spec.whatwg.org/multipage/#pixel-manipulation:dom-imagedata-3>
@@ -148,10 +151,11 @@ impl ImageData {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         width: u32,
         height: u32,
     ) -> Fallible<DomRoot<Self>> {
-        Self::new_without_jsobject(global, proto, width, height)
+        Self::new_without_jsobject(global, proto, width, height, can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#pixel-manipulation:dom-imagedata-4>
@@ -160,11 +164,12 @@ impl ImageData {
         cx: JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         jsobject: *mut JSObject,
         width: u32,
         opt_height: Option<u32>,
     ) -> Fallible<DomRoot<Self>> {
-        Self::new_with_jsobject(global, proto, width, opt_height, jsobject)
+        Self::new_with_jsobject(global, proto, width, opt_height, jsobject, can_gc)
     }
 
     /// Nothing must change the array on the JS side while the slice is live.

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct InputEvent {
@@ -42,6 +43,7 @@ impl InputEvent {
             }),
             window,
             proto,
+            CanGc::note(),
         );
         ev.uievent
             .InitUIEvent(type_, can_bubble, cancelable, view, detail);

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -34,6 +34,7 @@ impl InputEvent {
         detail: i32,
         data: Option<DOMString>,
         is_composing: bool,
+        can_gc: CanGc,
     ) -> DomRoot<InputEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(InputEvent {
@@ -43,7 +44,7 @@ impl InputEvent {
             }),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         ev.uievent
             .InitUIEvent(type_, can_bubble, cancelable, view, detail);
@@ -54,6 +55,7 @@ impl InputEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &InputEventBinding::InputEventInit,
     ) -> Fallible<DomRoot<InputEvent>> {
@@ -67,6 +69,7 @@ impl InputEvent {
             init.parent.detail,
             init.data.clone(),
             init.isComposing,
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct KeyboardEvent {
@@ -61,7 +62,12 @@ impl KeyboardEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<KeyboardEvent> {
-        reflect_dom_object_with_proto(Box::new(KeyboardEvent::new_inherited()), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(KeyboardEvent::new_inherited()),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -55,18 +55,19 @@ impl KeyboardEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<KeyboardEvent> {
-        Self::new_uninitialized_with_proto(window, None)
+        Self::new_uninitialized_with_proto(window, None, CanGc::note())
     }
 
     fn new_uninitialized_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<KeyboardEvent> {
         reflect_dom_object_with_proto(
             Box::new(KeyboardEvent::new_inherited()),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -103,6 +104,7 @@ impl KeyboardEvent {
             modifiers,
             char_code,
             key_code,
+            CanGc::note(),
         )
     }
 
@@ -123,8 +125,9 @@ impl KeyboardEvent {
         modifiers: Modifiers,
         char_code: u32,
         key_code: u32,
+        can_gc: CanGc,
     ) -> DomRoot<KeyboardEvent> {
-        let ev = KeyboardEvent::new_uninitialized_with_proto(window, proto);
+        let ev = KeyboardEvent::new_uninitialized_with_proto(window, proto, can_gc);
         ev.InitKeyboardEvent(
             type_,
             can_bubble,
@@ -149,6 +152,7 @@ impl KeyboardEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &KeyboardEventBinding::KeyboardEventInit,
     ) -> Fallible<DomRoot<KeyboardEvent>> {
@@ -173,6 +177,7 @@ impl KeyboardEvent {
             modifiers,
             0,
             0,
+            can_gc,
         );
         *event.key.borrow_mut() = init.key.clone();
         Ok(event)

--- a/components/script/dom/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/mediaelementaudiosourcenode.rs
@@ -58,7 +58,7 @@ impl MediaElementAudioSourceNode {
         context: &AudioContext,
         media_element: &HTMLMediaElement,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, media_element)
+        Self::new_with_proto(window, None, context, media_element, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -67,13 +67,14 @@ impl MediaElementAudioSourceNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         media_element: &HTMLMediaElement,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
         let node = MediaElementAudioSourceNode::new_inherited(context, media_element)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -81,10 +82,17 @@ impl MediaElementAudioSourceNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &AudioContext,
         options: &MediaElementAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        MediaElementAudioSourceNode::new_with_proto(window, proto, context, &options.mediaElement)
+        MediaElementAudioSourceNode::new_with_proto(
+            window,
+            proto,
+            context,
+            &options.mediaElement,
+            can_gc,
+        )
     }
 }
 

--- a/components/script/dom/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/mediaelementaudiosourcenode.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::htmlmediaelement::HTMLMediaElement;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaElementAudioSourceNode {
@@ -68,7 +69,12 @@ impl MediaElementAudioSourceNode {
         media_element: &HTMLMediaElement,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
         let node = MediaElementAudioSourceNode::new_inherited(context, media_element)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/mediametadata.rs
+++ b/components/script/dom/mediametadata.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::mediasession::MediaSession;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaMetadata {
@@ -45,7 +46,12 @@ impl MediaMetadata {
         proto: Option<HandleObject>,
         init: &MediaMetadataInit,
     ) -> DomRoot<MediaMetadata> {
-        reflect_dom_object_with_proto(Box::new(MediaMetadata::new_inherited(init)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(MediaMetadata::new_inherited(init)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     /// <https://w3c.github.io/mediasession/#dom-mediametadata-mediametadata>

--- a/components/script/dom/mediametadata.rs
+++ b/components/script/dom/mediametadata.rs
@@ -38,19 +38,20 @@ impl MediaMetadata {
     }
 
     pub fn new(global: &Window, init: &MediaMetadataInit) -> DomRoot<MediaMetadata> {
-        Self::new_with_proto(global, None, init)
+        Self::new_with_proto(global, None, init, CanGc::note())
     }
 
     fn new_with_proto(
         global: &Window,
         proto: Option<HandleObject>,
         init: &MediaMetadataInit,
+        can_gc: CanGc,
     ) -> DomRoot<MediaMetadata> {
         reflect_dom_object_with_proto(
             Box::new(MediaMetadata::new_inherited(init)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -59,9 +60,10 @@ impl MediaMetadata {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: &MediaMetadataInit,
     ) -> Fallible<DomRoot<MediaMetadata>> {
-        Ok(MediaMetadata::new_with_proto(window, proto, init))
+        Ok(MediaMetadata::new_with_proto(window, proto, init, can_gc))
     }
 
     fn queue_update_metadata_algorithm(&self) {

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -36,13 +36,14 @@ impl MediaQueryListEvent {
         proto: Option<HandleObject>,
         media: DOMString,
         matches: bool,
+        can_gc: CanGc,
     ) -> DomRoot<MediaQueryListEvent> {
         let ev = Box::new(MediaQueryListEvent {
             event: Event::new_inherited(),
             media,
             matches: Cell::new(matches),
         });
-        reflect_dom_object_with_proto(ev, global, proto, CanGc::note())
+        reflect_dom_object_with_proto(ev, global, proto, can_gc)
     }
 
     pub fn new(
@@ -53,7 +54,16 @@ impl MediaQueryListEvent {
         media: DOMString,
         matches: bool,
     ) -> DomRoot<MediaQueryListEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, media, matches)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            media,
+            matches,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -64,8 +74,9 @@ impl MediaQueryListEvent {
         cancelable: bool,
         media: DOMString,
         matches: bool,
+        can_gc: CanGc,
     ) -> DomRoot<MediaQueryListEvent> {
-        let ev = MediaQueryListEvent::new_initialized(global, proto, media, matches);
+        let ev = MediaQueryListEvent::new_initialized(global, proto, media, matches, can_gc);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
@@ -77,6 +88,7 @@ impl MediaQueryListEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &MediaQueryListEventInit,
     ) -> Fallible<DomRoot<MediaQueryListEvent>> {
@@ -89,6 +101,7 @@ impl MediaQueryListEvent {
             init.parent.cancelable,
             init.media.clone(),
             init.matches,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 // https://drafts.csswg.org/cssom-view/#dom-mediaquerylistevent-mediaquerylistevent
 #[dom_struct]
@@ -41,7 +42,7 @@ impl MediaQueryListEvent {
             media,
             matches: Cell::new(matches),
         });
-        reflect_dom_object_with_proto(ev, global, proto)
+        reflect_dom_object_with_proto(ev, global, proto, CanGc::note())
     }
 
     pub fn new(

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -17,6 +17,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaStream {
@@ -38,7 +39,12 @@ impl MediaStream {
     }
 
     fn new_with_proto(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<MediaStream> {
-        reflect_dom_object_with_proto(Box::new(MediaStream::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(MediaStream::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn new_single(

--- a/components/script/dom/mediastream.rs
+++ b/components/script/dom/mediastream.rs
@@ -35,15 +35,19 @@ impl MediaStream {
     }
 
     pub fn new(global: &GlobalScope) -> DomRoot<MediaStream> {
-        Self::new_with_proto(global, None)
+        Self::new_with_proto(global, None, CanGc::note())
     }
 
-    fn new_with_proto(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<MediaStream> {
+    fn new_with_proto(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<MediaStream> {
         reflect_dom_object_with_proto(
             Box::new(MediaStream::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -61,24 +65,27 @@ impl MediaStream {
     pub fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStream>> {
-        Ok(MediaStream::new_with_proto(&global.global(), proto))
+        Ok(MediaStream::new_with_proto(&global.global(), proto, can_gc))
     }
 
     pub fn Constructor_(
         _: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStream>> {
-        Ok(stream.clone_with_proto(proto))
+        Ok(stream.clone_with_proto(proto, can_gc))
     }
 
     pub fn Constructor__(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         tracks: Vec<DomRoot<MediaStreamTrack>>,
     ) -> Fallible<DomRoot<MediaStream>> {
-        let new = MediaStream::new_with_proto(&global.global(), proto);
+        let new = MediaStream::new_with_proto(&global.global(), proto, can_gc);
         for track in tracks {
             // this is quadratic, but shouldn't matter much
             // if this becomes a problem we can use a hash map
@@ -152,13 +159,13 @@ impl MediaStreamMethods for MediaStream {
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
     fn Clone(&self) -> DomRoot<MediaStream> {
-        self.clone_with_proto(None)
+        self.clone_with_proto(None, CanGc::note())
     }
 }
 
 impl MediaStream {
-    fn clone_with_proto(&self, proto: Option<HandleObject>) -> DomRoot<MediaStream> {
-        let new = MediaStream::new_with_proto(&self.global(), proto);
+    fn clone_with_proto(&self, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<MediaStream> {
+        let new = MediaStream::new_with_proto(&self.global(), proto, can_gc);
         for track in &*self.tracks.borrow() {
             new.add_track(track)
         }

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -60,7 +60,7 @@ impl MediaStreamAudioDestinationNode {
         context: &AudioContext,
         options: &AudioNodeOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -69,13 +69,14 @@ impl MediaStreamAudioDestinationNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         options: &AudioNodeOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let node = MediaStreamAudioDestinationNode::new_inherited(context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -83,10 +84,11 @@ impl MediaStreamAudioDestinationNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &AudioContext,
         options: &AudioNodeOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
-        MediaStreamAudioDestinationNode::new_with_proto(window, proto, context, options)
+        MediaStreamAudioDestinationNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/mediastreamaudiodestinationnode.rs
+++ b/components/script/dom/mediastreamaudiodestinationnode.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::mediastream::MediaStream;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaStreamAudioDestinationNode {
@@ -70,7 +71,12 @@ impl MediaStreamAudioDestinationNode {
         options: &AudioNodeOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioDestinationNode>> {
         let node = MediaStreamAudioDestinationNode::new_inherited(context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -56,7 +56,7 @@ impl MediaStreamAudioSourceNode {
         context: &AudioContext,
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, stream)
+        Self::new_with_proto(window, None, context, stream, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -65,13 +65,14 @@ impl MediaStreamAudioSourceNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         stream: &MediaStream,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let node = MediaStreamAudioSourceNode::new_inherited(context, stream)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -79,10 +80,17 @@ impl MediaStreamAudioSourceNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &AudioContext,
         options: &MediaStreamAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
-        MediaStreamAudioSourceNode::new_with_proto(window, proto, context, &options.mediaStream)
+        MediaStreamAudioSourceNode::new_with_proto(
+            window,
+            proto,
+            context,
+            &options.mediaStream,
+            can_gc,
+        )
     }
 }
 

--- a/components/script/dom/mediastreamaudiosourcenode.rs
+++ b/components/script/dom/mediastreamaudiosourcenode.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::mediastream::MediaStream;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaStreamAudioSourceNode {
@@ -66,7 +67,12 @@ impl MediaStreamAudioSourceNode {
         stream: &MediaStream,
     ) -> Fallible<DomRoot<MediaStreamAudioSourceNode>> {
         let node = MediaStreamAudioSourceNode::new_inherited(context, stream)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/mediastreamtrackaudiosourcenode.rs
@@ -47,7 +47,7 @@ impl MediaStreamTrackAudioSourceNode {
         context: &AudioContext,
         track: &MediaStreamTrack,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, track)
+        Self::new_with_proto(window, None, context, track, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -56,13 +56,14 @@ impl MediaStreamTrackAudioSourceNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         track: &MediaStreamTrack,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let node = MediaStreamTrackAudioSourceNode::new_inherited(context, track)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -70,6 +71,7 @@ impl MediaStreamTrackAudioSourceNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &AudioContext,
         options: &MediaStreamTrackAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
@@ -78,6 +80,7 @@ impl MediaStreamTrackAudioSourceNode {
             proto,
             context,
             &options.mediaStreamTrack,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/mediastreamtrackaudiosourcenode.rs
+++ b/components/script/dom/mediastreamtrackaudiosourcenode.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaStreamTrackAudioSourceNode {
@@ -57,7 +58,12 @@ impl MediaStreamTrackAudioSourceNode {
         track: &MediaStreamTrack,
     ) -> Fallible<DomRoot<MediaStreamTrackAudioSourceNode>> {
         let node = MediaStreamTrackAudioSourceNode::new_inherited(context, track)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/messagechannel.rs
+++ b/components/script/dom/messagechannel.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MessageChannel {
@@ -47,6 +48,7 @@ impl MessageChannel {
             Box::new(MessageChannel::new_inherited(&port1, &port2)),
             incumbent,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/messagechannel.rs
+++ b/components/script/dom/messagechannel.rs
@@ -25,12 +25,17 @@ impl MessageChannel {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<MessageChannel> {
-        MessageChannel::new(global, proto)
+        MessageChannel::new(global, proto, can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
-    fn new(incumbent: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<MessageChannel> {
+    fn new(
+        incumbent: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<MessageChannel> {
         // Step 1
         let port1 = MessagePort::new(incumbent);
 
@@ -48,7 +53,7 @@ impl MessageChannel {
             Box::new(MessageChannel::new_inherited(&port1, &port2)),
             incumbent,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -92,12 +92,13 @@ impl MessageEvent {
     }
 
     pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<MessageEvent> {
-        Self::new_uninitialized_with_proto(global, None)
+        Self::new_uninitialized_with_proto(global, None, CanGc::note())
     }
 
     fn new_uninitialized_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         MessageEvent::new_initialized(
             global,
@@ -107,6 +108,7 @@ impl MessageEvent {
             None,
             DOMString::new(),
             vec![],
+            can_gc,
         )
     }
 
@@ -118,6 +120,7 @@ impl MessageEvent {
         source: Option<&WindowProxyOrMessagePortOrServiceWorker>,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
         let ev = Box::new(MessageEvent::new_inherited(
             origin,
@@ -125,7 +128,7 @@ impl MessageEvent {
             lastEventId,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto(ev, global, proto, CanGc::note());
+        let ev = reflect_dom_object_with_proto(ev, global, proto, can_gc);
         ev.data.set(data.get());
 
         ev
@@ -154,6 +157,7 @@ impl MessageEvent {
             source,
             lastEventId,
             ports,
+            CanGc::note(),
         )
     }
 
@@ -169,9 +173,18 @@ impl MessageEvent {
         source: Option<&WindowProxyOrMessagePortOrServiceWorker>,
         lastEventId: DOMString,
         ports: Vec<DomRoot<MessagePort>>,
+        can_gc: CanGc,
     ) -> DomRoot<MessageEvent> {
-        let ev =
-            MessageEvent::new_initialized(global, proto, data, origin, source, lastEventId, ports);
+        let ev = MessageEvent::new_initialized(
+            global,
+            proto,
+            data,
+            origin,
+            source,
+            lastEventId,
+            ports,
+            can_gc,
+        );
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
@@ -182,6 +195,7 @@ impl MessageEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<MessageEventBinding::MessageEventInit>,
     ) -> Fallible<DomRoot<MessageEvent>> {
@@ -196,6 +210,7 @@ impl MessageEvent {
             init.source.as_ref(),
             init.lastEventId.clone(),
             init.ports.clone(),
+            can_gc,
         );
         Ok(ev)
     }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -26,7 +26,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageport::MessagePort;
 use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::windowproxy::WindowProxy;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[crown::unrooted_must_root_lint::must_root]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -125,7 +125,7 @@ impl MessageEvent {
             lastEventId,
             ports,
         ));
-        let ev = reflect_dom_object_with_proto(ev, global, proto);
+        let ev = reflect_dom_object_with_proto(ev, global, proto, CanGc::note());
         ev.data.set(data.get());
 
         ev

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -76,19 +76,15 @@ impl MouseEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<MouseEvent> {
-        Self::new_uninitialized_with_proto(window, None)
+        Self::new_uninitialized_with_proto(window, None, CanGc::note())
     }
 
     fn new_uninitialized_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<MouseEvent> {
-        reflect_dom_object_with_proto(
-            Box::new(MouseEvent::new_inherited()),
-            window,
-            proto,
-            CanGc::note(),
-        )
+        reflect_dom_object_with_proto(Box::new(MouseEvent::new_inherited()), window, proto, can_gc)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -132,6 +128,7 @@ impl MouseEvent {
             buttons,
             related_target,
             point_in_target,
+            CanGc::note(),
         )
     }
 
@@ -156,8 +153,9 @@ impl MouseEvent {
         buttons: u16,
         related_target: Option<&EventTarget>,
         point_in_target: Option<Point2D<f32>>,
+        can_gc: CanGc,
     ) -> DomRoot<MouseEvent> {
-        let ev = MouseEvent::new_uninitialized_with_proto(window, proto);
+        let ev = MouseEvent::new_uninitialized_with_proto(window, proto, can_gc);
         ev.InitMouseEvent(
             type_,
             bool::from(can_bubble),
@@ -187,6 +185,7 @@ impl MouseEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &MouseEventBinding::MouseEventInit,
     ) -> Fallible<DomRoot<MouseEvent>> {
@@ -212,6 +211,7 @@ impl MouseEvent {
             init.buttons,
             init.relatedTarget.as_deref(),
             None,
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -24,6 +24,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::node::Node;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MouseEvent {
@@ -82,7 +83,12 @@ impl MouseEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<MouseEvent> {
-        reflect_dom_object_with_proto(Box::new(MouseEvent::new_inherited()), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(MouseEvent::new_inherited()),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -73,9 +73,10 @@ impl MutationObserver {
         global: &Window,
         proto: Option<HandleObject>,
         callback: Rc<MutationCallback>,
+        can_gc: CanGc,
     ) -> DomRoot<MutationObserver> {
         let boxed_observer = Box::new(MutationObserver::new_inherited(callback));
-        reflect_dom_object_with_proto(boxed_observer, global, proto, CanGc::note())
+        reflect_dom_object_with_proto(boxed_observer, global, proto, can_gc)
     }
 
     fn new_inherited(callback: Rc<MutationCallback>) -> MutationObserver {
@@ -91,10 +92,11 @@ impl MutationObserver {
     pub fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         callback: Rc<MutationCallback>,
     ) -> Fallible<DomRoot<MutationObserver>> {
         global.set_exists_mut_observer();
-        let observer = MutationObserver::new_with_proto(global, proto, callback);
+        let observer = MutationObserver::new_with_proto(global, proto, callback, can_gc);
         ScriptThread::add_mutation_observer(&observer);
         Ok(observer)
     }

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -22,6 +22,7 @@ use crate::dom::mutationrecord::MutationRecord;
 use crate::dom::node::{Node, ShadowIncluding};
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -74,7 +75,7 @@ impl MutationObserver {
         callback: Rc<MutationCallback>,
     ) -> DomRoot<MutationObserver> {
         let boxed_observer = Box::new(MutationObserver::new_inherited(callback));
-        reflect_dom_object_with_proto(boxed_observer, global, proto)
+        reflect_dom_object_with_proto(boxed_observer, global, proto, CanGc::note())
     }
 
     fn new_inherited(callback: Rc<MutationCallback>) -> MutationObserver {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -103,6 +103,7 @@ use crate::dom::svgsvgelement::{LayoutSVGSVGElementHelpers, SVGSVGElement};
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::{vtable_for, VirtualMethods};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 //
@@ -1788,7 +1789,7 @@ impl Node {
         N: DerivedFrom<Node> + DomObject + DomObjectWrap,
     {
         let window = document.window();
-        reflect_dom_object_with_proto(node, window, proto)
+        reflect_dom_object_with_proto(node, window, proto, CanGc::note())
     }
 
     pub fn new_inherited(doc: &Document) -> Node {

--- a/components/script/dom/offlineaudiocompletionevent.rs
+++ b/components/script/dom/offlineaudiocompletionevent.rs
@@ -41,7 +41,15 @@ impl OfflineAudioCompletionEvent {
         cancelable: EventCancelable,
         rendered_buffer: &AudioBuffer,
     ) -> DomRoot<OfflineAudioCompletionEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, rendered_buffer)
+        Self::new_with_proto(
+            window,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            rendered_buffer,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -51,9 +59,10 @@ impl OfflineAudioCompletionEvent {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         rendered_buffer: &AudioBuffer,
+        can_gc: CanGc,
     ) -> DomRoot<OfflineAudioCompletionEvent> {
         let event = Box::new(OfflineAudioCompletionEvent::new_inherited(rendered_buffer));
-        let ev = reflect_dom_object_with_proto(event, window, proto, CanGc::note());
+        let ev = reflect_dom_object_with_proto(event, window, proto, can_gc);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -65,6 +74,7 @@ impl OfflineAudioCompletionEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &OfflineAudioCompletionEventInit,
     ) -> Fallible<DomRoot<OfflineAudioCompletionEvent>> {
@@ -77,6 +87,7 @@ impl OfflineAudioCompletionEvent {
             bubbles,
             cancelable,
             &init.renderedBuffer,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/offlineaudiocompletionevent.rs
+++ b/components/script/dom/offlineaudiocompletionevent.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct OfflineAudioCompletionEvent {
@@ -52,7 +53,7 @@ impl OfflineAudioCompletionEvent {
         rendered_buffer: &AudioBuffer,
     ) -> DomRoot<OfflineAudioCompletionEvent> {
         let event = Box::new(OfflineAudioCompletionEvent::new_inherited(rendered_buffer));
-        let ev = reflect_dom_object_with_proto(event, window, proto);
+        let ev = reflect_dom_object_with_proto(event, window, proto, CanGc::note());
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -31,6 +31,7 @@ use crate::dom::offlineaudiocompletionevent::OfflineAudioCompletionEvent;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::realms::InRealm;
+use crate::script_runtime::CanGc;
 use crate::task_source::TaskSource;
 
 #[dom_struct]
@@ -92,6 +93,7 @@ impl OfflineAudioContext {
             Box::new(context),
             window,
             proto,
+            CanGc::note(),
         ))
     }
 

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -78,6 +78,7 @@ impl OfflineAudioContext {
         channel_count: u32,
         length: u32,
         sample_rate: f32,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<OfflineAudioContext>> {
         if channel_count > MAX_CHANNEL_COUNT ||
             channel_count == 0 ||
@@ -93,13 +94,14 @@ impl OfflineAudioContext {
             Box::new(context),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         options: &OfflineAudioContextOptions,
     ) -> Fallible<DomRoot<OfflineAudioContext>> {
         OfflineAudioContext::new(
@@ -108,17 +110,26 @@ impl OfflineAudioContext {
             options.numberOfChannels,
             options.length,
             *options.sampleRate,
+            can_gc,
         )
     }
 
     pub fn Constructor_(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         number_of_channels: u32,
         length: u32,
         sample_rate: Finite<f32>,
     ) -> Fallible<DomRoot<OfflineAudioContext>> {
-        OfflineAudioContext::new(window, proto, number_of_channels, length, *sample_rate)
+        OfflineAudioContext::new(
+            window,
+            proto,
+            number_of_channels,
+            length,
+            *sample_rate,
+            can_gc,
+        )
     }
 }
 

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -63,12 +63,13 @@ impl OffscreenCanvas {
         width: u64,
         height: u64,
         placeholder: Option<&HTMLCanvasElement>,
+        can_gc: CanGc,
     ) -> DomRoot<OffscreenCanvas> {
         reflect_dom_object_with_proto(
             Box::new(OffscreenCanvas::new_inherited(width, height, placeholder)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -76,10 +77,11 @@ impl OffscreenCanvas {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         width: u64,
         height: u64,
     ) -> Fallible<DomRoot<OffscreenCanvas>> {
-        let offscreencanvas = OffscreenCanvas::new(global, proto, width, height, None);
+        let offscreencanvas = OffscreenCanvas::new(global, proto, width, height, None, can_gc);
         Ok(offscreencanvas)
     }
 

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -23,7 +23,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::offscreencanvasrenderingcontext2d::OffscreenCanvasRenderingContext2D;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[crown::unrooted_must_root_lint::must_root]
 #[derive(Clone, JSTraceable, MallocSizeOf)]
@@ -68,6 +68,7 @@ impl OffscreenCanvas {
             Box::new(OffscreenCanvas::new_inherited(width, height, placeholder)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -28,6 +28,7 @@ use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct OscillatorNode {
@@ -102,7 +103,12 @@ impl OscillatorNode {
         options: &OscillatorOptions,
     ) -> Fallible<DomRoot<OscillatorNode>> {
         let node = OscillatorNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -92,7 +92,7 @@ impl OscillatorNode {
         context: &BaseAudioContext,
         options: &OscillatorOptions,
     ) -> Fallible<DomRoot<OscillatorNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -101,13 +101,14 @@ impl OscillatorNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<OscillatorNode>> {
         let node = OscillatorNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -115,10 +116,11 @@ impl OscillatorNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
     ) -> Fallible<DomRoot<OscillatorNode>> {
-        OscillatorNode::new_with_proto(window, proto, context, options)
+        OscillatorNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/pagetransitionevent.rs
+++ b/components/script/dom/pagetransitionevent.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#pagetransitionevent
 #[dom_struct]
@@ -42,6 +43,7 @@ impl PageTransitionEvent {
             Box::new(PageTransitionEvent::new_inherited()),
             window,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/pagetransitionevent.rs
+++ b/components/script/dom/pagetransitionevent.rs
@@ -38,12 +38,13 @@ impl PageTransitionEvent {
     fn new_uninitialized(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<PageTransitionEvent> {
         reflect_dom_object_with_proto(
             Box::new(PageTransitionEvent::new_inherited()),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -54,7 +55,15 @@ impl PageTransitionEvent {
         cancelable: bool,
         persisted: bool,
     ) -> DomRoot<PageTransitionEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, persisted)
+        Self::new_with_proto(
+            window,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            persisted,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -64,8 +73,9 @@ impl PageTransitionEvent {
         bubbles: bool,
         cancelable: bool,
         persisted: bool,
+        can_gc: CanGc,
     ) -> DomRoot<PageTransitionEvent> {
-        let ev = PageTransitionEvent::new_uninitialized(window, proto);
+        let ev = PageTransitionEvent::new_uninitialized(window, proto, can_gc);
         ev.persisted.set(persisted);
         {
             let event = ev.upcast::<Event>();
@@ -78,6 +88,7 @@ impl PageTransitionEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &PageTransitionEventBinding::PageTransitionEventInit,
     ) -> Fallible<DomRoot<PageTransitionEvent>> {
@@ -88,6 +99,7 @@ impl PageTransitionEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             init.persisted,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -185,7 +185,7 @@ impl PannerNode {
         context: &BaseAudioContext,
         options: &PannerOptions,
     ) -> Fallible<DomRoot<PannerNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -194,13 +194,14 @@ impl PannerNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &PannerOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<PannerNode>> {
         let node = PannerNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -208,10 +209,11 @@ impl PannerNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &PannerOptions,
     ) -> Fallible<DomRoot<PannerNode>> {
-        PannerNode::new_with_proto(window, proto, context, options)
+        PannerNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -31,6 +31,7 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct PannerNode {
@@ -195,7 +196,12 @@ impl PannerNode {
         options: &PannerOptions,
     ) -> Fallible<DomRoot<PannerNode>> {
         let node = PannerNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -71,7 +71,7 @@ impl PerformanceObserver {
         callback: Rc<PerformanceObserverCallback>,
         entries: DOMPerformanceEntryList,
     ) -> DomRoot<PerformanceObserver> {
-        Self::new_with_proto(global, None, callback, entries)
+        Self::new_with_proto(global, None, callback, entries, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -80,15 +80,17 @@ impl PerformanceObserver {
         proto: Option<HandleObject>,
         callback: Rc<PerformanceObserverCallback>,
         entries: DOMPerformanceEntryList,
+        can_gc: CanGc,
     ) -> DomRoot<PerformanceObserver> {
         let observer = PerformanceObserver::new_inherited(callback, DomRefCell::new(entries));
-        reflect_dom_object_with_proto(Box::new(observer), global, proto, CanGc::note())
+        reflect_dom_object_with_proto(Box::new(observer), global, proto, can_gc)
     }
 
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         callback: Rc<PerformanceObserverCallback>,
     ) -> Fallible<DomRoot<PerformanceObserver>> {
         Ok(PerformanceObserver::new_with_proto(
@@ -96,6 +98,7 @@ impl PerformanceObserver {
             proto,
             callback,
             Vec::new(),
+            can_gc,
         ))
     }
 

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -24,7 +24,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::PerformanceEntryList;
 use crate::dom::performanceentry::PerformanceEntry;
 use crate::dom::performanceobserverentrylist::PerformanceObserverEntryList;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 /// List of allowed performance entry types, in alphabetical order.
 pub const VALID_ENTRY_TYPES: &[&str] = &[
@@ -82,7 +82,7 @@ impl PerformanceObserver {
         entries: DOMPerformanceEntryList,
     ) -> DomRoot<PerformanceObserver> {
         let observer = PerformanceObserver::new_inherited(callback, DomRefCell::new(entries));
-        reflect_dom_object_with_proto(Box::new(observer), global, proto)
+        reflect_dom_object_with_proto(Box::new(observer), global, proto, CanGc::note())
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -38,12 +38,16 @@ impl PopStateEvent {
         }
     }
 
-    fn new_uninitialized(window: &Window, proto: Option<HandleObject>) -> DomRoot<PopStateEvent> {
+    fn new_uninitialized(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<PopStateEvent> {
         reflect_dom_object_with_proto(
             Box::new(PopStateEvent::new_inherited()),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -54,8 +58,9 @@ impl PopStateEvent {
         bubbles: bool,
         cancelable: bool,
         state: HandleValue,
+        can_gc: CanGc,
     ) -> DomRoot<PopStateEvent> {
-        let ev = PopStateEvent::new_uninitialized(window, proto);
+        let ev = PopStateEvent::new_uninitialized(window, proto, can_gc);
         ev.state.set(state.get());
         {
             let event = ev.upcast::<Event>();
@@ -68,6 +73,7 @@ impl PopStateEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<PopStateEventBinding::PopStateEventInit>,
     ) -> Fallible<DomRoot<PopStateEvent>> {
@@ -78,11 +84,20 @@ impl PopStateEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             init.state.handle(),
+            can_gc,
         ))
     }
 
     pub fn dispatch_jsval(target: &EventTarget, window: &Window, state: HandleValue) {
-        let event = PopStateEvent::new(window, None, atom!("popstate"), false, false, state);
+        let event = PopStateEvent::new(
+            window,
+            None,
+            atom!("popstate"),
+            false,
+            false,
+            state,
+            CanGc::note(),
+        );
         event.upcast::<Event>().fire(target);
     }
 }

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 // https://html.spec.whatwg.org/multipage/#the-popstateevent-interface
 #[dom_struct]
@@ -39,7 +39,12 @@ impl PopStateEvent {
     }
 
     fn new_uninitialized(window: &Window, proto: Option<HandleObject>) -> DomRoot<PopStateEvent> {
-        reflect_dom_object_with_proto(Box::new(PopStateEvent::new_inherited()), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(PopStateEvent::new_inherited()),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     fn new(

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct ProgressEvent {
@@ -75,6 +76,7 @@ impl ProgressEvent {
             )),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -54,6 +54,7 @@ impl ProgressEvent {
             length_computable,
             loaded,
             total,
+            CanGc::note(),
         )
     }
 
@@ -67,6 +68,7 @@ impl ProgressEvent {
         length_computable: bool,
         loaded: u64,
         total: u64,
+        can_gc: CanGc,
     ) -> DomRoot<ProgressEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(ProgressEvent::new_inherited(
@@ -76,7 +78,7 @@ impl ProgressEvent {
             )),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -89,6 +91,7 @@ impl ProgressEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &ProgressEventBinding::ProgressEventInit,
     ) -> Fallible<DomRoot<ProgressEvent>> {
@@ -103,6 +106,7 @@ impl ProgressEvent {
             init.lengthComputable,
             init.loaded,
             init.total,
+            can_gc,
         );
         Ok(ev)
     }

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -60,6 +60,7 @@ impl PromiseRejectionEvent {
             cancelable,
             promise.promise_obj(),
             reason,
+            CanGc::note(),
         )
     }
 
@@ -72,12 +73,13 @@ impl PromiseRejectionEvent {
         cancelable: EventCancelable,
         promise: HandleObject,
         reason: HandleValue,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         let ev = reflect_dom_object_with_proto(
             Box::new(PromiseRejectionEvent::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         ev.promise.set(promise.get());
 
@@ -94,6 +96,7 @@ impl PromiseRejectionEvent {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<PromiseRejectionEventBinding::PromiseRejectionEventInit>,
     ) -> Fallible<DomRoot<Self>> {
@@ -109,6 +112,7 @@ impl PromiseRejectionEvent {
             cancelable,
             init.promise.handle(),
             reason,
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct PromiseRejectionEvent {
@@ -77,6 +77,7 @@ impl PromiseRejectionEvent {
             Box::new(PromiseRejectionEvent::new_inherited()),
             global,
             proto,
+            CanGc::note(),
         );
         ev.promise.set(promise.get());
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -72,9 +72,13 @@ impl Range {
         }
     }
 
-    pub fn new_with_doc(document: &Document, proto: Option<HandleObject>) -> DomRoot<Range> {
+    pub fn new_with_doc(
+        document: &Document,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<Range> {
         let root = document.upcast();
-        Range::new_with_proto(document, proto, root, 0, root, 0)
+        Range::new_with_proto(document, proto, root, 0, root, 0, can_gc)
     }
 
     pub fn new(
@@ -91,6 +95,7 @@ impl Range {
             start_offset,
             end_container,
             end_offset,
+            CanGc::note(),
         )
     }
 
@@ -101,6 +106,7 @@ impl Range {
         start_offset: u32,
         end_container: &Node,
         end_offset: u32,
+        can_gc: CanGc,
     ) -> DomRoot<Range> {
         let range = reflect_dom_object_with_proto(
             Box::new(Range::new_inherited(
@@ -111,7 +117,7 @@ impl Range {
             )),
             document.window(),
             proto,
-            CanGc::note(),
+            can_gc,
         );
         start_container.ranges().push(WeakRef::new(&range));
         if start_container != end_container {
@@ -122,9 +128,13 @@ impl Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range>
     #[allow(non_snake_case)]
-    pub fn Constructor(window: &Window, proto: Option<HandleObject>) -> Fallible<DomRoot<Range>> {
+    pub fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<Range>> {
         let document = window.Document();
-        Ok(Range::new_with_doc(&document, proto))
+        Ok(Range::new_with_doc(&document, proto, can_gc))
     }
 
     /// <https://dom.spec.whatwg.org/#contained>

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -35,6 +35,7 @@ use crate::dom::node::{Node, ShadowIncluding, UnbindContext};
 use crate::dom::selection::Selection;
 use crate::dom::text::Text;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct Range {
@@ -110,6 +111,7 @@ impl Range {
             )),
             document.window(),
             proto,
+            CanGc::note(),
         );
         start_container.ranges().push(WeakRef::new(&range));
         if start_container != end_container {

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -38,7 +38,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::{Guard, Headers};
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[dom_struct]
 pub struct Request {
@@ -60,7 +60,12 @@ impl Request {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>, url: ServoUrl) -> DomRoot<Request> {
-        reflect_dom_object_with_proto(Box::new(Request::new_inherited(global, url)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Request::new_inherited(global, url)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     // https://fetch.spec.whatwg.org/#dom-request

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -24,6 +24,7 @@ use crate::dom::node::{window_from_node, Node};
 use crate::dom::resizeobserverentry::ResizeObserverEntry;
 use crate::dom::resizeobserversize::{ResizeObserverSize, ResizeObserverSizeImpl};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 /// <https://drafts.csswg.org/resize-observer/#calculate-depth-for-node>
@@ -63,7 +64,7 @@ impl ResizeObserver {
         callback: Rc<ResizeObserverCallback>,
     ) -> DomRoot<ResizeObserver> {
         let observer = Box::new(ResizeObserver::new_inherited(callback));
-        reflect_dom_object_with_proto(observer, window, proto)
+        reflect_dom_object_with_proto(observer, window, proto, CanGc::note())
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver>

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -62,9 +62,10 @@ impl ResizeObserver {
         window: &Window,
         proto: Option<HandleObject>,
         callback: Rc<ResizeObserverCallback>,
+        can_gc: CanGc,
     ) -> DomRoot<ResizeObserver> {
         let observer = Box::new(ResizeObserver::new_inherited(callback));
-        reflect_dom_object_with_proto(observer, window, proto, CanGc::note())
+        reflect_dom_object_with_proto(observer, window, proto, can_gc)
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-resizeobserver>
@@ -72,9 +73,10 @@ impl ResizeObserver {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         callback: Rc<ResizeObserverCallback>,
     ) -> DomRoot<ResizeObserver> {
-        let rooted_observer = ResizeObserver::new(window, proto, callback);
+        let rooted_observer = ResizeObserver::new(window, proto, callback, can_gc);
         let document = window.Document();
         document.add_resize_observer(&rooted_observer);
         rooted_observer
@@ -129,6 +131,7 @@ impl ResizeObserver {
                 box_size.origin.y.to_f64_px(),
                 width,
                 height,
+                CanGc::note(),
             );
             let entry = ResizeObserverEntry::new(
                 &window,

--- a/components/script/dom/resizeobserverentry.rs
+++ b/components/script/dom/resizeobserverentry.rs
@@ -13,7 +13,7 @@ use crate::dom::domrectreadonly::DOMRectReadOnly;
 use crate::dom::element::Element;
 use crate::dom::resizeobserversize::ResizeObserverSize;
 use crate::dom::window::Window;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// <https://drafts.csswg.org/resize-observer/#resize-observer-entry-interface>
 #[dom_struct]
@@ -73,7 +73,7 @@ impl ResizeObserverEntry {
             content_box_size,
             device_pixel_content_box_size,
         ));
-        reflect_dom_object_with_proto(entry, window, None)
+        reflect_dom_object_with_proto(entry, window, None, CanGc::note())
     }
 }
 

--- a/components/script/dom/resizeobserversize.rs
+++ b/components/script/dom/resizeobserversize.rs
@@ -8,6 +8,7 @@ use crate::dom::bindings::codegen::Bindings::ResizeObserverSizeBinding::ResizeOb
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 /// Non-DOM implementation backing `ResizeObserverSize`.
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
@@ -50,7 +51,7 @@ impl ResizeObserverSize {
 
     pub fn new(window: &Window, size_impl: ResizeObserverSizeImpl) -> DomRoot<ResizeObserverSize> {
         let observer_size = Box::new(ResizeObserverSize::new_inherited(size_impl));
-        reflect_dom_object_with_proto(observer_size, window, None)
+        reflect_dom_object_with_proto(observer_size, window, None, CanGc::note())
     }
 }
 

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -77,15 +77,19 @@ impl Response {
 
     // https://fetch.spec.whatwg.org/#dom-response
     pub fn new(global: &GlobalScope) -> DomRoot<Response> {
-        Self::new_with_proto(global, None)
+        Self::new_with_proto(global, None, CanGc::note())
     }
 
-    fn new_with_proto(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Response> {
+    fn new_with_proto(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<Response> {
         reflect_dom_object_with_proto(
             Box::new(Response::new_inherited(global)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -93,6 +97,7 @@ impl Response {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         body: Option<BodyInit>,
         init: &ResponseBinding::ResponseInit,
     ) -> Fallible<DomRoot<Response>> {
@@ -112,7 +117,7 @@ impl Response {
             ));
         }
 
-        let r = Response::new_with_proto(global, proto);
+        let r = Response::new_with_proto(global, proto, can_gc);
 
         // Step 3
         *r.status.borrow_mut() = Some(StatusCode::from_u16(init.status).unwrap());

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -31,7 +31,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::{is_obs_text, is_vchar, Guard, Headers};
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::{ExternalUnderlyingSource, ReadableStream};
-use crate::script_runtime::{JSContext as SafeJSContext, StreamConsumer};
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext, StreamConsumer};
 
 #[dom_struct]
 pub struct Response {
@@ -81,7 +81,12 @@ impl Response {
     }
 
     fn new_with_proto(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Response> {
-        reflect_dom_object_with_proto(Box::new(Response::new_inherited(global)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Response::new_inherited(global)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     // https://fetch.spec.whatwg.org/#initialize-a-response

--- a/components/script/dom/rtcdatachannelevent.rs
+++ b/components/script/dom/rtcdatachannelevent.rs
@@ -18,6 +18,7 @@ use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::rtcdatachannel::RTCDataChannel;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCDataChannelEvent {
@@ -55,6 +56,7 @@ impl RTCDataChannelEvent {
             Box::new(RTCDataChannelEvent::new_inherited(channel)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = event.upcast::<Event>();

--- a/components/script/dom/rtcdatachannelevent.rs
+++ b/components/script/dom/rtcdatachannelevent.rs
@@ -41,7 +41,15 @@ impl RTCDataChannelEvent {
         cancelable: bool,
         channel: &RTCDataChannel,
     ) -> DomRoot<RTCDataChannelEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, channel)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            channel,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -51,12 +59,13 @@ impl RTCDataChannelEvent {
         bubbles: bool,
         cancelable: bool,
         channel: &RTCDataChannel,
+        can_gc: CanGc,
     ) -> DomRoot<RTCDataChannelEvent> {
         let event = reflect_dom_object_with_proto(
             Box::new(RTCDataChannelEvent::new_inherited(channel)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = event.upcast::<Event>();
@@ -69,6 +78,7 @@ impl RTCDataChannelEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &RTCDataChannelEventInit,
     ) -> DomRoot<RTCDataChannelEvent> {
@@ -79,6 +89,7 @@ impl RTCDataChannelEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.channel,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/rtcerror.rs
+++ b/components/script/dom/rtcerror.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCError {
@@ -56,6 +57,7 @@ impl RTCError {
             Box::new(RTCError::new_inherited(global, init, message)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/rtcerror.rs
+++ b/components/script/dom/rtcerror.rs
@@ -44,7 +44,7 @@ impl RTCError {
     }
 
     pub fn new(global: &GlobalScope, init: &RTCErrorInit, message: DOMString) -> DomRoot<RTCError> {
-        Self::new_with_proto(global, None, init, message)
+        Self::new_with_proto(global, None, init, message, CanGc::note())
     }
 
     fn new_with_proto(
@@ -52,12 +52,13 @@ impl RTCError {
         proto: Option<HandleObject>,
         init: &RTCErrorInit,
         message: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<RTCError> {
         reflect_dom_object_with_proto(
             Box::new(RTCError::new_inherited(global, init, message)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -65,10 +66,11 @@ impl RTCError {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: &RTCErrorInit,
         message: DOMString,
     ) -> DomRoot<RTCError> {
-        RTCError::new_with_proto(&window.global(), proto, init, message)
+        RTCError::new_with_proto(&window.global(), proto, init, message, can_gc)
     }
 }
 

--- a/components/script/dom/rtcerrorevent.rs
+++ b/components/script/dom/rtcerrorevent.rs
@@ -41,7 +41,15 @@ impl RTCErrorEvent {
         cancelable: bool,
         error: &RTCError,
     ) -> DomRoot<RTCErrorEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, error)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            error,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -51,12 +59,13 @@ impl RTCErrorEvent {
         bubbles: bool,
         cancelable: bool,
         error: &RTCError,
+        can_gc: CanGc,
     ) -> DomRoot<RTCErrorEvent> {
         let event = reflect_dom_object_with_proto(
             Box::new(RTCErrorEvent::new_inherited(error)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = event.upcast::<Event>();
@@ -69,6 +78,7 @@ impl RTCErrorEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &RTCErrorEventInit,
     ) -> DomRoot<RTCErrorEvent> {
@@ -79,6 +89,7 @@ impl RTCErrorEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.error,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/rtcerrorevent.rs
+++ b/components/script/dom/rtcerrorevent.rs
@@ -18,6 +18,7 @@ use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::rtcerror::RTCError;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCErrorEvent {
@@ -55,6 +56,7 @@ impl RTCErrorEvent {
             Box::new(RTCErrorEvent::new_inherited(error)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = event.upcast::<Event>();

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCIceCandidate {
@@ -74,6 +75,7 @@ impl RTCIceCandidate {
             )),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/rtcicecandidate.rs
+++ b/components/script/dom/rtcicecandidate.rs
@@ -55,6 +55,7 @@ impl RTCIceCandidate {
             sdp_m_id,
             sdp_m_line_index,
             username_fragment,
+            CanGc::note(),
         )
     }
 
@@ -65,6 +66,7 @@ impl RTCIceCandidate {
         sdp_m_id: Option<DOMString>,
         sdp_m_line_index: Option<u16>,
         username_fragment: Option<DOMString>,
+        can_gc: CanGc,
     ) -> DomRoot<RTCIceCandidate> {
         reflect_dom_object_with_proto(
             Box::new(RTCIceCandidate::new_inherited(
@@ -75,7 +77,7 @@ impl RTCIceCandidate {
             )),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -83,6 +85,7 @@ impl RTCIceCandidate {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         config: &RTCIceCandidateInit,
     ) -> Fallible<DomRoot<RTCIceCandidate>> {
         if config.sdpMid.is_none() && config.sdpMLineIndex.is_none() {
@@ -97,6 +100,7 @@ impl RTCIceCandidate {
             config.sdpMid.clone(),
             config.sdpMLineIndex,
             config.usernameFragment.clone(),
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -50,6 +50,7 @@ use crate::dom::rtcsessiondescription::RTCSessionDescription;
 use crate::dom::rtctrackevent::RTCTrackEvent;
 use crate::dom::window::Window;
 use crate::realms::{enter_realm, InRealm};
+use crate::script_runtime::CanGc;
 use crate::task::TaskCanceller;
 use crate::task_source::networking::NetworkingTaskSource;
 use crate::task_source::TaskSource;
@@ -202,6 +203,7 @@ impl RTCPeerConnection {
             Box::new(RTCPeerConnection::new_inherited()),
             global,
             proto,
+            CanGc::note(),
         );
         let signaller = this.make_signaller();
         *this.controller.borrow_mut() = Some(ServoMedia::get().unwrap().create_webrtc(signaller));

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -198,12 +198,13 @@ impl RTCPeerConnection {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         config: &RTCConfiguration,
+        can_gc: CanGc,
     ) -> DomRoot<RTCPeerConnection> {
         let this = reflect_dom_object_with_proto(
             Box::new(RTCPeerConnection::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         let signaller = this.make_signaller();
         *this.controller.borrow_mut() = Some(ServoMedia::get().unwrap().create_webrtc(signaller));
@@ -234,9 +235,15 @@ impl RTCPeerConnection {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         config: &RTCConfiguration,
     ) -> Fallible<DomRoot<RTCPeerConnection>> {
-        Ok(RTCPeerConnection::new(&window.global(), proto, config))
+        Ok(RTCPeerConnection::new(
+            &window.global(),
+            proto,
+            config,
+            can_gc,
+        ))
     }
 
     pub fn get_webrtc_controller(&self) -> &DomRefCell<Option<WebRtcController>> {
@@ -652,6 +659,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
                             let desc = RTCSessionDescription::Constructor(
                                 this.global().as_window(),
                                 None,
+                                CanGc::note(),
                                 &desc,
                             ).unwrap();
                             this.local_description.set(Some(&desc));
@@ -692,6 +700,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
                             let desc = RTCSessionDescription::Constructor(
                                 this.global().as_window(),
                                 None,
+                                CanGc::note(),
                                 &desc,
                             ).unwrap();
                             this.remote_description.set(Some(&desc));

--- a/components/script/dom/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/rtcpeerconnectioniceevent.rs
@@ -47,7 +47,7 @@ impl RTCPeerConnectionIceEvent {
         url: Option<DOMString>,
         trusted: bool,
     ) -> DomRoot<RTCPeerConnectionIceEvent> {
-        Self::new_with_proto(global, None, ty, candidate, url, trusted)
+        Self::new_with_proto(global, None, ty, candidate, url, trusted, CanGc::note())
     }
 
     fn new_with_proto(
@@ -57,12 +57,13 @@ impl RTCPeerConnectionIceEvent {
         candidate: Option<&RTCIceCandidate>,
         url: Option<DOMString>,
         trusted: bool,
+        can_gc: CanGc,
     ) -> DomRoot<RTCPeerConnectionIceEvent> {
         let e = reflect_dom_object_with_proto(
             Box::new(RTCPeerConnectionIceEvent::new_inherited(candidate, url)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         let evt = e.upcast::<Event>();
         evt.init_event(ty, false, false); // XXXManishearth bubbles/cancelable?
@@ -74,6 +75,7 @@ impl RTCPeerConnectionIceEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         ty: DOMString,
         init: &RTCPeerConnectionIceEventInit,
     ) -> Fallible<DomRoot<RTCPeerConnectionIceEvent>> {
@@ -87,6 +89,7 @@ impl RTCPeerConnectionIceEvent {
                 .map(|x| &**x),
             init.url.as_ref().and_then(|x| x.clone()),
             false,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/rtcpeerconnectioniceevent.rs
+++ b/components/script/dom/rtcpeerconnectioniceevent.rs
@@ -19,6 +19,7 @@ use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::rtcicecandidate::RTCIceCandidate;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCPeerConnectionIceEvent {
@@ -61,6 +62,7 @@ impl RTCPeerConnectionIceEvent {
             Box::new(RTCPeerConnectionIceEvent::new_inherited(candidate, url)),
             global,
             proto,
+            CanGc::note(),
         );
         let evt = e.upcast::<Event>();
         evt.init_event(ty, false, false); // XXXManishearth bubbles/cancelable?

--- a/components/script/dom/rtcsessiondescription.rs
+++ b/components/script/dom/rtcsessiondescription.rs
@@ -37,12 +37,13 @@ impl RTCSessionDescription {
         proto: Option<HandleObject>,
         ty: RTCSdpType,
         sdp: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<RTCSessionDescription> {
         reflect_dom_object_with_proto(
             Box::new(RTCSessionDescription::new_inherited(ty, sdp)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -50,6 +51,7 @@ impl RTCSessionDescription {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         config: &RTCSessionDescriptionInit,
     ) -> Fallible<DomRoot<RTCSessionDescription>> {
         Ok(RTCSessionDescription::new(
@@ -57,6 +59,7 @@ impl RTCSessionDescription {
             proto,
             config.type_,
             config.sdp.clone(),
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/rtcsessiondescription.rs
+++ b/components/script/dom/rtcsessiondescription.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCSessionDescription {
@@ -41,6 +42,7 @@ impl RTCSessionDescription {
             Box::new(RTCSessionDescription::new_inherited(ty, sdp)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/rtctrackevent.rs
+++ b/components/script/dom/rtctrackevent.rs
@@ -41,7 +41,15 @@ impl RTCTrackEvent {
         cancelable: bool,
         track: &MediaStreamTrack,
     ) -> DomRoot<RTCTrackEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, track)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            track,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -51,12 +59,13 @@ impl RTCTrackEvent {
         bubbles: bool,
         cancelable: bool,
         track: &MediaStreamTrack,
+        can_gc: CanGc,
     ) -> DomRoot<RTCTrackEvent> {
         let trackevent = reflect_dom_object_with_proto(
             Box::new(RTCTrackEvent::new_inherited(track)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = trackevent.upcast::<Event>();
@@ -69,6 +78,7 @@ impl RTCTrackEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &RTCTrackEventBinding::RTCTrackEventInit,
     ) -> Fallible<DomRoot<RTCTrackEvent>> {
@@ -79,6 +89,7 @@ impl RTCTrackEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.track,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/rtctrackevent.rs
+++ b/components/script/dom/rtctrackevent.rs
@@ -17,6 +17,7 @@ use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::mediastreamtrack::MediaStreamTrack;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct RTCTrackEvent {
@@ -55,6 +56,7 @@ impl RTCTrackEvent {
             Box::new(RTCTrackEvent::new_inherited(track)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = trackevent.upcast::<Event>();

--- a/components/script/dom/securitypolicyviolationevent.rs
+++ b/components/script/dom/securitypolicyviolationevent.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 // https://w3c.github.io/webappsec-csp/#securitypolicyviolationevent
 #[dom_struct]
@@ -64,6 +65,7 @@ impl SecurityPolicyViolationEvent {
             Box::new(SecurityPolicyViolationEvent::new_inherited(init)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/securitypolicyviolationevent.rs
+++ b/components/script/dom/securitypolicyviolationevent.rs
@@ -60,12 +60,13 @@ impl SecurityPolicyViolationEvent {
         global: &GlobalScope,
         init: &SecurityPolicyViolationEventInit,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<SecurityPolicyViolationEvent> {
         reflect_dom_object_with_proto(
             Box::new(SecurityPolicyViolationEvent::new_inherited(init)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -76,8 +77,9 @@ impl SecurityPolicyViolationEvent {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         init: &SecurityPolicyViolationEventInit,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let ev = SecurityPolicyViolationEvent::new_initialized(global, init, proto);
+        let ev = SecurityPolicyViolationEvent::new_initialized(global, init, proto, can_gc);
         {
             let event = ev.upcast::<Event>();
             event.init_event(type_, bool::from(bubbles), bool::from(cancelable));
@@ -92,13 +94,22 @@ impl SecurityPolicyViolationEvent {
         cancelable: EventCancelable,
         init: &SecurityPolicyViolationEventInit,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, init)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            init,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &SecurityPolicyViolationEventInit,
     ) -> DomRoot<Self> {
@@ -109,6 +120,7 @@ impl SecurityPolicyViolationEvent {
             EventBubbles::from(init.parent.bubbles),
             EventCancelable::from(init.parent.cancelable),
             init,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/staticrange.rs
+++ b/components/script/dom/staticrange.rs
@@ -42,14 +42,16 @@ impl StaticRange {
         document: &Document,
         proto: Option<HandleObject>,
         init: &StaticRangeInit,
+        can_gc: CanGc,
     ) -> DomRoot<StaticRange> {
-        StaticRange::new_with_proto(document, proto, init)
+        StaticRange::new_with_proto(document, proto, init, can_gc)
     }
 
     pub fn new_with_proto(
         document: &Document,
         proto: Option<HandleObject>,
         init: &StaticRangeInit,
+        can_gc: CanGc,
     ) -> DomRoot<StaticRange> {
         let staticrange = reflect_dom_object_with_proto(
             Box::new(StaticRange::new_inherited(
@@ -60,7 +62,7 @@ impl StaticRange {
             )),
             document.window(),
             proto,
-            CanGc::note(),
+            can_gc,
         );
         staticrange
     }
@@ -70,6 +72,7 @@ impl StaticRange {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: &StaticRangeInit,
     ) -> Fallible<DomRoot<StaticRange>> {
         match init.startContainer.type_id() {
@@ -85,6 +88,6 @@ impl StaticRange {
             _ => (),
         }
         let document = window.Document();
-        Ok(StaticRange::new_with_doc(&document, proto, init))
+        Ok(StaticRange::new_with_doc(&document, proto, init, can_gc))
     }
 }

--- a/components/script/dom/staticrange.rs
+++ b/components/script/dom/staticrange.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct StaticRange {
@@ -59,6 +60,7 @@ impl StaticRange {
             )),
             document.window(),
             proto,
+            CanGc::note(),
         );
         staticrange
     }

--- a/components/script/dom/stereopannernode.rs
+++ b/components/script/dom/stereopannernode.rs
@@ -22,6 +22,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct StereoPannerNode {
@@ -89,7 +90,12 @@ impl StereoPannerNode {
         options: &StereoPannerOptions,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
         let node = StereoPannerNode::new_inherited(window, context, options)?;
-        Ok(reflect_dom_object_with_proto(Box::new(node), window, proto))
+        Ok(reflect_dom_object_with_proto(
+            Box::new(node),
+            window,
+            proto,
+            CanGc::note(),
+        ))
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/stereopannernode.rs
+++ b/components/script/dom/stereopannernode.rs
@@ -79,7 +79,7 @@ impl StereoPannerNode {
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
-        Self::new_with_proto(window, None, context, options)
+        Self::new_with_proto(window, None, context, options, CanGc::note())
     }
 
     #[allow(crown::unrooted_must_root)]
@@ -88,13 +88,14 @@ impl StereoPannerNode {
         proto: Option<HandleObject>,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
         let node = StereoPannerNode::new_inherited(window, context, options)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         ))
     }
 
@@ -102,10 +103,11 @@ impl StereoPannerNode {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
-        StereoPannerNode::new_with_proto(window, proto, context, options)
+        StereoPannerNode::new_with_proto(window, proto, context, options, can_gc)
     }
 }
 

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::storage::Storage;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct StorageEvent {
@@ -61,6 +62,7 @@ impl StorageEvent {
             Box::new(StorageEvent::new_inherited(None, None, None, url, None)),
             window,
             proto,
+            CanGc::note(),
         )
     }
 
@@ -113,6 +115,7 @@ impl StorageEvent {
             )),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -50,19 +50,20 @@ impl StorageEvent {
     }
 
     pub fn new_uninitialized(window: &Window, url: DOMString) -> DomRoot<StorageEvent> {
-        Self::new_uninitialized_with_proto(window, None, url)
+        Self::new_uninitialized_with_proto(window, None, url, CanGc::note())
     }
 
     fn new_uninitialized_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
         url: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<StorageEvent> {
         reflect_dom_object_with_proto(
             Box::new(StorageEvent::new_inherited(None, None, None, url, None)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -89,6 +90,7 @@ impl StorageEvent {
             newValue,
             url,
             storageArea,
+            CanGc::note(),
         )
     }
 
@@ -104,6 +106,7 @@ impl StorageEvent {
         newValue: Option<DOMString>,
         url: DOMString,
         storageArea: Option<&Storage>,
+        can_gc: CanGc,
     ) -> DomRoot<StorageEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(StorageEvent::new_inherited(
@@ -115,7 +118,7 @@ impl StorageEvent {
             )),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -127,6 +130,7 @@ impl StorageEvent {
     pub fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &StorageEventBinding::StorageEventInit,
     ) -> Fallible<DomRoot<StorageEvent>> {
@@ -148,6 +152,7 @@ impl StorageEvent {
             newValue,
             url,
             storageArea,
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/submitevent.rs
+++ b/components/script/dom/submitevent.rs
@@ -41,7 +41,15 @@ impl SubmitEvent {
         cancelable: bool,
         submitter: Option<DomRoot<HTMLElement>>,
     ) -> DomRoot<SubmitEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, submitter)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            submitter,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -51,12 +59,13 @@ impl SubmitEvent {
         bubbles: bool,
         cancelable: bool,
         submitter: Option<DomRoot<HTMLElement>>,
+        can_gc: CanGc,
     ) -> DomRoot<SubmitEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(SubmitEvent::new_inherited(submitter)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -69,6 +78,7 @@ impl SubmitEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &SubmitEventBinding::SubmitEventInit,
     ) -> DomRoot<SubmitEvent> {
@@ -79,6 +89,7 @@ impl SubmitEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             init.submitter.as_ref().map(|s| DomRoot::from_ref(&**s)),
+            can_gc,
         )
     }
 }

--- a/components/script/dom/submitevent.rs
+++ b/components/script/dom/submitevent.rs
@@ -17,6 +17,7 @@ use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 #[allow(non_snake_case)]
@@ -55,6 +56,7 @@ impl SubmitEvent {
             Box::new(SubmitEvent::new_inherited(submitter)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -49,7 +49,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::url::URL;
 use crate::realms::InRealm;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::timers::OneshotTimerCallback;
 
 #[dom_struct]
@@ -68,7 +68,12 @@ impl TestBinding {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TestBinding> {
-        reflect_dom_object_with_proto(Box::new(TestBinding::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(TestBinding::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn Constructor(

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -67,38 +67,45 @@ impl TestBinding {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TestBinding> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<TestBinding> {
         reflect_dom_object_with_proto(
             Box::new(TestBinding::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBinding>> {
-        Ok(TestBinding::new(global, proto))
+        Ok(TestBinding::new(global, proto, can_gc))
     }
 
     #[allow(unused_variables)]
     pub fn Constructor_(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         nums: Vec<f64>,
     ) -> Fallible<DomRoot<TestBinding>> {
-        Ok(TestBinding::new(global, proto))
+        Ok(TestBinding::new(global, proto, can_gc))
     }
 
     #[allow(unused_variables)]
     pub fn Constructor__(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         num: f64,
     ) -> Fallible<DomRoot<TestBinding>> {
-        Ok(TestBinding::new(global, proto))
+        Ok(TestBinding::new(global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/testbindingiterable.rs
+++ b/components/script/dom/testbindingiterable.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TestBindingIterable {
@@ -30,6 +31,7 @@ impl TestBindingIterable {
             }),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/testbindingiterable.rs
+++ b/components/script/dom/testbindingiterable.rs
@@ -23,7 +23,11 @@ pub struct TestBindingIterable {
 }
 
 impl TestBindingIterable {
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TestBindingIterable> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<TestBindingIterable> {
         reflect_dom_object_with_proto(
             Box::new(TestBindingIterable {
                 reflector: Reflector::new(),
@@ -31,7 +35,7 @@ impl TestBindingIterable {
             }),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -39,8 +43,9 @@ impl TestBindingIterable {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingIterable>> {
-        Ok(TestBindingIterable::new(global, proto))
+        Ok(TestBindingIterable::new(global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/testbindingmaplike.rs
+++ b/components/script/dom/testbindingmaplike.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::maplike;
+use crate::script_runtime::CanGc;
 
 /// maplike<DOMString, long>
 #[dom_struct]
@@ -36,6 +37,7 @@ impl TestBindingMaplike {
             }),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/testbindingmaplike.rs
+++ b/components/script/dom/testbindingmaplike.rs
@@ -29,7 +29,11 @@ pub struct TestBindingMaplike {
 }
 
 impl TestBindingMaplike {
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TestBindingMaplike> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<TestBindingMaplike> {
         reflect_dom_object_with_proto(
             Box::new(TestBindingMaplike {
                 reflector: Reflector::new(),
@@ -37,7 +41,7 @@ impl TestBindingMaplike {
             }),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -45,8 +49,9 @@ impl TestBindingMaplike {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingMaplike>> {
-        Ok(TestBindingMaplike::new(global, proto))
+        Ok(TestBindingMaplike::new(global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/testbindingpairiterable.rs
+++ b/components/script/dom/testbindingpairiterable.rs
@@ -15,6 +15,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TestBindingPairIterable {
@@ -50,6 +51,7 @@ impl TestBindingPairIterable {
             }),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/testbindingpairiterable.rs
+++ b/components/script/dom/testbindingpairiterable.rs
@@ -43,7 +43,11 @@ impl Iterable for TestBindingPairIterable {
 }
 
 impl TestBindingPairIterable {
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TestBindingPairIterable> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<TestBindingPairIterable> {
         reflect_dom_object_with_proto(
             Box::new(TestBindingPairIterable {
                 reflector: Reflector::new(),
@@ -51,7 +55,7 @@ impl TestBindingPairIterable {
             }),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -59,8 +63,9 @@ impl TestBindingPairIterable {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingPairIterable>> {
-        Ok(TestBindingPairIterable::new(global, proto))
+        Ok(TestBindingPairIterable::new(global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/testbindingsetlike.rs
+++ b/components/script/dom/testbindingsetlike.rs
@@ -28,7 +28,11 @@ pub struct TestBindingSetlike {
 }
 
 impl TestBindingSetlike {
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TestBindingSetlike> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<TestBindingSetlike> {
         reflect_dom_object_with_proto(
             Box::new(TestBindingSetlike {
                 reflector: Reflector::new(),
@@ -36,7 +40,7 @@ impl TestBindingSetlike {
             }),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -44,8 +48,9 @@ impl TestBindingSetlike {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBindingSetlike>> {
-        Ok(TestBindingSetlike::new(global, proto))
+        Ok(TestBindingSetlike::new(global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/testbindingsetlike.rs
+++ b/components/script/dom/testbindingsetlike.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 use crate::setlike;
 
 // setlike<DOMString>
@@ -35,6 +36,7 @@ impl TestBindingSetlike {
             }),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/testworklet.rs
+++ b/components/script/dom/testworklet.rs
@@ -37,13 +37,13 @@ impl TestWorklet {
         }
     }
 
-    fn new(window: &Window, proto: Option<HandleObject>) -> DomRoot<TestWorklet> {
+    fn new(window: &Window, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<TestWorklet> {
         let worklet = Worklet::new(window, WorkletGlobalScopeType::Test);
         reflect_dom_object_with_proto(
             Box::new(TestWorklet::new_inherited(&worklet)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -51,8 +51,9 @@ impl TestWorklet {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestWorklet>> {
-        Ok(TestWorklet::new(window, proto))
+        Ok(TestWorklet::new(window, proto, can_gc))
     }
 }
 

--- a/components/script/dom/testworklet.rs
+++ b/components/script/dom/testworklet.rs
@@ -20,6 +20,7 @@ use crate::dom::window::Window;
 use crate::dom::worklet::Worklet;
 use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::realms::InRealm;
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 #[dom_struct]
@@ -42,6 +43,7 @@ impl TestWorklet {
             Box::new(TestWorklet::new_inherited(&worklet)),
             window,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -18,6 +18,7 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 /// An HTML text node.
 #[dom_struct]
@@ -52,6 +53,7 @@ impl Text {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        _can_gc: CanGc,
         text: DOMString,
     ) -> Fallible<DomRoot<Text>> {
         let document = window.Document();

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -66,12 +66,13 @@ impl TextDecoder {
         encoding: &'static Encoding,
         fatal: bool,
         ignoreBOM: bool,
+        can_gc: CanGc,
     ) -> DomRoot<TextDecoder> {
         reflect_dom_object_with_proto(
             Box::new(TextDecoder::new_inherited(encoding, fatal, ignoreBOM)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -79,6 +80,7 @@ impl TextDecoder {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         label: DOMString,
         options: &TextDecoderBinding::TextDecoderOptions,
     ) -> Fallible<DomRoot<TextDecoder>> {
@@ -92,6 +94,7 @@ impl TextDecoder {
             encoding,
             options.fatal,
             options.ignoreBOM,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 #[allow(non_snake_case)]
@@ -70,6 +71,7 @@ impl TextDecoder {
             Box::new(TextDecoder::new_inherited(encoding, fatal, ignoreBOM)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -30,12 +30,16 @@ impl TextEncoder {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TextEncoder> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<TextEncoder> {
         reflect_dom_object_with_proto(
             Box::new(TextEncoder::new_inherited()),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -44,8 +48,9 @@ impl TextEncoder {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<TextEncoder>> {
-        Ok(TextEncoder::new(global, proto))
+        Ok(TextEncoder::new(global, proto, can_gc))
     }
 }
 

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct TextEncoder {
@@ -31,7 +31,12 @@ impl TextEncoder {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<TextEncoder> {
-        reflect_dom_object_with_proto(Box::new(TextEncoder::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(TextEncoder::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     // https://encoding.spec.whatwg.org/#dom-textencoder

--- a/components/script/dom/trackevent.rs
+++ b/components/script/dom/trackevent.rs
@@ -67,7 +67,15 @@ impl TrackEvent {
         cancelable: bool,
         track: &Option<VideoTrackOrAudioTrackOrTextTrack>,
     ) -> DomRoot<TrackEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, track)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            track,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -77,12 +85,13 @@ impl TrackEvent {
         bubbles: bool,
         cancelable: bool,
         track: &Option<VideoTrackOrAudioTrackOrTextTrack>,
+        can_gc: CanGc,
     ) -> DomRoot<TrackEvent> {
         let te = reflect_dom_object_with_proto(
             Box::new(TrackEvent::new_inherited(track)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = te.upcast::<Event>();
@@ -94,6 +103,7 @@ impl TrackEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &TrackEventBinding::TrackEventInit,
     ) -> Fallible<DomRoot<TrackEvent>> {
@@ -104,6 +114,7 @@ impl TrackEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.track,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/trackevent.rs
+++ b/components/script/dom/trackevent.rs
@@ -21,6 +21,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::videotrack::VideoTrack;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[crown::unrooted_must_root_lint::must_root]
 #[derive(JSTraceable, MallocSizeOf)]
@@ -81,6 +82,7 @@ impl TrackEvent {
             Box::new(TrackEvent::new_inherited(track)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = te.upcast::<Event>();

--- a/components/script/dom/transitionevent.rs
+++ b/components/script/dom/transitionevent.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TransitionEvent {
@@ -56,6 +57,7 @@ impl TransitionEvent {
             Box::new(TransitionEvent::new_inherited(init)),
             window,
             proto,
+            CanGc::note(),
         );
         {
             let event = ev.upcast::<Event>();

--- a/components/script/dom/transitionevent.rs
+++ b/components/script/dom/transitionevent.rs
@@ -44,7 +44,7 @@ impl TransitionEvent {
         type_: Atom,
         init: &TransitionEventInit,
     ) -> DomRoot<TransitionEvent> {
-        Self::new_with_proto(window, None, type_, init)
+        Self::new_with_proto(window, None, type_, init, CanGc::note())
     }
 
     fn new_with_proto(
@@ -52,12 +52,13 @@ impl TransitionEvent {
         proto: Option<HandleObject>,
         type_: Atom,
         init: &TransitionEventInit,
+        can_gc: CanGc,
     ) -> DomRoot<TransitionEvent> {
         let ev = reflect_dom_object_with_proto(
             Box::new(TransitionEvent::new_inherited(init)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = ev.upcast::<Event>();
@@ -70,6 +71,7 @@ impl TransitionEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &TransitionEventInit,
     ) -> Fallible<DomRoot<TransitionEvent>> {
@@ -78,6 +80,7 @@ impl TransitionEvent {
             proto,
             Atom::from(type_),
             init,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -39,19 +39,15 @@ impl UIEvent {
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<UIEvent> {
-        Self::new_uninitialized_with_proto(window, None)
+        Self::new_uninitialized_with_proto(window, None, CanGc::note())
     }
 
     fn new_uninitialized_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> DomRoot<UIEvent> {
-        reflect_dom_object_with_proto(
-            Box::new(UIEvent::new_inherited()),
-            window,
-            proto,
-            CanGc::note(),
-        )
+        reflect_dom_object_with_proto(Box::new(UIEvent::new_inherited()), window, proto, can_gc)
     }
 
     pub fn new(
@@ -62,7 +58,16 @@ impl UIEvent {
         view: Option<&Window>,
         detail: i32,
     ) -> DomRoot<UIEvent> {
-        Self::new_with_proto(window, None, type_, can_bubble, cancelable, view, detail)
+        Self::new_with_proto(
+            window,
+            None,
+            type_,
+            can_bubble,
+            cancelable,
+            view,
+            detail,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -73,8 +78,9 @@ impl UIEvent {
         cancelable: EventCancelable,
         view: Option<&Window>,
         detail: i32,
+        can_gc: CanGc,
     ) -> DomRoot<UIEvent> {
-        let ev = UIEvent::new_uninitialized_with_proto(window, proto);
+        let ev = UIEvent::new_uninitialized_with_proto(window, proto, can_gc);
         ev.InitUIEvent(
             type_,
             bool::from(can_bubble),
@@ -89,6 +95,7 @@ impl UIEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &UIEventBinding::UIEventInit,
     ) -> Fallible<DomRoot<UIEvent>> {
@@ -102,6 +109,7 @@ impl UIEvent {
             cancelable,
             init.view.as_deref(),
             init.detail,
+            can_gc,
         );
         Ok(event)
     }

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 // https://w3c.github.io/uievents/#interface-uievent
 #[dom_struct]
@@ -45,7 +46,12 @@ impl UIEvent {
         window: &Window,
         proto: Option<HandleObject>,
     ) -> DomRoot<UIEvent> {
-        reflect_dom_object_with_proto(Box::new(UIEvent::new_inherited()), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(UIEvent::new_inherited()),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn new(

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -47,13 +47,13 @@ impl URL {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>, url: ServoUrl) -> DomRoot<URL> {
-        reflect_dom_object_with_proto(
-            Box::new(URL::new_inherited(url)),
-            global,
-            proto,
-            CanGc::note(),
-        )
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        url: ServoUrl,
+        can_gc: CanGc,
+    ) -> DomRoot<URL> {
+        reflect_dom_object_with_proto(Box::new(URL::new_inherited(url)), global, proto, can_gc)
     }
 
     pub fn query_pairs(&self) -> Vec<(String, String)> {
@@ -85,6 +85,7 @@ impl URL {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         url: USVString,
         base: Option<USVString>,
     ) -> Fallible<DomRoot<URL>> {
@@ -119,7 +120,7 @@ impl URL {
         // Step 7. Set this’s query object’s URL object to this.
 
         // Step 4. Set this’s URL to parsedURL.
-        Ok(URL::new(global, proto, parsed_url))
+        Ok(URL::new(global, proto, parsed_url, can_gc))
     }
 
     /// <https://url.spec.whatwg.org/#dom-url-canparse>
@@ -158,7 +159,7 @@ impl URL {
         // These steps are all handled while mapping the Result to an Option<ServoUrl>.
         // Regarding initialization, the same condition should apply here as stated in the comments
         // in Self::Constructor above - construct it on-demand inside `URL::SearchParams`.
-        Some(URL::new(global, None, parsed_url.ok()?))
+        Some(URL::new(global, None, parsed_url.ok()?, CanGc::note()))
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-createObjectURL>

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -23,6 +23,7 @@ use crate::dom::blob::Blob;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::urlhelper::UrlHelper;
 use crate::dom::urlsearchparams::URLSearchParams;
+use crate::script_runtime::CanGc;
 
 /// <https://url.spec.whatwg.org/#url>
 #[dom_struct]
@@ -47,7 +48,12 @@ impl URL {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>, url: ServoUrl) -> DomRoot<URL> {
-        reflect_dom_object_with_proto(Box::new(URL::new_inherited(url)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(URL::new_inherited(url)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     pub fn query_pairs(&self) -> Vec<(String, String)> {

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::weakref::MutableWeakRef;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::url::URL;
+use crate::script_runtime::CanGc;
 
 /// <https://url.spec.whatwg.org/#interface-urlsearchparams>
 #[dom_struct]
@@ -46,7 +47,12 @@ impl URLSearchParams {
         proto: Option<HandleObject>,
         url: Option<&URL>,
     ) -> DomRoot<URLSearchParams> {
-        reflect_dom_object_with_proto(Box::new(URLSearchParams::new_inherited(url)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(URLSearchParams::new_inherited(url)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     /// <https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams>

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -39,19 +39,20 @@ impl URLSearchParams {
     }
 
     pub fn new(global: &GlobalScope, url: Option<&URL>) -> DomRoot<URLSearchParams> {
-        Self::new_with_proto(global, None, url)
+        Self::new_with_proto(global, None, url, CanGc::note())
     }
 
     pub fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         url: Option<&URL>,
+        can_gc: CanGc,
     ) -> DomRoot<URLSearchParams> {
         reflect_dom_object_with_proto(
             Box::new(URLSearchParams::new_inherited(url)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -60,10 +61,11 @@ impl URLSearchParams {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         init: USVStringSequenceSequenceOrUSVStringUSVStringRecordOrUSVString,
     ) -> Fallible<DomRoot<URLSearchParams>> {
         // Step 1.
-        let query = URLSearchParams::new_with_proto(global, proto, None);
+        let query = URLSearchParams::new_with_proto(global, proto, None, can_gc);
         match init {
             USVStringSequenceSequenceOrUSVStringUSVStringRecordOrUSVString::USVStringSequenceSequence(init) => {
                 // Step 2.

--- a/components/script/dom/vttcue.rs
+++ b/components/script/dom/vttcue.rs
@@ -67,12 +67,13 @@ impl VTTCue {
         start_time: f64,
         end_time: f64,
         text: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object_with_proto(
             Box::new(Self::new_inherited(start_time, end_time, text)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -80,11 +81,19 @@ impl VTTCue {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         start_time: Finite<f64>,
         end_time: Finite<f64>,
         text: DOMString,
     ) -> DomRoot<Self> {
-        VTTCue::new(&window.global(), proto, *start_time, *end_time, text)
+        VTTCue::new(
+            &window.global(),
+            proto,
+            *start_time,
+            *end_time,
+            text,
+            can_gc,
+        )
     }
 }
 

--- a/components/script/dom/vttcue.rs
+++ b/components/script/dom/vttcue.rs
@@ -22,6 +22,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::vttregion::VTTRegion;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct VTTCue {
@@ -71,6 +72,7 @@ impl VTTCue {
             Box::new(Self::new_inherited(start_time, end_time, text)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/vttregion.rs
+++ b/components/script/dom/vttregion.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct VTTRegion {
@@ -46,7 +47,12 @@ impl VTTRegion {
     }
 
     fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(Box::new(Self::new_inherited()), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(Self::new_inherited()),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/vttregion.rs
+++ b/components/script/dom/vttregion.rs
@@ -46,18 +46,17 @@ impl VTTRegion {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<Self> {
-        reflect_dom_object_with_proto(
-            Box::new(Self::new_inherited()),
-            global,
-            proto,
-            CanGc::note(),
-        )
+    fn new(global: &GlobalScope, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object_with_proto(Box::new(Self::new_inherited()), global, proto, can_gc)
     }
 
     #[allow(non_snake_case)]
-    pub fn Constructor(window: &Window, proto: Option<HandleObject>) -> Fallible<DomRoot<Self>> {
-        Ok(VTTRegion::new(&window.global(), proto))
+    pub fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<Self>> {
+        Ok(VTTRegion::new(&window.global(), proto, can_gc))
     }
 }
 

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -52,7 +52,15 @@ impl WebGLContextEvent {
         cancelable: EventCancelable,
         status_message: DOMString,
     ) -> DomRoot<WebGLContextEvent> {
-        Self::new_with_proto(window, None, type_, bubbles, cancelable, status_message)
+        Self::new_with_proto(
+            window,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            status_message,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -62,12 +70,13 @@ impl WebGLContextEvent {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         status_message: DOMString,
+        can_gc: CanGc,
     ) -> DomRoot<WebGLContextEvent> {
         let event = reflect_dom_object_with_proto(
             Box::new(WebGLContextEvent::new_inherited(status_message)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         );
 
         {
@@ -82,6 +91,7 @@ impl WebGLContextEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &WebGLContextEventInit,
     ) -> Fallible<DomRoot<WebGLContextEvent>> {
@@ -101,6 +111,7 @@ impl WebGLContextEvent {
             bubbles,
             cancelable,
             status_message,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct WebGLContextEvent {
@@ -66,6 +67,7 @@ impl WebGLContextEvent {
             Box::new(WebGLContextEvent::new_inherited(status_message)),
             window,
             proto,
+            CanGc::note(),
         );
 
         {

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -134,12 +134,13 @@ impl WebSocket {
         proto: Option<HandleObject>,
         url: ServoUrl,
         sender: IpcSender<WebSocketDomAction>,
+        can_gc: CanGc,
     ) -> DomRoot<WebSocket> {
         reflect_dom_object_with_proto(
             Box::new(WebSocket::new_inherited(url, sender)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -148,6 +149,7 @@ impl WebSocket {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         url: DOMString,
         protocols: Option<StringOrStringSequence>,
     ) -> Fallible<DomRoot<WebSocket>> {
@@ -201,7 +203,7 @@ impl WebSocket {
             ProfiledIpc::IpcReceiver<WebSocketNetworkEvent>,
         ) = ProfiledIpc::channel(global.time_profiler_chan().clone()).unwrap();
 
-        let ws = WebSocket::new(global, proto, url_record.clone(), dom_action_sender);
+        let ws = WebSocket::new(global, proto, url_record.clone(), dom_action_sender, can_gc);
         let address = Trusted::new(&*ws);
 
         // Step 8.

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -38,8 +38,8 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
-use crate::script_runtime::CommonScriptMsg;
 use crate::script_runtime::ScriptThreadEventCategory::WebSocketEvent;
+use crate::script_runtime::{CanGc, CommonScriptMsg};
 use crate::task::{TaskCanceller, TaskOnce};
 use crate::task_source::websocket::WebsocketTaskSource;
 use crate::task_source::TaskSource;
@@ -139,6 +139,7 @@ impl WebSocket {
             Box::new(WebSocket::new_inherited(url, sender)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -41,13 +41,12 @@ impl WheelEvent {
         }
     }
 
-    fn new_unintialized(window: &Window, proto: Option<HandleObject>) -> DomRoot<WheelEvent> {
-        reflect_dom_object_with_proto(
-            Box::new(WheelEvent::new_inherited()),
-            window,
-            proto,
-            CanGc::note(),
-        )
+    fn new_unintialized(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<WheelEvent> {
+        reflect_dom_object_with_proto(Box::new(WheelEvent::new_inherited()), window, proto, can_gc)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -64,8 +63,18 @@ impl WheelEvent {
         delta_mode: u32,
     ) -> DomRoot<WheelEvent> {
         Self::new_with_proto(
-            window, None, type_, can_bubble, cancelable, view, detail, delta_x, delta_y, delta_z,
+            window,
+            None,
+            type_,
+            can_bubble,
+            cancelable,
+            view,
+            detail,
+            delta_x,
+            delta_y,
+            delta_z,
             delta_mode,
+            CanGc::note(),
         )
     }
 
@@ -82,8 +91,9 @@ impl WheelEvent {
         delta_y: Finite<f64>,
         delta_z: Finite<f64>,
         delta_mode: u32,
+        can_gc: CanGc,
     ) -> DomRoot<WheelEvent> {
-        let ev = WheelEvent::new_unintialized(window, proto);
+        let ev = WheelEvent::new_unintialized(window, proto, can_gc);
         ev.InitWheelEvent(
             type_,
             bool::from(can_bubble),
@@ -103,6 +113,7 @@ impl WheelEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &WheelEventBinding::WheelEventInit,
     ) -> Fallible<DomRoot<WheelEvent>> {
@@ -118,6 +129,7 @@ impl WheelEvent {
             init.deltaY,
             init.deltaZ,
             init.deltaMode,
+            can_gc,
         );
 
         Ok(event)

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -19,6 +19,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::mouseevent::MouseEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct WheelEvent {
@@ -41,7 +42,12 @@ impl WheelEvent {
     }
 
     fn new_unintialized(window: &Window, proto: Option<HandleObject>) -> DomRoot<WheelEvent> {
-        reflect_dom_object_with_proto(Box::new(WheelEvent::new_inherited()), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(WheelEvent::new_inherited()),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -74,12 +74,13 @@ impl Worker {
         proto: Option<HandleObject>,
         sender: Sender<DedicatedWorkerScriptMsg>,
         closing: Arc<AtomicBool>,
+        can_gc: CanGc,
     ) -> DomRoot<Worker> {
         reflect_dom_object_with_proto(
             Box::new(Worker::new_inherited(sender, closing)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -88,6 +89,7 @@ impl Worker {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         script_url: USVString,
         worker_options: &WorkerOptions,
     ) -> Fallible<DomRoot<Worker>> {
@@ -99,7 +101,7 @@ impl Worker {
 
         let (sender, receiver) = unbounded();
         let closing = Arc::new(AtomicBool::new(false));
-        let worker = Worker::new(global, proto, sender.clone(), closing.clone());
+        let worker = Worker::new(global, proto, sender.clone(), closing.clone(), can_gc);
         let worker_ref = Trusted::new(&*worker);
 
         let worker_load_origin = WorkerScriptLoadOrigin {

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -37,7 +37,7 @@ use crate::dom::messageevent::MessageEvent;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::prepare_workerscope_init;
 use crate::realms::enter_realm;
-use crate::script_runtime::{ContextForRequestInterrupt, JSContext};
+use crate::script_runtime::{CanGc, ContextForRequestInterrupt, JSContext};
 use crate::task::TaskOnce;
 
 pub type TrustedWorkerAddress = Trusted<Worker>;
@@ -79,6 +79,7 @@ impl Worker {
             Box::new(Worker::new_inherited(sender, closing)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -71,7 +71,7 @@ use crate::dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
 use crate::dom::xmlhttprequestupload::XMLHttpRequestUpload;
 use crate::fetch::FetchCanceller;
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 use crate::task_source::networking::NetworkingTaskSource;
 use crate::task_source::TaskSourceName;
 use crate::timers::{OneshotTimerCallback, OneshotTimerHandle};
@@ -224,6 +224,7 @@ impl XMLHttpRequest {
             Box::new(XMLHttpRequest::new_inherited(global)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -219,12 +219,16 @@ impl XMLHttpRequest {
         }
     }
 
-    fn new(global: &GlobalScope, proto: Option<HandleObject>) -> DomRoot<XMLHttpRequest> {
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<XMLHttpRequest> {
         reflect_dom_object_with_proto(
             Box::new(XMLHttpRequest::new_inherited(global)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -233,8 +237,9 @@ impl XMLHttpRequest {
     pub fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLHttpRequest>> {
-        Ok(XMLHttpRequest::new(global, proto))
+        Ok(XMLHttpRequest::new(global, proto, can_gc))
     }
 
     fn sync_in_window(&self) -> bool {

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -29,12 +29,16 @@ impl XMLSerializer {
         }
     }
 
-    pub fn new(window: &Window, proto: Option<HandleObject>) -> DomRoot<XMLSerializer> {
+    pub fn new(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<XMLSerializer> {
         reflect_dom_object_with_proto(
             Box::new(XMLSerializer::new_inherited(window)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -42,8 +46,9 @@ impl XMLSerializer {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLSerializer>> {
-        Ok(XMLSerializer::new(window, proto))
+        Ok(XMLSerializer::new(window, proto, can_gc))
     }
 }
 

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XMLSerializer {
@@ -33,6 +34,7 @@ impl XMLSerializer {
             Box::new(XMLSerializer::new_inherited(window)),
             window,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xrinputsourceevent.rs
+++ b/components/script/dom/xrinputsourceevent.rs
@@ -47,7 +47,16 @@ impl XRInputSourceEvent {
         frame: &XRFrame,
         source: &XRInputSource,
     ) -> DomRoot<XRInputSourceEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, frame, source)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            frame,
+            source,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -58,12 +67,13 @@ impl XRInputSourceEvent {
         cancelable: bool,
         frame: &XRFrame,
         source: &XRInputSource,
+        can_gc: CanGc,
     ) -> DomRoot<XRInputSourceEvent> {
         let trackevent = reflect_dom_object_with_proto(
             Box::new(XRInputSourceEvent::new_inherited(frame, source)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = trackevent.upcast::<Event>();
@@ -76,6 +86,7 @@ impl XRInputSourceEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &XRInputSourceEventBinding::XRInputSourceEventInit,
     ) -> Fallible<DomRoot<XRInputSourceEvent>> {
@@ -87,6 +98,7 @@ impl XRInputSourceEvent {
             init.parent.cancelable,
             &init.frame,
             &init.inputSource,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/xrinputsourceevent.rs
+++ b/components/script/dom/xrinputsourceevent.rs
@@ -20,6 +20,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::dom::xrframe::XRFrame;
 use crate::dom::xrinputsource::XRInputSource;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRInputSourceEvent {
@@ -62,6 +63,7 @@ impl XRInputSourceEvent {
             Box::new(XRInputSourceEvent::new_inherited(frame, source)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = trackevent.upcast::<Event>();

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -56,7 +56,15 @@ impl XRInputSourcesChangeEvent {
         removed: &[DomRoot<XRInputSource>],
     ) -> DomRoot<XRInputSourcesChangeEvent> {
         Self::new_with_proto(
-            global, None, type_, bubbles, cancelable, session, added, removed,
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            session,
+            added,
+            removed,
+            CanGc::note(),
         )
     }
 
@@ -71,12 +79,13 @@ impl XRInputSourcesChangeEvent {
         session: &XRSession,
         added: &[DomRoot<XRInputSource>],
         removed: &[DomRoot<XRInputSource>],
+        can_gc: CanGc,
     ) -> DomRoot<XRInputSourcesChangeEvent> {
         let changeevent = reflect_dom_object_with_proto(
             Box::new(XRInputSourcesChangeEvent::new_inherited(session)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = changeevent.upcast::<Event>();
@@ -100,6 +109,7 @@ impl XRInputSourcesChangeEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &XRInputSourcesChangeEventBinding::XRInputSourcesChangeEventInit,
     ) -> DomRoot<XRInputSourcesChangeEvent> {
@@ -112,6 +122,7 @@ impl XRInputSourcesChangeEvent {
             &init.session,
             &init.added,
             &init.removed,
+            can_gc,
         )
     }
 }

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -23,7 +23,7 @@ use crate::dom::window::Window;
 use crate::dom::xrinputsource::XRInputSource;
 use crate::dom::xrsession::XRSession;
 use crate::realms::enter_realm;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct XRInputSourcesChangeEvent {
@@ -76,6 +76,7 @@ impl XRInputSourcesChangeEvent {
             Box::new(XRInputSourcesChangeEvent::new_inherited(session)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = changeevent.upcast::<Event>();

--- a/components/script/dom/xrlayerevent.rs
+++ b/components/script/dom/xrlayerevent.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::window::Window;
 use crate::dom::xrlayer::XRLayer;
+use crate::script_runtime::CanGc;
 
 // https://w3c.github.io/uievents/#interface-uievent
 #[dom_struct]
@@ -33,7 +34,12 @@ impl XRLayerEvent {
     }
 
     fn new(window: &Window, proto: Option<HandleObject>, layer: &XRLayer) -> DomRoot<XRLayerEvent> {
-        reflect_dom_object_with_proto(Box::new(XRLayerEvent::new_inherited(layer)), window, proto)
+        reflect_dom_object_with_proto(
+            Box::new(XRLayerEvent::new_inherited(layer)),
+            window,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/xrlayerevent.rs
+++ b/components/script/dom/xrlayerevent.rs
@@ -33,12 +33,17 @@ impl XRLayerEvent {
         }
     }
 
-    fn new(window: &Window, proto: Option<HandleObject>, layer: &XRLayer) -> DomRoot<XRLayerEvent> {
+    fn new(
+        window: &Window,
+        proto: Option<HandleObject>,
+        layer: &XRLayer,
+        can_gc: CanGc,
+    ) -> DomRoot<XRLayerEvent> {
         reflect_dom_object_with_proto(
             Box::new(XRLayerEvent::new_inherited(layer)),
             window,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -46,10 +51,11 @@ impl XRLayerEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &XRLayerEventInit,
     ) -> DomRoot<XRLayerEvent> {
-        let event = XRLayerEvent::new(window, proto, &init.layer);
+        let event = XRLayerEvent::new(window, proto, &init.layer, can_gc);
         let type_ = Atom::from(type_);
         let bubbles = init.parent.bubbles;
         let cancelable = init.parent.cancelable;

--- a/components/script/dom/xrmediabinding.rs
+++ b/components/script/dom/xrmediabinding.rs
@@ -16,6 +16,7 @@ use crate::dom::xrcylinderlayer::XRCylinderLayer;
 use crate::dom::xrequirectlayer::XREquirectLayer;
 use crate::dom::xrquadlayer::XRQuadLayer;
 use crate::dom::xrsession::XRSession;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRMediaBinding {
@@ -40,6 +41,7 @@ impl XRMediaBinding {
             Box::new(XRMediaBinding::new_inherited(session)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xrmediabinding.rs
+++ b/components/script/dom/xrmediabinding.rs
@@ -36,12 +36,13 @@ impl XRMediaBinding {
         global: &Window,
         proto: Option<HandleObject>,
         session: &XRSession,
+        can_gc: CanGc,
     ) -> DomRoot<XRMediaBinding> {
         reflect_dom_object_with_proto(
             Box::new(XRMediaBinding::new_inherited(session)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -49,6 +50,7 @@ impl XRMediaBinding {
     pub fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         session: &XRSession,
     ) -> Fallible<DomRoot<XRMediaBinding>> {
         // Step 1.
@@ -62,7 +64,7 @@ impl XRMediaBinding {
         }
 
         // Steps 3-5.
-        Ok(XRMediaBinding::new(global, proto, session))
+        Ok(XRMediaBinding::new(global, proto, session, can_gc))
     }
 }
 

--- a/components/script/dom/xrray.rs
+++ b/components/script/dom/xrray.rs
@@ -18,7 +18,7 @@ use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::dom::xrrigidtransform::XRRigidTransform;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct XRRay {
@@ -44,7 +44,12 @@ impl XRRay {
         proto: Option<HandleObject>,
         ray: Ray<ApiSpace>,
     ) -> DomRoot<XRRay> {
-        reflect_dom_object_with_proto(Box::new(XRRay::new_inherited(ray)), global, proto)
+        reflect_dom_object_with_proto(
+            Box::new(XRRay::new_inherited(ray)),
+            global,
+            proto,
+            CanGc::note(),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/components/script/dom/xrray.rs
+++ b/components/script/dom/xrray.rs
@@ -43,13 +43,9 @@ impl XRRay {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         ray: Ray<ApiSpace>,
+        can_gc: CanGc,
     ) -> DomRoot<XRRay> {
-        reflect_dom_object_with_proto(
-            Box::new(XRRay::new_inherited(ray)),
-            global,
-            proto,
-            CanGc::note(),
-        )
+        reflect_dom_object_with_proto(Box::new(XRRay::new_inherited(ray)), global, proto, can_gc)
     }
 
     #[allow(non_snake_case)]
@@ -57,6 +53,7 @@ impl XRRay {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         origin: &DOMPointInit,
         direction: &XRRayDirectionInit,
     ) -> Fallible<DomRoot<Self>> {
@@ -84,6 +81,7 @@ impl XRRay {
             &window.global(),
             proto,
             Ray { origin, direction },
+            can_gc,
         ))
     }
 
@@ -92,6 +90,7 @@ impl XRRay {
     pub fn Constructor_(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         transform: &XRRigidTransform,
     ) -> Fallible<DomRoot<Self>> {
         let transform = transform.transform();
@@ -104,6 +103,7 @@ impl XRRay {
             &window.global(),
             proto,
             Ray { origin, direction },
+            can_gc,
         ))
     }
 

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -17,7 +17,7 @@ use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::dom::xrsession::ApiRigidTransform;
-use crate::script_runtime::JSContext;
+use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
 pub struct XRRigidTransform {
@@ -57,6 +57,7 @@ impl XRRigidTransform {
             Box::new(XRRigidTransform::new_inherited(transform)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -45,19 +45,20 @@ impl XRRigidTransform {
     }
 
     pub fn new(global: &GlobalScope, transform: ApiRigidTransform) -> DomRoot<XRRigidTransform> {
-        Self::new_with_proto(global, None, transform)
+        Self::new_with_proto(global, None, transform, CanGc::note())
     }
 
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
         transform: ApiRigidTransform,
+        can_gc: CanGc,
     ) -> DomRoot<XRRigidTransform> {
         reflect_dom_object_with_proto(
             Box::new(XRRigidTransform::new_inherited(transform)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -71,6 +72,7 @@ impl XRRigidTransform {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         position: &DOMPointInit,
         orientation: &DOMPointInit,
     ) -> Fallible<DomRoot<Self>> {
@@ -99,6 +101,7 @@ impl XRRigidTransform {
             &window.global(),
             proto,
             transform,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/xrsessionevent.rs
+++ b/components/script/dom/xrsessionevent.rs
@@ -41,7 +41,15 @@ impl XRSessionEvent {
         cancelable: bool,
         session: &XRSession,
     ) -> DomRoot<XRSessionEvent> {
-        Self::new_with_proto(global, None, type_, bubbles, cancelable, session)
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            session,
+            CanGc::note(),
+        )
     }
 
     fn new_with_proto(
@@ -51,12 +59,13 @@ impl XRSessionEvent {
         bubbles: bool,
         cancelable: bool,
         session: &XRSession,
+        can_gc: CanGc,
     ) -> DomRoot<XRSessionEvent> {
         let trackevent = reflect_dom_object_with_proto(
             Box::new(XRSessionEvent::new_inherited(session)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         );
         {
             let event = trackevent.upcast::<Event>();
@@ -69,6 +78,7 @@ impl XRSessionEvent {
     pub fn Constructor(
         window: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         type_: DOMString,
         init: &XRSessionEventBinding::XRSessionEventInit,
     ) -> Fallible<DomRoot<XRSessionEvent>> {
@@ -79,6 +89,7 @@ impl XRSessionEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.session,
+            can_gc,
         ))
     }
 }

--- a/components/script/dom/xrsessionevent.rs
+++ b/components/script/dom/xrsessionevent.rs
@@ -17,6 +17,7 @@ use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use crate::dom::xrsession::XRSession;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRSessionEvent {
@@ -55,6 +56,7 @@ impl XRSessionEvent {
             Box::new(XRSessionEvent::new_inherited(session)),
             global,
             proto,
+            CanGc::note(),
         );
         {
             let event = trackevent.upcast::<Event>();

--- a/components/script/dom/xrwebglbinding.rs
+++ b/components/script/dom/xrwebglbinding.rs
@@ -50,12 +50,13 @@ impl XRWebGLBinding {
         proto: Option<HandleObject>,
         session: &XRSession,
         context: &WebGLRenderingContext,
+        can_gc: CanGc,
     ) -> DomRoot<XRWebGLBinding> {
         reflect_dom_object_with_proto(
             Box::new(XRWebGLBinding::new_inherited(session, context)),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -63,6 +64,7 @@ impl XRWebGLBinding {
     pub fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         session: &XRSession,
         context: WebGLRenderingContextOrWebGL2RenderingContext,
     ) -> DomRoot<XRWebGLBinding> {
@@ -72,7 +74,7 @@ impl XRWebGLBinding {
                 ctx.base_context()
             },
         };
-        XRWebGLBinding::new(global, proto, session, &context)
+        XRWebGLBinding::new(global, proto, session, &context, can_gc)
     }
 }
 

--- a/components/script/dom/xrwebglbinding.rs
+++ b/components/script/dom/xrwebglbinding.rs
@@ -27,6 +27,7 @@ use crate::dom::xrquadlayer::XRQuadLayer;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrview::XRView;
 use crate::dom::xrwebglsubimage::XRWebGLSubImage;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct XRWebGLBinding {
@@ -54,6 +55,7 @@ impl XRWebGLBinding {
             Box::new(XRWebGLBinding::new_inherited(session, context)),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -30,6 +30,7 @@ use crate::dom::xrlayer::XRLayer;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrview::XRView;
 use crate::dom::xrviewport::XRViewport;
+use crate::script_runtime::CanGc;
 
 impl<'a> From<&'a XRWebGLLayerInit> for LayerInit {
     fn from(init: &'a XRWebGLLayerInit) -> LayerInit {
@@ -94,6 +95,7 @@ impl XRWebGLLayer {
             )),
             global,
             proto,
+            CanGc::note(),
         )
     }
 

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -84,6 +84,7 @@ impl XRWebGLLayer {
         init: &XRWebGLLayerInit,
         framebuffer: Option<&WebGLFramebuffer>,
         layer_id: Option<LayerId>,
+        can_gc: CanGc,
     ) -> DomRoot<XRWebGLLayer> {
         reflect_dom_object_with_proto(
             Box::new(XRWebGLLayer::new_inherited(
@@ -95,7 +96,7 @@ impl XRWebGLLayer {
             )),
             global,
             proto,
-            CanGc::note(),
+            can_gc,
         )
     }
 
@@ -104,6 +105,7 @@ impl XRWebGLLayer {
     pub fn Constructor(
         global: &Window,
         proto: Option<HandleObject>,
+        can_gc: CanGc,
         session: &XRSession,
         context: XRWebGLRenderingContext,
         init: &XRWebGLLayerInit,
@@ -155,6 +157,7 @@ impl XRWebGLLayer {
             init,
             framebuffer.as_deref(),
             layer_id,
+            can_gc,
         ))
     }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -39,6 +39,7 @@ use crate::network_listener::{
     self, submit_timing_data, NetworkListener, PreInvoke, ResourceTimingListener,
 };
 use crate::realms::{enter_realm, InRealm};
+use crate::script_runtime::CanGc;
 use crate::task_source::TaskSourceName;
 
 struct FetchContext {
@@ -150,7 +151,7 @@ pub fn Fetch(
     let response = Response::new(global);
 
     // Step 2
-    let request = match Request::Constructor(global, None, input, init) {
+    let request = match Request::Constructor(global, None, CanGc::note(), input, init) {
         Err(e) => {
             response.error_stream(e.clone());
             promise.reject_error(e);

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1119,3 +1119,11 @@ impl Runnable {
         }
     }
 }
+
+pub struct CanGc(());
+
+impl CanGc {
+    pub fn note() -> CanGc {
+        CanGc(())
+    }
+}

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -60,7 +60,7 @@ use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::{Documents, ScriptThread};
 
 fn find_node_by_unique_id(
@@ -722,7 +722,7 @@ pub fn handle_get_page_source(
                     Some(element) => match element.GetOuterHTML() {
                         Ok(source) => Ok(source.to_string()),
                         Err(_) => {
-                            match XMLSerializer::new(document.window(), None)
+                            match XMLSerializer::new(document.window(), None, CanGc::note())
                                 .SerializeToString(element.upcast::<Node>())
                             {
                                 Ok(source) => Ok(source.to_string()),


### PR DESCRIPTION
Per #33140, adding this zero-size argument to functions that can transitively GC makes it easier to recognize where hazards are present. This work can be done incrementally and iteratively as time allows.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #33140.
- [x] These changes do not require tests because there is no functional difference.