### PR TITLE
layout: Lay out absolutes in atomic containing blocks

### DIFF
--- a/tests/wpt/meta/css/CSS2/positioning/abspos-inline-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/abspos-inline-007.xht.ini
@@ -1,2 +1,0 @@
-[abspos-inline-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vlr-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vlr-ltr-htb.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vlr-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vlr-ltr-vlr.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vlr-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vlr-ltr-vrl.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vlr-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vlr-rtl-htb.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vlr-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vlr-rtl-vlr.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vlr-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vlr-rtl-vrl.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vrl-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vrl-ltr-htb.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vrl-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vrl-ltr-vlr.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vrl-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vrl-ltr-vrl.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vrl-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vrl-rtl-htb.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vrl-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vrl-rtl-vlr.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-vrl-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-vrl-rtl-vrl.html.ini
@@ -20,9 +20,6 @@
   [.item 7]
     expected: FAIL
 
-  [.item 8]
-    expected: FAIL
-
   [.item 9]
     expected: FAIL
 
@@ -42,7 +39,4 @@
     expected: FAIL
 
   [.item 15]
-    expected: FAIL
-
-  [.item 16]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-ltr-htb.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-ltr-vlr.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-ltr-vrl.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-rtl-htb.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-rtl-vlr.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vlr-rtl-vrl.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-ltr-htb.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-ltr-vlr.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-ltr-vrl.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-rtl-htb.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-rtl-vlr.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-vrl-rtl-vrl.html.ini
@@ -26,9 +26,6 @@
   [.item 9]
     expected: FAIL
 
-  [.item 10]
-    expected: FAIL
-
   [.item 11]
     expected: FAIL
 
@@ -54,7 +51,4 @@
     expected: FAIL
 
   [.item 19]
-    expected: FAIL
-
-  [.item 20]
     expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-htb.html.ini
@@ -8,9 +8,6 @@
   [.item 3]
     expected: FAIL
 
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
@@ -18,9 +15,6 @@
     expected: FAIL
 
   [.item 7]
-    expected: FAIL
-
-  [.item 8]
     expected: FAIL
 
   [.item 10]

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-htb-vrl.html.ini
@@ -8,9 +8,6 @@
   [.item 3]
     expected: FAIL
 
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
@@ -18,9 +15,6 @@
     expected: FAIL
 
   [.item 7]
-    expected: FAIL
-
-  [.item 8]
     expected: FAIL
 
   [.item 10]

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-htb.html.ini
@@ -8,9 +8,6 @@
   [.item 3]
     expected: FAIL
 
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
@@ -18,9 +15,6 @@
     expected: FAIL
 
   [.item 7]
-    expected: FAIL
-
-  [.item 8]
     expected: FAIL
 
   [.item 10]

--- a/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl.html.ini
@@ -8,9 +8,6 @@
   [.item 3]
     expected: FAIL
 
-  [.item 4]
-    expected: FAIL
-
   [.item 5]
     expected: FAIL
 
@@ -18,9 +15,6 @@
     expected: FAIL
 
   [.item 7]
-    expected: FAIL
-
-  [.item 8]
     expected: FAIL
 
   [.item 10]

--- a/tests/wpt/meta/css/css-backgrounds/border-left-width-medium.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-left-width-medium.html.ini
@@ -1,2 +1,0 @@
-[border-left-width-medium.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-left-width-thick.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-left-width-thick.html.ini
@@ -1,2 +1,0 @@
-[border-left-width-thick.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-left-width-thin.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-left-width-thin.html.ini
@@ -1,2 +1,0 @@
-[border-left-width-thin.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-right-width-medium.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-right-width-medium.html.ini
@@ -1,2 +1,0 @@
-[border-right-width-medium.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-right-width-thick.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-right-width-thick.html.ini
@@ -1,2 +1,0 @@
-[border-right-width-thick.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-right-width-thin.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-right-width-thin.html.ini
@@ -1,2 +1,0 @@
-[border-right-width-thin.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-replaced-minmax.html.ini
@@ -1,69 +1,9 @@
 [position-absolute-replaced-minmax.html]
   expected: TIMEOUT
-  [minmax replaced IFRAME 1]
-    expected: FAIL
-
-  [minmax replaced IFRAME 2]
-    expected: FAIL
-
-  [minmax replaced IFRAME 3]
-    expected: FAIL
-
-  [minmax replaced IFRAME 4]
-    expected: FAIL
-
-  [minmax replaced IFRAME 5]
-    expected: FAIL
-
-  [minmax replaced IFRAME 6]
-    expected: FAIL
-
-  [minmax replaced IFRAME 7]
-    expected: FAIL
-
-  [minmax replaced IFRAME 8]
-    expected: FAIL
-
-  [minmax replaced IFRAME 9]
-    expected: FAIL
-
   [minmax replaced IFRAME 10]
     expected: FAIL
 
   [minmax replaced IFRAME 11]
-    expected: FAIL
-
-  [minmax replaced IMG 12]
-    expected: FAIL
-
-  [minmax replaced IMG 13]
-    expected: FAIL
-
-  [minmax replaced IMG 14]
-    expected: FAIL
-
-  [minmax replaced IMG 15]
-    expected: FAIL
-
-  [minmax replaced IMG 16]
-    expected: FAIL
-
-  [minmax replaced IMG 17]
-    expected: FAIL
-
-  [minmax replaced IMG 18]
-    expected: FAIL
-
-  [minmax replaced IMG 19]
-    expected: FAIL
-
-  [minmax replaced IMG 20]
-    expected: FAIL
-
-  [minmax replaced IMG 21]
-    expected: FAIL
-
-  [minmax replaced IMG 22]
     expected: FAIL
 
   [minmax replaced IMG svg 23]

--- a/tests/wpt/meta/css/css-values/animations/calc-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-values/animations/calc-interpolation.html.ini
@@ -77,69 +77,6 @@
   [Web Animations: property <left> from [0px\] to [calc(infinity * 1px)\] at (1.25) should be [33554400px\]]
     expected: FAIL
 
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [-10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [-10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [-10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [50px\]]
-    expected: FAIL
-
   [Web Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [-10px\]]
     expected: FAIL
 

--- a/tests/wpt/meta/css/filter-effects/backdrop-filter-boundary.html.ini
+++ b/tests/wpt/meta/css/filter-effects/backdrop-filter-boundary.html.ini
@@ -1,0 +1,2 @@
+[backdrop-filter-boundary.html]
+  expected: FAIL


### PR DESCRIPTION
When inline atomics establish containing blocks for absolute
descendants, layout should happen with those atomics as the containing
block. This ensures that the absolute descendents have the correct
containing block and Fragment parent. This wasn't happening before and
this change fixes that.

One test starts to fail because of the lack of `overflow: clip` support.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
