### PR TITLE
ci: Fix the WPT export job after the repository change

### DIFF
--- a/python/wpt/exporter/__init__.py
+++ b/python/wpt/exporter/__init__.py
@@ -180,7 +180,7 @@ class WPTSync:
                 wpt_branch_name_from_servo_pr_number(servo_pr.number)
             )
             upstream_pr = self.wpt.get_open_pull_request_for_branch(
-                downstream_wpt_branch
+                self.github_username, downstream_wpt_branch
             )
             if upstream_pr:
                 logging.info(

--- a/python/wpt/exporter/github.py
+++ b/python/wpt/exporter/github.py
@@ -72,7 +72,9 @@ class GithubRepository:
         return GithubBranch(self, name)
 
     def get_open_pull_request_for_branch(
-        self, branch: GithubBranch
+        self,
+        github_username: str,
+        branch: GithubBranch
     ) -> Optional[PullRequest]:
         """If this repository has an open pull request with the
         given source head reference targeting the main branch,
@@ -82,7 +84,7 @@ class GithubRepository:
             "is:pr",
             "state:open",
             f"repo:{self.repo}",
-            f"author:{branch.repo.org}",
+            f"author:{github_username}",
             f"head:{branch.name}",
         ])
         response = authenticated(self.sync, "GET", f"search/issues?q={params}")

--- a/python/wpt/test.py
+++ b/python/wpt/test.py
@@ -140,12 +140,11 @@ class MockGitHubAPIServer():
 
             assert params["is"] == "pr"
             assert params["state"] == "open"
-            assert "author" in params
             assert "head" in params
-            head_ref = f"{params['author']}:{params['head']}"
+            head_ref = f":{params['head']}"
 
             for pull_request in self.pulls:
-                if pull_request.head == head_ref:
+                if pull_request.head.endswith(head_ref):
                     return json.dumps({
                         "total_count": 1,
                         "items": [{


### PR DESCRIPTION
The GitHub search API is a bit sensitive. There isn't a great way to
search for the repository organization and the branch name when looking
for open PRs. Instead use the bot username as the author name, which
should likely have been having before. This fixes the WPT export job.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
