### PR TITLE
Treat `align-self: normal` as `stretch` on flex items

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -247,7 +247,8 @@ impl FlexContainerConfig {
     fn align_for(&self, align_self: AlignSelf) -> AlignItems {
         let value = align_self.0 .0.value();
         let mapped_value = match value {
-            AlignFlags::AUTO | AlignFlags::NORMAL => self.align_items.0,
+            AlignFlags::AUTO => self.align_items.0,
+            AlignFlags::NORMAL => AlignFlags::STRETCH,
             _ => value,
         };
         AlignItems(mapped_value)

--- a/tests/wpt/tests/css/css-align/self-alignment/self-align-normal-flex.html
+++ b/tests/wpt/tests/css/css-align/self-alignment/self-align-normal-flex.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>align-self:normal on flex items</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-align/#align-flex">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="align-self:normal behaves as stretch on flex items." />
+<style>
+.flex {
+  display: flex;
+  align-items: center;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.item {
+  flex: 1;
+  align-self: normal;
+  background: green;
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class="flex">
+  <div class="item"></div>
+</div>


### PR DESCRIPTION
According to https://drafts.csswg.org/css-align/#align-flex
It was being treated as `auto` instead.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
