### PR TITLE
Add fallback value for data['message']

### DIFF
--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -306,7 +306,7 @@ class ServoFormatter(mozlog.formatters.base.BaseFormatter, ServoHandler):
         # Print reason that tests are skipped.
         if data["status"] == "SKIP":
             self.number_skipped += 1
-            lines = [f"SKIP {data['test']}", f"{data['message']}\n"]
+            lines = [f"SKIP {data['test']}", f"{data.get('message', '')}\n"]
             output_for_skipped_test = UnexpectedResult.wrap_and_indent_lines(lines, indent="  ")
             return self.generate_output(text=output_for_skipped_test, new_display=self.build_status_line())
 


### PR DESCRIPTION
Speculative fix for https://github.com/servo/servo/issues/33184


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33184
- [x] There are tests for these changes in CI logs

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
