### PR TITLE
servoshell: Add close buttons and increase interactivity of tabs

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -176,6 +176,7 @@ impl Minibrowser {
         webview_id: TopLevelBrowsingContextId,
     ) -> Option<EmbedderEvent> {
         let old_item_spacing = ui.spacing().item_spacing;
+        let old_visuals = ui.visuals().clone();
         ui.spacing_mut().item_spacing = egui::vec2(0.0, 0.0);
 
         let visuals = ui.visuals_mut();
@@ -233,6 +234,7 @@ impl Minibrowser {
 
         ui.spacing_mut().item_spacing = old_item_spacing;
         let close_button = ui.add(egui::Button::new("X").fill(fill_color));
+        *ui.visuals_mut() = old_visuals;
         if close_button.clicked() || close_button.middle_clicked() || tab.middle_clicked() {
             Some(EmbedderEvent::CloseWebView(webview_id))
         } else if !selected && tab.clicked() {


### PR DESCRIPTION
Hey, I've tried to improve the UI of the new tab bar a bit, mainly by adding a close button for each tab as well as another button for opening new tabs, also changed the styling so it looks more like other browsers. One can now click with the middle mouse button on a tab to close it.

<img width="915" alt="Screenshot 2024-08-29 at 13 16 12" src="https://github.com/user-attachments/assets/fdc975d4-a64e-4df0-8674-216def404933">

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they are for the minibrowser UI

