### PR TITLE
minibrowser: Reset the location field when switching tabs

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -366,6 +366,7 @@ impl Minibrowser {
                             if let Some(event) =
                                 Self::browser_tab(ui, label, webview.focused, webview_id)
                             {
+                                location_dirty.set(false);
                                 embedder_events.push(event);
                             }
                         }
@@ -523,6 +524,7 @@ impl Minibrowser {
                     app_event_queue.push(EmbedderEvent::Reload(browser_id));
                 },
                 MinibrowserEvent::NewWebView => {
+                    self.location_dirty.set(false);
                     let url = ServoUrl::parse("servo:newtab").unwrap();
                     app_event_queue.push(EmbedderEvent::NewWebView(url, WebViewId::new()));
                 },


### PR DESCRIPTION
The state of the location bar was not reset when switching tabs, hence it would stick to the currently edited value when it was being edited.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33311(GitHub issue number if applicable)
