### PR TITLE
layout: Stop using `unicode-segmentation`  in layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,7 +3741,6 @@ dependencies = [
  "style_traits",
  "unicode-bidi",
  "unicode-script",
- "unicode-segmentation",
  "url",
  "webrender_api",
  "webrender_traits",

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -47,7 +47,6 @@ style = { workspace = true }
 style_traits = { workspace = true }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }
-unicode-segmentation = { workspace = true }
 url = { workspace = true }
 webrender_api = { workspace = true }
 webrender_traits = { workspace = true }

--- a/components/layout_2020/flow/inline/construct.rs
+++ b/components/layout_2020/flow/inline/construct.rs
@@ -5,11 +5,11 @@
 use std::borrow::Cow;
 use std::char::{ToLowercase, ToUppercase};
 
+use icu_segmenter::WordSegmenter;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::values::computed::TextDecorationLine;
 use style::values::specified::text::TextTransformCase;
 use unicode_bidi::Level;
-use unicode_segmentation::UnicodeSegmentation;
 
 use super::text_run::TextRun;
 use super::{InlineBox, InlineBoxIdentifier, InlineBoxes, InlineFormattingContext, InlineItem};
@@ -601,13 +601,14 @@ fn capitalize_string(string: &str, allow_word_at_start: bool) -> String {
     let mut output_string = String::new();
     output_string.reserve(string.len());
 
-    let mut bounds = string.unicode_word_indices().peekable();
+    let word_segmenter = WordSegmenter::new_auto();
+    let mut bounds = word_segmenter.segment_str(string).peekable();
     let mut byte_index = 0;
     for character in string.chars() {
         let current_byte_index = byte_index;
         byte_index += character.len_utf8();
 
-        if let Some((next_index, _)) = bounds.peek() {
+        if let Some(next_index) = bounds.peek() {
             if *next_index == current_byte_index {
                 bounds.next();
 


### PR DESCRIPTION
`layout` already uses `icu_segmentation` so there's no need to pull in
another segmenter. This reduces the number of segmenters used in the
crate to 2 from 3.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
