### PR TITLE
Bump xi_unicode to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3900,7 +3900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7922,7 +7922,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8427,9 +8427,9 @@ checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
 name = "xi-unicode"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xkbcommon-dl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ webrender_traits = { path = "components/shared/webrender" }
 wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "338678ad5f66b74d1df1daee6afb028f964244b8" }
 wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "338678ad5f66b74d1df1daee6afb028f964244b8" }
 windows-sys = "0.59"
-xi-unicode = "0.1.0"
+xi-unicode = "0.3.0"
 xml5ever = "0.19"
 
 [profile.release]

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -36,7 +36,7 @@ pub(crate) const XI_LINE_BREAKING_CLASS_CM: u8 = 9;
 pub(crate) const XI_LINE_BREAKING_CLASS_GL: u8 = 12;
 pub(crate) const XI_LINE_BREAKING_CLASS_ZW: u8 = 28;
 pub(crate) const XI_LINE_BREAKING_CLASS_WJ: u8 = 30;
-pub(crate) const XI_LINE_BREAKING_CLASS_ZWJ: u8 = 40;
+pub(crate) const XI_LINE_BREAKING_CLASS_ZWJ: u8 = 42;
 
 /// <https://www.w3.org/TR/css-display-3/#css-text-run>
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
There is no changelog available, but we only use `linebreak_property` and `LineBreakLeafiter` from `xi_unicode`, so it should be safe to update,

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

