### PR TITLE
Use the proper aspect ratio in flexbox

### DIFF
--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -238,7 +238,7 @@ impl ReplacedContent {
         LogicalVec2::from_physical_size(&intrinsic_size, style.effective_writing_mode())
     }
 
-    pub(crate) fn inline_size_over_block_size_intrinsic_ratio(
+    fn inline_size_over_block_size_intrinsic_ratio(
         &self,
         style: &ComputedValues,
     ) -> Option<CSSFloat> {

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-055.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-055.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="
+    The automatic minimum size makes the flex item be 50px wide (converted from the height through the aspect ratio).
+    Adding the borders, the flex container is then a 100x100 square.">
+
+<style>
+.flex {
+  display: inline-flex;
+  border: solid 25px green;
+}
+.flex img {
+  height: 50px;
+  flex: 0 0 0px;
+  aspect-ratio: 1 / 1;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div class="flex">
+  <img src="support/20x50-green.png">
+</div>


### PR DESCRIPTION
When computing the automatic minimum size, flex layout was using the natural aspect ratio, ignoring the `aspect-ratio` property.

`ReplacedContent::inline_size_over_block_size_intrinsic_ratio()` is now made private to avoid more accidental uses.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
