### PR TITLE
Display the process type and PID in log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,10 +198,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -1009,6 +1053,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -1924,15 +1974,15 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
  "humantime",
- "is-terminal",
  "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -3964,6 +4014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,7 +4402,7 @@ dependencies = [
  "devtools_traits",
  "dpi",
  "embedder_traits",
- "env_logger 0.10.2",
+ "env_logger 0.11.5",
  "euclid",
  "fonts",
  "gaol",
@@ -8099,6 +8155,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ devtools_traits = { path = "components/shared/devtools" }
 dpi = { version = "0.1" }
 embedder_traits = { path = "components/shared/embedder" }
 encoding_rs = "0.8"
-env_logger = "0.10"
+env_logger = "0.11"
 euclid = "0.22"
 fnv = "1.0"
 fonts_traits = { path = "components/shared/fonts" }


### PR DESCRIPTION
This adds the type of process (currently either `MAIN` or `CONT` and the process id to log lines. That makes it easier to figure out what's running where in multiprocess mode. I also added the source line along with the module path since it makes it easier to jump to the log source. 

I had to update `log` to 0.11 to be able to style the log level.

Here's a comparison when running `RUST_LOG=info ./mach run --multiprocess https://example.com` 

Before:
```log
[2024-08-28T00:46:41Z INFO  servoshell::desktop::app] window scale factor changed to 1.25, setting scale factor to 1.25
[2024-08-28T00:46:41Z WARN  constellation::constellation] Trying to get an event-loop from an unknown browsing context group
[2024-08-28T00:46:41Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:41Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:41Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:41Z WARN  constellation::constellation] Pipeline(1,1): Visibility change for closed pipeline
[2024-08-28T00:46:41Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:41Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:41Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:41Z INFO  net::cookie_storage]  === COOKIES SENT: 
[2024-08-28T00:46:41Z INFO  net::http_loader] GET request for https://example.com/
[2024-08-28T00:46:42Z INFO  net::http_loader] got 200 response for "https://example.com/"
[2024-08-28T00:46:42Z WARN  script::timers] Resuming an already resumed timer.
[2024-08-28T00:46:42Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:42Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:42Z WARN  webrender::device::gl] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[2024-08-28T00:46:42Z INFO  script::dom::bindings::refcounted] growing refcounted references by 3
[2024-08-28T00:46:42Z INFO  script::dom::bindings::refcounted] removing 0 refcounted references
```

After:
```
[MAIN 1202347 2024-08-28T00:56:30Z INFO  servoshell::desktop::app:246] window scale factor changed to 1.25, setting scale factor to 1.25
[MAIN 1202347 2024-08-28T00:56:30Z WARN  constellation::constellation:985] Trying to get an event-loop from an unknown browsing context group
[MAIN 1202347 2024-08-28T00:56:30Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:30Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:30Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:30Z WARN  constellation::constellation:4293] Pipeline(1,1): Visibility change for closed pipeline
[MAIN 1202347 2024-08-28T00:56:30Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:30Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:30Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:31Z INFO  net::cookie_storage:208]  === COOKIES SENT: 
[MAIN 1202347 2024-08-28T00:56:31Z INFO  net::http_loader:1688] GET request for https://example.com/
[MAIN 1202347 2024-08-28T00:56:31Z INFO  net::http_loader:1791] got 200 response for "https://example.com/"
[CONT 1202410 2024-08-28T00:56:31Z WARN  script::timers:283] Resuming an already resumed timer.
[MAIN 1202347 2024-08-28T00:56:31Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:31Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[MAIN 1202347 2024-08-28T00:56:31Z WARN  webrender::device::gl:4647] Cropping texture upload Box2D((0, 0), (0, 1)) to None
[CONT 1202410 2024-08-28T00:56:31Z INFO  script::dom::bindings::refcounted:261] growing refcounted references by 3
[CONT 1202410 2024-08-28T00:56:31Z INFO  script::dom::bindings::refcounted:290] removing 0 refcounted references
```

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
