### PR TITLE
Pass keyboard events to WebView on Windows

### DIFF
--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -533,7 +533,11 @@ where
     }
 
     #[cfg(target_os = "windows")]
-    fn platform_handle_key(&mut self, _key_event: KeyboardEvent) {}
+    fn platform_handle_key(&mut self, key_event: KeyboardEvent) {
+        if self.focused_webview_id.is_some() {
+            self.event_queue.push(EmbedderEvent::Keyboard(key_event));
+        }
+    }
 
     /// Handle key events after they have been handled by Servo.
     fn handle_key_from_servo(&mut self, _: Option<WebViewId>, event: KeyboardEvent) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Send keyboard events to focused `WebView` for key events not handled by `WebViewManager`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because tests aren't run for Windows yet.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
