### PR TITLE
Don't allow minibrowser tab titles to be empty

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -276,9 +276,9 @@ impl Minibrowser {
                     |ui| {
                         for (webview_id, webview) in webviews.webviews().into_iter() {
                             let msg = match (&webview.title, &webview.url) {
-                                (Some(title), _) => title.clone(),
-                                (None, Some(url)) => url.to_string(),
-                                _ => "".to_owned(),
+                                (Some(title), _) if !title.is_empty() => title.clone(),
+                                (_, Some(url)) => url.to_string(),
+                                _ => "New Tab".to_owned(),
                             };
                             let tab = ui.add(SelectableLabel::new(
                                 webview.focused,

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -275,8 +275,8 @@ impl Minibrowser {
                     egui::Layout::left_to_right(egui::Align::Center),
                     |ui| {
                         for (webview_id, webview) in webviews.webviews().into_iter() {
-                            let msg = match (webview.title.clone(), webview.url.clone()) {
-                                (Some(title), _) => title,
+                            let msg = match (&webview.title, &webview.url) {
+                                (Some(title), _) => title.clone(),
                                 (None, Some(url)) => url.to_string(),
                                 _ => "".to_owned(),
                             };


### PR DESCRIPTION
Empty tab titles look very confusing (I didn't even recognize it as a tab bar at first)

**Before:**
![image](https://github.com/user-attachments/assets/3cf5f098-6182-481f-b676-059bacdcc60c)


**After:**
![image](https://github.com/user-attachments/assets/b3d84a6f-629c-4c88-86dc-794c0ccf144e)


---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's just a UI for debugging


