### PR TITLE
Fix minibrowser scroll by keyboard

### DIFF
--- a/ports/servoshell/desktop/webview.rs
+++ b/ports/servoshell/desktop/webview.rs
@@ -613,7 +613,7 @@ where
         // In minibrowser mode the webview is offset by the toolbar
         let origin = webview_id
             .and_then(|id| self.webviews.get(&id))
-            .and_then(|webview| Some(webview.rect.min.ceil().to_i32()))
+            .map(|webview| webview.rect.min.ceil().to_i32())
             .unwrap_or(Point2D::zero());
         let event = EmbedderEvent::Scroll(scroll_location, origin, phase);
         self.event_queue.push(event);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`EmbedderEvent::Scroll` events from scroll by keyboard inputs used `0,0` cursor point but in minibrowser mode the webview is offset on y-axis by the toolbar.

On Windows this https://github.com/servo/servo/pull/33225 is required to get the keyboard inputs working.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because they are for the minibrowser UI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
