### PR TITLE
webgpu: Clean up `GPUCommandEncoders` and add some validation

### DIFF
--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -2,26 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
-
 use dom_struct::dom_struct;
 use webgpu::{WebGPU, WebGPUCommandBuffer, WebGPURequest};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUCommandBufferMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::gpubuffer::GPUBuffer;
-
-impl Eq for DomRoot<GPUBuffer> {}
-impl Hash for DomRoot<GPUBuffer> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id().hash(state);
-    }
-}
 
 #[dom_struct]
 pub struct GPUCommandBuffer {
@@ -32,14 +21,12 @@ pub struct GPUCommandBuffer {
     label: DomRefCell<USVString>,
     #[no_trace]
     command_buffer: WebGPUCommandBuffer,
-    buffers: DomRefCell<HashSet<Dom<GPUBuffer>>>,
 }
 
 impl GPUCommandBuffer {
     fn new_inherited(
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
-        buffers: HashSet<DomRoot<GPUBuffer>>,
         label: USVString,
     ) -> Self {
         Self {
@@ -47,7 +34,6 @@ impl GPUCommandBuffer {
             reflector_: Reflector::new(),
             label: DomRefCell::new(label),
             command_buffer,
-            buffers: DomRefCell::new(buffers.into_iter().map(|b| Dom::from_ref(&*b)).collect()),
         }
     }
 
@@ -55,14 +41,12 @@ impl GPUCommandBuffer {
         global: &GlobalScope,
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
-        buffers: HashSet<DomRoot<GPUBuffer>>,
         label: USVString,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUCommandBuffer::new_inherited(
                 channel,
                 command_buffer,
-                buffers,
                 label,
             )),
             global,

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -7,14 +7,12 @@ use webgpu::wgc::command as wgpu_com;
 use webgpu::{self, wgt, WebGPU, WebGPUComputePass, WebGPURenderPass, WebGPURequest};
 
 use super::bindings::error::Fallible;
-use super::gpuconvert::convert_label;
+use super::gpuconvert::{convert_color, convert_label};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCommandBufferDescriptor, GPUCommandEncoderMethods, GPUComputePassDescriptor, GPUExtent3D,
     GPUImageCopyBuffer, GPUImageCopyTexture, GPURenderPassDescriptor, GPUSize64,
 };
-use crate::dom::bindings::codegen::UnionTypes::DoubleSequenceOrGPUColorDict;
-use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
@@ -125,7 +123,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
     fn BeginRenderPass(
         &self,
         descriptor: &GPURenderPassDescriptor,
-    ) -> DomRoot<GPURenderPassEncoder> {
+    ) -> Fallible<DomRoot<GPURenderPassEncoder>> {
         let depth_stencil_attachment = descriptor.depthStencilAttachment.as_ref().map(|depth| {
             wgpu_com::RenderPassDepthStencilAttachment {
                 depth: wgpu_com::PassChannel {
@@ -147,44 +145,25 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
         let color_attachments = descriptor
             .colorAttachments
             .iter()
-            .map(|color| {
+            .map(|color| -> Fallible<_> {
                 let channel = wgpu_com::PassChannel {
                     load_op: convert_load_op(Some(color.loadOp)),
                     store_op: convert_store_op(Some(color.storeOp)),
-                    clear_value: if let Some(clear_val) = &color.clearValue {
-                        match clear_val {
-                            DoubleSequenceOrGPUColorDict::DoubleSequence(s) => {
-                                let mut w = s.clone();
-                                if w.len() < 3 {
-                                    w.resize(3, Finite::wrap(0.0f64));
-                                }
-                                w.resize(4, Finite::wrap(1.0f64));
-                                wgt::Color {
-                                    r: *w[0],
-                                    g: *w[1],
-                                    b: *w[2],
-                                    a: *w[3],
-                                }
-                            },
-                            DoubleSequenceOrGPUColorDict::GPUColorDict(d) => wgt::Color {
-                                r: *d.r,
-                                g: *d.g,
-                                b: *d.b,
-                                a: *d.a,
-                            },
-                        }
-                    } else {
-                        wgt::Color::TRANSPARENT
-                    },
+                    clear_value: color
+                        .clearValue
+                        .as_ref()
+                        .map(|color| convert_color(color))
+                        .transpose()?
+                        .unwrap_or_default(),
                     read_only: false,
                 };
-                Some(wgpu_com::RenderPassColorAttachment {
+                Ok(Some(wgpu_com::RenderPassColorAttachment {
                     resolve_target: color.resolveTarget.as_ref().map(|t| t.id().0),
                     channel,
                     view: color.view.id().0,
-                })
+                }))
             })
-            .collect::<Vec<_>>();
+            .collect::<Fallible<Vec<_>>>()?;
         let render_pass_id = self
             .global()
             .wgpu_id_hub()
@@ -201,13 +180,13 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             warn!("Failed to send WebGPURequest::BeginRenderPass {e:?}");
         }
 
-        GPURenderPassEncoder::new(
+        Ok(GPURenderPassEncoder::new(
             &self.global(),
             self.channel.clone(),
             WebGPURenderPass(render_pass_id),
             self,
             descriptor.parent.label.clone(),
-        )
+        ))
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertobuffer>

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -244,7 +244,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .send(WebGPURequest::CopyBufferToTexture {
                 command_encoder_id: self.encoder.0,
                 source: convert_ic_buffer(source),
-                destination: convert_ic_texture(destination),
+                destination: convert_ic_texture(destination)?,
                 copy_size: convert_texture_size(&copy_size)?,
             })
             .expect("Failed to send CopyBufferToTexture");
@@ -263,7 +263,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .0
             .send(WebGPURequest::CopyTextureToBuffer {
                 command_encoder_id: self.encoder.0,
-                source: convert_ic_texture(source),
+                source: convert_ic_texture(source)?,
                 destination: convert_ic_buffer(destination),
                 copy_size: convert_texture_size(&copy_size)?,
             })
@@ -283,8 +283,8 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             .0
             .send(WebGPURequest::CopyTextureToTexture {
                 command_encoder_id: self.encoder.0,
-                source: convert_ic_texture(source),
-                destination: convert_ic_texture(destination),
+                source: convert_ic_texture(source)?,
+                destination: convert_ic_texture(destination)?,
                 copy_size: convert_texture_size(&copy_size)?,
             })
             .expect("Failed to send CopyTextureToTexture");

--- a/components/script/dom/gpuconvert.rs
+++ b/components/script/dom/gpuconvert.rs
@@ -11,7 +11,7 @@ use webgpu::wgt::{self, AstcBlock, AstcChannel};
 use super::bindings::error::Error;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupLayoutEntry, GPUBlendComponent, GPUBlendFactor, GPUBlendOperation,
-    GPUBufferBindingType, GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode,
+    GPUBufferBindingType, GPUColor, GPUCompareFunction, GPUCullMode, GPUExtent3D, GPUFilterMode,
     GPUFrontFace, GPUImageCopyBuffer, GPUImageCopyTexture, GPUImageDataLayout, GPUIndexFormat,
     GPULoadOp, GPUObjectDescriptorBase, GPUOrigin3D, GPUPrimitiveState, GPUPrimitiveTopology,
     GPUSamplerBindingType, GPUStencilOperation, GPUStorageTextureAccess, GPUStoreOp,
@@ -554,4 +554,28 @@ pub fn convert_bind_group_layout_entry(
         ty,
         count: None,
     }))
+}
+
+pub fn convert_color(color: &GPUColor) -> Fallible<wgt::Color> {
+    match color {
+        GPUColor::DoubleSequence(s) => {
+            // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpucolor-shape
+            if s.len() != 4 {
+                Err(Error::Type("GPUColor sequence must be len 4".to_string()))
+            } else {
+                Ok(wgt::Color {
+                    r: *s[0],
+                    g: *s[1],
+                    b: *s[2],
+                    a: *s[3],
+                })
+            }
+        },
+        GPUColor::GPUColorDict(d) => Ok(wgt::Color {
+            r: *d.r,
+            g: *d.g,
+            b: *d.b,
+            a: *d.a,
+        }),
+    }
 }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -761,7 +761,9 @@ impl GPUDeviceMethods for GPUDevice {
             .send(WebGPURequest::CreateCommandEncoder {
                 device_id: self.device.0,
                 command_encoder_id,
-                label: convert_label(&descriptor.parent),
+                desc: wgt::CommandEncoderDescriptor {
+                    label: convert_label(&descriptor.parent),
+                },
             })
             .expect("Failed to create WebGPU command encoder");
 

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -7,7 +7,6 @@
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::num::NonZeroU64;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
@@ -29,6 +28,7 @@ use super::bindings::codegen::Bindings::WebGPUBinding::{
 use super::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use super::bindings::error::Fallible;
 use super::gpu::AsyncWGPUListener;
+use super::gpuconvert::convert_bind_group_layout_entry;
 use super::gpudevicelostinfo::GPUDeviceLostInfo;
 use super::gpupipelineerror::GPUPipelineError;
 use super::gpusupportedlimits::GPUSupportedLimits;
@@ -37,13 +37,12 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBindingResource, GPUBufferBindingType,
-    GPUBufferDescriptor, GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor,
-    GPUDeviceLostReason, GPUDeviceMethods, GPUErrorFilter, GPUPipelineLayoutDescriptor,
-    GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor, GPUSamplerBindingType,
-    GPUSamplerDescriptor, GPUShaderModuleDescriptor, GPUStorageTextureAccess,
-    GPUSupportedLimitsMethods, GPUTextureDescriptor, GPUTextureDimension, GPUTextureSampleType,
-    GPUUncapturedErrorEventInit, GPUVertexStepMode,
+    GPUBindGroupDescriptor, GPUBindGroupLayoutDescriptor, GPUBindingResource, GPUBufferDescriptor,
+    GPUCommandEncoderDescriptor, GPUComputePipelineDescriptor, GPUDeviceLostReason,
+    GPUDeviceMethods, GPUErrorFilter, GPUPipelineLayoutDescriptor,
+    GPURenderBundleEncoderDescriptor, GPURenderPipelineDescriptor, GPUSamplerDescriptor,
+    GPUShaderModuleDescriptor, GPUSupportedLimitsMethods, GPUTextureDescriptor,
+    GPUTextureDimension, GPUUncapturedErrorEventInit, GPUVertexStepMode,
 };
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
@@ -63,7 +62,6 @@ use crate::dom::gpuconvert::{
     convert_address_mode, convert_blend_component, convert_compare_function, convert_filter_mode,
     convert_label, convert_primitive_state, convert_stencil_op, convert_texture_format,
     convert_texture_size_to_dict, convert_texture_size_to_wgt, convert_vertex_format,
-    convert_view_dimension,
 };
 use crate::dom::gpupipelinelayout::GPUPipelineLayout;
 use crate::dom::gpuqueue::GPUQueue;
@@ -484,91 +482,21 @@ impl GPUDeviceMethods for GPUDevice {
         &self,
         descriptor: &GPUBindGroupLayoutDescriptor,
     ) -> Fallible<DomRoot<GPUBindGroupLayout>> {
-        // TODO(sagudev): pass invalid bits to wgpu
-        let mut valid = true;
         let entries = descriptor
             .entries
             .iter()
-            .map(|bind| {
-                let visibility = match wgt::ShaderStages::from_bits(bind.visibility) {
-                    Some(visibility) => visibility,
-                    None => {
-                        valid = false;
-                        wgt::ShaderStages::empty()
-                    },
-                };
-                let ty = if let Some(buffer) = &bind.buffer {
-                    wgt::BindingType::Buffer {
-                        ty: match buffer.type_ {
-                            GPUBufferBindingType::Uniform => wgt::BufferBindingType::Uniform,
-                            GPUBufferBindingType::Storage => {
-                                wgt::BufferBindingType::Storage { read_only: false }
-                            },
-                            GPUBufferBindingType::Read_only_storage => {
-                                wgt::BufferBindingType::Storage { read_only: true }
-                            },
-                        },
-                        has_dynamic_offset: buffer.hasDynamicOffset,
-                        min_binding_size: NonZeroU64::new(buffer.minBindingSize),
-                    }
-                } else if let Some(sampler) = &bind.sampler {
-                    wgt::BindingType::Sampler(match sampler.type_ {
-                        GPUSamplerBindingType::Filtering => wgt::SamplerBindingType::Filtering,
-                        GPUSamplerBindingType::Non_filtering => {
-                            wgt::SamplerBindingType::NonFiltering
-                        },
-                        GPUSamplerBindingType::Comparison => wgt::SamplerBindingType::Comparison,
-                    })
-                } else if let Some(storage) = &bind.storageTexture {
-                    wgt::BindingType::StorageTexture {
-                        access: match storage.access {
-                            GPUStorageTextureAccess::Write_only => {
-                                wgt::StorageTextureAccess::WriteOnly
-                            },
-                        },
-                        format: self.validate_texture_format_required_features(&storage.format)?,
-                        view_dimension: convert_view_dimension(storage.viewDimension),
-                    }
-                } else if let Some(texture) = &bind.texture {
-                    wgt::BindingType::Texture {
-                        sample_type: match texture.sampleType {
-                            GPUTextureSampleType::Float => {
-                                wgt::TextureSampleType::Float { filterable: true }
-                            },
-                            GPUTextureSampleType::Unfilterable_float => {
-                                wgt::TextureSampleType::Float { filterable: false }
-                            },
-                            GPUTextureSampleType::Depth => wgt::TextureSampleType::Depth,
-                            GPUTextureSampleType::Sint => wgt::TextureSampleType::Sint,
-                            GPUTextureSampleType::Uint => wgt::TextureSampleType::Uint,
-                        },
-                        view_dimension: convert_view_dimension(texture.viewDimension),
-                        multisampled: texture.multisampled,
-                    }
-                } else {
-                    valid = false;
-                    todo!("Handle error");
-                };
+            .map(|bgle| convert_bind_group_layout_entry(bgle, &self))
+            .collect::<Fallible<Result<Vec<_>, _>>>()?;
 
-                Ok(wgt::BindGroupLayoutEntry {
-                    binding: bind.binding,
-                    visibility,
-                    ty,
-                    count: None,
-                })
-            })
-            .collect::<Fallible<Vec<_>>>()?;
-
-        let desc = if valid {
-            Some(wgpu_bind::BindGroupLayoutDescriptor {
+        let desc = match entries {
+            Ok(entries) => Some(wgpu_bind::BindGroupLayoutDescriptor {
                 label: convert_label(&descriptor.parent),
                 entries: Cow::Owned(entries),
-            })
-        } else {
-            self.dispatch_error(webgpu::Error::Validation(String::from(
-                "Invalid GPUShaderStage",
-            )));
-            None
+            }),
+            Err(error) => {
+                self.dispatch_error(error);
+                None
+            },
         };
 
         let bind_group_layout_id = self

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -61,7 +61,7 @@ use crate::dom::gpucomputepipeline::GPUComputePipeline;
 use crate::dom::gpuconvert::{
     convert_address_mode, convert_blend_component, convert_compare_function, convert_filter_mode,
     convert_label, convert_primitive_state, convert_stencil_op, convert_texture_format,
-    convert_texture_size_to_dict, convert_texture_size_to_wgt, convert_vertex_format,
+    convert_texture_size, convert_vertex_format,
 };
 use crate::dom::gpupipelinelayout::GPUPipelineLayout;
 use crate::dom::gpuqueue::GPUQueue;
@@ -778,11 +778,10 @@ impl GPUDeviceMethods for GPUDevice {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
     fn CreateTexture(&self, descriptor: &GPUTextureDescriptor) -> Fallible<DomRoot<GPUTexture>> {
-        // TODO(sagudev): This should be https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpuextent3d-shape
-        let size = convert_texture_size_to_dict(&descriptor.size);
+        let size = convert_texture_size(&descriptor.size)?;
         let desc = wgpu_res::TextureDescriptor {
             label: convert_label(&descriptor.parent),
-            size: convert_texture_size_to_wgt(&size),
+            size,
             mip_level_count: descriptor.mipLevelCount,
             sample_count: descriptor.sampleCount,
             dimension: match descriptor.dimension {

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -22,10 +22,7 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubuffer::GPUBuffer;
 use crate::dom::gpucommandbuffer::GPUCommandBuffer;
-use crate::dom::gpuconvert::{
-    convert_ic_texture, convert_image_data_layout, convert_texture_size_to_dict,
-    convert_texture_size_to_wgt,
-};
+use crate::dom::gpuconvert::{convert_ic_texture, convert_image_data_layout, convert_texture_size};
 use crate::dom::gpudevice::GPUDevice;
 use crate::dom::promise::Promise;
 
@@ -168,7 +165,7 @@ impl GPUQueueMethods for GPUQueue {
 
         let texture_cv = convert_ic_texture(destination);
         let texture_layout = convert_image_data_layout(data_layout);
-        let write_size = convert_texture_size_to_wgt(&convert_texture_size_to_dict(&size));
+        let write_size = convert_texture_size(&size)?;
         let final_data = IpcSharedMemory::from_bytes(&bytes);
 
         if let Err(e) = self.channel.0.send(WebGPURequest::WriteTexture {

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -163,7 +163,7 @@ impl GPUQueueMethods for GPUQueue {
             return Err(Error::Operation);
         }
 
-        let texture_cv = convert_ic_texture(destination);
+        let texture_cv = convert_ic_texture(destination)?;
         let texture_layout = convert_image_data_layout(data_layout);
         let write_size = convert_texture_size(&size)?;
         let final_data = IpcSharedMemory::from_bytes(&bytes);

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -12,7 +12,7 @@ use webgpu::{wgt, WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 use super::bindings::error::Fallible;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
-    GPUExtent3DDict, GPUTextureAspect, GPUTextureDimension, GPUTextureFormat, GPUTextureMethods,
+    GPUTextureAspect, GPUTextureDimension, GPUTextureFormat, GPUTextureMethods,
     GPUTextureViewDescriptor,
 };
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
@@ -33,8 +33,9 @@ pub struct GPUTexture {
     #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
-    #[ignore_malloc_size_of = "defined in webgpu"]
-    texture_size: GPUExtent3DDict,
+    #[ignore_malloc_size_of = "defined in wgpu"]
+    #[no_trace]
+    texture_size: wgt::Extent3d,
     mip_level_count: u32,
     sample_count: u32,
     dimension: GPUTextureDimension,
@@ -49,7 +50,7 @@ impl GPUTexture {
         texture: WebGPUTexture,
         device: &GPUDevice,
         channel: WebGPU,
-        texture_size: GPUExtent3DDict,
+        texture_size: wgt::Extent3d,
         mip_level_count: u32,
         sample_count: u32,
         dimension: GPUTextureDimension,
@@ -79,7 +80,7 @@ impl GPUTexture {
         texture: WebGPUTexture,
         device: &GPUDevice,
         channel: WebGPU,
-        texture_size: GPUExtent3DDict,
+        texture_size: wgt::Extent3d,
         mip_level_count: u32,
         sample_count: u32,
         dimension: GPUTextureDimension,
@@ -230,7 +231,7 @@ impl GPUTextureMethods for GPUTexture {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-depthorarraylayers>
     fn DepthOrArrayLayers(&self) -> u32 {
-        self.texture_size.depthOrArrayLayers
+        self.texture_size.depth_or_array_layers
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-miplevelcount>

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -874,7 +874,7 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 interface GPUCommandEncoder {
     [NewObject]
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
-    [NewObject]
+    [NewObject, Throws]
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
 
     undefined copyBufferToBuffer(
@@ -952,6 +952,7 @@ interface GPURenderPassEncoder {
     undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
                              GPUIntegerCoordinate width, GPUIntegerCoordinate height);
 
+    [Throws]
     undefined setBlendConstant(GPUColor color);
     undefined setStencilReference(GPUStencilValue reference);
 

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -884,16 +884,19 @@ interface GPUCommandEncoder {
         GPUSize64 destinationOffset,
         GPUSize64 size);
 
+    [Throws]
     undefined copyBufferToTexture(
         GPUImageCopyBuffer source,
         GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
+    [Throws]
     undefined copyTextureToBuffer(
         GPUImageCopyTexture source,
         GPUImageCopyBuffer destination,
         GPUExtent3D copySize);
 
+    [Throws]
     undefined copyTextureToTexture(
         GPUImageCopyTexture source,
         GPUImageCopyTexture destination,

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -462,10 +462,12 @@ dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
 dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
+
     GPUBufferBindingLayout buffer;
     GPUSamplerBindingLayout sampler;
     GPUTextureBindingLayout texture;
     GPUStorageTextureBindingLayout storageTexture;
+    GPUExternalTextureBindingLayout externalTexture;
 };
 
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
@@ -514,12 +516,17 @@ dictionary GPUTextureBindingLayout {
 
 enum GPUStorageTextureAccess {
     "write-only",
+    "read-only",
+    "read-write",
 };
 
 dictionary GPUStorageTextureBindingLayout {
     GPUStorageTextureAccess access = "write-only";
     required GPUTextureFormat format;
     GPUTextureViewDimension viewDimension = "2d";
+};
+
+dictionary GPUExternalTextureBindingLayout {
 };
 
 [Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -5,8 +5,6 @@
 //! IPC messages that are received in wgpu thread
 //! (usually from script thread more specifically from dom objects)
 
-use std::borrow::Cow;
-
 use arrayvec::ArrayVec;
 use base::id::PipelineId;
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
@@ -27,6 +25,7 @@ use wgc::resource::{
     BufferDescriptor, SamplerDescriptor, TextureDescriptor, TextureViewDescriptor,
 };
 use wgpu_core::command::{RenderPassColorAttachment, RenderPassDepthStencilAttachment};
+use wgpu_core::Label;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
 use crate::identity::*;
@@ -46,9 +45,7 @@ pub enum WebGPURequest {
     CommandEncoderFinish {
         command_encoder_id: id::CommandEncoderId,
         device_id: id::DeviceId,
-        is_error: bool,
-        // TODO(zakorgy): Serialize CommandBufferDescriptor in wgpu-core
-        // wgc::command::CommandBufferDescriptor,
+        desc: wgt::CommandBufferDescriptor<Label<'static>>,
     },
     CopyBufferToBuffer {
         command_encoder_id: id::CommandEncoderId,
@@ -93,10 +90,8 @@ pub enum WebGPURequest {
     },
     CreateCommandEncoder {
         device_id: id::DeviceId,
-        // TODO(zakorgy): Serialize CommandEncoderDescriptor in wgpu-core
-        // wgc::command::CommandEncoderDescriptor,
         command_encoder_id: id::CommandEncoderId,
-        label: Option<Cow<'static, str>>,
+        desc: wgt::CommandEncoderDescriptor<Label<'static>>,
     },
     CreateComputePipeline {
         device_id: id::DeviceId,
@@ -203,7 +198,7 @@ pub enum WebGPURequest {
     BeginComputePass {
         command_encoder_id: id::CommandEncoderId,
         compute_pass_id: ComputePassId,
-        label: Option<Cow<'static, str>>,
+        label: Label<'static>,
         device_id: id::DeviceId,
     },
     ComputePassSetPipeline {
@@ -240,7 +235,7 @@ pub enum WebGPURequest {
     BeginRenderPass {
         command_encoder_id: id::CommandEncoderId,
         render_pass_id: RenderPassId,
-        label: Option<Cow<'static, str>>,
+        label: Label<'static>,
         color_attachments: Vec<Option<RenderPassColorAttachment>>,
         depth_stencil_attachment: Option<RenderPassDepthStencilAttachment>,
         device_id: id::DeviceId,

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -144,7 +144,7 @@ pub enum WebGPURequest {
     CreateTexture {
         device_id: id::DeviceId,
         texture_id: id::TextureId,
-        descriptor: Option<TextureDescriptor<'static>>,
+        descriptor: TextureDescriptor<'static>,
     },
     CreateTextureView {
         texture_id: id::TextureId,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -230,21 +230,15 @@ impl WGPU {
                     WebGPURequest::CommandEncoderFinish {
                         command_encoder_id,
                         device_id,
-                        is_error,
+                        desc,
                     } => {
                         let global = &self.global;
-                        let result = if is_error {
-                            Err(Error::Validation(String::from("Invalid GPUCommandEncoder")))
-                        } else if let Some(err) =
+                        let result = if let Some(err) =
                             self.error_command_encoders.get(&command_encoder_id)
                         {
                             Err(Error::Validation(err.clone()))
-                        } else if let Some(error) = global
-                            .command_encoder_finish(
-                                command_encoder_id,
-                                &wgt::CommandBufferDescriptor::default(),
-                            )
-                            .1
+                        } else if let Some(error) =
+                            global.command_encoder_finish(command_encoder_id, &desc).1
                         {
                             Err(Error::from_error(error))
                         } else {
@@ -363,10 +357,9 @@ impl WGPU {
                     WebGPURequest::CreateCommandEncoder {
                         device_id,
                         command_encoder_id,
-                        label,
+                        desc,
                     } => {
                         let global = &self.global;
-                        let desc = wgt::CommandEncoderDescriptor { label };
                         let (_, error) = global.device_create_command_encoder(
                             device_id,
                             &desc,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -579,11 +579,9 @@ impl WGPU {
                         descriptor,
                     } => {
                         let global = &self.global;
-                        if let Some(desc) = descriptor {
-                            let (_, error) =
-                                global.device_create_texture(device_id, &desc, Some(texture_id));
-                            self.maybe_dispatch_wgpu_error(device_id, error);
-                        }
+                        let (_, error) =
+                            global.device_create_texture(device_id, &descriptor, Some(texture_id));
+                        self.maybe_dispatch_wgpu_error(device_id, error);
                     },
                     WebGPURequest::CreateTextureView {
                         texture_id,


### PR DESCRIPTION
This clears up 3 `TODO(sagudev)` comments, 5 `TODO` comments in total. Some stuff is from https://github.com/servo/servo/pull/30504

Reviewable per commit.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
