### PR TITLE
Respect min/max constraints in the block axis of block containers

### DIFF
--- a/tests/wpt/meta/css/CSS2/normal-flow/max-height-applies-to-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/max-height-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[max-height-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/normal-flow/max-height-applies-to-017.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/max-height-applies-to-017.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSS Test: Max-Height applied to element with 'display' set to 'inline-block'</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#min-max-heights">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="The percentage in #child should resolve against the 100px maximum of #parent, not against 200px.">
+
+<style>
+#parent {
+  display: inline-block;
+  height: 200px;
+  max-height: 100px;
+  background: red;
+}
+#child {
+  display: inline-block;
+  width: 100px;
+  height: 100%;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="parent">
+  <span id="child"></span>
+</div>


### PR DESCRIPTION
Consider a block container that establishes an inline formatting context and has a definite `block-size` which is clamped by `min-block-size` or `max-block-size`.

We were already sizing such container correctly, however, its contents were resolving their percentages against the unclamped `block-size` value.

This patch fixes the `ContainingBlock` that we pass to the contents so that they resolve percentages correctly.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
