### PR TITLE
webxr: Update XRPose interface to latest spec

### DIFF
--- a/components/script/dom/webidls/XRPose.webidl
+++ b/components/script/dom/webidls/XRPose.webidl
@@ -6,6 +6,9 @@
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRPose {
-  readonly attribute XRRigidTransform transform;
-  // readonly attribute boolean emulatedPosition;
+  [SameObject] readonly attribute XRRigidTransform transform;
+  [SameObject] readonly attribute DOMPointReadOnly? linearVelocity;
+  [SameObject] readonly attribute DOMPointReadOnly? angularVelocity;
+
+  readonly attribute boolean emulatedPosition;
 };

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -8,6 +8,7 @@ use crate::dom::bindings::codegen::Bindings::XRPoseBinding::XRPoseMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::ApiRigidTransform;
 
@@ -36,5 +37,24 @@ impl XRPoseMethods for XRPose {
     /// <https://immersive-web.github.io/webxr/#dom-xrpose-transform>
     fn Transform(&self) -> DomRoot<XRRigidTransform> {
         DomRoot::from_ref(&self.transform)
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrpose-linearvelocity>
+    fn GetLinearVelocity(&self) -> Option<DomRoot<DOMPointReadOnly>> {
+        // TODO: Expose from webxr crate
+        None
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrpose-angularvelocity>
+    fn GetAngularVelocity(&self) -> Option<DomRoot<DOMPointReadOnly>> {
+        // TODO: Expose from webxr crate
+        None
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrpose-emulatedposition>
+    fn EmulatedPosition(&self) -> bool {
+        // There are currently no instances in which we would need to rely
+        // on emulation for reporting pose, so return false.
+        false
     }
 }

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -7,8 +7,8 @@ use dom_struct::dom_struct;
 use crate::dom::bindings::codegen::Bindings::XRPoseBinding::XRPoseMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::dompointreadonly::DOMPointReadOnly;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::ApiRigidTransform;
 

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -17,9 +17,6 @@
   [XRRay interface object length]
     expected: FAIL
 
-  [XRPose interface: attribute emulatedPosition]
-    expected: FAIL
-
   [XRBoundedReferenceSpace interface object length]
     expected: FAIL
 
@@ -315,12 +312,6 @@
     expected: FAIL
 
   [XRSession interface: calling cancelAnimationFrame(unsigned long) on xrSession with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [XRPose interface: attribute linearVelocity]
-    expected: FAIL
-
-  [XRPose interface: attribute angularVelocity]
     expected: FAIL
 
   [XRWebGLLayer interface: attribute fixedFoveation]

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -41,9 +41,6 @@
   [XRSession interface: xrSession must inherit property "onend" with the proper type]
     expected: FAIL
 
-  [XRPose interface: attribute emulatedPosition]
-    expected: FAIL
-
   [XRInputSourcesChangeEvent must be primary interface of xrInputSourcesChangeEvent]
     expected: FAIL
 
@@ -258,12 +255,6 @@
     expected: FAIL
 
   [XRSession interface: calling cancelAnimationFrame(unsigned long) on xrSession with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [XRPose interface: attribute linearVelocity]
-    expected: FAIL
-
-  [XRPose interface: attribute angularVelocity]
     expected: FAIL
 
   [XRWebGLLayer interface: attribute fixedFoveation]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds the `linearVelocity`, `angularVelocity`, and `emulatedPosition` members on XRPose. Exposing velocity will require companion work in the WebXR crate and changes to pose handling, so that will be saved for a follow-up. `emulatedPosition` returns false by default, as there are currently no scenarios in which we would need to rely on emulation for pose reporting.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
