### PR TITLE
Fix a memory leak in `components/script/script_runtime.rs` and add more leak suppressions

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -444,6 +444,7 @@ pub struct Runtime {
     rt: RustRuntime,
     pub microtask_queue: Rc<MicrotaskQueue>,
     job_queue: *mut JobQueue,
+    networking_task_src: Option<Box<NetworkingTaskSource>>,
 }
 
 impl Drop for Runtime {
@@ -561,12 +562,13 @@ unsafe fn new_rt_and_cx_with_parent(
         networking_task_src.queue_unconditionally(task).is_ok()
     }
 
+    let mut networking_task_src_ptr = std::ptr::null_mut();
     if let Some(source) = networking_task_source {
-        let networking_task_src = Box::new(source);
+        networking_task_src_ptr = Box::into_raw(Box::new(source));
         InitDispatchToEventLoop(
             cx,
             Some(dispatch_to_event_loop),
-            Box::into_raw(networking_task_src) as *mut c_void,
+            networking_task_src_ptr as *mut c_void,
         );
     }
 
@@ -721,6 +723,8 @@ unsafe fn new_rt_and_cx_with_parent(
         rt: runtime,
         microtask_queue,
         job_queue,
+        networking_task_src: (!networking_task_src_ptr.is_null())
+            .then(|| Box::from_raw(networking_task_src_ptr)),
     }
 }
 

--- a/support/suppressed_leaks_for_asan.txt
+++ b/support/suppressed_leaks_for_asan.txt
@@ -1,5 +1,7 @@
 # intentional Box::leak, introduced here: https://github.com/servo/stylo/blob/f4cde5d89d03db92d111eaa4b4b34e622b6eecac/style/sharing/mod.rs#L481
 leak:style::sharing::SHARING_CACHE_KEY::__init
+# intentional Box::leak, introduced here: https://github.com/servo/stylo/blob/80292f83789ec9d0c66f73ee7e6e142f7478d167/style/bloom.rs#L22
+leak:style::bloom::BLOOM_KEY::__init
 
 # std::sync::LazyLock never frees memory because it never runs destructors, see https://doc.rust-lang.org/std/sync/struct.LazyLock.html#examples
 leak:std::sync::LazyLock

--- a/support/suppressed_leaks_for_asan.txt
+++ b/support/suppressed_leaks_for_asan.txt
@@ -5,3 +5,7 @@ leak:style::bloom::BLOOM_KEY::__init
 
 # std::sync::LazyLock never frees memory because it never runs destructors, see https://doc.rust-lang.org/std/sync/struct.LazyLock.html#examples
 leak:std::sync::LazyLock
+
+# lazy_static never frees memory because it never runs destructors, see https://docs.rs/lazy_static/1.4.0/lazy_static/index.html#semantics
+# Needed because transitive dependency are still using it
+leak:lazy_static::lazy::Lazy*::get


### PR DESCRIPTION
- More suppression for intentional leaks
- Restored suppression for lazy_static leak as dependencies still use it
- fix memory leak of `Box<NetworkingTaskSource>` by storing it inside `Runtime` instead of forgetting the raw pointer so that it gets dropped when the GC'ed `Runtime` is dropped

We only got leaks left now for <https://example.com> under Wayland. Some stuff with clipboard and so on (for details see the wayland leaks on this older stack trace: https://github.com/servo/servo/issues/32223#issuecomment-2185102990).

When running with XWayland (`unset WAYLAND_DISPLAY`), there are only leaks from `libfontconfig.so` left, which don't contain a full stack trace.

```
Direct leak of 512 byte(s) in 2 object(s) allocated from:
    #0 0x5c1875ec342f in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x73eabd4df055  (/usr/lib/libfontconfig.so.1+0x21055) (BuildId: 6aec681ec5b2fb80f3a60e3cf3d75abac345c9b3)

Indirect leak of 64 byte(s) in 2 object(s) allocated from:
    #0 0x5c1875ec35f9 in calloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:75:3
    #1 0x73eabd4e347d  (/usr/lib/libfontconfig.so.1+0x2547d) (BuildId: 6aec681ec5b2fb80f3a60e3cf3d75abac345c9b3)

Indirect leak of 22 byte(s) in 2 object(s) allocated from:
    #0 0x5c1875eab40a in strdup /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:570:3
    #1 0x73eabd4de8a8 in FcValueSave (/usr/lib/libfontconfig.so.1+0x208a8) (BuildId: 6aec681ec5b2fb80f3a60e3cf3d75abac345c9b3)
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32223 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
