### PR TITLE
layout: Add an indefinite containing block for intrinsic sizing

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -24,7 +24,7 @@ pub type AuOrAuto = AutoOr<Au>;
 pub type LengthOrAuto = AutoOr<Length>;
 pub type LengthPercentageOrAuto<'a> = AutoOr<&'a LengthPercentage>;
 
-#[derive(Clone, Copy, Serialize)]
+#[derive(Clone, Copy, PartialEq, Serialize)]
 pub struct LogicalVec2<T> {
     pub inline: T,
     pub block: T,
@@ -150,7 +150,7 @@ impl<T: Clone> LogicalVec2<AutoOr<T>> {
 }
 
 impl LogicalVec2<LengthPercentageOrAuto<'_>> {
-    pub fn percentages_relative_to(
+    pub(crate) fn percentages_relative_to(
         &self,
         containing_block: &ContainingBlock,
     ) -> LogicalVec2<LengthOrAuto> {
@@ -165,8 +165,32 @@ impl LogicalVec2<LengthPercentageOrAuto<'_>> {
     }
 }
 
+impl LogicalVec2<LengthPercentageOrAuto<'_>> {
+    pub(crate) fn percentages_relative_to_basis(
+        &self,
+        basis: &LogicalVec2<Length>,
+    ) -> LogicalVec2<LengthOrAuto> {
+        LogicalVec2 {
+            inline: self.inline.percentage_relative_to(basis.inline),
+            block: self.block.percentage_relative_to(basis.block),
+        }
+    }
+}
+
+impl LogicalVec2<LengthPercentageOrAuto<'_>> {
+    pub(crate) fn maybe_percentages_relative_to_basis(
+        &self,
+        basis: &LogicalVec2<Option<Length>>,
+    ) -> LogicalVec2<LengthOrAuto> {
+        LogicalVec2 {
+            inline: self.inline.maybe_percentage_relative_to(basis.inline),
+            block: self.block.maybe_percentage_relative_to(basis.block),
+        }
+    }
+}
+
 impl LogicalVec2<Option<&'_ LengthPercentage>> {
-    pub fn percentages_relative_to(
+    pub(crate) fn percentages_relative_to(
         &self,
         containing_block: &ContainingBlock,
     ) -> LogicalVec2<Option<Length>> {
@@ -179,6 +203,22 @@ impl LogicalVec2<Option<&'_ LengthPercentage>> {
                     containing_block.block_size.map(|t| t.into()).non_auto(),
                 )
             }),
+        }
+    }
+}
+
+impl LogicalVec2<Option<&'_ LengthPercentage>> {
+    pub(crate) fn maybe_percentages_relative_to_basis(
+        &self,
+        basis: &LogicalVec2<Option<Length>>,
+    ) -> LogicalVec2<Option<Length>> {
+        LogicalVec2 {
+            inline: self
+                .inline
+                .and_then(|v| v.maybe_percentage_relative_to(basis.inline)),
+            block: self
+                .block
+                .and_then(|v| v.maybe_percentage_relative_to(basis.block)),
         }
     }
 }

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -31,9 +31,75 @@ pub use fragment_tree::FragmentTree;
 use geom::AuOrAuto;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
-use style_ext::ComputedValuesExt;
+use style_ext::{Clamp, ComputedValuesExt};
 
 use crate::geom::LogicalVec2;
+
+/// A containing block useful for calculating inline content sizes, which may
+/// have inline sizes that depend on block sizes due to aspect ratio.
+pub(crate) struct IndefiniteContainingBlock<'a> {
+    pub size: LogicalVec2<AuOrAuto>,
+    pub style: &'a ComputedValues,
+}
+
+impl<'a> IndefiniteContainingBlock<'a> {
+    fn new_for_style(style: &'a ComputedValues) -> Self {
+        Self::new_for_style_and_block_size(style, AuOrAuto::Auto)
+    }
+
+    /// Creates an [`IndefiniteContainingBlock`] with the provided style and block size,
+    /// and the inline size is set to auto.
+    /// This is useful when finding the min-content or max-content size of an element,
+    /// since then we ignore its 'inline-size', 'min-inline-size' and 'max-inline-size'.
+    fn new_for_style_and_block_size(style: &'a ComputedValues, block_size: AuOrAuto) -> Self {
+        Self {
+            size: LogicalVec2 {
+                inline: AuOrAuto::Auto,
+                block: block_size,
+            },
+            style,
+        }
+    }
+
+    fn new_for_intrinsic_inline_size_of_child(
+        &self,
+        style: &'a ComputedValues,
+        auto_minimum: &LogicalVec2<Au>,
+    ) -> Self {
+        let (content_box_size, content_min_size, content_max_size, _) =
+            style.content_box_sizes_and_padding_border_margin(&self);
+        let block_size = content_box_size.block.map(|v| {
+            v.clamp_between_extremums(
+                content_min_size.block.auto_is(|| auto_minimum.block),
+                content_max_size.block,
+            )
+        });
+        IndefiniteContainingBlock::new_for_style_and_block_size(style, block_size)
+    }
+}
+
+impl<'a> From<&'_ ContainingBlock<'a>> for IndefiniteContainingBlock<'a> {
+    fn from(containing_block: &ContainingBlock<'a>) -> Self {
+        Self {
+            size: LogicalVec2 {
+                inline: AuOrAuto::LengthPercentage(containing_block.inline_size),
+                block: containing_block.block_size,
+            },
+            style: containing_block.style,
+        }
+    }
+}
+
+impl<'a> From<&'_ DefiniteContainingBlock<'a>> for IndefiniteContainingBlock<'a> {
+    fn from(containing_block: &DefiniteContainingBlock<'a>) -> Self {
+        Self {
+            size: containing_block
+                .size
+                .map(|v| AuOrAuto::LengthPercentage(*v)),
+            style: containing_block.style,
+        }
+    }
+}
 
 pub struct ContainingBlock<'a> {
     inline_size: Au,
@@ -44,6 +110,23 @@ pub struct ContainingBlock<'a> {
 impl<'a> ContainingBlock<'a> {
     pub(crate) fn effective_writing_mode(&self) -> WritingMode {
         self.style.effective_writing_mode()
+    }
+}
+
+impl<'a> TryFrom<&'_ IndefiniteContainingBlock<'a>> for ContainingBlock<'a> {
+    type Error = &'static str;
+
+    fn try_from(
+        indefinite_containing_block: &IndefiniteContainingBlock<'a>,
+    ) -> Result<Self, Self::Error> {
+        match indefinite_containing_block.size.inline {
+            AuOrAuto::Auto => Err("ContainingBlock doesn't accept auto inline sizes"),
+            AuOrAuto::LengthPercentage(inline_size) => Ok(ContainingBlock {
+                inline_size,
+                block_size: indefinite_containing_block.size.block,
+                style: indefinite_containing_block.style,
+            }),
+        }
     }
 }
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -27,7 +27,7 @@ use crate::geom::{
     PhysicalPoint, PhysicalRect, ToLogical,
 };
 use crate::style_ext::{ComputedValuesExt, DisplayInside};
-use crate::{ContainingBlock, DefiniteContainingBlock};
+use crate::{ContainingBlock, DefiniteContainingBlock, IndefiniteContainingBlock};
 
 #[derive(Debug, Serialize)]
 pub(crate) struct AbsolutelyPositionedBox {
@@ -578,8 +578,16 @@ impl HoistedAbsolutelyPositionedBox {
                         let margin_sum = inline_axis.margin_start + inline_axis.margin_end;
                         let available_size =
                             cbis - anchor - pbm.padding_border_sums.inline - margin_sum;
+
+                        let style = non_replaced.style.clone();
+                        let containing_block_for_children =
+                            IndefiniteContainingBlock::from(containing_block)
+                                .new_for_intrinsic_inline_size_of_child(
+                                    &style,
+                                    &LogicalVec2::zero(),
+                                );
                         non_replaced
-                            .inline_content_sizes(layout_context)
+                            .inline_content_sizes(layout_context, &containing_block_for_children)
                             .shrink_to_fit(available_size)
                     });
 

--- a/tests/wpt/meta/css/css-flexbox/flex-basis-011.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-basis-011.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-015.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-015.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column-percentage-ignored.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-flex-direction-column-percentage-ignored.html.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-direction-column-percentage-ignored.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/item-with-max-height-and-scrollbar.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/item-with-max-height-and-scrollbar.html.ini
@@ -1,2 +1,0 @@
-[item-with-max-height-and-scrollbar.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/nested-flex-image-loading-invalidates-intrinsic-sizes.html.ini
@@ -1,2 +1,0 @@
-[nested-flex-image-loading-invalidates-intrinsic-sizes.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/percentage-heights-014.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/percentage-heights-014.html.ini
@@ -1,2 +1,0 @@
-[percentage-heights-014.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/position-fixed-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/position-fixed-001.html.ini
@@ -1,2 +1,0 @@
-[position-fixed-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio-affects-container-width-when-height-changes.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio-affects-container-width-when-height-changes.html.ini
@@ -1,3 +1,0 @@
-[aspect-ratio-affects-container-width-when-height-changes.html]
-  [#container 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-001.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-002.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-dynamic-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-003.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-dynamic-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-004.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-004.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-dynamic-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-006.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-006.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-dynamic-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-009.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-009.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-dynamic-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/calc-rounding-002.html.ini
+++ b/tests/wpt/meta/css/css-values/calc-rounding-002.html.ini
@@ -1,2 +1,0 @@
-[calc-rounding-002.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-flexbox/percentage-padding-005.html
+++ b/tests/wpt/tests/css/css-flexbox/percentage-padding-005.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#item-margins">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#intrinsic-main-sizes">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The flex container becomes 100px tall because the padding percentage of the item resolves against its width.">
+
+<p>Test passes if there is a filled green square.</p>
+<div style="display: flex; background: green; flex-direction: column; width: 100px;">
+  <div style="width: 100px; padding-bottom: 100%"></div>
+</div>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When computing the min-content or max-content size of an element we
need to ignore `inline-size`, `min-inline-size` and `max-inline-size`.

However, we should take the block-axis sizing properties into account.
That's because the contents could have percentages depending on them,
which can then affect their inline size via an aspect ratio.

Therefore, this patch adds `IndefiniteContainingBlock`, which is similar
to `ContainingBlock`, but it allows an indefinite inline-size. This
struct is then passed arround during intrinsic sizing.

More refinement will be needed in follow-up patches in order to fully
address the problem.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
