### PR TITLE
CI: Force github hosted runners and remove concurrency on select-runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,9 +61,9 @@ jobs:
       unique-id: ${{ steps.select.outputs.unique_id }}
       selected-runner-label: ${{ steps.select.outputs.selected_runner_label }}
       is-self-hosted: ${{ steps.select.outputs.is_self_hosted }}
-    concurrency:
-      group: servo-reserve-self-hosted-runner
-      cancel-in-progress: false
+    #concurrency:
+    #  group: servo-reserve-self-hosted-runner
+    #  cancel-in-progress: false
     permissions: write-all
     steps:
       - name: Select and reserve best available runner
@@ -82,6 +82,9 @@ jobs:
             echo 'is_self_hosted=false' | tee -a $GITHUB_OUTPUT
             exit 0
           }
+
+          echo 'forced github hosted runners!'
+          fall_back_to_github_hosted
 
           # Generate a unique id that allows the workload job to find the runner
           # we are reserving for it (via runner labels), and allows the timeout


### PR DESCRIPTION
temporary fix for #33276

Either this or complete revert of #33081 is needed or MQ will progress very slowly (no PR landed in last 20 hours).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because CI changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
