### PR TITLE
Make all platforms use a delay during cookie tests.

### DIFF
--- a/components/net/tests/cookie.rs
+++ b/components/net/tests/cookie.rs
@@ -165,7 +165,6 @@ fn test_cookie_host_prefix() {
     assert!(ServoCookie::new_wrapped(cookie, url, CookieSource::HTTP).is_some());
 }
 
-#[cfg(target_os = "windows")]
 fn delay_to_ensure_different_timestamp() {
     use std::thread;
     use std::time::Duration;
@@ -174,9 +173,6 @@ fn delay_to_ensure_different_timestamp() {
     // that two back-to-back calls to Cookie::new_wrapped generate different timestamps .
     thread::sleep(Duration::from_millis(500));
 }
-
-#[cfg(not(target_os = "windows"))]
-fn delay_to_ensure_different_timestamp() {}
 
 #[test]
 fn test_sort_order() {


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes hopefully fix #33278.
- [x] There are tests for these changes