### PR TITLE
Add `dom.allow_scripts_to_close_windows` pref

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -238,6 +238,7 @@ mod gen {
                         enabled: bool,
                     }
                 },
+                allow_scripts_to_close_windows: bool,
                 canvas_capture: {
                     enabled: bool,
                 },

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -60,6 +60,7 @@ use script_traits::{
 use selectors::attr::CaseSensitivity;
 use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
+use servo_config::pref;
 use servo_geometry::{f32_rect_to_au_rect, MaxRect};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::dom::OpaqueNode;
@@ -757,7 +758,9 @@ impl WindowMethods for Window {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
-            let is_script_closable = (self.is_top_level() && history_length == 1) || is_auxiliary;
+            let is_script_closable = (self.is_top_level() && history_length == 1) ||
+                is_auxiliary ||
+                pref!(dom.allow_scripts_to_close_windows);
 
             // TODO: rest of Step 3:
             // Is the incumbent settings object's responsible browsing context familiar with current?

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -1,6 +1,7 @@
 {
   "devtools.server.enabled": false,
   "devtools.server.port": 0,
+  "dom.allow_scripts_to_close_windows": false,
   "dom.bluetooth.enabled": false,
   "dom.bluetooth.testing.enabled": false,
   "dom.canvas_capture.enabled": false,


### PR DESCRIPTION
It's also present in firefox: https://searchfox.org/mozilla-central/search?q=allow_scripts_to_close_windows

This will allow running speedometer in headless: https://github.com/sagudev/Speedometer/commit/faf6ae166097b21ef1b91effa9e8edc06049b9c5


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because minimal pref work to workaround strict spec.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
