### PR TITLE
Obey `min-block-size` and `max-block-size` in floats

### DIFF
--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -949,7 +949,7 @@ impl FloatBox {
                                     inline_size.into(),
                                 ),
                                 None => (
-                                    box_size.block.auto_is(|| {
+                                    block_size.auto_is(|| {
                                         Length::from(independent_layout.content_block_size)
                                             .clamp_between_extremums(
                                                 min_box_size.block,

--- a/tests/wpt/tests/css/CSS2/normal-flow/max-height-applies-to-018.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/max-height-applies-to-018.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: Max-Height applied to element with 'float' set to 'left'</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The float should be 100px tall, not 200px.">
+
+<style>
+.float {
+  float: left;
+  width: 100px;
+  height: 200px;
+  max-height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div class="float"></div>

--- a/tests/wpt/tests/css/CSS2/normal-flow/max-width-applies-to-018.html
+++ b/tests/wpt/tests/css/CSS2/normal-flow/max-width-applies-to-018.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>CSS Test: Max-Width applied to element with 'float' set to 'left'</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The float should be 100px wide, not 200px.">
+
+<style>
+.float {
+  float: left;
+  height: 100px;
+  width: 200px;
+  max-width: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+<div class="float"></div>


### PR DESCRIPTION
We were using the unclamped `box_size.block` instead of `block_size`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
