### PR TITLE
Obey min and max cross sizes of flex items

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1626,7 +1626,12 @@ impl FlexItem<'_> {
             IndependentFormattingContext::NonReplaced(non_replaced) => {
                 let cross_size = match used_cross_size_override {
                     Some(s) => AuOrAuto::LengthPercentage(s),
-                    None => self.content_box_size.cross.map(|t| t),
+                    None => self.content_box_size.cross.map(|cross_size| {
+                        cross_size.clamp_between_extremums(
+                            self.content_min_size.cross,
+                            self.content_max_size.cross,
+                        )
+                    }),
                 };
 
                 let item_writing_mode = non_replaced.style.effective_writing_mode();

--- a/tests/wpt/tests/css/css-flexbox/percentage-max-height-005.html
+++ b/tests/wpt/tests/css/css-flexbox/percentage-max-height-005.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>CSS Flexbox Test: flex item with max cross size</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#max-size-properties">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="The content of the flex item should resolve the percentage against 100px, not against 200px">
+
+<style>
+.flex {
+  display: flex;
+}
+.item {
+  height: 200px;
+  max-height: 100px;
+  align-self: flex-start;
+  background: red;
+}
+.content {
+  height: 100%;
+  width: 100px;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <div class="item">
+    <div class="content"></div>
+  </div>
+</div>


### PR DESCRIPTION
When laying out the contents of a flex item, we used to resolve their cross-axis percentages against the preferred cross size of the item. Now we will take the min and max cross sizes into account.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
