### PR TITLE
Allow prefs to be overridden from a file and set WPT-specific prefs from file

### DIFF
--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -45,6 +45,12 @@ pub fn main() {
         "A preference to set to disable",
         "dom.webgpu.enabled=false",
     );
+    opts.optmulti(
+        "",
+        "prefs-file",
+        "Load in additional prefs from a file.",
+        "--prefs-file /path/to/prefs.json",
+    );
 
     let opts_matches;
     let content_process_token;

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -22,7 +22,7 @@ pub fn register_user_prefs(opts_matches: &Matches) {
         .filter(|path| path.exists());
 
     let mut userprefs = if let Some(path) = user_prefs_path {
-        read_prefs_file(path)
+        read_prefs_file(path.to_str().expect("Failed to read user prefs"))
     } else {
         HashMap::new()
     };

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -79,6 +79,7 @@ fn read_prefs_file(path: &str) -> HashMap<String, PrefValue> {
 fn test_parse_pref(arg: &str) {
     let mut opts = getopts::Options::new();
     opts.optmulti("", "pref", "", "");
+    opts.optmulti("", "prefs-file", "", "");
     let args = vec!["servo".to_string(), "--pref".to_string(), arg.to_string()];
     let matches = match opts::from_cmdline_args(opts, &args) {
         opts::ArgumentParsingResult::ContentProcess(m, _) => m,

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,0 +1,3 @@
+{
+  "dom.webxr.test": true
+}

--- a/tests/wpt/mozilla/meta-legacy-layout/mozilla/interfaces.html.ini
+++ b/tests/wpt/mozilla/meta-legacy-layout/mozilla/interfaces.html.ini
@@ -1,0 +1,1 @@
+prefs: [dom.webxr.test: false]

--- a/tests/wpt/mozilla/meta/mozilla/interfaces.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/interfaces.html.ini
@@ -1,0 +1,1 @@
+prefs: [dom.webxr.test: false]

--- a/tests/wpt/mozilla/meta/webxr/create_session.https.html.ini
+++ b/tests/wpt/mozilla/meta/webxr/create_session.https.html.ini
@@ -1,4 +1,0 @@
-[create_session.https.html]
-  expected: ERROR
-  [create_session]
-    expected: TIMEOUT

--- a/tests/wpt/mozilla/meta/webxr/obtain_frame.https.html.ini
+++ b/tests/wpt/mozilla/meta/webxr/obtain_frame.https.html.ini
@@ -1,3 +1,0 @@
-[obtain_frame.https.html]
-  [obtain_frame]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/webxr/sessionavailable.https.html.ini
+++ b/tests/wpt/mozilla/meta/webxr/sessionavailable.https.html.ini
@@ -1,4 +1,4 @@
 [sessionavailable.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Requesting immersive session in a sessionavailable handler should succeed]
     expected: TIMEOUT

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -78,6 +78,7 @@ class ServoExecutor(ProcessTestExecutor):
             args += ["--user-stylesheet", stylesheet]
         for pref, value in self.environment.get('prefs', {}).items():
             args += ["--pref", f"{pref}={value}"]
+        args += ["--prefs-file", "resources/wpt-prefs.json"]
         if self.browser.ca_certificate_path:
             args += ["--certificate-path", self.browser.ca_certificate_path]
         if extra_args:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds the ability to pass in a separate prefs file to override prefs.json. It also adds a new `wpt-prefs.json` file in the resources, designed to designate any prefs that should be overridden in Servo's wpt.fyi runs. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
