### PR TITLE
webxr: Implement XRBoundedReferenceSpace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#13a0b240d10479180a9e100d7b4e25cfc142db8d"
+source = "git+https://github.com/servo/webxr#06cf8102e1ee7954e4ea1e5a08a905dda60e35cd"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7795,7 +7795,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#13a0b240d10479180a9e100d7b4e25cfc142db8d"
+source = "git+https://github.com/servo/webxr#06cf8102e1ee7954e4ea1e5a08a905dda60e35cd"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -623,6 +623,7 @@ pub mod xmlhttprequest;
 pub mod xmlhttprequesteventtarget;
 pub mod xmlhttprequestupload;
 pub mod xmlserializer;
+pub mod xrboundedreferencespace;
 pub mod xrcompositionlayer;
 pub mod xrcubelayer;
 pub mod xrcylinderlayer;

--- a/components/script/dom/webidls/XRBoundedReferenceSpace.webidl
+++ b/components/script/dom/webidls/XRBoundedReferenceSpace.webidl
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://immersive-web.github.io/webxr/#xrboundedreferencespace-interface
+
+[SecureContext, Exposed=Window]
+interface XRBoundedReferenceSpace : XRReferenceSpace {
+  readonly attribute /*FrozenArray<DOMPointReadOnly>*/ any boundsGeometry;
+};

--- a/components/script/dom/webidls/XRBoundedReferenceSpace.webidl
+++ b/components/script/dom/webidls/XRBoundedReferenceSpace.webidl
@@ -4,7 +4,7 @@
 
 // https://immersive-web.github.io/webxr/#xrboundedreferencespace-interface
 
-[SecureContext, Exposed=Window]
+[SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRBoundedReferenceSpace : XRReferenceSpace {
   readonly attribute /*FrozenArray<DOMPointReadOnly>*/ any boundsGeometry;
 };

--- a/components/script/dom/webidls/XRReferenceSpace.webidl
+++ b/components/script/dom/webidls/XRReferenceSpace.webidl
@@ -14,6 +14,7 @@ enum XRReferenceSpaceType {
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRReferenceSpace : XRSpace {
-  XRReferenceSpace getOffsetReferenceSpace(XRRigidTransform originOffset);
+  [NewObject] XRReferenceSpace getOffsetReferenceSpace(XRRigidTransform originOffset);
+
   // attribute EventHandler onreset;
 };

--- a/components/script/dom/xrboundedreferencespace.rs
+++ b/components/script/dom/xrboundedreferencespace.rs
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::jsval::JSVal;
+
+use crate::dom::bindings::codegen::Bindings::XRBoundedReferenceSpaceBinding::XRBoundedReferenceSpaceMethods;
+use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::utils::to_frozen_array;
+use crate::dom::dompointreadonly::DOMPointReadOnly;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::xrreferencespace::XRReferenceSpace;
+use crate::dom::xrrigidtransform::XRRigidTransform;
+use crate::dom::xrsession::XRSession;
+use crate::script_runtime::JSContext;
+
+#[dom_struct]
+pub struct XRBoundedReferenceSpace {
+    xrspace: XRReferenceSpace,
+    offset: Dom<XRRigidTransform>,
+}
+
+impl XRBoundedReferenceSpace {
+    pub fn new_inherited(
+        session: &XRSession,
+        offset: &XRRigidTransform,
+    ) -> XRBoundedReferenceSpace {
+        XRBoundedReferenceSpace {
+            xrspace: XRReferenceSpace::new_inherited(
+                session,
+                offset,
+                XRReferenceSpaceType::Bounded_floor,
+            ),
+            offset: Dom::from_ref(offset),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn new(global: &GlobalScope, session: &XRSession) -> DomRoot<XRBoundedReferenceSpace> {
+        let offset = XRRigidTransform::identity(global);
+        Self::new_offset(global, session, &offset)
+    }
+
+    #[allow(unused)]
+    pub fn new_offset(
+        global: &GlobalScope,
+        session: &XRSession,
+        offset: &XRRigidTransform,
+    ) -> DomRoot<XRBoundedReferenceSpace> {
+        reflect_dom_object(
+            Box::new(XRBoundedReferenceSpace::new_inherited(session, offset)),
+            global,
+        )
+    }
+}
+
+impl XRBoundedReferenceSpaceMethods for XRBoundedReferenceSpace {
+    /// <https://www.w3.org/TR/webxr/#dom-xrboundedreferencespace-boundsgeometry>
+    fn BoundsGeometry(&self, cx: JSContext) -> JSVal {
+        if let Some(bounds) = self.xrspace.get_bounds() {
+            let point1 = DOMPointReadOnly::new(
+                &self.global(),
+                bounds.min.x.into(),
+                0.0,
+                bounds.min.y.into(),
+                1.0,
+            );
+            let point2 = DOMPointReadOnly::new(
+                &self.global(),
+                bounds.min.x.into(),
+                0.0,
+                bounds.max.y.into(),
+                1.0,
+            );
+            let point3 = DOMPointReadOnly::new(
+                &self.global(),
+                bounds.max.x.into(),
+                0.0,
+                bounds.max.y.into(),
+                1.0,
+            );
+            let point4 = DOMPointReadOnly::new(
+                &self.global(),
+                bounds.max.x.into(),
+                0.0,
+                bounds.min.y.into(),
+                1.0,
+            );
+
+            to_frozen_array(&[point1, point2, point3, point4], cx)
+        } else {
+            to_frozen_array::<DomRoot<DOMPointReadOnly>>(&[], cx)
+        }
+    }
+}

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use euclid::RigidTransform3D;
-use webxr_api::{self, Frame, Space};
+use euclid::{Box2D, RigidTransform3D};
+use webxr_api::{self, Floor, Frame, Space};
 
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::{
     XRReferenceSpaceMethods, XRReferenceSpaceType,
@@ -65,6 +65,7 @@ impl XRReferenceSpace {
             XRReferenceSpaceType::Local => webxr_api::BaseSpace::Local,
             XRReferenceSpaceType::Viewer => webxr_api::BaseSpace::Viewer,
             XRReferenceSpaceType::Local_floor => webxr_api::BaseSpace::Floor,
+            XRReferenceSpaceType::Bounded_floor => webxr_api::BaseSpace::BoundedFloor,
             _ => panic!("unsupported reference space found"),
         };
         let offset = self.offset.transform();
@@ -121,7 +122,7 @@ impl XRReferenceSpace {
                 // for most devices is (0, 0, 0)
                 Some(RigidTransform3D::identity())
             },
-            XRReferenceSpaceType::Local_floor => {
+            XRReferenceSpaceType::Local_floor | XRReferenceSpaceType::Bounded_floor => {
                 let native_to_floor = self
                     .upcast::<XRSpace>()
                     .session()
@@ -133,5 +134,11 @@ impl XRReferenceSpace {
             },
             _ => unimplemented!(),
         }
+    }
+
+    pub fn get_bounds(&self) -> Option<Box2D<f32, Floor>> {
+        self.upcast::<XRSpace>()
+            .session()
+            .with_session(|s| s.reference_space_bounds())
     }
 }

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -17,25 +17,16 @@
   [XRRay interface object length]
     expected: FAIL
 
-  [XRBoundedReferenceSpace interface object length]
-    expected: FAIL
-
   [XRRay interface: attribute matrix]
     expected: FAIL
 
   [XRReferenceSpaceEvent interface object length]
     expected: FAIL
 
-  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
   [XRReferenceSpaceEvent interface: existence and properties of interface object]
     expected: FAIL
 
   [XRReferenceSpaceEvent interface: attribute transform]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: existence and properties of interface object]
     expected: FAIL
 
   [XRRay interface: attribute direction]
@@ -48,12 +39,6 @@
     expected: FAIL
 
   [XRRay interface: existence and properties of interface object]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: attribute boundsGeometry]
     expected: FAIL
 
   [XRReferenceSpaceEvent interface object name]
@@ -84,12 +69,6 @@
     expected: FAIL
 
   [XR interface: operation supportsSession(XRSessionMode)]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface object name]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [XR interface: calling requestSession(XRSessionMode, XRSessionInit) on navigator.xr with too few arguments must throw TypeError]

--- a/tests/wpt/meta-legacy-layout/webxr/xrReferenceSpace_originOffsetBounded.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/xrReferenceSpace_originOffsetBounded.https.html.ini
@@ -1,7 +1,6 @@
 [xrReferenceSpace_originOffsetBounded.https.html]
-  expected: ERROR
   [Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl2]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/webxr/xrReferenceSpace_relationships.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/xrReferenceSpace_relationships.https.html.ini
@@ -1,7 +1,0 @@
-[xrReferenceSpace_relationships.https.html]
-  expected: ERROR
-  [Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl2]
-    expected: NOTRUN
-
-  [Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl]
-    expected: TIMEOUT

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -53,9 +53,6 @@
   [Stringification of xrReferenceSpace]
     expected: FAIL
 
-  [XRBoundedReferenceSpace interface object length]
-    expected: FAIL
-
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "framebuffer" with the proper type]
     expected: FAIL
 
@@ -89,9 +86,6 @@
   [XRReferenceSpace must be primary interface of xrReferenceSpace]
     expected: FAIL
 
-  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
   [XRReferenceSpaceEvent interface: existence and properties of interface object]
     expected: FAIL
 
@@ -117,9 +111,6 @@
     expected: FAIL
 
   [XRReferenceSpaceEvent interface: attribute transform]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: existence and properties of interface object]
     expected: FAIL
 
   [XRInputSourcesChangeEvent interface: xrInputSourcesChangeEvent must inherit property "added" with the proper type]
@@ -161,16 +152,10 @@
   [XRSession interface: xrSession must inherit property "onsqueezeend" with the proper type]
     expected: FAIL
 
-  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [XRPermissionStatus interface object name]
     expected: FAIL
 
   [XRRenderState interface: xrRenderState must inherit property "inlineVerticalFieldOfView" with the proper type]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: attribute boundsGeometry]
     expected: FAIL
 
   [XRSession interface: calling cancelAnimationFrame(long) on xrSession with too few arguments must throw TypeError]
@@ -227,9 +212,6 @@
   [XRSessionEvent must be primary interface of xrSessionEvent]
     expected: FAIL
 
-  [XRBoundedReferenceSpace interface object name]
-    expected: FAIL
-
   [XRRenderState interface: xrRenderState must inherit property "depthFar" with the proper type]
     expected: FAIL
 
@@ -240,9 +222,6 @@
     expected: FAIL
 
   [XRSession interface: calling updateRenderState(optional XRRenderStateInit) on xrSession with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [Stringification of xrInputSourceArray]

--- a/tests/wpt/meta/webxr/xrReferenceSpace_originOffsetBounded.https.html.ini
+++ b/tests/wpt/meta/webxr/xrReferenceSpace_originOffsetBounded.https.html.ini
@@ -1,7 +1,6 @@
 [xrReferenceSpace_originOffsetBounded.https.html]
-  expected: ERROR
   [Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry. - webgl2]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/webxr/xrReferenceSpace_relationships.https.html.ini
+++ b/tests/wpt/meta/webxr/xrReferenceSpace_relationships.https.html.ini
@@ -1,7 +1,0 @@
-[xrReferenceSpace_relationships.https.html]
-  expected: ERROR
-  [Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl2]
-    expected: NOTRUN
-
-  [Bounded space, viewer space, local and local-floor space have correct poses w.r.t. each other - webgl]
-    expected: TIMEOUT

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13473,7 +13473,7 @@
      ]
     ],
     "interfaces.html": [
-     "7a7d6c0a467ab2006d5edd9ef3a3b4a07f99cd64",
+     "dd0f564f708a2a0e8cf1ed571bd2bd45977fa469",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -278,6 +278,7 @@ test_interfaces([
   "XMLHttpRequestEventTarget",
   "XMLHttpRequestUpload",
   "XMLSerializer",
+  "XRBoundedReferenceSpace",
   "XRFrame",
   "XRHand",
   "XRHitTestResult",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds support for XRBoundedReferenceSpace, surfacing the bounds geometry from the WebXR crate.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
