### PR TITLE
Handle all `white-space` values when intrinsically sizing an IFC

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -291,15 +291,17 @@ bitflags! {
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct ShapingFlags: u8 {
         /// Set if the text is entirely whitespace.
-        const IS_WHITESPACE_SHAPING_FLAG = 0x01;
+        const IS_WHITESPACE_SHAPING_FLAG = 1 << 0;
+        /// Set if the text ends with whitespace.
+        const ENDS_WITH_WHITESPACE_SHAPING_FLAG = 1 << 1;
         /// Set if we are to ignore ligatures.
-        const IGNORE_LIGATURES_SHAPING_FLAG = 0x02;
+        const IGNORE_LIGATURES_SHAPING_FLAG = 1 << 2;
         /// Set if we are to disable kerning.
-        const DISABLE_KERNING_SHAPING_FLAG = 0x04;
+        const DISABLE_KERNING_SHAPING_FLAG = 1 << 3;
         /// Text direction is right-to-left.
-        const RTL_FLAG = 0x08;
+        const RTL_FLAG = 1 << 4;
         /// Set if word-break is set to keep-all.
-        const KEEP_ALL_FLAG = 0x10;
+        const KEEP_ALL_FLAG = 1 << 5;
     }
 }
 
@@ -344,6 +346,9 @@ impl Font {
             options
                 .flags
                 .contains(ShapingFlags::IS_WHITESPACE_SHAPING_FLAG),
+            options
+                .flags
+                .contains(ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG),
             is_single_preserved_newline,
             options.flags.contains(ShapingFlags::RTL_FLAG),
         );
@@ -946,10 +951,10 @@ mod test {
 
         assert!(font.can_do_fast_shaping(text, &shaping_options));
 
-        let mut expected_glyphs = GlyphStore::new(text.len(), false, false, false);
+        let mut expected_glyphs = GlyphStore::new(text.len(), false, false, false, false);
         font.shape_text_harfbuzz(text, &shaping_options, &mut expected_glyphs);
 
-        let mut glyphs = GlyphStore::new(text.len(), false, false, false);
+        let mut glyphs = GlyphStore::new(text.len(), false, false, false, false);
         font.shape_text_fast(text, &shaping_options, &mut glyphs);
 
         assert_eq!(glyphs.len(), expected_glyphs.len());

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -446,6 +446,11 @@ pub struct GlyphStore {
     /// Whether or not this glyph store contains only glyphs for whitespace.
     is_whitespace: bool,
 
+    /// Whether or not this glyph store ends with whitespace glyphs.
+    /// Typically whitespace glyphs are placed in a separate store,
+    /// but that may not be the case with `white-space: break-spaces`.
+    ends_with_whitespace: bool,
+
     /// Whether or not this glyph store contains only a single glyph for a single
     /// preserved newline.
     is_single_preserved_newline: bool,
@@ -460,6 +465,7 @@ impl<'a> GlyphStore {
     pub fn new(
         length: usize,
         is_whitespace: bool,
+        ends_with_whitespace: bool,
         is_single_preserved_newline: bool,
         is_rtl: bool,
     ) -> GlyphStore {
@@ -472,6 +478,7 @@ impl<'a> GlyphStore {
             total_word_separators: 0,
             has_detailed_glyphs: false,
             is_whitespace,
+            ends_with_whitespace,
             is_single_preserved_newline,
             is_rtl,
         }
@@ -490,6 +497,11 @@ impl<'a> GlyphStore {
     #[inline]
     pub fn is_whitespace(&self) -> bool {
         self.is_whitespace
+    }
+
+    #[inline]
+    pub fn ends_with_whitespace(&self) -> bool {
+        self.ends_with_whitespace
     }
 
     #[inline]

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -217,6 +217,8 @@ impl TextRunSegment {
                 continue;
             }
 
+            let mut options = *shaping_options;
+
             // Extend the slice to the next UAX#14 line break opportunity.
             let mut slice = last_slice.end..*break_index;
             let word = &formatting_context_text[slice.clone()];
@@ -247,6 +249,9 @@ impl TextRunSegment {
                     !can_break_anywhere
                 {
                     whitespace.start += first_white_space_character.len_utf8();
+                    options
+                        .flags
+                        .insert(ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG);
                 }
 
                 slice.end = whitespace.start;
@@ -267,17 +272,17 @@ impl TextRunSegment {
 
             // Push the non-whitespace part of the range.
             if !slice.is_empty() {
-                self.shape_and_push_range(&slice, formatting_context_text, &font, shaping_options);
+                self.shape_and_push_range(&slice, formatting_context_text, &font, &options);
             }
 
             if whitespace.is_empty() {
                 continue;
             }
 
-            let mut options = *shaping_options;
-            options
-                .flags
-                .insert(ShapingFlags::IS_WHITESPACE_SHAPING_FLAG);
+            options.flags.insert(
+                ShapingFlags::IS_WHITESPACE_SHAPING_FLAG |
+                    ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG,
+            );
 
             // If `white-space-collapse: break-spaces` is active, insert a line breaking opportunity
             // between each white space character in the white space that we trimmed off.

--- a/tests/wpt/meta/css/css-flexbox/flexbox_flex-formatting-interop.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_flex-formatting-interop.html.ini
@@ -1,0 +1,2 @@
+[flexbox_flex-formatting-interop.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-quirks.html.ini
@@ -2,8 +2,5 @@
   [table 1]
     expected: FAIL
 
-  [table 3]
-    expected: FAIL
-
   [table 6]
     expected: FAIL

--- a/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-002.html.ini
+++ b/tests/wpt/meta/css/css-text/white-space/white-space-intrinsic-size-002.html.ini
@@ -1,2 +1,0 @@
-[white-space-intrinsic-size-002.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/white_space_intrinsic_sizes_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/white_space_intrinsic_sizes_a.html.ini
@@ -1,2 +1,0 @@
-[white_space_intrinsic_sizes_a.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-text/white-space/white-space-intrinsic-size-021.html
+++ b/tests/wpt/tests/css/css-text/white-space/white-space-intrinsic-size-021.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 4 Test: intrinsic sizes of block containers with various 'white-space' values</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#white-space-property">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+.container {
+  font: 10px / 1 Ahem;
+  color: gray;
+}
+.container.narrow {
+  float: left;
+  width: 0;
+  margin-right: 50px;
+}
+.container.wide {
+  width: 800px;
+}
+.container > div {
+  display: inline-block;
+  border: solid black;
+}
+hr {
+  clear: both;
+}
+.collapse.wrap {
+  white-space: normal;
+}
+.collapse.nowrap {
+  white-space: nowrap;
+}
+.preserve.wrap {
+  white-space: pre-wrap;
+}
+.preserve.nowrap {
+  white-space: pre;
+}
+.preserve-breaks.wrap {
+  white-space: preserve-breaks;
+}
+.preserve-breaks.nowrap {
+  white-space: preserve-breaks nowrap;
+}
+.break-spaces.wrap {
+  white-space: break-spaces;
+}
+.break-spaces.nowrap {
+  white-space: break-spaces nowrap;
+}
+</style>
+
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="collapse nowrap"        data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve wrap"          data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve nowrap"        data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve-breaks wrap"   data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve-breaks nowrap" data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="break-spaces wrap"      data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="break-spaces nowrap"    data-expected-client-width= "0" data-expected-client-height= "0"></div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="collapse nowrap"        data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="preserve wrap"          data-expected-client-width= "0" data-expected-client-height="10"> </div>
+  <div class="preserve nowrap"        data-expected-client-width="10" data-expected-client-height="10"> </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="10"> </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="10" data-expected-client-height="10"> </div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="collapse nowrap"        data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="preserve wrap"          data-expected-client-width= "0" data-expected-client-height="10">  </div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="10">  </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="20">  </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="10">  </div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve nowrap"        data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="10" data-expected-client-height="10">X</div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20"> X</div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="10"> X</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="20"> X</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="10"> X</div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20">  X</div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">  X</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="30">  X</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">  X</div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="10">X </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="10">X </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="10">X </div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X  </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X  </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X  </div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="20">X É</div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20">X É</div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="20">X É</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X É</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X É</div>
+</div>
+<div class="container narrow">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="20">X  É</div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X  É</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="20">X  É</div>
+  <div class="preserve nowrap"        data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="20">X  É</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X  É</div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="20">X  É</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+</div>
+
+<hr>
+
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="collapse nowrap"        data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve wrap"          data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve nowrap"        data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve-breaks wrap"   data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="preserve-breaks nowrap" data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="break-spaces wrap"      data-expected-client-width= "0" data-expected-client-height= "0"></div>
+  <div class="break-spaces nowrap"    data-expected-client-width= "0" data-expected-client-height= "0"></div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="collapse nowrap"        data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="10"> </div>
+  <div class="preserve nowrap"        data-expected-client-width="10" data-expected-client-height="10"> </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width= "0" data-expected-client-height= "0"> </div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="10"> </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="10" data-expected-client-height="10"> </div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="collapse nowrap"        data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="preserve wrap"          data-expected-client-width="20" data-expected-client-height="10">  </div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="10">  </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width= "0" data-expected-client-height= "0">  </div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="10">  </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="10">  </div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve wrap"          data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve nowrap"        data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="break-spaces wrap"      data-expected-client-width="10" data-expected-client-height="10">X</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="10" data-expected-client-height="10">X</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="preserve wrap"          data-expected-client-width="20" data-expected-client-height="10"> X</div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="10"> X</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10"> X</div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="10"> X</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="10"> X</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="preserve wrap"          data-expected-client-width="30" data-expected-client-height="10">  X</div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">  X</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">  X</div>
+  <div class="break-spaces wrap"      data-expected-client-width="30" data-expected-client-height="10">  X</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">  X</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="preserve wrap"          data-expected-client-width="20" data-expected-client-height="10">X </div>
+  <div class="preserve nowrap"        data-expected-client-width="20" data-expected-client-height="10">X </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">X </div>
+  <div class="break-spaces wrap"      data-expected-client-width="20" data-expected-client-height="10">X </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="20" data-expected-client-height="10">X </div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="collapse nowrap"        data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="preserve wrap"          data-expected-client-width="30" data-expected-client-height="10">X  </div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X  </div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="10" data-expected-client-height="10">X  </div>
+  <div class="break-spaces wrap"      data-expected-client-width="30" data-expected-client-height="10">X  </div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X  </div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="preserve wrap"          data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="preserve nowrap"        data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="break-spaces wrap"      data-expected-client-width="30" data-expected-client-height="10">X É</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="30" data-expected-client-height="10">X É</div>
+</div>
+<div class="container wide">
+  <div class="collapse wrap"          data-expected-client-width="30" data-expected-client-height="10">X  É</div>
+  <div class="collapse nowrap"        data-expected-client-width="30" data-expected-client-height="10">X  É</div>
+  <div class="preserve wrap"          data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+  <div class="preserve nowrap"        data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+  <div class="preserve-breaks wrap"   data-expected-client-width="30" data-expected-client-height="10">X  É</div>
+  <div class="preserve-breaks nowrap" data-expected-client-width="30" data-expected-client-height="10">X  É</div>
+  <div class="break-spaces wrap"      data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+  <div class="break-spaces nowrap"    data-expected-client-width="40" data-expected-client-height="10">X  É</div>
+</div>
+
+<hr>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".container > div");
+</script>


### PR DESCRIPTION
There were various cases like `text-wrap-mode: nowrap` and
`white-space-collapse: break-spaces` that weren't handled well.

Fixes #33335

flexbox_flex-formatting-interop.html fails now because we don't support
`table-layout: fixed`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33335
- [X] There are tests for these change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
