### PR TITLE
webgpu: Support pipeline-overridable constants

### DIFF
--- a/components/script/dom/gpuconvert.rs
+++ b/components/script/dom/gpuconvert.rs
@@ -582,20 +582,22 @@ pub fn convert_color(color: &GPUColor) -> Fallible<wgt::Color> {
     }
 }
 
-pub fn convert_stage_desc<'a>(stage: &GPUProgrammableStage) -> ProgrammableStageDescriptor<'a> {
-    ProgrammableStageDescriptor {
-        module: stage.module.id().0,
-        entry_point: stage
-            .entryPoint
-            .as_ref()
-            .map(|ep| Cow::Owned(ep.to_string())),
-        constants: Cow::Owned(
-            stage
-                .constants
+impl<'a> From<&GPUProgrammableStage> for ProgrammableStageDescriptor<'a> {
+    fn from(stage: &GPUProgrammableStage) -> Self {
+        Self {
+            module: stage.module.id().0,
+            entry_point: stage
+                .entryPoint
                 .as_ref()
-                .map(|records| records.iter().map(|(k, v)| (k.0.clone(), **v)).collect())
-                .unwrap_or_default(),
-        ),
-        zero_initialize_workgroup_memory: true,
+                .map(|ep| Cow::Owned(ep.to_string())),
+            constants: Cow::Owned(
+                stage
+                    .constants
+                    .as_ref()
+                    .map(|records| records.iter().map(|(k, v)| (k.0.clone(), **v)).collect())
+                    .unwrap_or_default(),
+            ),
+            zero_initialize_workgroup_memory: true,
+        }
     }
 }

--- a/components/script/dom/gpuconvert.rs
+++ b/components/script/dom/gpuconvert.rs
@@ -475,7 +475,7 @@ pub fn convert_ic_texture(
     })
 }
 
-pub fn convert_label(parent: &GPUObjectDescriptorBase) -> Option<Cow<'static, str>> {
+pub fn convert_label<'a>(parent: &GPUObjectDescriptorBase) -> Option<Cow<'a, str>> {
     if parent.label.is_empty() {
         None
     } else {
@@ -582,9 +582,7 @@ pub fn convert_color(color: &GPUColor) -> Fallible<wgt::Color> {
     }
 }
 
-pub fn convert_stage_desc<'a, 'b>(
-    stage: &'a GPUProgrammableStage,
-) -> ProgrammableStageDescriptor<'b> {
+pub fn convert_stage_desc<'a>(stage: &GPUProgrammableStage) -> ProgrammableStageDescriptor<'a> {
     ProgrammableStageDescriptor {
         module: stage.module.id().0,
         entry_point: stage

--- a/components/script/dom/gpuconvert.rs
+++ b/components/script/dom/gpuconvert.rs
@@ -6,8 +6,10 @@ use std::borrow::Cow;
 use std::num::NonZeroU64;
 
 use webgpu::wgc::command as wgpu_com;
+use webgpu::wgc::pipeline::ProgrammableStageDescriptor;
 use webgpu::wgt::{self, AstcBlock, AstcChannel};
 
+use super::bindings::codegen::Bindings::WebGPUBinding::GPUProgrammableStage;
 use super::bindings::error::Error;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUAddressMode, GPUBindGroupLayoutEntry, GPUBlendComponent, GPUBlendFactor, GPUBlendOperation,
@@ -577,5 +579,25 @@ pub fn convert_color(color: &GPUColor) -> Fallible<wgt::Color> {
             b: *d.b,
             a: *d.a,
         }),
+    }
+}
+
+pub fn convert_stage_desc<'a, 'b>(
+    stage: &'a GPUProgrammableStage,
+) -> ProgrammableStageDescriptor<'b> {
+    ProgrammableStageDescriptor {
+        module: stage.module.id().0,
+        entry_point: stage
+            .entryPoint
+            .as_ref()
+            .map(|ep| Cow::Owned(ep.to_string())),
+        constants: Cow::Owned(
+            stage
+                .constants
+                .as_ref()
+                .map(|records| records.iter().map(|(k, v)| (k.0.clone(), **v)).collect())
+                .unwrap_or_default(),
+        ),
+        zero_initialize_workgroup_memory: true,
     }
 }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -6,7 +6,6 @@
 
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
@@ -28,7 +27,7 @@ use super::bindings::codegen::Bindings::WebGPUBinding::{
 use super::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use super::bindings::error::Fallible;
 use super::gpu::AsyncWGPUListener;
-use super::gpuconvert::convert_bind_group_layout_entry;
+use super::gpuconvert::{convert_bind_group_layout_entry, convert_stage_desc};
 use super::gpudevicelostinfo::GPUDeviceLostInfo;
 use super::gpupipelineerror::GPUPipelineError;
 use super::gpusupportedlimits::GPUSupportedLimits;
@@ -260,17 +259,7 @@ impl GPUDevice {
             layout,
             cache: None,
             vertex: wgpu_pipe::VertexState {
-                stage: wgpu_pipe::ProgrammableStageDescriptor {
-                    module: descriptor.vertex.parent.module.id().0,
-                    entry_point: descriptor
-                        .vertex
-                        .parent
-                        .entryPoint
-                        .as_ref()
-                        .map(|ep| Cow::Owned(ep.to_string())),
-                    constants: Cow::Owned(HashMap::new()),
-                    zero_initialize_workgroup_memory: true,
-                },
+                stage: convert_stage_desc(&descriptor.vertex.parent),
                 buffers: Cow::Owned(
                     descriptor
                         .vertex
@@ -302,16 +291,7 @@ impl GPUDevice {
                 .as_ref()
                 .map(|stage| -> Fallible<wgpu_pipe::FragmentState> {
                     Ok(wgpu_pipe::FragmentState {
-                        stage: wgpu_pipe::ProgrammableStageDescriptor {
-                            module: stage.parent.module.id().0,
-                            entry_point: stage
-                                .parent
-                                .entryPoint
-                                .as_ref()
-                                .map(|ep| Cow::Owned(ep.to_string())),
-                            constants: Cow::Owned(HashMap::new()),
-                            zero_initialize_workgroup_memory: true,
-                        },
+                        stage: convert_stage_desc(&stage.parent),
                         targets: Cow::Owned(
                             stage
                                 .targets
@@ -670,16 +650,7 @@ impl GPUDeviceMethods for GPUDevice {
         let desc = wgpu_pipe::ComputePipelineDescriptor {
             label: convert_label(&descriptor.parent.parent),
             layout,
-            stage: wgpu_pipe::ProgrammableStageDescriptor {
-                module: descriptor.compute.module.id().0,
-                entry_point: descriptor
-                    .compute
-                    .entryPoint
-                    .as_ref()
-                    .map(|ep| Cow::Owned(ep.to_string())),
-                constants: Cow::Owned(HashMap::new()),
-                zero_initialize_workgroup_memory: true,
-            },
+            stage: convert_stage_desc(&descriptor.compute),
             cache: None,
         };
 
@@ -721,16 +692,7 @@ impl GPUDeviceMethods for GPUDevice {
         let desc = wgpu_pipe::ComputePipelineDescriptor {
             label: convert_label(&descriptor.parent.parent),
             layout,
-            stage: wgpu_pipe::ProgrammableStageDescriptor {
-                module: descriptor.compute.module.id().0,
-                entry_point: descriptor
-                    .compute
-                    .entryPoint
-                    .as_ref()
-                    .map(|ep| Cow::Owned(ep.to_string())),
-                constants: Cow::Owned(HashMap::new()),
-                zero_initialize_workgroup_memory: true,
-            },
+            stage: convert_stage_desc(&descriptor.compute),
             cache: None,
         };
 

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -27,7 +27,7 @@ use super::bindings::codegen::Bindings::WebGPUBinding::{
 use super::bindings::codegen::UnionTypes::GPUPipelineLayoutOrGPUAutoLayoutMode;
 use super::bindings::error::Fallible;
 use super::gpu::AsyncWGPUListener;
-use super::gpuconvert::{convert_bind_group_layout_entry, convert_stage_desc};
+use super::gpuconvert::convert_bind_group_layout_entry;
 use super::gpudevicelostinfo::GPUDeviceLostInfo;
 use super::gpupipelineerror::GPUPipelineError;
 use super::gpusupportedlimits::GPUSupportedLimits;
@@ -259,7 +259,7 @@ impl GPUDevice {
             layout,
             cache: None,
             vertex: wgpu_pipe::VertexState {
-                stage: convert_stage_desc(&descriptor.vertex.parent),
+                stage: (&descriptor.vertex.parent).into(),
                 buffers: Cow::Owned(
                     descriptor
                         .vertex
@@ -291,7 +291,7 @@ impl GPUDevice {
                 .as_ref()
                 .map(|stage| -> Fallible<wgpu_pipe::FragmentState> {
                     Ok(wgpu_pipe::FragmentState {
-                        stage: convert_stage_desc(&stage.parent),
+                        stage: (&stage.parent).into(),
                         targets: Cow::Owned(
                             stage
                                 .targets
@@ -650,7 +650,7 @@ impl GPUDeviceMethods for GPUDevice {
         let desc = wgpu_pipe::ComputePipelineDescriptor {
             label: convert_label(&descriptor.parent.parent),
             layout,
-            stage: convert_stage_desc(&descriptor.compute),
+            stage: (&descriptor.compute).into(),
             cache: None,
         };
 
@@ -692,7 +692,7 @@ impl GPUDeviceMethods for GPUDevice {
         let desc = wgpu_pipe::ComputePipelineDescriptor {
             label: convert_label(&descriptor.parent.parent),
             layout,
-            stage: convert_stage_desc(&descriptor.compute),
+            stage: (&descriptor.compute).into(),
             cache: None,
         };
 

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -245,12 +245,12 @@ impl GPUDevice {
         }
     }
 
-    fn parse_render_pipeline(
+    fn parse_render_pipeline<'a>(
         &self,
         descriptor: &GPURenderPipelineDescriptor,
     ) -> Fallible<(
         Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)>,
-        RenderPipelineDescriptor<'static>,
+        RenderPipelineDescriptor<'a>,
     )> {
         let (layout, implicit_ids, _) = self.get_pipeline_layout_data(&descriptor.parent.layout);
 

--- a/components/script/dom/webidls/WebGPU.webidl
+++ b/components/script/dom/webidls/WebGPU.webidl
@@ -625,7 +625,10 @@ interface mixin GPUPipelineBase {
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;
     USVString entryPoint;
+    record<USVString, GPUPipelineConstantValue> constants;
 };
+
+typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32, and f16 if enabled.
 
 [Exposed=(Window, DedicatedWorker), Serializable, Pref="dom.webgpu.enabled"]
 interface GPUComputePipeline {


### PR DESCRIPTION
Sync [GPUProgrammableStage](https://www.w3.org/TR/webgpu/#gpuprogrammablestage) with spec and implements handling of user provided pipeline-overridable constants by passing them to wgpu. To make things easier all `GPUProgrammableStage` -> `ProgrammableStageDescriptor` conversions are extracted into `From` implementation and some lifetimes are made more general.

Spec: https://www.w3.org/TR/webgpu/#dom-gpuprogrammablestage-constants

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
