### PR TITLE
ci: Use Servo's `wpt` repository for WPT export

### DIFF
--- a/python/wpt/export.py
+++ b/python/wpt/export.py
@@ -27,7 +27,7 @@ def main() -> int:
     success = WPTSync(
         servo_repo='servo/servo',
         wpt_repo='web-platform-tests/wpt',
-        downstream_wpt_repo='servo-wpt-sync/web-platform-tests',
+        downstream_wpt_repo='servo/wpt',
         servo_path='./servo',
         wpt_path='./wpt',
         github_api_token=os.environ['WPT_SYNC_TOKEN'],

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -363,8 +363,8 @@ class TestFullSyncRun(unittest.TestCase):
         self.assertListEqual(
             self.run_test("opened.json", ["18746.diff"]),
             [
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_18746",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_18746→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_18746",
+                "OpenPRStep:servo/wpt/servo_export_18746→wpt/wpt#1",
                 "CommentStep:servo/servo#18746:🤖 Opened new upstream WPT pull request "
                 "(wpt/wpt#1) with upstreamable changes.",
             ],
@@ -374,8 +374,8 @@ class TestFullSyncRun(unittest.TestCase):
         self.assertListEqual(
             self.run_test("opened.json", ["move-into-wpt.diff"]),
             [
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_18746",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_18746→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_18746",
+                "OpenPRStep:servo/wpt/servo_export_18746→wpt/wpt#1",
                 "CommentStep:servo/servo#18746:🤖 Opened new upstream WPT pull request "
                 "(wpt/wpt#1) with upstreamable changes.",
             ],
@@ -395,8 +395,8 @@ class TestFullSyncRun(unittest.TestCase):
                 ],
             ),
             [
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_18746",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_18746→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_18746",
+                "OpenPRStep:servo/wpt/servo_export_18746→wpt/wpt#1",
                 "CommentStep:servo/servo#18746:🤖 Opened new upstream WPT pull request "
                 "(wpt/wpt#1) with upstreamable changes.",
             ],
@@ -406,8 +406,8 @@ class TestFullSyncRun(unittest.TestCase):
         self.assertListEqual(
             self.run_test("opened.json", ["move-out-of-wpt.diff"]),
             [
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_18746",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_18746→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_18746",
+                "OpenPRStep:servo/wpt/servo_export_18746→wpt/wpt#1",
                 "CommentStep:servo/servo#18746:🤖 Opened new upstream WPT pull request "
                 "(wpt/wpt#1) with upstreamable changes.",
             ],
@@ -436,11 +436,11 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "opened.json",
                 ["18746.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_18746", 1)],
+                [MockPullRequest("servo:servo_export_18746", 1)],
             ),
             [
                 "ChangePRStep:wpt/wpt#1:opened:This is a test:<!-- Please...[95]",
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_18746",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_18746",
                 "CommentStep:servo/servo#18746:📝 Transplanted new upstreamable changes to "
                 "existing upstream WPT pull request (wpt/wpt#1).",
             ],
@@ -451,13 +451,13 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "opened.json",
                 ["non-wpt.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_18746", 1)],
+                [MockPullRequest("servo:servo_export_18746", 1)],
             ),
             [
                 "CommentStep:wpt/wpt#1:👋 Downstream pull request (servo/servo#18746) no longer "
                 "contains any upstreamable changes. Closing pull request without merging.",
                 "ChangePRStep:wpt/wpt#1:closed",
-                "RemoveBranchForPRStep:servo-wpt-sync/wpt/servo_export_18746",
+                "RemoveBranchForPRStep:servo/wpt/servo_export_18746",
                 "CommentStep:servo/servo#18746:🤖 This change no longer contains upstreamable changes "
                 "to WPT; closed existing upstream pull request (wpt/wpt#1).",
             ]
@@ -467,8 +467,8 @@ class TestFullSyncRun(unittest.TestCase):
         self.assertListEqual(
             self.run_test("opened.json", ["add-non-utf8-file.diff"]),
             [
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_18746",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_18746→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_18746",
+                "OpenPRStep:servo/wpt/servo_export_18746→wpt/wpt#1",
                 "CommentStep:servo/servo#18746:🤖 Opened new upstream WPT pull request "
                 "(wpt/wpt#1) with upstreamable changes.",
             ],
@@ -481,7 +481,7 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "opened.json",
                 ["does-not-apply-cleanly.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_18746", 1)],
+                [MockPullRequest("servo:servo_export_18746", 1)],
             ),
             [
                 "ChangePRStep:wpt/wpt#1:opened:This is a test:<!-- Please...[95]",
@@ -501,11 +501,11 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "closed.json",
                 ["18746.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_18746", 10)],
+                [MockPullRequest("servo:servo_export_18746", 10)],
             ),
             [
                 "ChangePRStep:wpt/wpt#10:closed",
-                "RemoveBranchForPRStep:servo-wpt-sync/wpt/servo_export_18746"
+                "RemoveBranchForPRStep:servo/wpt/servo_export_18746"
             ]
         )
 
@@ -514,11 +514,11 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "synchronize.json",
                 ["18746.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_19612", 10)],
+                [MockPullRequest("servo:servo_export_19612", 10)],
             ),
             [
                 "ChangePRStep:wpt/wpt#10:opened:deny warnings:<!-- Please...[142]",
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_19612",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_19612",
                 "CommentStep:servo/servo#19612:📝 Transplanted new upstreamable changes to existing "
                 "upstream WPT pull request (wpt/wpt#10).",
             ]
@@ -529,13 +529,13 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "synchronize.json",
                 ["non-wpt.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_19612", 11)],
+                [MockPullRequest("servo:servo_export_19612", 11)],
             ),
             [
                 "CommentStep:wpt/wpt#11:👋 Downstream pull request (servo/servo#19612) no longer contains any "
                 "upstreamable changes. Closing pull request without merging.",
                 "ChangePRStep:wpt/wpt#11:closed",
-                "RemoveBranchForPRStep:servo-wpt-sync/wpt/servo_export_19612",
+                "RemoveBranchForPRStep:servo/wpt/servo_export_19612",
                 "CommentStep:servo/servo#19612:🤖 This change no longer contains upstreamable changes to WPT; "
                 "closed existing upstream pull request (wpt/wpt#11).",
             ]
@@ -545,8 +545,8 @@ class TestFullSyncRun(unittest.TestCase):
         self.assertListEqual(
             self.run_test("synchronize.json", ["18746.diff"]),
             [
-                "CreateOrUpdateBranchForPRStep:1:servo-wpt-sync/wpt/servo_export_19612",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_19612→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:1:servo/wpt/servo_export_19612",
+                "OpenPRStep:servo/wpt/servo_export_19612→wpt/wpt#1",
                 "CommentStep:servo/servo#19612:🤖 Opened new upstream WPT pull request "
                 "(wpt/wpt#1) with upstreamable changes.",
             ]
@@ -559,7 +559,7 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "synchronize.json",
                 ["does-not-apply-cleanly.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_19612", 11)],
+                [MockPullRequest("servo:servo_export_19612", 11)],
             ),
             [
                 "ChangePRStep:wpt/wpt#11:opened:deny warnings:<!-- Please...[142]",
@@ -575,7 +575,7 @@ class TestFullSyncRun(unittest.TestCase):
         self.assertListEqual(
             self.run_test(
                 "edited.json", ["wpt.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_19620", 10)]
+                [MockPullRequest("servo:servo_export_19620", 10)]
             ),
             [
                 "ChangePRStep:wpt/wpt#10:open:A cool new title:Reference #<!--...[136]",
@@ -595,8 +595,8 @@ class TestFullSyncRun(unittest.TestCase):
                 "synchronize-multiple.json", ["18746.diff", "non-wpt.diff", "wpt.diff"]
             ),
             [
-                "CreateOrUpdateBranchForPRStep:2:servo-wpt-sync/wpt/servo_export_19612",
-                "OpenPRStep:servo-wpt-sync/wpt/servo_export_19612→wpt/wpt#1",
+                "CreateOrUpdateBranchForPRStep:2:servo/wpt/servo_export_19612",
+                "OpenPRStep:servo/wpt/servo_export_19612→wpt/wpt#1",
                 "CommentStep:servo/servo#19612:"
                 "🤖 Opened new upstream WPT pull request (wpt/wpt#1) with upstreamable changes.",
             ]
@@ -610,11 +610,11 @@ class TestFullSyncRun(unittest.TestCase):
             self.run_test(
                 "merged.json",
                 ["18746.diff"],
-                [MockPullRequest("servo-wpt-sync:servo_export_19620", 100)]
+                [MockPullRequest("servo:servo_export_19620", 100)]
             ),
             [
                 "MergePRStep:wpt/wpt#100",
-                "RemoveBranchForPRStep:servo-wpt-sync/wpt/servo_export_19620"
+                "RemoveBranchForPRStep:servo/wpt/servo_export_19620"
             ]
         )
 
@@ -633,7 +633,7 @@ def setUpModule():
     SYNC = WPTSync(
         servo_repo="servo/servo",
         wpt_repo="wpt/wpt",
-        downstream_wpt_repo="servo-wpt-sync/wpt",
+        downstream_wpt_repo="servo/wpt",
         servo_path=os.path.join(TMP_DIR, "servo-mock"),
         wpt_path=os.path.join(TMP_DIR, "wpt-mock"),
         github_api_token="",


### PR DESCRIPTION
This switches the WPT export script to use Servo's fork of the `wpt`
upstream repository. The reasoning is that Servo developers can fix
issues with branches there. This isn't possible right now because no 
one has permissions to the servo-wpt-sync fork of the repository.

I have given `servo-wpt-sync` write permissions to `servo/wpt`.

This also updates the tests a bit to reflect the new default repository.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just modify how the WPT export script works.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
