### PR TITLE
background_hang_monitor: Add musl compatibility

### DIFF
--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -25,6 +25,6 @@ serde_json = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = "0.4"
 
-[target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos"))))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos", target_env = "musl"))))'.dependencies]
 nix = { workspace = true, features = ["signal"] }
 unwind-sys = "0.1.4"

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -98,14 +98,24 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
         let sampler = crate::sampler_mac::MacOsSampler::new_boxed();
         #[cfg(all(
             target_os = "linux",
-            not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos")),
+            not(any(
+                target_arch = "arm",
+                target_arch = "aarch64",
+                target_env = "ohos",
+                target_env = "musl"
+            )),
         ))]
         let sampler = crate::sampler_linux::LinuxSampler::new_boxed();
         #[cfg(any(
             target_os = "android",
             all(
                 target_os = "linux",
-                any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos")
+                any(
+                    target_arch = "arm",
+                    target_arch = "aarch64",
+                    target_env = "ohos",
+                    target_env = "musl"
+                )
             )
         ))]
         let sampler = crate::sampler::DummySampler::new_boxed();

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -8,7 +8,12 @@ pub mod background_hang_monitor;
 mod sampler;
 #[cfg(all(
     target_os = "linux",
-    not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos"))
+    not(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_env = "ohos",
+        target_env = "musl"
+    ))
 ))]
 mod sampler_linux;
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
musl does not have libunwind readily available; even if it did, it has no concept of ucontext (needing an external lib).  Similar to ohos, disable the background hang monitor and use the DummySampler.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because: it only disables the sampler on a platform it was never supported on in the first place.