### PR TITLE
script: Stop using `time` in DOM timers and `XMLHttpRequest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5735,7 +5735,6 @@ dependencies = [
  "servo_url",
  "smallvec",
  "style_traits",
- "time 0.1.45",
  "uuid",
  "webdriver",
  "webgpu",

--- a/components/constellation/timer_scheduler.rs
+++ b/components/constellation/timer_scheduler.rs
@@ -64,10 +64,9 @@ impl TimerScheduler {
     /// Handle an incoming timer request.
     pub fn handle_timer_request(&mut self, request: TimerSchedulerMsg) {
         let TimerEventRequest(_, _, _, delay) = request.0;
-        let schedule = Instant::now() + Duration::from_millis(delay.get());
         let event = ScheduledEvent {
             request: request.0,
-            for_time: schedule,
+            for_time: Instant::now() + delay,
         };
         self.0.push(event);
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -47,8 +47,7 @@ use profile_traits::time::{TimerMetadata, TimerMetadataFrameType, TimerMetadataR
 use script_layout_interface::{PendingRestyle, ReflowGoal, TrustedNodeAddress};
 use script_traits::{
     AnimationState, AnimationTickType, CompositorEvent, DocumentActivity, MouseButton,
-    MouseEventType, MsDuration, ScriptMsg, TouchEventType, TouchId, UntrustedNodeAddress,
-    WheelDelta,
+    MouseEventType, ScriptMsg, TouchEventType, TouchId, UntrustedNodeAddress, WheelDelta,
 };
 use servo_arc::Arc;
 use servo_atoms::Atom;
@@ -1993,7 +1992,7 @@ impl Document {
             };
             self.global().schedule_callback(
                 OneshotTimerCallback::FakeRequestAnimationFrame(callback),
-                MsDuration::new(FAKE_REQUEST_ANIMATION_FRAME_DELAY),
+                Duration::from_millis(FAKE_REQUEST_ANIMATION_FRAME_DELAY),
             );
         } else if !self.running_animation_callbacks.get() {
             // No need to send a `ChangeRunningAnimationsState` if we're running animation callbacks:
@@ -2443,7 +2442,7 @@ impl Document {
                                     window: window_from_node(&*document),
                                     url: url.clone(),
                                 }),
-                                MsDuration::new(time.saturating_mul(1000)),
+                                Duration::from_secs(*time),
                             );
                         }
                         // Note: this will, among others, result in the "iframe-load-event-steps" being run.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{mem, ptr};
 
 use base::id::{
@@ -53,7 +53,7 @@ use script_traits::serializable::{BlobData, BlobImpl, FileBlob};
 use script_traits::transferable::MessagePortImpl;
 use script_traits::{
     BroadcastMsg, GamepadEvent, GamepadSupportedHapticEffects, GamepadUpdateType, MessagePortMsg,
-    MsDuration, PortMessageTask, ScriptMsg, ScriptToConstellationChan, TimerEvent, TimerEventId,
+    PortMessageTask, ScriptMsg, ScriptToConstellationChan, TimerEvent, TimerEventId,
     TimerSchedulerMsg, TimerSource,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
@@ -2741,7 +2741,7 @@ impl GlobalScope {
     pub fn schedule_callback(
         &self,
         callback: OneshotTimerCallback,
-        duration: MsDuration,
+        duration: Duration,
     ) -> OneshotTimerHandle {
         self.setup_timers();
         self.timers
@@ -2757,7 +2757,7 @@ impl GlobalScope {
         &self,
         callback: TimerCallback,
         arguments: Vec<HandleValue>,
-        timeout: i32,
+        timeout: Duration,
         is_interval: IsInterval,
     ) -> i32 {
         self.setup_timers();

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -4,12 +4,13 @@
 
 use std::str::FromStr;
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
 use js::rust::HandleObject;
 use regex::bytes::Regex;
-use script_traits::{HistoryEntryReplacement, MsDuration};
+use script_traits::HistoryEntryReplacement;
 use servo_url::ServoUrl;
 use style::str::HTML_SPACE_CHARACTERS;
 
@@ -207,7 +208,7 @@ impl HTMLMetaElement {
                     window: window.clone(),
                     url: url_record,
                 }),
-                MsDuration::new(time.saturating_mul(1000)),
+                Duration::from_secs(time),
             );
             document.set_declarative_refresh(DeclarativeRefresh::CreatedAfterLoad);
         } else {

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -7,6 +7,7 @@
 use std::borrow::ToOwned;
 use std::ptr::{self, NonNull};
 use std::rc::Rc;
+use std::time::Duration;
 
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, JS_NewPlainObject};
@@ -14,7 +15,6 @@ use js::jsval::{JSVal, NullValue};
 use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue};
 use js::typedarray::{self, Uint8ClampedArray};
 use script_traits::serializable::BlobImpl;
-use script_traits::MsDuration;
 use servo_config::prefs;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -999,7 +999,7 @@ impl TestBindingMethods for TestBinding {
         };
         let _ = self.global().schedule_callback(
             OneshotTimerCallback::TestBindingCallback(cb),
-            MsDuration::new(delay),
+            Duration::from_millis(delay),
         );
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -12,6 +12,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use std::{cmp, env, mem};
 
 use app_units::Au;
@@ -882,7 +883,7 @@ impl WindowMethods for Window {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             callback,
             args,
-            timeout,
+            Duration::from_millis(timeout.max(0) as u64),
             IsInterval::NonInterval,
         )
     }
@@ -908,7 +909,7 @@ impl WindowMethods for Window {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             callback,
             args,
-            timeout,
+            Duration::from_millis(timeout.max(0) as u64),
             IsInterval::Interval,
         )
     }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -6,6 +6,7 @@ use std::default::Default;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use base::id::{PipelineId, PipelineNamespace};
 use crossbeam_channel::Receiver;
@@ -345,7 +346,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             callback,
             args,
-            timeout,
+            Duration::from_millis(timeout.max(0) as u64),
             IsInterval::NonInterval,
         )
     }
@@ -371,7 +372,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         self.upcast::<GlobalScope>().set_timeout_or_interval(
             callback,
             args,
-            timeout,
+            Duration::from_millis(timeout.max(0) as u64),
             IsInterval::Interval,
         )
     }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -39,7 +39,6 @@ servo_atoms = { workspace = true }
 servo_url = { path = "../../url" }
 smallvec = { workspace = true }
 style_traits = { workspace = true }
-time = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }
 webgpu = { path = "../../webgpu" }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -18,6 +18,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 
 use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use base::id::{
@@ -32,7 +33,7 @@ use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
 use embedder_traits::CompositorEventVariant;
 use euclid::default::Point2D;
-use euclid::{Length, Rect, Scale, Size2D, UnknownUnit, Vector2D};
+use euclid::{Rect, Scale, Size2D, UnknownUnit, Vector2D};
 use http::{HeaderMap, Method};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use ipc_channel::Error as IpcError;
@@ -577,7 +578,7 @@ pub struct TimerEventRequest(
     pub IpcSender<TimerEvent>,
     pub TimerSource,
     pub TimerEventId,
-    pub MsDuration,
+    pub Duration,
 );
 
 /// The message used to send a request to the timer scheduler.
@@ -602,23 +603,6 @@ pub enum TimerSource {
 /// The id to be used for a `TimerEvent` is defined by the corresponding `TimerEventRequest`.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub struct TimerEventId(pub u32);
-
-/// Unit of measurement.
-#[derive(Clone, Copy, MallocSizeOf)]
-pub enum Milliseconds {}
-/// Unit of measurement.
-#[derive(Clone, Copy, MallocSizeOf)]
-pub enum Nanoseconds {}
-
-/// Amount of milliseconds.
-pub type MsDuration = Length<u64, Milliseconds>;
-/// Amount of nanoseconds.
-pub type NsDuration = Length<u64, Nanoseconds>;
-
-/// Returns the duration since an unspecified epoch measured in ms.
-pub fn precise_time_ms() -> MsDuration {
-    Length::new(time::precise_time_ns() / (1000 * 1000))
-}
 
 /// Data needed to construct a script thread.
 ///


### PR DESCRIPTION
This switches to using `std::time` types for DOM timer operations, which
allows removing our custom time units in favor of `Duration`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #30150.
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
