### PR TITLE
net: use saturating_sub when substracting durations to prevent underflows

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -198,10 +198,7 @@ fn get_response_expiry(response: &Response) -> Duration {
             return Duration::ZERO;
         }
         if let Some(max_age) = directives.max_age().or(directives.s_max_age()) {
-            if max_age < age {
-                return Duration::ZERO;
-            }
-            return max_age - age;
+            return max_age.saturating_sub(age);
         }
     }
     match response.headers.typed_get::<Expires>() {
@@ -221,7 +218,7 @@ fn get_response_expiry(response: &Response) -> Duration {
         // <https://tools.ietf.org/html/rfc7234#section-5.5.4>
         // Since presently we do not generate a Warning header field with a 113 warn-code,
         // 24 hours minus response age is the max for heuristic calculation.
-        let max_heuristic = Duration::from_secs(24 * 60 * 60) - age;
+        let max_heuristic = Duration::from_secs(24 * 60 * 60).saturating_sub(age);
         let heuristic_freshness = if let Some(last_modified) =
             // If the response has a Last-Modified header field,
             // caches are encouraged to use a heuristic expiration value

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1,5 +1,16 @@
 {
  "items": {
+  "crashtest": {
+   "mozilla": {
+    "cache_old_response-crash.html": [
+     "d14e7c830f52bb77e81d91b533e0ce6d4a1ede82",
+     [
+      null,
+      {}
+     ]
+    ]
+   }
+  },
   "reftest": {
    "css": {
     "abs-overflow-stackingcontext.html": [
@@ -10505,6 +10516,10 @@
     ],
     "nested_asap_script.js": [
      "59562a8c9c39130cad411815059513c4ce0a7c04",
+     []
+    ],
+    "old_page.py": [
+     "3f096b6f5a6611f97f625d8a0420aaa96f2e2b01",
      []
     ],
     "partial_shadow_dom_layout_style_ref.html": [

--- a/tests/wpt/mozilla/tests/mozilla/cache_old_response-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/cache_old_response-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:jdm@servo.org">
+<link rel="help" href="https://github.com/servo/servo/issues/33340">
+<meta name="assert" content="The http cache should not panic.">
+
+<iframe src="old_page.py"></iframe>

--- a/tests/wpt/mozilla/tests/mozilla/old_page.py
+++ b/tests/wpt/mozilla/tests/mozilla/old_page.py
@@ -1,0 +1,14 @@
+# Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+def main(request, response):
+    response.headers.set(b"Age", b"90000")
+    response.headers.set(b"Last-Modified", b"Wed, 21 Oct 2015 07:28:00 GMT")
+    response.write_status_headers()
+    response.writer.write_content(b"Body")


### PR DESCRIPTION
Using `saturating_sub()` prevents panic from happening and give the expected `ZERO` duration in the case we fix here. The other change is a trivial refactoring to replace the manual implementation of the same logic.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33340(GitHub issue number if applicable)

