### PR TITLE
Use global exports from derives

### DIFF
--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -38,7 +38,7 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! (
                 #s2
 
-                impl crate::dom::bindings::inheritance::HasParent for #name {
+                impl crate::HasParent for #name {
                     type Parent = #ty;
                     /// This is used in a type assertion to ensure that
                     /// the source and webidls agree as to what the parent type is

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -40,19 +40,19 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
             unsafe fn to_jsval(&self,
                                 cx: *mut js::jsapi::JSContext,
                                 rval: js::rust::MutableHandleValue) {
-                let object = crate::dom::bindings::reflector::DomObject::reflector(self).get_jsobject();
+                let object = crate::DomObject::reflector(self).get_jsobject();
                 object.to_jsval(cx, rval)
             }
         }
 
-        impl #impl_generics crate::dom::bindings::reflector::DomObject for #name #ty_generics #where_clause {
+        impl #impl_generics crate::DomObject for #name #ty_generics #where_clause {
             #[inline]
-            fn reflector(&self) -> &crate::dom::bindings::reflector::Reflector {
+            fn reflector(&self) -> &crate::Reflector {
                 self.#first_field_name.reflector()
             }
         }
 
-        impl #impl_generics crate::dom::bindings::reflector::MutDomObject for #name #ty_generics #where_clause {
+        impl #impl_generics crate::MutDomObject for #name #ty_generics #where_clause {
             unsafe fn init_reflector(&self, obj: *mut js::jsapi::JSObject) {
                 self.#first_field_name.init_reflector(obj);
             }
@@ -74,7 +74,7 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
 
     let mut generics = input.generics.clone();
     generics.params.push(parse_quote!(
-        __T: crate::dom::bindings::reflector::DomObject
+        __T: crate::DomObject
     ));
 
     let (impl_generics, _, where_clause) = generics.split_for_impl();

--- a/components/jstraceable_derive/lib.rs
+++ b/components/jstraceable_derive/lib.rs
@@ -96,14 +96,14 @@ fn assert_not_impl_traceable(ty: &syn::Type) -> proc_macro2::TokenStream {
             #[allow(dead_code)]
             struct Invalid0;
             // forbids JSTraceable
-            impl<T> NoTraceOnJSTraceable<Invalid0> for T where T: ?Sized + crate::dom::bindings::trace::JSTraceable {}
+            impl<T> NoTraceOnJSTraceable<Invalid0> for T where T: ?Sized + crate::JSTraceable {}
 
             #[allow(dead_code)]
             struct Invalid2;
             // forbids HashMap<JSTraceble, _>
             impl<K, V, S> NoTraceOnJSTraceable<Invalid2> for std::collections::HashMap<K, V, S>
             where
-                K: crate::dom::bindings::trace::JSTraceable + std::cmp::Eq + std::hash::Hash,
+                K: crate::JSTraceable + std::cmp::Eq + std::hash::Hash,
                 S: std::hash::BuildHasher,
             {
             }
@@ -114,7 +114,7 @@ fn assert_not_impl_traceable(ty: &syn::Type) -> proc_macro2::TokenStream {
             impl<K, V, S> NoTraceOnJSTraceable<Invalid3> for std::collections::HashMap<K, V, S>
             where
                 K: std::cmp::Eq + std::hash::Hash,
-                V: crate::dom::bindings::trace::JSTraceable,
+                V: crate::JSTraceable,
                 S: std::hash::BuildHasher,
             {
             }
@@ -123,7 +123,7 @@ fn assert_not_impl_traceable(ty: &syn::Type) -> proc_macro2::TokenStream {
             struct Invalid4;
             // forbids BTreeMap<_, JSTraceble>
             impl<K, V> NoTraceOnJSTraceable<Invalid4> for std::collections::BTreeMap<K, V> where
-                K: crate::dom::bindings::trace::JSTraceable + std::cmp::Eq + std::hash::Hash
+                K: crate::JSTraceable + std::cmp::Eq + std::hash::Hash
             {
             }
 
@@ -133,7 +133,7 @@ fn assert_not_impl_traceable(ty: &syn::Type) -> proc_macro2::TokenStream {
             impl<K, V> NoTraceOnJSTraceable<Invalid5> for std::collections::BTreeMap<K, V>
             where
                 K: std::cmp::Eq + std::hash::Hash,
-                V: crate::dom::bindings::trace::JSTraceable,
+                V: crate::JSTraceable,
             {
             }
 
@@ -157,7 +157,7 @@ fn js_traceable_derive(s: synstructure::Structure) -> proc_macro2::TokenStream {
                 }
                 return None;
             } else if attr.path().is_ident("custom_trace") {
-                return Some(quote!(<dyn crate::dom::bindings::trace::CustomTraceable>::trace(#binding, tracer);));
+                return Some(quote!(<dyn crate::CustomTraceable>::trace(#binding, tracer);));
             }
         }
         Some(quote!(#binding.trace(tracer);))
@@ -171,18 +171,18 @@ fn js_traceable_derive(s: synstructure::Structure) -> proc_macro2::TokenStream {
         let ident = &param.ident;
         where_clause
             .predicates
-            .push(parse_quote!(#ident: crate::dom::bindings::trace::JSTraceable))
+            .push(parse_quote!(#ident: crate::JSTraceable))
     }
 
     let tokens = quote! {
         #asserts
 
         #[allow(unsafe_code)]
-        unsafe impl #impl_generics crate::dom::bindings::trace::JSTraceable for #name #ty_generics #where_clause {
+        unsafe impl #impl_generics crate::JSTraceable for #name #ty_generics #where_clause {
             #[inline]
             #[allow(unused_variables, unused_imports)]
             unsafe fn trace(&self, tracer: *mut js::jsapi::JSTracer) {
-                use crate::dom::bindings::trace::JSTraceable;
+                use crate::JSTraceable;
                 match *self {
                     #match_body
                 }

--- a/components/script/dom/bindings/inheritance.rs
+++ b/components/script/dom/bindings/inheritance.rs
@@ -53,6 +53,7 @@ pub trait Castable: IDLInterface + DomObject + Sized {
     }
 }
 
+#[allow(missing_docs)]
 pub trait HasParent {
     type Parent;
     fn as_parent(&self) -> &Self::Parent;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -100,3 +100,4 @@ pub use script_runtime::JSEngineSetup;
 // pub exports for derive macros
 pub use crate::dom::bindings::trace::JSTraceable;
 pub use crate::dom::bindings::trace::CustomTraceable;
+pub use crate::dom::bindings::inheritance::HasParent;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -97,8 +97,8 @@ mod window_named_properties;
 pub use init::init;
 pub use script_runtime::JSEngineSetup;
 
+// export traits to be available for derive macros
 pub use crate::dom::bindings::inheritance::HasParent;
 pub use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
 pub use crate::dom::bindings::trace::CustomTraceable;
-// pub exports for derive macros
 pub use crate::dom::bindings::trace::JSTraceable;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -97,8 +97,8 @@ mod window_named_properties;
 pub use init::init;
 pub use script_runtime::JSEngineSetup;
 
+pub use crate::dom::bindings::inheritance::HasParent;
+pub use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
+pub use crate::dom::bindings::trace::CustomTraceable;
 // pub exports for derive macros
 pub use crate::dom::bindings::trace::JSTraceable;
-pub use crate::dom::bindings::trace::CustomTraceable;
-pub use crate::dom::bindings::inheritance::HasParent;
-pub use crate::dom::bindings::reflector::{DomObject, Reflector, MutDomObject};

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -97,7 +97,9 @@ mod window_named_properties;
 pub use init::init;
 pub use script_runtime::JSEngineSetup;
 
-// export traits to be available for derive macros
+// These trait exports are public, because they are used in the DOM bindings.
+// Since they are used in derive macros,
+// it is useful that they are accessible at the root of the crate.
 pub use crate::dom::bindings::inheritance::HasParent;
 pub use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
 pub use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -100,5 +100,4 @@ pub use script_runtime::JSEngineSetup;
 // export traits to be available for derive macros
 pub use crate::dom::bindings::inheritance::HasParent;
 pub use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
-pub use crate::dom::bindings::trace::CustomTraceable;
-pub use crate::dom::bindings::trace::JSTraceable;
+pub use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -96,3 +96,7 @@ mod window_named_properties;
 
 pub use init::init;
 pub use script_runtime::JSEngineSetup;
+
+// pub exports for derive macros
+pub use crate::dom::bindings::trace::JSTraceable;
+pub use crate::dom::bindings::trace::CustomTraceable;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -101,3 +101,4 @@ pub use script_runtime::JSEngineSetup;
 pub use crate::dom::bindings::trace::JSTraceable;
 pub use crate::dom::bindings::trace::CustomTraceable;
 pub use crate::dom::bindings::inheritance::HasParent;
+pub use crate::dom::bindings::reflector::{DomObject, Reflector, MutDomObject};


### PR DESCRIPTION
This will make it easier to use derives from multiple crates (in preparations for #1799).

I think this is nicer solution to what was done in #21371, where you needed to manually specify base in derive invocation [`#[base = "script"]`](https://github.com/servo/servo/pull/21371#discussion_r1729789614).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are refators (rust keeps us safe)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
