### PR TITLE
Redesigned minibrowser toolbar to use icons instead of text

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -145,7 +145,7 @@ impl Minibrowser {
         position.y < self.toolbar_height.get()
     }
 
-    /// Create a frameless button with square sizing, as used in the toolbar
+    /// Create a frameless button with square sizing, as used in the toolbar.
     fn toolbar_button(text: &str) -> egui::Button {
         egui::Button::new(text)
             .frame(false)
@@ -201,7 +201,7 @@ impl Minibrowser {
                             match self.load_status {
                                 LoadStatus::LoadStart | LoadStatus::HeadParsed => {
                                     if ui.add(Minibrowser::toolbar_button("X")).clicked() {
-                                        warn!("Tried to stop loading a page");
+                                        warn!("Do not support stop yet.");
                                     }
                                 },
                                 LoadStatus::LoadComplete => {


### PR DESCRIPTION
Hey there, 

I changed the toolbar to look a little bit more like the one from Chrome/Firefox, not sure how important the minibrowser appearance is but it kinda bugged me so I thought I'd improve it somewhat

<img width="807" alt="Screenshot 2024-08-25 at 20 02 48" src="https://github.com/user-attachments/assets/05905eeb-ce52-4cf0-922f-2e96fe183cd7">


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are for the minibrowser

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
