### PR TITLE
Fix automatic minimum size for column flexbox

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1917,9 +1917,16 @@ impl FlexItemBox {
                 )
             },
         );
-        let content_min_size_no_auto = LogicalVec2 {
-            inline: content_min_size.inline.auto_is(|| automatic_min_size),
-            block: content_min_size.block.auto_is(Au::zero),
+        let content_min_size_no_auto = if cross_axis_is_item_block_axis {
+            LogicalVec2 {
+                inline: content_min_size.inline.auto_is(|| automatic_min_size),
+                block: content_min_size.block.auto_is(Au::zero),
+            }
+        } else {
+            LogicalVec2 {
+                inline: content_min_size.inline.auto_is(Au::zero),
+                block: content_min_size.block.auto_is(|| automatic_min_size),
+            }
         };
         let block_content_size_callback = |item: &mut FlexItemBox| {
             item.layout_for_block_content_size(

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-031.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-height-flex-items-031.html.ini
@@ -1,215 +1,107 @@
 [flex-minimum-height-flex-items-031.html]
-  [.flex 1]
-    expected: FAIL
-
   [.flex 2]
-    expected: FAIL
-
-  [.flex 3]
     expected: FAIL
 
   [.flex 4]
     expected: FAIL
 
-  [.flex 5]
-    expected: FAIL
-
   [.flex 6]
-    expected: FAIL
-
-  [.flex 7]
     expected: FAIL
 
   [.flex 8]
     expected: FAIL
 
-  [.flex 9]
-    expected: FAIL
-
   [.flex 10]
-    expected: FAIL
-
-  [.flex 11]
     expected: FAIL
 
   [.flex 12]
     expected: FAIL
 
-  [.flex 13]
-    expected: FAIL
-
   [.flex 14]
-    expected: FAIL
-
-  [.flex 15]
     expected: FAIL
 
   [.flex 16]
     expected: FAIL
 
-  [.flex 17]
-    expected: FAIL
-
   [.flex 18]
-    expected: FAIL
-
-  [.flex 19]
     expected: FAIL
 
   [.flex 20]
     expected: FAIL
 
-  [.flex 21]
-    expected: FAIL
-
   [.flex 22]
-    expected: FAIL
-
-  [.flex 23]
     expected: FAIL
 
   [.flex 24]
     expected: FAIL
 
-  [.flex 25]
-    expected: FAIL
-
   [.flex 26]
-    expected: FAIL
-
-  [.flex 27]
     expected: FAIL
 
   [.flex 28]
     expected: FAIL
 
-  [.flex 29]
-    expected: FAIL
-
   [.flex 30]
-    expected: FAIL
-
-  [.flex 31]
     expected: FAIL
 
   [.flex 32]
     expected: FAIL
 
-  [.flex 33]
-    expected: FAIL
-
   [.flex 34]
-    expected: FAIL
-
-  [.flex 35]
     expected: FAIL
 
   [.flex 36]
     expected: FAIL
 
-  [.flex 37]
-    expected: FAIL
-
   [.flex 38]
-    expected: FAIL
-
-  [.flex 39]
     expected: FAIL
 
   [.flex 40]
     expected: FAIL
 
-  [.flex 41]
-    expected: FAIL
-
   [.flex 42]
-    expected: FAIL
-
-  [.flex 43]
     expected: FAIL
 
   [.flex 44]
     expected: FAIL
 
-  [.flex 45]
-    expected: FAIL
-
   [.flex 46]
-    expected: FAIL
-
-  [.flex 47]
     expected: FAIL
 
   [.flex 48]
     expected: FAIL
 
-  [.flex 49]
-    expected: FAIL
-
   [.flex 50]
-    expected: FAIL
-
-  [.flex 51]
     expected: FAIL
 
   [.flex 52]
     expected: FAIL
 
-  [.flex 53]
-    expected: FAIL
-
   [.flex 54]
-    expected: FAIL
-
-  [.flex 55]
     expected: FAIL
 
   [.flex 56]
     expected: FAIL
 
-  [.flex 57]
-    expected: FAIL
-
   [.flex 58]
-    expected: FAIL
-
-  [.flex 59]
     expected: FAIL
 
   [.flex 60]
     expected: FAIL
 
-  [.flex 61]
-    expected: FAIL
-
   [.flex 62]
-    expected: FAIL
-
-  [.flex 63]
     expected: FAIL
 
   [.flex 64]
     expected: FAIL
 
-  [.flex 65]
-    expected: FAIL
-
   [.flex 66]
-    expected: FAIL
-
-  [.flex 67]
     expected: FAIL
 
   [.flex 68]
     expected: FAIL
 
-  [.flex 69]
-    expected: FAIL
-
   [.flex 70]
-    expected: FAIL
-
-  [.flex 71]
     expected: FAIL
 
   [.flex 72]

--- a/tests/wpt/meta/css/css-flexbox/flex-minimum-size-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-minimum-size-001.html.ini
@@ -1,3 +1,0 @@
-[flex-minimum-size-001.html]
-  [.flexbox, .inline-flexbox 3]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/stretch-obeys-min-max-001.html.ini
@@ -1,2 +1,0 @@
-[stretch-obeys-min-max-001.html]
-  expected: FAIL


### PR DESCRIPTION
`main_content_size_info()` was always assigning the main-axis automatic minimum size into the inline axis. But in a column flexbox, the main axis corresponds to the block axis.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
