### PR TITLE
Fix several clippy warnings in `components/devtools`

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -138,12 +138,12 @@ impl PageStyleActor {
         stream: &mut TcpStream,
     ) -> Result<ActorMessageStatus, ()> {
         let target = msg.get("node").ok_or(())?.as_str().ok_or(())?;
-        let node = registry.find::<NodeActor>(&target);
+        let node = registry.find::<NodeActor>(target);
         let walker = registry.find::<WalkerActor>(&node.walker);
         let entries: Vec<_> = find_child(
             &node.script_chan,
             node.pipeline,
-            &target,
+            target,
             registry,
             &walker.root_node.actor,
             vec![],
@@ -182,7 +182,7 @@ impl PageStyleActor {
                                 let actor = StyleRuleActor::new(
                                     name.clone(),
                                     node_actor.name(),
-                                    (e.key().0 != "").then_some(e.key().clone()),
+                                    (!e.key().0.is_empty()).then_some(e.key().clone()),
                                 );
                                 let rule = actor.applied(registry)?;
 
@@ -226,7 +226,7 @@ impl PageStyleActor {
         stream: &mut TcpStream,
     ) -> Result<ActorMessageStatus, ()> {
         let target = msg.get("node").ok_or(())?.as_str().ok_or(())?;
-        let node_actor = registry.find::<NodeActor>(&target);
+        let node_actor = registry.find::<NodeActor>(target);
         let computed = (|| match node_actor
             .style_rules
             .borrow_mut()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500

<!-- Either: -->
- [x] These changes do not require tests because they only fix clippy warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
