### PR TITLE
Initial support for `<link rel="prefetch">`

### DIFF
--- a/components/constellation/network_listener.rs
+++ b/components/constellation/network_listener.rs
@@ -8,12 +8,12 @@
 
 use base::id::PipelineId;
 use crossbeam_channel::Sender;
-use http::HeaderMap;
+use http::{header, HeaderMap};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use log::warn;
-use net::http_loader::{set_default_accept, set_default_accept_language};
-use net_traits::request::{Destination, Referrer, RequestBuilder};
+use net::http_loader::{set_default_accept_language, DOCUMENT_ACCEPT_HEADER_VALUE};
+use net_traits::request::{Referrer, RequestBuilder};
 use net_traits::response::ResponseInit;
 use net_traits::{
     CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseMsg, IpcSend, NetworkError,
@@ -66,7 +66,17 @@ impl NetworkListener {
                 None,
             ),
             None => {
-                set_default_accept(Destination::Document, &mut listener.request_builder.headers);
+                if !listener
+                    .request_builder
+                    .headers
+                    .contains_key(header::ACCEPT)
+                {
+                    listener
+                        .request_builder
+                        .headers
+                        .insert(header::ACCEPT, DOCUMENT_ACCEPT_HEADER_VALUE);
+                }
+
                 set_default_accept_language(&mut listener.request_builder.headers);
 
                 CoreResourceMsg::Fetch(

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -133,7 +133,7 @@ pub async fn fetch_with_cors_cache(
     }
 
     // Step 3.
-    set_default_accept(request.destination, &mut request.headers);
+    set_default_accept(request);
 
     // Step 4.
     set_default_accept_language(&mut request.headers);

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -68,7 +68,7 @@ impl RequestGenerationId {
     }
 }
 
-/// <https://html.spec.whatwg.org/multipage/semantics.html#link-processing-options>
+/// <https://html.spec.whatwg.org/multipage/#link-processing-options>
 struct LinkProcessingOptions {
     href: String,
     destination: Option<Destination>,
@@ -300,7 +300,7 @@ impl VirtualMethods for HTMLLinkElement {
 }
 
 impl HTMLLinkElement {
-    /// <https://html.spec.whatwg.org/multipage/semantics.html#create-link-options-from-element>
+    /// <https://html.spec.whatwg.org/multipage/#create-link-options-from-element>
     fn processing_options(&self) -> LinkProcessingOptions {
         let element = self.upcast::<Element>();
 
@@ -347,7 +347,7 @@ impl HTMLLinkElement {
         options
     }
 
-    /// The `fetch and process the linked resource` algorithm for [`rel="prefetch"`](https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch)
+    /// The `fetch and process the linked resource` algorithm for [`rel="prefetch"`](https://html.spec.whatwg.org/multipage/#link-type-prefetch)
     fn fetch_and_process_prefetch_link(&self, href: &str) {
         // Step 1.
         if href.is_empty() {
@@ -647,7 +647,7 @@ impl HTMLLinkElementMethods for HTMLLinkElement {
 }
 
 impl LinkProcessingOptions {
-    /// <https://html.spec.whatwg.org/multipage/semantics.html#create-a-link-request>
+    /// <https://html.spec.whatwg.org/multipage/#create-a-link-request>
     fn create_link_request(self) -> Option<RequestBuilder> {
         // Step 1.
         assert!(!self.href.is_empty());
@@ -682,7 +682,7 @@ impl LinkProcessingOptions {
     }
 }
 
-/// <https://html.spec.whatwg.org/multipage/links.html#translate-a-preload-destination>
+/// <https://html.spec.whatwg.org/multipage/#translate-a-preload-destination>
 fn translate_a_preload_destination(potential_destination: &str) -> Destination {
     match potential_destination {
         "fetch" => Destination::None,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -94,6 +94,8 @@ mod webdriver_handlers;
 #[warn(deprecated)]
 mod window_named_properties;
 
+mod link_relations;
+
 pub use init::init;
 pub use script_runtime::JSEngineSetup;
 

--- a/components/script/link_relations.rs
+++ b/components/script/link_relations.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use html5ever::{local_name, namespace_url, ns};
 use malloc_size_of::malloc_size_of_is_0;
 use style::str::HTML_SPACE_CHARACTERS;

--- a/components/script/link_relations.rs
+++ b/components/script/link_relations.rs
@@ -1,0 +1,127 @@
+use html5ever::{local_name, namespace_url, ns};
+use malloc_size_of::malloc_size_of_is_0;
+use style::str::HTML_SPACE_CHARACTERS;
+
+use crate::dom::types::Element;
+
+bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    pub struct LinkRelations: u32 {
+        const ALTERNATE = 1;
+        const AUTHOR = 1 << 1;
+        const BOOKMARK = 1 << 2;
+        const CANONICAL = 1 << 3;
+        const DNS_PREFETCH = 1 << 4;
+        const EXPECT = 1 << 5;
+        const EXTERNAL = 1 << 6;
+        const HELP = 1 << 7;
+        const ICON = 1 << 8;
+        const LICENSE = 1 << 9;
+        const NEXT = 1 << 10;
+        const MANIFEST = 1 << 11;
+        const MODULE_PRELOAD = 1 << 12;
+        const NO_FOLLOW = 1 << 13;
+        const NO_OPENER = 1 << 14;
+        const NO_REFERRER = 1 << 15;
+        const OPENER = 1 << 16;
+        const PING_BACK = 1 << 17;
+        const PRECONNECT = 1 << 18;
+        const PREFETCH = 1 << 19;
+        const PRELOAD = 1 << 20;
+        const PREV = 1 << 21;
+        const PRIVACY_POLICY = 1 << 22;
+        const SEARCH = 1 << 23;
+        const STYLESHEET = 1 << 24;
+        const TAG = 1 << 25;
+        const TermsOfService = 1 << 26;
+    }
+}
+
+impl LinkRelations {
+    pub fn for_element(element: &Element) -> Self {
+        let rel = element.get_attribute(&ns!(), &local_name!("rel")).map(|e| {
+            let value = e.value();
+            (**value).to_owned()
+        });
+
+        // FIXME: for a, area and form elements we need to allow a different
+        //        set of attributes
+        let mut relations = rel
+            .map(|attribute| {
+                attribute
+                    .split(HTML_SPACE_CHARACTERS)
+                    .map(Self::from_single_keyword_for_link_element)
+                    .collect()
+            })
+            .unwrap_or(Self::empty());
+
+        // For historical reasons, "rev=made" is treated as if the "author" relation was specified
+        let has_legacy_author_relation = element
+            .get_attribute(&ns!(), &local_name!("rev"))
+            .is_some_and(|rev| &**rev.value() == "made");
+        if has_legacy_author_relation {
+            relations |= Self::AUTHOR;
+        }
+
+        relations
+    }
+
+    /// Parse one of the relations allowed for the `<link>` element
+    ///
+    /// If the keyword is invalid then `Self::empty` is returned.
+    fn from_single_keyword_for_link_element(keyword: &str) -> Self {
+        if keyword.eq_ignore_ascii_case("alternate") {
+            Self::ALTERNATE
+        } else if keyword.eq_ignore_ascii_case("canonical") {
+            Self::CANONICAL
+        } else if keyword.eq_ignore_ascii_case("author") {
+            Self::AUTHOR
+        } else if keyword.eq_ignore_ascii_case("dns-prefetch") {
+            Self::DNS_PREFETCH
+        } else if keyword.eq_ignore_ascii_case("expect") {
+            Self::EXPECT
+        } else if keyword.eq_ignore_ascii_case("help") {
+            Self::HELP
+        } else if keyword.eq_ignore_ascii_case("icon") ||
+            keyword.eq_ignore_ascii_case("shortcut icon") ||
+            keyword.eq_ignore_ascii_case("apple-touch-icon")
+        {
+            // TODO: "apple-touch-icon" is not in the spec. Where did it come from? Do we need it?
+            //       There is also "apple-touch-icon-precomposed" listed in
+            //       https://github.com/servo/servo/blob/e43e4778421be8ea30db9d5c553780c042161522/components/script/dom/htmllinkelement.rs#L452-L467
+            Self::ICON
+        } else if keyword.eq_ignore_ascii_case("manifest") {
+            Self::MANIFEST
+        } else if keyword.eq_ignore_ascii_case("modulepreload") {
+            Self::MODULE_PRELOAD
+        } else if keyword.eq_ignore_ascii_case("license") ||
+            keyword.eq_ignore_ascii_case("copyright")
+        {
+            Self::LICENSE
+        } else if keyword.eq_ignore_ascii_case("next") {
+            Self::NEXT
+        } else if keyword.eq_ignore_ascii_case("pingback") {
+            Self::PING_BACK
+        } else if keyword.eq_ignore_ascii_case("preconnect") {
+            Self::PRECONNECT
+        } else if keyword.eq_ignore_ascii_case("prefetch") {
+            Self::PREFETCH
+        } else if keyword.eq_ignore_ascii_case("preload") {
+            Self::PRELOAD
+        } else if keyword.eq_ignore_ascii_case("prev") || keyword.eq_ignore_ascii_case("previous") {
+            Self::PREV
+        } else if keyword.eq_ignore_ascii_case("privacy-policy") {
+            Self::PRIVACY_POLICY
+        } else if keyword.eq_ignore_ascii_case("search") {
+            Self::SEARCH
+        } else if keyword.eq_ignore_ascii_case("stylesheet") {
+            Self::STYLESHEET
+        } else if keyword.eq_ignore_ascii_case("terms-of-service") {
+            Self::TermsOfService
+        } else {
+            Self::empty()
+        }
+    }
+}
+
+malloc_size_of_is_0!(LinkRelations);

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -25,6 +25,8 @@ pub enum Initiator {
     ImageSet,
     Manifest,
     XSLT,
+    Prefetch,
+    Link,
 }
 
 /// A request [destination](https://fetch.spec.whatwg.org/#concept-request-destination)

--- a/tests/wpt/meta/fetch/metadata/generated/element-link-prefetch.https.optional.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/element-link-prefetch.https.optional.sub.html.ini
@@ -1,97 +1,93 @@
 [element-link-prefetch.https.optional.sub.html]
-  expected: TIMEOUT
   [sec-fetch-site - Same origin no attributes]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sec-fetch-site - Cross-site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Origin -> Same-Site -> Same-Origin redirect no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Cross-Site -> Same Origin no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Cross-Site -> Same-Site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Cross-Site -> Cross-Site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Origin -> Same Origin no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Origin -> Same-Site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Origin -> Cross-Site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Site -> Same Origin no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Site -> Same-Site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - Same-Site -> Cross-Site no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-mode no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-mode attributes: crossorigin]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-mode attributes: crossorigin=anonymous]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-mode attributes: crossorigin=use-credentials]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=audio]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=document]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=embed]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=fetch]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=font]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=image]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=object]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=script]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=style]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=track]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=video]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-dest attributes: as=worker]
-    expected: NOTRUN
-
-  [sec-fetch-user no attributes]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/element-link-prefetch.optional.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/element-link-prefetch.optional.sub.html.ini
@@ -1,46 +1,6 @@
 [element-link-prefetch.optional.sub.html]
-  expected: TIMEOUT
-  [sec-fetch-site - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: TIMEOUT
-
-  [sec-fetch-site - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-dest - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-dest - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-dest - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - HTTPS downgrade (header not sent) no attributes]
-    expected: NOTRUN
-
   [sec-fetch-site - HTTPS upgrade no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - HTTPS downgrade-upgrade no attributes]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/navigation-timing/prefetch-transfer-size-executor.html.ini
+++ b/tests/wpt/meta/navigation-timing/prefetch-transfer-size-executor.html.ini
@@ -1,4 +1,0 @@
-[prefetch-transfer-size-executor.html]
-  expected: TIMEOUT
-  [Navigation timing transfer size for a prefetched navigation should be 0.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/navigation-timing/prefetch-transfer-size-iframe.html.ini
+++ b/tests/wpt/meta/navigation-timing/prefetch-transfer-size-iframe.html.ini
@@ -1,4 +1,0 @@
-[prefetch-transfer-size-iframe.html]
-  expected: TIMEOUT
-  [Navigation timing transfer size for a prefetched navigation should be 0.]
-    expected: TIMEOUT


### PR DESCRIPTION
This PR adds basic support for prefetching resources using the [`rel="prefetch"`](https://html.spec.whatwg.org/multipage/#link-type-prefetch) attribute on `<link>` elements.

To allow this, I first changed the way link relations are determined. Previously, we always examined the `rel` attribute with functions like `string_is_stylesheet`. 
https://github.com/servo/servo/blob/ebed9218f2907767ba3c9dd9f27f30a6a6e9f225/components/script/dom/htmllinkelement.rs#L209-L214
This is error prone for the following reasons:
* There are synonyms for some `rel` keywords (`rel="copyright"` is the same as `rel="license"`)
* Some `rel` keywords are enabled by other attributes (`rev="made"` implies `rel="author"`)
* `rel` keywords are not mutually exclusive (`rel="stylesheet icon"` is totally valid, yet the code above doesn't handle this)

Instead, we now store the possible link relations in a bitset that can be obtained using `LinkRelations::for_element`.

---

This implementation is mostly concerned with sending the fetch request and dispatching the correct events in response. The following wpt tests now pass:
* `preload/prefetch-cache.html`
* `preload/prefetch-events.html`
* `preload/prefetch-time-to-fetch.https.html`
* `preload/prefetch-accept.html` 

The remaining tests for prefetching are mostly related to incorrect/missing headers. I'm not familiar with servos fetch api so these might be easy fixes. Is there some API in `RequestBuilder` for `sec-fetch-purpose`/`sec-fetch-dest` headers?
Failing wpt tests:

* `preload/prefetch-document.html` 
* `preload/prefetch-types.https.html` (missing `sec-fetch-*` headers)
* `preload/prefetch-headers.https.html` (missing `sec-fetch-*` headers)

I can split this PR into smaller ones if that's preferred for review.

[try run wpt-2020](https://github.com/Wuelle/servo/actions/runs/10746056589)

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors


<!-- Either: -->
- [X] There are tests for these changes (WPT)
