### PR TITLE
net: Stop using legacy time in the HTTP and CORS caches

### DIFF
--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -9,11 +9,12 @@
 //! This library will eventually become the core of the Fetch crate
 //! with CORSRequest being expanded into FetchRequest (etc)
 
+use std::time::{Duration, Instant};
+
 use http::header::HeaderName;
 use http::Method;
 use net_traits::request::{CredentialsMode, Origin, Request};
 use servo_url::ServoUrl;
-use time::{self, Timespec};
 
 /// Union type for CORS cache entries
 ///
@@ -45,17 +46,17 @@ impl HeaderOrMethod {
 pub struct CorsCacheEntry {
     pub origin: Origin,
     pub url: ServoUrl,
-    pub max_age: u32,
+    pub max_age: Duration,
     pub credentials: bool,
     pub header_or_method: HeaderOrMethod,
-    created: Timespec,
+    created: Instant,
 }
 
 impl CorsCacheEntry {
     fn new(
         origin: Origin,
         url: ServoUrl,
-        max_age: u32,
+        max_age: Duration,
         credentials: bool,
         header_or_method: HeaderOrMethod,
     ) -> CorsCacheEntry {
@@ -65,7 +66,7 @@ impl CorsCacheEntry {
             max_age,
             credentials,
             header_or_method,
-            created: time::now().to_timespec(),
+            created: Instant::now(),
         }
     }
 }
@@ -107,10 +108,10 @@ impl CorsCache {
     /// Remove old entries
     pub fn cleanup(&mut self) {
         let CorsCache(buf) = self.clone();
-        let now = time::now().to_timespec();
+        let now = Instant::now();
         let new_buf: Vec<CorsCacheEntry> = buf
             .into_iter()
-            .filter(|e| now.sec < e.created.sec + e.max_age as i64)
+            .filter(|e| now < e.created + e.max_age)
             .collect();
         *self = CorsCache(new_buf);
     }
@@ -129,7 +130,7 @@ impl CorsCache {
         &mut self,
         request: &Request,
         header_name: &HeaderName,
-        new_max_age: u32,
+        new_max_age: Duration,
     ) -> bool {
         match self
             .find_entry_by_header(request, header_name)
@@ -163,7 +164,7 @@ impl CorsCache {
         &mut self,
         request: &Request,
         method: Method,
-        new_max_age: u32,
+        new_max_age: Duration,
     ) -> bool {
         match self
             .find_entry_by_method(request, method.clone())

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2097,7 +2097,6 @@ async fn cors_preflight_fetch(
             .typed_get::<AccessControlMaxAge>()
             .map(|acma| acma.into())
             .unwrap_or(Duration::from_secs(5));
-        let max_age = max_age.as_secs() as u32;
         // Substep 10
         // TODO: Need to define what an imposed limit on max-age is
 


### PR DESCRIPTION
This is part of switching away from using a very old version of `time`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of ##30150.
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
