### PR TITLE
mach: Do not manually install toolchain for non-cross builds

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -813,7 +813,6 @@ class CommandBase(object):
             check_call(["rustup", "target", "add", self.target.triple()],
                        cwd=self.context.topdir)
 
-
     def ensure_rustup_version(self):
         try:
             version_line = subprocess.check_output(

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -799,15 +799,20 @@ class CommandBase(object):
             return
 
         servo.platform.get().passive_bootstrap()
+        self.context.bootstrapped = True
 
-        needs_toolchain_install = self.target.triple() not in \
-            check_output(["rustup", "target", "list", "--installed"],
-                         cwd=self.context.topdir).decode()
-        if needs_toolchain_install:
+        # Toolchain installation is handled automatically for non cross compilation builds.
+        if not self.target.is_cross_build():
+            return
+
+        installed_targets = check_output(
+            ["rustup", "target", "list", "--installed"],
+            cwd=self.context.topdir
+        ).decode()
+        if self.target.triple() not in installed_targets:
             check_call(["rustup", "target", "add", self.target.triple()],
                        cwd=self.context.topdir)
 
-        self.context.bootstrapped = True
 
     def ensure_rustup_version(self):
         try:


### PR DESCRIPTION
This fixes the Apple Silicon build where the installed toolchain does
not match the host triple. We only install toolchains manually for cross
builds, because cargo and friends will do this automatically when
executing.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
