### PR TITLE
clippy: Fix warnings in `layout_2020`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1114,7 +1114,7 @@ impl InitialFlexLineLayout<'_> {
         let item_layout_results = items
             .iter_mut()
             .zip(&item_used_main_sizes)
-            .map(|(item, &used_main_size)| item.layout(used_main_size, &flex_context, None))
+            .map(|(item, &used_main_size)| item.layout(used_main_size, flex_context, None))
             .collect::<Vec<_>>();
 
         // https://drafts.csswg.org/css-flexbox/#algo-cross-line
@@ -1411,7 +1411,7 @@ impl InitialFlexLineLayout<'_> {
                 //  treating this used size as its definite cross size
                 //  so that percentage-sized children can be resolved.”
                 *item_layout_result =
-                    item.layout(*used_main_size, &flex_context, Some(used_cross_size));
+                    item.layout(*used_main_size, flex_context, Some(used_cross_size));
             }
 
             // TODO: This also needs to check whether we have a compatible writing mode.

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1442,9 +1442,7 @@ impl<'layout_dta> InlineFormattingContextLayout<'layout_dta> {
             assert!(!will_break);
         }
 
-        self.current_line
-            .line_items
-            .extend(segment_items.into_iter());
+        self.current_line.line_items.extend(segment_items);
         self.current_line.has_content |= self.current_line_segment.has_content;
 
         self.current_line_segment.reset();
@@ -1964,7 +1962,6 @@ impl IndependentFormattingContext {
                     non_replaced
                         .inline_content_sizes(layout.layout_context)
                         .shrink_to_fit(available_size)
-                        .into()
                 });
 
                 // https://drafts.csswg.org/css2/visudet.html#min-max-widths

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -374,7 +374,7 @@ impl TextRun {
                     specified_word_spacing.to_used_value(Au::from_f64_px(space_width))
                 });
 
-                let mut flags = flags.clone();
+                let mut flags = flags;
                 if segment.bidi_level.is_rtl() {
                     flags.insert(ShapingFlags::RTL_FLAG);
                 }


### PR DESCRIPTION
Fix warnings in `layout_2020`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors