### PR TITLE
android: Remove unused imports in android.rs

### DIFF
--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -9,13 +9,11 @@ mod simpleservo;
 use std::collections::HashMap;
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
-use std::thread;
 
 use android_logger::{self, Config, FilterBuilder};
 use jni::objects::{GlobalRef, JClass, JObject, JString, JValue, JValueOwned};
 use jni::sys::{jboolean, jfloat, jint, jobject, jstring, JNI_TRUE};
 use jni::{JNIEnv, JavaVM};
-use libc::{dup2, pipe, read};
 use log::{debug, error, info, warn};
 use simpleservo::{
     DeviceIntRect, EventLoopWaker, InitOptions, InputMethodType, MediaSessionPlaybackState,


### PR DESCRIPTION
Moved this commit from the OpenHarmony vsync PR into a separate PR, since the vsync one has been sitting for a while.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors