### PR TITLE
ohos: Enable Webgl context creation on OH 5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,7 +3896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5543,15 +5543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb7ac86243095b70a7920639507b71d51a63390d1ba26c4f60a552fbb914a37"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5772,12 +5763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdd"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
-
-[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
@@ -5873,31 +5858,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
-dependencies = [
- "futures 0.3.30",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -6623,12 +6583,12 @@ dependencies = [
 
 [[package]]
 name = "surfman"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6160d797855bc381e63c076cea21697b76c9d67887e83961941834572c2f2dcd"
+checksum = "bb5f2d85c044920e1f2aaf5ad3795ae3b935025297271f2eadb021931571b4c3"
 dependencies = [
- "bitflags 1.3.2",
- "cfg_aliases 0.1.1",
+ "bitflags 2.6.0",
+ "cfg_aliases 0.2.1",
  "cgl",
  "cocoa",
  "core-foundation",
@@ -6644,7 +6604,6 @@ dependencies = [
  "metal 0.24.0",
  "objc",
  "raw-window-handle",
- "serial_test",
  "servo-display-link",
  "sparkle",
  "wayland-sys 0.30.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ style = { git = "https://github.com/servo/stylo", branch = "2024-07-16", feature
 style_config = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 style_dom = { git = "https://github.com/servo/stylo", package = "dom", branch = "2024-07-16" }
 style_traits = { git = "https://github.com/servo/stylo", branch = "2024-07-16", features = ["servo"] }
-surfman = { version = "0.9.6", features = ["chains"] }
+surfman = { version = "0.9.8", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -477,8 +477,6 @@ impl WebGLThread {
             "WebGLThread::create_webgl_context({:?}, {:?}, {:?})",
             webgl_version, requested_size, attributes
         );
-        #[cfg(target_env = "ohos")]
-        return Err("WebGL is not working yet on ohos".into());
 
         // Creating a new GLContext may make the current bound context_id dirty.
         // Clear it to ensure that  make_current() is called in subsequent commands.


### PR DESCRIPTION
The main changes are in `surfman`. 
This PR raises the minimum required API level to 12 (i.e. OpenHarmony 5.0). 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix WebGL context creation on OH 5.0

