### PR TITLE
CI: label self-hosted runners with run id to aid debugging

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -127,6 +127,7 @@ jobs:
           gh api "$self_hosted_runner_scope/$(cat $runner_id)/labels" \
             -f "labels[]=reserved-for:$unique_id" \
             -f "labels[]=reserved-since:$reserved_since" \
+            -f 'labels[]=reserved-by:${{ github.repository }}/actions/runs/${{ github.run_id }}' \
             --method POST --silent
           echo "selected_runner_label=reserved-for:$unique_id" | tee -a $GITHUB_OUTPUT
           echo 'is_self_hosted=true' | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
This patch adds `reserved-by:` labels to self-hosted runners, so that we can look at a busy runner and find the workflow run that reserved it.

For example, [in run 10666002164](https://github.com/servo/servo/actions/runs/10666002164/job/29560562028), we add the label `reserved-by:servo/servo/actions/runs/10666002164`, which we can combine with the job uuid (`reserved-for:931a2e13-72bb-4af5-9928-2aae454f2128`) to find the workload under:

- <https://github.com/servo/servo/actions/runs/10666002164>
- <https://api.github.com/repos/servo/servo/actions/runs/10666002164> `.jobs_url`
  - <https://api.github.com/repos/servo/servo/actions/runs/10666002164/jobs>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors