### PR TITLE
Fix panic in abort-block-bfcache.window.js

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -313,7 +313,7 @@ impl ServoParser {
         script.execute(result);
         self.script_nesting_level.set(script_nesting_level);
 
-        if !self.suspended.get() {
+        if !self.suspended.get() && !self.aborted.get() {
             self.parse_sync();
         }
     }

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js.ini
@@ -1,2 +1,2 @@
 [abort-block-bfcache.window.html]
-  expected: CRASH
+  expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js.ini
@@ -1,2 +1,3 @@
 [abort-block-bfcache.window.html]
-  expected: FAIL
+  [aborting a parser should block bfcache.]
+    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #32988

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
