### PR TITLE
Remove measurement of layout query wait time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,12 +2852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "histogram"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,7 +3760,6 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "fxhash",
- "histogram",
  "ipc-channel",
  "layout_2013",
  "log",
@@ -3787,7 +3780,6 @@ dependencies = [
  "servo_url",
  "style",
  "style_traits",
- "time 0.1.45",
  "url",
  "webrender_api",
  "webrender_traits",

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -20,7 +20,6 @@ fnv = { workspace = true }
 fxhash = { workspace = true }
 fonts = { path = "../fonts" }
 fonts_traits = { workspace = true }
-histogram = "0.6.8"
 ipc-channel = { workspace = true }
 layout = { path = "../layout", package = "layout_2013" }
 log = { workspace = true }
@@ -41,7 +40,6 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 style = { workspace = true }
 style_traits = { workspace = true }
-time = { workspace = true }
 url = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2066,10 +2066,7 @@ impl Window {
     }
 
     pub fn layout_reflow(&self, query_msg: QueryMsg) -> bool {
-        self.reflow(
-            ReflowGoal::LayoutQuery(query_msg, time::precise_time_ns()),
-            ReflowReason::Query,
-        )
+        self.reflow(ReflowGoal::LayoutQuery(query_msg), ReflowReason::Query)
     }
 
     pub fn resolved_font_style_query(&self, node: &Node, value: String) -> Option<ServoArc<Font>> {
@@ -2732,7 +2729,7 @@ fn debug_reflow_events(id: PipelineId, reflow_goal: &ReflowGoal, reason: &Reflow
         ReflowGoal::Full => "\tFull",
         ReflowGoal::TickAnimations => "\tTickAnimations",
         ReflowGoal::UpdateScrollNode(_) => "\tUpdateScrollNode",
-        ReflowGoal::LayoutQuery(ref query_msg, _) => match *query_msg {
+        ReflowGoal::LayoutQuery(ref query_msg) => match *query_msg {
             QueryMsg::ContentBox => "\tContentBoxQuery",
             QueryMsg::ContentBoxes => "\tContentBoxesQuery",
             QueryMsg::NodesFromPointQuery => "\tNodesFromPointQuery",

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -310,7 +310,7 @@ pub enum QueryMsg {
 pub enum ReflowGoal {
     Full,
     TickAnimations,
-    LayoutQuery(QueryMsg, u64),
+    LayoutQuery(QueryMsg),
 
     /// Tells layout about a single new scrolling offset from the script. The rest will
     /// remain untouched and layout won't forward this back to script.
@@ -323,7 +323,7 @@ impl ReflowGoal {
     pub fn needs_display_list(&self) -> bool {
         match *self {
             ReflowGoal::Full | ReflowGoal::TickAnimations | ReflowGoal::UpdateScrollNode(_) => true,
-            ReflowGoal::LayoutQuery(ref querymsg, _) => match *querymsg {
+            ReflowGoal::LayoutQuery(ref querymsg) => match *querymsg {
                 QueryMsg::ElementInnerTextQuery |
                 QueryMsg::InnerWindowDimensionsQuery |
                 QueryMsg::NodesFromPointQuery |
@@ -345,7 +345,7 @@ impl ReflowGoal {
     pub fn needs_display(&self) -> bool {
         match *self {
             ReflowGoal::Full | ReflowGoal::TickAnimations | ReflowGoal::UpdateScrollNode(_) => true,
-            ReflowGoal::LayoutQuery(ref querymsg, _) => match *querymsg {
+            ReflowGoal::LayoutQuery(ref querymsg) => match *querymsg {
                 QueryMsg::NodesFromPointQuery |
                 QueryMsg::TextIndexQuery |
                 QueryMsg::ElementInnerTextQuery => true,


### PR DESCRIPTION
Now that the script thread and the layout thread are the same the wait
time effectively zero, so there's no need to measure it. This also
removes one dependency and removes one use of legacy time.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just removes some effectively useless timing code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
