### PR TITLE
Remove `width` and `height` presentational hints for `<canvas>`

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -107,7 +107,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::htmlbodyelement::{HTMLBodyElement, HTMLBodyElementLayoutHelpers};
 use crate::dom::htmlbuttonelement::HTMLButtonElement;
-use crate::dom::htmlcanvaselement::{HTMLCanvasElement, LayoutHTMLCanvasElementHelpers};
+use crate::dom::htmlcanvaselement::LayoutHTMLCanvasElementHelpers;
 use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
@@ -852,8 +852,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         } else if let Some(this) = self.downcast::<HTMLHRElement>() {
             // https://html.spec.whatwg.org/multipage/#the-hr-element-2:attr-hr-width
             this.get_width()
-        } else if let Some(this) = self.downcast::<HTMLCanvasElement>() {
-            this.get_width()
         } else {
             LengthOrPercentageOrAuto::Auto
         };
@@ -886,8 +884,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         let height = if let Some(this) = self.downcast::<HTMLIFrameElement>() {
             this.get_height()
         } else if let Some(this) = self.downcast::<HTMLImageElement>() {
-            this.get_height()
-        } else if let Some(this) = self.downcast::<HTMLCanvasElement>() {
             this.get_height()
         } else {
             LengthOrPercentageOrAuto::Auto

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -17,7 +17,7 @@ use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
 use script_traits::ScriptMsg;
 use servo_media::streams::registry::MediaStreamId;
 use servo_media::streams::MediaStreamType;
-use style::attr::{AttrValue, LengthOrPercentageOrAuto};
+use style::attr::AttrValue;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{ref_filter_map, DomRefCell, Ref};
@@ -127,8 +127,6 @@ pub trait LayoutCanvasRenderingContextHelpers {
 
 pub trait LayoutHTMLCanvasElementHelpers {
     fn data(self) -> HTMLCanvasData;
-    fn get_width(self) -> LengthOrPercentageOrAuto;
-    fn get_height(self) -> LengthOrPercentageOrAuto;
     fn get_canvas_id_for_layout(self) -> CanvasId;
 }
 
@@ -159,20 +157,6 @@ impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
             height: height_attr.map_or(DEFAULT_HEIGHT, |val| val.as_uint()),
             canvas_id: self.get_canvas_id_for_layout(),
         }
-    }
-
-    fn get_width(self) -> LengthOrPercentageOrAuto {
-        self.upcast::<Element>()
-            .get_attr_for_layout(&ns!(), &local_name!("width"))
-            .map(AttrValue::as_uint_px_dimension)
-            .unwrap_or(LengthOrPercentageOrAuto::Auto)
-    }
-
-    fn get_height(self) -> LengthOrPercentageOrAuto {
-        self.upcast::<Element>()
-            .get_attr_for_layout(&ns!(), &local_name!("height"))
-            .map(AttrValue::as_uint_px_dimension)
-            .unwrap_or(LengthOrPercentageOrAuto::Auto)
     }
 
     #[allow(unsafe_code)]

--- a/tests/wpt/meta/css/css-flexbox/canvas-contain-size.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/canvas-contain-size.html.ini
@@ -1,2 +1,0 @@
-[canvas-contain-size.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-017.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-017.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-017.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-023.html.ini
+++ b/tests/wpt/meta/css/css-sizing/aspect-ratio/replaced-element-023.html.ini
@@ -1,2 +1,0 @@
-[replaced-element-023.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/replaced-fractional-height-from-aspect-ratio-2.html.ini
+++ b/tests/wpt/meta/css/css-sizing/replaced-fractional-height-from-aspect-ratio-2.html.ini
@@ -1,3 +1,0 @@
-[replaced-fractional-height-from-aspect-ratio-2.html]
-  [canvas 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/replaced-max-size-saturation.html.ini
+++ b/tests/wpt/meta/css/css-sizing/replaced-max-size-saturation.html.ini
@@ -1,2 +1,0 @@
-[replaced-max-size-saturation.html]
-  expected: FAIL

--- a/tests/wpt/tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/canvas-dimension-attributes.html
+++ b/tests/wpt/tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/canvas-dimension-attributes.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Canvas width and height attributes are used as the surface size, and also to infer aspect ratio</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images">
+<link rel="match" href="/css/reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+    Unlike <img>, <canvas> doesn't map its dimension attributes to the dimension properties.
+    Therefore, the 1st <canvas> should be 100px wide since it infers an aspect ratio of 150 / 150.
+    The 2nd <canvas> should be 100px tall since it infers an aspect ratio of 150 / 300.
+    The 3rd <canvas> should be 150px wide since it infers an aspect ratio of 150 / 100.
+    The 4th <canvas> should be 100px tall since it infers an aspect ratio of 150 / 300.">
+
+<style>
+div {
+  background: red;
+  width: 200px;
+  font-size: 0;
+}
+canvas {
+  vertical-align: top;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div>
+  <canvas id="canvas" width="150" style="background: green; height: 100px"></canvas>
+  <canvas id="canvas" height="300" style="background: green; width: 100px"></canvas>
+  <canvas id="canvas" width="150" height="100" style="background: green; height: 100px"></canvas>
+  <canvas id="canvas" width="150" height="300" style="background: green; width: 50px"></canvas>
+</div>


### PR DESCRIPTION
According to HTML, the `width` and `height` attributes should only set the natural sizes and the aspect ratio.
The `width` and `height` properties should stay as `initial` by default.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
