### PR TITLE
net: Stop using both versions of the `time` crate in the cookie code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -2967,8 +2966,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_test",
- "time 0.1.45",
- "time 0.3.36",
 ]
 
 [[package]]
@@ -4518,7 +4515,6 @@ dependencies = [
  "servo_url",
  "sha2",
  "time 0.1.45",
- "time 0.3.36",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ syn = { version = "2", default-features = false, features = ["clone-impls", "der
 synstructure = "0.13"
 thin-vec = "0.2.13"
 time = "0.1.41"
-time_03 = { package = "time", version = "0.3", features = ["serde"] }
 to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 tokio = "1"
 tokio-rustls = "0.24"

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -23,8 +23,6 @@ hyper = { workspace = true }
 mime = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-time = { workspace = true }
-time_03 = { workspace = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/components/hyper_serde/tests/supported.rs
+++ b/components/hyper_serde/tests/supported.rs
@@ -15,7 +15,6 @@ use hyper::{Method, StatusCode, Uri};
 use hyper_serde::{De, Ser, Serde};
 use mime::Mime;
 use serde::{Deserialize, Serialize};
-use time::Tm;
 
 fn is_supported<T>()
 where
@@ -33,6 +32,5 @@ fn supported() {
     is_supported::<Method>();
     is_supported::<Mime>();
     is_supported::<StatusCode>();
-    is_supported::<Tm>();
     is_supported::<Uri>();
 }

--- a/components/hyper_serde/tests/tokens.rs
+++ b/components/hyper_serde/tests/tokens.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::time::Duration;
+
 use cookie::{Cookie, CookieBuilder};
 use headers::ContentType;
 use http::header::{self, HeaderMap, HeaderValue};
@@ -15,7 +17,6 @@ use http::StatusCode;
 use hyper::{Method, Uri};
 use hyper_serde::{De, Ser};
 use serde_test::{assert_de_tokens, assert_ser_tokens, Token};
-use time_03::Duration;
 
 #[test]
 fn test_content_type() {
@@ -32,7 +33,7 @@ fn test_cookie() {
     // string with a bunch of indices in it which apparently is different from the exact same
     // cookie but parsed as a bunch of strings.
     let cookie: Cookie = CookieBuilder::new("Hello", "World!")
-        .max_age(Duration::seconds(42))
+        .max_age(Duration::from_secs(42).try_into().unwrap_or_default())
         .domain("servo.org")
         .path("/")
         .secure(true)
@@ -109,17 +110,6 @@ fn test_raw_status() {
 
     assert_ser_tokens(&Ser::new(&raw_status), tokens);
     assert_de_tokens(&De::new(raw_status), tokens);
-}
-
-#[test]
-fn test_tm() {
-    use time::strptime;
-
-    let time = strptime("2017-02-22T12:03:31Z", "%Y-%m-%dT%H:%M:%SZ").unwrap();
-    let tokens = &[Token::Str("2017-02-22T12:03:31Z")];
-
-    assert_ser_tokens(&Ser::new(&time), tokens);
-    assert_de_tokens(&De::new(time), tokens);
 }
 
 #[test]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -57,7 +57,6 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 sha2 = "0.10"
 time = { workspace = true }
-time_03 = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tokio-rustls = { workspace = true }


### PR DESCRIPTION
`std::time` is good enough for us here. `cookie` is using `time 0.3`,
but Servo can convert to standard library types when getting data from
`cookie`. This reduces our direct dependencies and removes more use of
the very old `time 0.1` series.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30150.
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
