### PR TITLE
chore: Update wgpu to 34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,7 +4373,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 [[package]]
 name = "naga"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=338678ad5f66b74d1df1daee6afb028f964244b8#338678ad5f66b74d1df1daee6afb028f964244b8"
+source = "git+https://github.com/gfx-rs/wgpu?rev=34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c#34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -7812,7 +7812,7 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=338678ad5f66b74d1df1daee6afb028f964244b8#338678ad5f66b74d1df1daee6afb028f964244b8"
+source = "git+https://github.com/gfx-rs/wgpu?rev=34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c#34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=338678ad5f66b74d1df1daee6afb028f964244b8#338678ad5f66b74d1df1daee6afb028f964244b8"
+source = "git+https://github.com/gfx-rs/wgpu?rev=34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c#34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7879,7 +7879,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=338678ad5f66b74d1df1daee6afb028f964244b8#338678ad5f66b74d1df1daee6afb028f964244b8"
+source = "git+https://github.com/gfx-rs/wgpu?rev=34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c#34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,8 +138,8 @@ webpki-roots = "0.25"
 webrender = { git = "https://github.com/servo/webrender", branch = "0.65", features = ["capture"] }
 webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65" }
 webrender_traits = { path = "components/shared/webrender" }
-wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "338678ad5f66b74d1df1daee6afb028f964244b8" }
-wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "338678ad5f66b74d1df1daee6afb028f964244b8" }
+wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c" }
+wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c" }
 windows-sys = "0.59"
 xi-unicode = "0.3.0"
 xml5ever = "0.19"


### PR DESCRIPTION
https://github.com/gfx-rs/wgpu/commit/34bb9e4ceb45a5b1cfc5df6aa2b2e201cc55372c

My https://github.com/gfx-rs/wgpu/pull/6156 landed and I need servo to be up to date so I can keep testing my wgpu changes against CTS.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
