### PR TITLE
script: fix `querySelector` returning the root

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -982,8 +982,10 @@ impl Node {
                     NeedsSelectorFlags::No,
                     MatchingForInvalidation::No,
                 );
-                Ok(self
-                    .traverse_preorder(ShadowIncluding::No)
+                let mut descendants = self.traverse_preorder(ShadowIncluding::No);
+                // Skip the root of the tree.
+                assert!(&*descendants.next().unwrap() == self);
+                Ok(descendants
                     .filter_map(DomRoot::downcast)
                     .find(|element| matches_selector_list(&selectors, element, &mut ctx)))
             },

--- a/tests/wpt/meta/dom/nodes/ParentNode-querySelector-scope.html.ini
+++ b/tests/wpt/meta/dom/nodes/ParentNode-querySelector-scope.html.ini
@@ -8,8 +8,5 @@
   [querySelector with :scope]
     expected: FAIL
 
-  [querySelector with id and sibling]
-    expected: FAIL
-
   [querySelectorAll with :scope]
     expected: FAIL

--- a/tests/wpt/meta/dom/nodes/ParentNode-querySelectors-exclusive.html.ini
+++ b/tests/wpt/meta/dom/nodes/ParentNode-querySelectors-exclusive.html.ini
@@ -1,4 +1,0 @@
-[ParentNode-querySelectors-exclusive.html]
-  [querySelector/querySelectorAll should not include their thisArg]
-    expected: FAIL
-


### PR DESCRIPTION
This fixes a small bug in `Element.prototype.querySelector`:

```js
const button = document.createElement('button')

button.querySelector('*') // should return null, but returns <button> in Servo
```

This fixes a couple WPT tests, which I've also updated.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___