### PR TITLE
webxr: Add some missing internal checks/validation

### DIFF
--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -83,6 +83,26 @@ impl XRRigidTransform {
             )));
         }
 
+        if !position.x.is_finite() ||
+            !position.y.is_finite() ||
+            !position.z.is_finite() ||
+            !position.w.is_finite()
+        {
+            return Err(Error::Type(
+                "Position must not contain non-finite values".into(),
+            ));
+        }
+
+        if !orientation.x.is_finite() ||
+            !orientation.y.is_finite() ||
+            !orientation.z.is_finite() ||
+            !orientation.w.is_finite()
+        {
+            return Err(Error::Type(
+                "Orientation must not contain non-finite values".into(),
+            ));
+        }
+
         let translate = Vector3D::new(position.x as f32, position.y as f32, position.z as f32);
         let rotate = Rotation3D::unit_quaternion(
             orientation.x as f32,

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -709,11 +709,16 @@ impl XRSessionMethods for XRSession {
             pending.set_depth_near(near);
         }
         if let Some(far) = init.depthFar {
+            let mut far = *far;
             // Step 9 from #apply-the-pending-render-state
             // this may need to be changed if backends wish to impose
             // further constraints
-            // currently the maximum is infinity, so we do nothing
-            pending.set_depth_far(*far);
+            // currently the maximum is infinity, so just check that
+            // the value is non-negative
+            if far < 0. {
+                far = 0.;
+            }
+            pending.set_depth_far(far);
         }
         if let Some(fov) = init.inlineVerticalFieldOfView {
             let mut fov = *fov;

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -187,8 +187,6 @@ impl XRSystemMethods for XRSystem {
         let mut optional_features = vec![];
         let cx = GlobalScope::get_cx();
 
-        // We are supposed to include "viewer" and on immersive devices "local"
-        // by default here, but this is handled directly in requestReferenceSpace()
         if let Some(ref r) = init.requiredFeatures {
             for feature in r {
                 unsafe {
@@ -220,6 +218,14 @@ impl XRSystemMethods for XRSystem {
                     }
                 }
             }
+        }
+
+        if !required_features.contains(&"viewer".to_string()) {
+            required_features.push("viewer".to_string());
+        }
+
+        if !required_features.contains(&"local".to_string()) && mode != XRSessionMode::Inline {
+            required_features.push("local".to_string());
         }
 
         let init = SessionInit {

--- a/tests/wpt/meta-legacy-layout/webxr/render_state_update.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/render_state_update.https.html.ini
@@ -1,7 +1,2 @@
 [render_state_update.https.html]
   expected: ERROR
-  [updateRenderState clamps appropriately near/far clipping planes - webgl]
-    expected: FAIL
-
-  [updateRenderState clamps appropriately near/far clipping planes - webgl2]
-    expected: FAIL

--- a/tests/wpt/meta-legacy-layout/webxr/xrRigidTransform_constructor.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/xrRigidTransform_constructor.https.html.ini
@@ -1,7 +1,0 @@
-[xrRigidTransform_constructor.https.html]
-  [XRRigidTransform constructor works - webgl2]
-    expected: FAIL
-
-  [XRRigidTransform constructor works - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/webxr/xrSession_enabledFeatures.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/xrSession_enabledFeatures.https.html.ini
@@ -1,6 +1,0 @@
-[xrSession_enabledFeatures.https.html]
-  [Validate enabledFeatures on XRSession - webgl]
-    expected: FAIL
-
-  [Validate enabledFeatures on XRSession - webgl2]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/render_state_update.https.html.ini
+++ b/tests/wpt/meta/webxr/render_state_update.https.html.ini
@@ -1,7 +1,2 @@
 [render_state_update.https.html]
   expected: ERROR
-  [updateRenderState clamps appropriately near/far clipping planes - webgl]
-    expected: FAIL
-
-  [updateRenderState clamps appropriately near/far clipping planes - webgl2]
-    expected: FAIL

--- a/tests/wpt/meta/webxr/xrRigidTransform_constructor.https.html.ini
+++ b/tests/wpt/meta/webxr/xrRigidTransform_constructor.https.html.ini
@@ -1,7 +1,0 @@
-[xrRigidTransform_constructor.https.html]
-  [XRRigidTransform constructor works - webgl2]
-    expected: FAIL
-
-  [XRRigidTransform constructor works - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta/webxr/xrSession_enabledFeatures.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_enabledFeatures.https.html.ini
@@ -1,6 +1,0 @@
-[xrSession_enabledFeatures.https.html]
-  [Validate enabledFeatures on XRSession - webgl]
-    expected: FAIL
-
-  [Validate enabledFeatures on XRSession - webgl2]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This makes the following adjustments:

- Rejecting in XRRigidTransform constructor if non-finite values are present in position or orientation
- Properly appending default features in requestSession if they are not present (previously "viewer" would not appear in enabledFeatures if not explicitly passed, despite being default)
- Clamping depthFar in updateRenderState if it is negative

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
