### PR TITLE
webxr: Update XRInputSource interface to latest spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#474d53835cec0ad6e054dca3c97c98ae2dcff9f0"
+source = "git+https://github.com/servo/webxr#13a0b240d10479180a9e100d7b4e25cfc142db8d"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7774,7 +7774,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#474d53835cec0ad6e054dca3c97c98ae2dcff9f0"
+source = "git+https://github.com/servo/webxr#13a0b240d10479180a9e100d7b4e25cfc142db8d"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -327,6 +327,7 @@ impl From<XRTargetRayMode> for TargetRayMode {
             XRTargetRayMode::Gaze => TargetRayMode::Gaze,
             XRTargetRayMode::Tracked_pointer => TargetRayMode::TrackedPointer,
             XRTargetRayMode::Screen => TargetRayMode::Screen,
+            XRTargetRayMode::Transient_pointer => TargetRayMode::TransientPointer,
         }
     }
 }

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -126,6 +126,7 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
             XRTargetRayMode::Gaze => TargetRayMode::Gaze,
             XRTargetRayMode::Tracked_pointer => TargetRayMode::TrackedPointer,
             XRTargetRayMode::Screen => TargetRayMode::Screen,
+            XRTargetRayMode::Transient_pointer => TargetRayMode::TransientPointer,
         };
         self.send_message(MockInputMsg::SetTargetRayMode(t));
     }

--- a/components/script/dom/webidls/XRInputSource.webidl
+++ b/components/script/dom/webidls/XRInputSource.webidl
@@ -13,7 +13,8 @@ enum XRHandedness {
 enum XRTargetRayMode {
   "gaze",
   "tracked-pointer",
-  "screen"
+  "screen",
+  "transient-pointer"
 };
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
@@ -22,9 +23,13 @@ interface XRInputSource {
   readonly attribute XRTargetRayMode targetRayMode;
   [SameObject] readonly attribute XRSpace targetRaySpace;
   [SameObject] readonly attribute XRSpace? gripSpace;
-  [SameObject] readonly attribute Gamepad? gamepad;
   /* [SameObject] */ readonly attribute /* FrozenArray<DOMString> */ any profiles;
+  readonly attribute boolean skipRendering;
 
+  // WebXR Gamepads Module
+  [SameObject] readonly attribute Gamepad? gamepad;
+
+  // Hand Input
   [Pref="dom.webxr.hands.enabled"]
   readonly attribute XRHand? hand;
 };

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -127,6 +127,7 @@ impl XRInputSourceMethods for XRInputSource {
             TargetRayMode::Gaze => XRTargetRayMode::Gaze,
             TargetRayMode::TrackedPointer => XRTargetRayMode::Tracked_pointer,
             TargetRayMode::Screen => XRTargetRayMode::Screen,
+            TargetRayMode::TransientPointer => XRTargetRayMode::Transient_pointer,
         }
     }
 
@@ -152,6 +153,12 @@ impl XRInputSourceMethods for XRInputSource {
     // https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles
     fn Profiles(&self, _cx: JSContext) -> JSVal {
         self.profiles.get()
+    }
+
+    fn SkipRendering(&self) -> bool {
+        // Servo is not currently supported anywhere that would allow for skipped
+        // controller rendering.
+        false
     }
 
     /// <https://www.w3.org/TR/webxr-gamepads-module-1/#xrinputsource-interface>

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -155,6 +155,7 @@ impl XRInputSourceMethods for XRInputSource {
         self.profiles.get()
     }
 
+    /// <https://www.w3.org/TR/webxr/#dom-xrinputsource-skiprendering>
     fn SkipRendering(&self) -> bool {
         // Servo is not currently supported anywhere that would allow for skipped
         // controller rendering.

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -349,6 +349,3 @@
 
   [XRSession interface: xrSession must inherit property "isSystemKeyboardSupported" with the proper type]
     expected: FAIL
-
-  [XRInputSource interface: attribute skipRendering]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -292,6 +292,3 @@
 
   [XRSession interface: xrSession must inherit property "isSystemKeyboardSupported" with the proper type]
     expected: FAIL
-
-  [XRInputSource interface: attribute skipRendering]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds the `transient-pointer` XRTargetRayMode and the `skipRendering` attribute on XRInputSource.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
