### PR TITLE
android: Fix mach install

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -330,7 +330,7 @@ class CommandBase(object):
 
     def get_apk_path(self, build_type: BuildType):
         base_path = util.get_target_dir()
-        base_path = path.join(base_path, "android", self.config["android"]["target"])
+        base_path = path.join(base_path, "android", self.target.triple())
         apk_name = "servoapp.apk"
         return path.join(base_path, build_type.directory_name(), apk_name)
 


### PR DESCRIPTION
self.config["android"]["target"] is unset, causing an exception. We can just use self.target.triple() instead.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix `./mach install --target=aarch64-linux-android`

