### PR TITLE
ohos: Add FFI-APIs to navigate back and forward

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 
 use log::{debug, error, info, warn, LevelFilter};
 use napi_derive_ohos::{module_exports, napi};
-use napi_ohos::bindgen_prelude::Undefined;
 use napi_ohos::threadsafe_function::{
     ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode,
 };
@@ -85,6 +84,8 @@ enum TouchEventType {
 enum ServoAction {
     WakeUp,
     LoadUrl(String),
+    GoBack,
+    GoForward,
     TouchEvent {
         kind: TouchEventType,
         x: f32,
@@ -120,6 +121,8 @@ impl ServoAction {
         let res = match self {
             WakeUp => servo.perform_updates(),
             LoadUrl(url) => servo.load_uri(url.as_str()),
+            GoBack => servo.go_back(),
+            GoForward => servo.go_forward(),
             TouchEvent {
                 kind,
                 x,
@@ -357,9 +360,19 @@ fn init(exports: JsObject, env: Env) -> napi_ohos::Result<()> {
 }
 
 #[napi(js_name = "loadURL")]
-pub fn load_url(url: String) -> Undefined {
+pub fn load_url(url: String) {
     debug!("load url");
     call(ServoAction::LoadUrl(url)).expect("Failed to load url");
+}
+
+#[napi]
+pub fn go_back() {
+    call(ServoAction::GoBack).expect("Failed to call servo");
+}
+
+#[napi]
+pub fn go_forward() {
+    call(ServoAction::GoForward).expect("Failed to call servo");
 }
 
 #[napi(js_name = "registerURLcallback")]


### PR DESCRIPTION
To be useful it requires using the [latest version of the OH demo ArkTS app](https://github.com/jschwe/ServoDemo/commit/8aa467a223f7d80b78f3fcf6ed962c9c866f7670), but it is still compatible with older versions, as the newly added FFI functions will simply be unused in such a case.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
