### PR TITLE
webxr: Update XRView to latest spec

### DIFF
--- a/components/script/dom/webidls/XRView.webidl
+++ b/components/script/dom/webidls/XRView.webidl
@@ -14,7 +14,10 @@ enum XREye {
 interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
-  readonly attribute XRRigidTransform transform;
+  [SameObject] readonly attribute XRRigidTransform transform;
+  readonly attribute double? recommendedViewportScale;
+
+  undefined requestViewportScale(double? scale);
 
   // AR Module
   readonly attribute boolean isFirstPersonObserver;

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
+
 use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
 use js::typedarray::{Float32, Float32Array};
@@ -9,6 +11,7 @@ use webxr_api::{ApiSpace, View};
 
 use super::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::{XREye, XRViewMethods};
+use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
@@ -28,6 +31,9 @@ pub struct XRView {
     #[no_trace]
     view: View<ApiSpace>,
     transform: Dom<XRRigidTransform>,
+    viewport_modifiable: Cell<bool>,
+    requested_viewport_scale: Cell<f64>,
+    current_viewport_scale: Cell<f64>,
 }
 
 impl XRView {
@@ -46,6 +52,9 @@ impl XRView {
             proj: HeapBufferSource::default(),
             view,
             transform: Dom::from_ref(transform),
+            viewport_modifiable: Cell::new(true),
+            requested_viewport_scale: Cell::new(1.0),
+            current_viewport_scale: Cell::new(1.0),
         }
     }
 
@@ -105,6 +114,22 @@ impl XRViewMethods for XRView {
     /// <https://immersive-web.github.io/webxr/#dom-xrview-transform>
     fn Transform(&self) -> DomRoot<XRRigidTransform> {
         DomRoot::from_ref(&self.transform)
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrview-recommendedviewportscale>
+    fn GetRecommendedViewportScale(&self) -> Option<Finite<f64>> {
+        // Just return 1.0 since we currently will always use full-sized viewports
+        Finite::new(1.0)
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrview-requestviewportscale>
+    fn RequestViewportScale(&self, scale: Option<Finite<f64>>) {
+        if let Some(scale) = scale {
+            if *scale > 0.0 {
+                let clamped_scale = scale.clamp(0.0, 1.0);
+                self.requested_viewport_scale.set(clamped_scale);
+            }
+        }
     }
 
     /// <https://www.w3.org/TR/webxr-ar-module-1/#dom-xrview-isfirstpersonobserver>

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -31,9 +31,7 @@ pub struct XRView {
     #[no_trace]
     view: View<ApiSpace>,
     transform: Dom<XRRigidTransform>,
-    viewport_modifiable: Cell<bool>,
     requested_viewport_scale: Cell<f64>,
-    current_viewport_scale: Cell<f64>,
 }
 
 impl XRView {
@@ -52,9 +50,7 @@ impl XRView {
             proj: HeapBufferSource::default(),
             view,
             transform: Dom::from_ref(transform),
-            viewport_modifiable: Cell::new(true),
             requested_viewport_scale: Cell::new(1.0),
-            current_viewport_scale: Cell::new(1.0),
         }
     }
 

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -316,13 +316,18 @@ impl XRWebGLLayerMethods for XRWebGLLayer {
         let index = view.viewport_index();
 
         let viewport = self.session().with_session(|s| {
-            // Inline sssions
+            // Inline sessions
             if s.viewports().is_empty() {
                 Rect::from_size(self.size().to_i32())
             } else {
                 s.viewports()[index]
             }
         });
+
+        // NOTE: According to spec, viewport sizes should be recalculated here if the
+        // requested viewport scale has changed. However, existing browser implementations
+        // don't seem to do this for stereoscopic immersive sessions.
+        // Revisit if Servo gets support for handheld AR/VR via ARCore/ARKit
 
         Some(XRViewport::new(&self.global(), viewport))
     }

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -317,12 +317,6 @@
   [XRSession interface: calling cancelAnimationFrame(unsigned long) on xrSession with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRView interface: attribute recommendedViewportScale]
-    expected: FAIL
-
-  [XRView interface: operation requestViewportScale(double?)]
-    expected: FAIL
-
   [XRPose interface: attribute linearVelocity]
     expected: FAIL
 

--- a/tests/wpt/meta-legacy-layout/webxr/xr_viewport_scale.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/xr_viewport_scale.https.html.ini
@@ -1,85 +1,24 @@
 [xr_viewport_scale.https.html]
-  expected: ERROR
-  [requestViewportScale valid viewport for inline session - webgl]
-    expected: TIMEOUT
-
-  [recommendedViewportScale for immersive-vr session - webgl2]
-    expected: NOTRUN
-
   [requestViewportScale applied next frame for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for inline session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for inline session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for inline session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale applied next frame for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale applied next frame for inline session - webgl]
-    expected: NOTRUN
-
-  [recommendedViewportScale for inline session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for inline session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for inline session - webgl2]
-    expected: NOTRUN
-
-  [recommendedViewportScale for inline session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for inline session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale applied next frame for inline session - webgl2]
-    expected: NOTRUN
-
-  [recommendedViewportScale for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for inline session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for inline session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for inline session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -260,12 +260,6 @@
   [XRSession interface: calling cancelAnimationFrame(unsigned long) on xrSession with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRView interface: attribute recommendedViewportScale]
-    expected: FAIL
-
-  [XRView interface: operation requestViewportScale(double?)]
-    expected: FAIL
-
   [XRPose interface: attribute linearVelocity]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/xr_viewport_scale.https.html.ini
+++ b/tests/wpt/meta/webxr/xr_viewport_scale.https.html.ini
@@ -1,127 +1,24 @@
 [xr_viewport_scale.https.html]
-  expected: ERROR
-  [requestViewportScale valid viewport for inline session]
-    expected: TIMEOUT
-
-  [requestViewportScale valid viewport w/ null scale for inline session]
-    expected: NOTRUN
-
-  [recommendedViewportScale for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale applied next frame for inline session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for inline session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale same frame for inline session]
-    expected: NOTRUN
-
-  [recommendedViewportScale for inline session]
-    expected: NOTRUN
-
-  [requestViewportScale same frame for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for inline session]
-    expected: NOTRUN
-
-  [requestViewportScale applied next frame for immersive-vr session]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for inline session - webgl]
-    expected: TIMEOUT
-
-  [recommendedViewportScale for immersive-vr session - webgl2]
-    expected: NOTRUN
-
   [requestViewportScale applied next frame for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for inline session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for inline session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for inline session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale applied next frame for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale applied next frame for inline session - webgl]
-    expected: NOTRUN
-
-  [recommendedViewportScale for inline session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for inline session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for inline session - webgl2]
-    expected: NOTRUN
-
-  [recommendedViewportScale for inline session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for immersive-vr session - webgl]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale same frame for inline session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED
 
   [requestViewportScale applied next frame for inline session - webgl2]
-    expected: NOTRUN
-
-  [recommendedViewportScale for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport for inline session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for inline session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ null scale for immersive-vr session - webgl2]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ very small scale for immersive-vr session - webgl]
-    expected: NOTRUN
-
-  [requestViewportScale valid viewport w/ undefined scale for inline session - webgl2]
-    expected: NOTRUN
+    expected: PRECONDITION_FAILED


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds the recommendedViewportScale and requestViewportScale members to XRView. The actual process of dynamic viewport resizing is currently omitted, as this functionality is currently only really used in model-viewer out in the wild, and I can find no examples of it being used in stereoscopic immersive sessions. It seems the original motivation for its addition was performance considerations on monoscopic mobile AR, so this could potentially be revisited if Servo supports ARCore/ARKit-backed sessions in the future.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
