### PR TITLE
`jsstring_to_str` should accept a `NonNull` argument for the JS string

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -71,13 +71,14 @@ pub fn handle_evaluate_js(global: &GlobalScope, eval: String, reply: IpcSender<E
                 },
             )
         } else if rval.is_string() {
-            EvaluateJSReply::StringValue(String::from(jsstring_to_str(*cx, rval.to_string())))
+            let jsstr = std::ptr::NonNull::new(rval.to_string()).unwrap();
+            EvaluateJSReply::StringValue(String::from(jsstring_to_str(*cx, jsstr)))
         } else if rval.is_null() {
             EvaluateJSReply::NullValue
         } else {
             assert!(rval.is_object());
 
-            let jsstr = ToString(*cx, rval.handle());
+            let jsstr = std::ptr::NonNull::new(ToString(*cx, rval.handle())).unwrap();
             let class_name = jsstring_to_str(*cx, jsstr);
 
             EvaluateJSReply::ActorValue {

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -259,7 +259,7 @@ unsafe fn id_to_source(cx: SafeJSContext, id: RawHandleId) -> Option<DOMString> 
             jsstr.set(jsapi::JS_ValueToSource(*cx, value.handle().into()));
             jsstr.get()
         })
-        .filter(|jsstr| !jsstr.is_null())
+        .and_then(|jsstr| ptr::NonNull::new(jsstr))
         .map(|jsstr| jsstring_to_str(*cx, jsstr))
 }
 

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -237,19 +237,19 @@ pub unsafe fn find_enum_value<'a, T>(
     v: HandleValue,
     pairs: &'a [(&'static str, T)],
 ) -> Result<(Option<&'a T>, DOMString), ()> {
-    let jsstr = ToString(cx, v);
-    if jsstr.is_null() {
-        return Err(());
+    match ptr::NonNull::new(ToString(cx, v)) {
+        Some(jsstr) => {
+            let search = jsstring_to_str(cx, jsstr);
+            Ok((
+                pairs
+                    .iter()
+                    .find(|&&(key, _)| search == *key)
+                    .map(|(_, ev)| ev),
+                search,
+            ))
+        },
+        None => Err(()),
     }
-
-    let search = jsstring_to_str(cx, jsstr);
-    Ok((
-        pairs
-            .iter()
-            .find(|&&(key, _)| search == *key)
-            .map(|(_, ev)| ev),
-        search,
-    ))
 }
 
 /// Returns wether `obj` is a platform object using dynamic unwrap

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -609,7 +609,7 @@ impl ModuleTree {
         url: &ServoUrl,
         specifier: RawHandle<*mut JSString>,
     ) -> Result<ServoUrl, UrlParseError> {
-        let specifier_str = unsafe { jsstring_to_str(cx, *specifier) };
+        let specifier_str = unsafe { jsstring_to_str(cx, ptr::NonNull::new(*specifier).unwrap()) };
 
         // Step 1.
         if let Ok(specifier_url) = ServoUrl::parse(&specifier_str) {


### PR DESCRIPTION
Instead of asserting the raw pointer is not null, force callers to produce a NonNull pointer.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes address the suggestion in #33292
- [x] These changes do not require tests because they do not change the behavior, just move the existing verification into the callers by changing types

Please let me know if there's something else I should do or if I missed anything - this is my first PR here.