### PR TITLE
Correct LLVM target triple detection for Apple Silicon

### DIFF
--- a/python/servo/platform/__init__.py
+++ b/python/servo/platform/__init__.py
@@ -40,7 +40,7 @@ def host_triple():
         cpu_type = "x86_64"
     elif cpu_type == "arm":
         cpu_type = "arm"
-    elif cpu_type == "aarch64":
+    elif cpu_type in ["aarch64", "arm64"]:
         cpu_type = "aarch64"
     else:
         cpu_type = "unknown"


### PR DESCRIPTION
The LLVM target triple for Apple Silicon was not detected properly.
The Python `platform` module reports the CPU architectures as
`arm64`, but the component in the LLVM triple that Rust uses should
be `aarch64`. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are minor changes to the build scripts

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
