### PR TITLE
Only handle most recent resize event in script thread

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1688,7 +1688,7 @@ impl ScriptThread {
             // TODO(#31665): Implement the "run the scroll steps" from
             // https://drafts.csswg.org/cssom-view/#document-run-the-scroll-steps.
 
-            for (size, size_type) in document.window().steal_resize_events().into_iter() {
+            if let Some((size, size_type)) = document.window().take_unhandled_resize_event() {
                 // Resize steps.
                 self.run_the_resize_steps(pipeline_id, size, size_type);
 


### PR DESCRIPTION
We don't need to bother with resize events that are outdated in the script thread.

This change removes the  resize event queue in `dom::Window` and only keeps track of the most recent one that has not been handled yet.

Refer to #33293 for an example of how can make resizing look snappier on pages where layout takes a while.

The queue was originally introduced to pass tests (https://github.com/servo/servo/pull/31505#discussion_r1592802909) but removing it does not seem to cause issues (https://github.com/Wuelle/servo/pull/1#issuecomment-2325682387)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33293

