### PR TITLE
mach: Add `test-speedometer` command and `--bmf-output` to speedometer and dromaeo

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -402,9 +402,10 @@ class MachCommands(CommandBase):
 
     @Command('test-dromaeo', description='Run the Dromaeo test suite', category='testing')
     @CommandArgument('tests', default=["recommended"], nargs="...", help="Specific tests to run")
+    @CommandArgument('--bmf-output', default=None, help="Specify BMF JSON output file")
     @CommandBase.common_command_arguments(binary_selection=True)
-    def test_dromaeo(self, tests, servo_binary: str):
-        return self.dromaeo_test_runner(tests, servo_binary)
+    def test_dromaeo(self, tests, servo_binary: str, bmf_output: str | None = None):
+        return self.dromaeo_test_runner(tests, servo_binary, bmf_output)
 
     @Command('update-jquery',
              description='Update the jQuery test suite expected results',
@@ -488,10 +489,14 @@ class MachCommands(CommandBase):
 
         return call([run_file, cmd, bin_path, base_dir])
 
-    def dromaeo_test_runner(self, tests, binary: str):
+    def dromaeo_test_runner(self, tests, binary: str, bmf_output: str | None):
         base_dir = path.abspath(path.join("tests", "dromaeo"))
         dromaeo_dir = path.join(base_dir, "dromaeo")
         run_file = path.join(base_dir, "run_dromaeo.py")
+        if bmf_output:
+            bmf_output = path.abspath(bmf_output)
+        else:
+            bmf_output = ""
 
         # Clone the Dromaeo repository if it doesn't exist
         if not os.path.isdir(dromaeo_dir):
@@ -510,7 +515,7 @@ class MachCommands(CommandBase):
         bin_path = path.abspath(binary)
 
         return check_call(
-            [run_file, "|".join(tests), bin_path, base_dir])
+            [run_file, "|".join(tests), bin_path, base_dir, bmf_output])
 
 
 def create_parser_create():

--- a/tests/dromaeo/run_dromaeo.py
+++ b/tests/dromaeo/run_dromaeo.py
@@ -26,7 +26,7 @@ def run_servo(servo_exe, tests):
 
 # Print usage if command line args are incorrect
 def print_usage():
-    print("USAGE: {0} tests servo_binary dromaeo_base_dir".format(sys.argv[0]))
+    print("USAGE: {0} tests servo_binary dromaeo_base_dir [BMF JSON output]".format(sys.argv[0]))
 
 
 post_data = None
@@ -48,10 +48,13 @@ class RequestHandler(SimpleHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) == 4:
+    if len(sys.argv) == 4 or len(sys.argv) == 5:
         tests = sys.argv[1]
         servo_exe = sys.argv[2]
         base_dir = sys.argv[3]
+        bmf_output = ""
+        if len(sys.argv) == 5:
+            bmf_output = sys.argv[4]
         os.chdir(base_dir)
 
         # Ensure servo binary can be found
@@ -76,6 +79,12 @@ if __name__ == '__main__':
         print("-{0}-|-{1}-".format("-" * length, "-" * number))
         for test in data:
             print(" {0}{1} | {2}".format(test, " " * (length - len(test)), data[test]))
+        if bmf_output:
+            output = dict()
+            for (k, v) in data.items():
+                output[f"Dromaeo/{k}"] = {'throughput': {'value': float(v)}}
+            with open(bmf_output, 'w', encoding='utf-8') as f:
+                json.dump(output, f, indent=4)
         proc.kill()
     else:
         print_usage()


### PR DESCRIPTION
Speedometer uses my fork https://github.com/sagudev/Speedometer/tree/servo deployed at https://servospeedometer.netlify.app/ that has some servo specific patches (only selected suites, reporting to console, ...).

[BMF JSON](https://bencher.dev/docs/reference/bencher-metric-format/) is format for https://bencher.dev

reviewable per commit

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There changes are tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
