### PR TITLE
bootstrap: Avoid needless sudo when pkgs are installed

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -57,7 +57,7 @@ DNF_PKGS = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
             'gstreamer1-devel', 'gstreamer1-plugins-base-devel',
             'gstreamer1-plugins-good', 'gstreamer1-plugins-bad-free-devel',
             'gstreamer1-plugins-ugly-free', 'libjpeg-turbo-devel',
-            'zlib', 'libjpeg', 'vulkan-loader', 'libxkbcommon',
+            'zlib-ng', 'libjpeg-turbo', 'vulkan-loader', 'libxkbcommon',
             'libxkbcommon-x11']
 
 # https://voidlinux.org/packages/
@@ -181,11 +181,14 @@ class Linux(Base):
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
                 install = True
         elif self.distro in ['CentOS', 'CentOS Linux', 'Fedora', 'Fedora Linux', 'Fedora Linux Asahi Remix']:
-            installed_pkgs = str(subprocess.check_output(['rpm', '-qa'])).replace('\n', '|')
+            command = ['dnf', 'install']
+            installed_pkgs: [str] = (
+                subprocess.check_output(['rpm', '--query', '--all', '--queryformat', '%{NAME}\n'],
+                                        encoding='utf-8')
+                .split('\n'))
             pkgs = DNF_PKGS
             for pkg in pkgs:
-                command = ['dnf', 'install']
-                if "|{}".format(pkg) not in installed_pkgs:
+                if pkg not in installed_pkgs:
                     install = True
                     break
         elif self.distro == 'void':


### PR DESCRIPTION
- Previously on fedora `./mach bootstrap` would always detect it needs to reinstall packages and require root permissions.
- use custom queryformat for `rpm -qa` to to just get the package name (e.g. `openssl-libs` instead of `openssl-libs-3.2.2-3.fc40.i686`
- Use a list to store the output result instead of one string
- Fedora (40) installs `zlib-ng` instead of `zlib` and `libjpeg-turbo` instead of `libjpeg`, meaning that `rpm` / dnf commands report `zlib` as not installed. Specifying the actually installed package avoids this problem.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
