### PR TITLE
Fix several clippy warnings in `components/canvas`

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1046,7 +1046,7 @@ impl WebGLImpl {
                 gl.clear_color(r, g, b, a);
             },
             WebGLCommand::ClearDepth(depth) => {
-                let value = depth.max(0.).min(1.) as f64;
+                let value = depth.clamp(0., 1.) as f64;
                 state.depth_clear_value = value;
                 gl.clear_depth(value)
             },
@@ -1085,7 +1085,7 @@ impl WebGLImpl {
                 state.restore_depth_invariant(gl);
             },
             WebGLCommand::DepthRange(near, far) => {
-                gl.depth_range(near.max(0.).min(1.) as f64, far.max(0.).min(1.) as f64)
+                gl.depth_range(near.clamp(0., 1.) as f64, far.clamp(0., 1.) as f64)
             },
             WebGLCommand::Disable(cap) => match cap {
                 gl::SCISSOR_TEST => {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #31500

<!-- Either: -->
- [x] These changes do not require tests because they only fix clippy warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
