### PR TITLE
mach: Extract binary select into common_command_arguments

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -593,7 +593,7 @@ class CommandBase(object):
 
         if binary_selection:
             decorators += [
-                CommandArgumentGroup('Binary select'),
+                CommandArgumentGroup('Binary selection'),
                 CommandArgument('--bin', default=None,
                                 help='Launch with specific binary'),
                 CommandArgument('--nightly', '-n', default=None,

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -520,9 +520,9 @@ class CommandBase(object):
         return env
 
     @staticmethod
-    def common_command_arguments(build_configuration=False, build_type=False, binary=False):
+    def common_command_arguments(build_configuration=False, build_type=False, binary_selection=False):
         decorators = []
-        if build_type or binary:
+        if build_type or binary_selection:
             decorators += [
                 CommandArgumentGroup('Build Type'),
                 CommandArgument('--release', '-r', group="Build Type",
@@ -591,7 +591,7 @@ class CommandBase(object):
                 )
             ]
 
-        if binary:
+        if binary_selection:
             decorators += [
                 CommandArgumentGroup('Binary select'),
                 CommandArgument('--bin', default=None,
@@ -602,7 +602,7 @@ class CommandBase(object):
 
         def decorator_function(original_function):
             def configuration_decorator(self, *args, **kwargs):
-                if build_type or binary:
+                if build_type or binary_selection:
                     # If `build_type` already exists in kwargs we are doing a recursive dispatch.
                     if 'build_type' not in kwargs:
                         kwargs['build_type'] = self.configure_build_type(
@@ -618,7 +618,7 @@ class CommandBase(object):
                     self.features = kwargs.get("features", None) or []
                     self.enable_media = self.is_media_enabled(kwargs['media_stack'])
 
-                if binary:
+                if binary_selection:
                     if 'servo_binary' not in kwargs:
                         kwargs['servo_binary'] = (kwargs.get('bin')
                                                   or self.get_nightly_binary_path(kwargs.get('nightly'))

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -76,14 +76,14 @@ class PostBuildCommands(CommandBase):
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=False, binary=True)
+    @CommandBase.common_command_arguments(binary_selection=True)
     @CommandBase.allow_target_configuration
-    def run(self, servo_binary, params, debugger=False, debugger_cmd=None,
+    def run(self, servo_binary: str, params, debugger=False, debugger_cmd=None,
             headless=False, software=False, emulator=False, usb=False):
         self._run(servo_binary, params, debugger, debugger_cmd,
                   headless, software, emulator, usb)
 
-    def _run(self, servo_binary, params, debugger=False, debugger_cmd=None,
+    def _run(self, servo_binary: str, params, debugger=False, debugger_cmd=None,
              headless=False, software=False, emulator=False, usb=False):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
@@ -201,8 +201,8 @@ class PostBuildCommands(CommandBase):
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
-    @CommandBase.common_command_arguments(binary=True)
-    def rr_record(self, servo_binary, with_asan=False, params=[]):
+    @CommandBase.common_command_arguments(binary_selection=True)
+    def rr_record(self, servo_binary: str, params=[]):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import textwrap
 
+from python.servo.post_build_commands import PostBuildCommands
 import wpt
 import wpt.manifestupdate
 import wpt.run
@@ -303,9 +304,9 @@ class MachCommands(CommandBase):
              description='Run the regular web platform test suite',
              category='testing',
              parser=wpt.create_parser)
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def test_wpt(self, build_type: BuildType, with_asan=False, **kwargs):
-        return self._test_wpt(build_type=build_type, with_asan=with_asan, **kwargs)
+    @CommandBase.common_command_arguments(binary=True)
+    def test_wpt(self, servo_binary, **kwargs):
+        return self._test_wpt(servo_binary, **kwargs)
 
     @Command('test-wpt-android',
              description='Run the web platform test suite in an Android emulator',
@@ -319,13 +320,12 @@ class MachCommands(CommandBase):
             binary_args=self.in_android_emulator(build_type) + (binary_args or []),
             binary=sys.executable,
         )
-        return self._test_wpt(build_type=build_type, android=True, **kwargs)
+        return self._test_wpt(sys.executable, android=True, **kwargs)
 
     @CommandBase.allow_target_configuration
-    def _test_wpt(self, build_type: BuildType, with_asan=False, **kwargs):
+    def _test_wpt(self, servo_binary, **kwargs):
         # TODO(mrobinson): Why do we pass the wrong binary path in when running WPT on Android?
-        binary_path = self.get_binary_path(build_type, asan=with_asan)
-        return_value = wpt.run.run_tests(binary_path, **kwargs)
+        return_value = wpt.run.run_tests(servo_binary, **kwargs)
         return return_value if not kwargs["always_succeed"] else 0
 
     @Command('update-manifest',
@@ -402,16 +402,16 @@ class MachCommands(CommandBase):
 
     @Command('test-dromaeo', description='Run the Dromaeo test suite', category='testing')
     @CommandArgument('tests', default=["recommended"], nargs="...", help="Specific tests to run")
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def test_dromaeo(self, tests, build_type: BuildType):
-        return self.dromaeo_test_runner(tests, build_type)
+    @CommandBase.common_command_arguments(binary=True)
+    def test_dromaeo(self, tests, servo_binary):
+        return self.dromaeo_test_runner(tests, servo_binary)
 
     @Command('update-jquery',
              description='Update the jQuery test suite expected results',
              category='testing')
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def update_jquery(self, build_type: BuildType):
-        return self.jquery_test_runner("update", build_type)
+    @CommandBase.common_command_arguments(binary=True)
+    def update_jquery(self, servo_binary):
+        return self.jquery_test_runner("update", servo_binary)
 
     @Command('compare_dromaeo',
              description='Compare outputs of two runs of ./mach test-dromaeo command',
@@ -469,7 +469,7 @@ class MachCommands(CommandBase):
                     print("{}|{}|{}|{}".format(a1.ljust(width_col1), str(b1).ljust(width_col2),
                           str(c1).ljust(width_col3), str(d1).ljust(width_col4)))
 
-    def jquery_test_runner(self, cmd, build_type: BuildType):
+    def jquery_test_runner(self, cmd, binary):
         base_dir = path.abspath(path.join("tests", "jquery"))
         jquery_dir = path.join(base_dir, "jquery")
         run_file = path.join(base_dir, "run_jquery.py")
@@ -484,11 +484,11 @@ class MachCommands(CommandBase):
             ["git", "-C", jquery_dir, "pull"])
 
         # Check that a release servo build exists
-        bin_path = path.abspath(self.get_binary_path(build_type))
+        bin_path = path.abspath(binary)
 
         return call([run_file, cmd, bin_path, base_dir])
 
-    def dromaeo_test_runner(self, tests, build_type: BuildType):
+    def dromaeo_test_runner(self, tests, binary):
         base_dir = path.abspath(path.join("tests", "dromaeo"))
         dromaeo_dir = path.join(base_dir, "dromaeo")
         run_file = path.join(base_dir, "run_dromaeo.py")
@@ -507,7 +507,7 @@ class MachCommands(CommandBase):
             ["make", "-C", dromaeo_dir, "web"])
 
         # Check that a release servo build exists
-        bin_path = path.abspath(self.get_binary_path(build_type))
+        bin_path = path.abspath(binary)
 
         return check_call(
             [run_file, "|".join(tests), bin_path, base_dir])
@@ -764,13 +764,13 @@ tests/wpt/mozilla/tests for Servo-only tests""" % reference_path)
              category='testing')
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Servo")
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def smoketest(self, build_type: BuildType, params, with_asan=False):
+    @CommandBase.common_command_arguments(binary=True)
+    def smoketest(self, servo_binary, params):
         # We pass `-f` here so that any thread panic will cause Servo to exit,
         # preventing a panic from hanging execution. This means that these kind
         # of panics won't cause timeouts on CI.
-        return self.context.commands.dispatch('run', self.context, build_type=build_type, with_asan=with_asan,
-                                              params=params + ['-f', 'tests/html/close-on-load.html'])
+        return PostBuildCommands(self.context)._run(servo_binary,
+                                                    params + ['-f', 'tests/html/close-on-load.html'])
 
     @Command('try', description='Runs try jobs by force pushing to try branch', category='testing')
     @CommandArgument('--remote', '-r', default="origin", help='A git remote to run the try job on')

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -304,8 +304,8 @@ class MachCommands(CommandBase):
              description='Run the regular web platform test suite',
              category='testing',
              parser=wpt.create_parser)
-    @CommandBase.common_command_arguments(binary=True)
-    def test_wpt(self, servo_binary, **kwargs):
+    @CommandBase.common_command_arguments(binary_selection=True)
+    def test_wpt(self, servo_binary: str, **kwargs):
         return self._test_wpt(servo_binary, **kwargs)
 
     @Command('test-wpt-android',
@@ -323,7 +323,7 @@ class MachCommands(CommandBase):
         return self._test_wpt(sys.executable, android=True, **kwargs)
 
     @CommandBase.allow_target_configuration
-    def _test_wpt(self, servo_binary, **kwargs):
+    def _test_wpt(self, servo_binary: str, **kwargs):
         # TODO(mrobinson): Why do we pass the wrong binary path in when running WPT on Android?
         return_value = wpt.run.run_tests(servo_binary, **kwargs)
         return return_value if not kwargs["always_succeed"] else 0
@@ -402,15 +402,15 @@ class MachCommands(CommandBase):
 
     @Command('test-dromaeo', description='Run the Dromaeo test suite', category='testing')
     @CommandArgument('tests', default=["recommended"], nargs="...", help="Specific tests to run")
-    @CommandBase.common_command_arguments(binary=True)
-    def test_dromaeo(self, tests, servo_binary):
+    @CommandBase.common_command_arguments(binary_selection=True)
+    def test_dromaeo(self, tests, servo_binary: str):
         return self.dromaeo_test_runner(tests, servo_binary)
 
     @Command('update-jquery',
              description='Update the jQuery test suite expected results',
              category='testing')
-    @CommandBase.common_command_arguments(binary=True)
-    def update_jquery(self, servo_binary):
+    @CommandBase.common_command_arguments(binary_selection=True)
+    def update_jquery(self, servo_binary: str):
         return self.jquery_test_runner("update", servo_binary)
 
     @Command('compare_dromaeo',
@@ -469,7 +469,7 @@ class MachCommands(CommandBase):
                     print("{}|{}|{}|{}".format(a1.ljust(width_col1), str(b1).ljust(width_col2),
                           str(c1).ljust(width_col3), str(d1).ljust(width_col4)))
 
-    def jquery_test_runner(self, cmd, binary):
+    def jquery_test_runner(self, cmd, binary: str):
         base_dir = path.abspath(path.join("tests", "jquery"))
         jquery_dir = path.join(base_dir, "jquery")
         run_file = path.join(base_dir, "run_jquery.py")
@@ -488,7 +488,7 @@ class MachCommands(CommandBase):
 
         return call([run_file, cmd, bin_path, base_dir])
 
-    def dromaeo_test_runner(self, tests, binary):
+    def dromaeo_test_runner(self, tests, binary: str):
         base_dir = path.abspath(path.join("tests", "dromaeo"))
         dromaeo_dir = path.join(base_dir, "dromaeo")
         run_file = path.join(base_dir, "run_dromaeo.py")
@@ -764,8 +764,8 @@ tests/wpt/mozilla/tests for Servo-only tests""" % reference_path)
              category='testing')
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Servo")
-    @CommandBase.common_command_arguments(binary=True)
-    def smoketest(self, servo_binary, params):
+    @CommandBase.common_command_arguments(binary_selection=True)
+    def smoketest(self, servo_binary: str, params):
         # We pass `-f` here so that any thread panic will cause Servo to exit,
         # preventing a panic from hanging execution. This means that these kind
         # of panics won't cause timeouts on CI.


### PR DESCRIPTION
Multiple commands support specifying binary, this will unify them all so we can use any binary on any such commands (I think nightly binaries needs to start using GitHub, but this is for followup).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are mach changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
