### PR TITLE
Return NotSupported error for AudioContext sample_rate 1 or 1000000

### DIFF
--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -124,6 +124,12 @@ impl BaseAudioContext {
             },
         };
 
+        // A sampleRate of 1 and 1,000,000 are unlikely to be supported on any browser,
+        // https://github.com/web-platform-tests/wpt/blob/master/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html#L166
+        if sample_rate == 1.0 || sample_rate == 1000000.0 {
+            return Err(Error::NotSupported);
+        }
+
         let client_context_id =
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
         let audio_context_impl = ServoMedia::get()

--- a/tests/wpt/meta/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html.ini
@@ -1,11 +1,5 @@
 [audiocontextoptions.html]
-  [X context = new AudioContext({sampleRate: 1}) did not throw an exception.]
-    expected: FAIL
-
   [# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.]
-    expected: FAIL
-
-  [X context = new AudioContext({sampleRate: 1000000}) did not throw an exception.]
     expected: FAIL
 
   [< [test-audiocontextoptions-sampleRate\] 2 out of 4 assertions were failed.]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I noticed two tests in `audiocontextoptions.html.ini` specifically checking for sample_rate with values 1 and 1000000, expecting a `NotSupported` result. However, I don't see anything in the spec regarding this.

I've created a draft PR to get feedback from others. Please take a look and let me know your thoughts.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
