### PR TITLE
Allow caching `IndependentFormattingContext::inline_content_sizes()`

### DIFF
--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -178,9 +178,7 @@ impl IndependentFormattingContext {
 
     pub fn inline_content_sizes(&mut self, layout_context: &LayoutContext) -> ContentSizes {
         match self {
-            Self::NonReplaced(inner) => inner
-                .contents
-                .inline_content_sizes(layout_context, inner.style.effective_writing_mode()),
+            Self::NonReplaced(inner) => inner.inline_content_sizes(layout_context),
             Self::Replaced(inner) => inner.contents.inline_content_sizes(&inner.style),
         }
     }


### PR DESCRIPTION
For non-replaced formatting contexts, this method redirected directly to `NonReplacedFormattingContextContents::inline_content_sizes()`, which has the actual logic for the computation.

Thus it was bypassing the cache, which is handled in `NonReplacedFormattingContext::inline_content_sizes()`.

Therefore, this patch redirects to the latter.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there shouldn't be any behavior change other than improved speed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
