### PR TITLE
layout: Do not use orthogonal baselines in flex layout

### DIFF
--- a/components/layout_2020/flexbox/mod.rs
+++ b/components/layout_2020/flexbox/mod.rs
@@ -2,20 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use geom::{FlexAxis, MainStartCrossStart};
+use geom::{FlexAxis, FlexRelativeVec2, MainStartCrossStart};
 use serde::Serialize;
 use servo_arc::Arc as ServoArc;
+use style::logical_geometry::WritingMode;
 use style::properties::longhands::align_items::computed_value::T as AlignItems;
 use style::properties::longhands::flex_direction::computed_value::T as FlexDirection;
 use style::properties::longhands::flex_wrap::computed_value::T as FlexWrap;
 use style::properties::ComputedValues;
 use style::values::computed::{AlignContent, JustifyContent};
-use style::values::specified::align::AlignFlags;
+use style::values::specified::align::{AlignFlags, AxisDirection};
 
 use crate::cell::ArcRefCell;
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
 use crate::positioned::AbsolutelyPositionedBox;
+use crate::style_ext::ComputedValuesExt;
 
 mod construct;
 mod geom;
@@ -26,6 +28,7 @@ mod layout;
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct FlexContainerConfig {
     container_is_single_line: bool,
+    writing_mode: WritingMode,
     flex_axis: FlexAxis,
     flex_direction: FlexDirection,
     flex_direction_is_reversed: bool,
@@ -66,6 +69,7 @@ impl FlexContainerConfig {
 
         FlexContainerConfig {
             container_is_single_line,
+            writing_mode: container_style.effective_writing_mode(),
             flex_axis,
             flex_direction,
             flex_direction_is_reversed,

--- a/tests/wpt/tests/css/css-flexbox/flexbox-align-self-baseline-compatability.html
+++ b/tests/wpt/tests/css/css-flexbox/flexbox-align-self-baseline-compatability.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+    <link rel="match" href="/css/reference/ref-filled-green-100px-square.xht"/>
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-baselines"/>
+    <meta name="assert" content="Test checks that item baselines orthogonal to the flex container's main axis do not affect baseline alignment.">
+
+    <style>
+        .flex  {
+            display: flex;
+            background: red;
+            width: 100px;
+            flex-direction: column;
+            flex-wrap: wrap;
+        }
+
+        .flex > div {
+            width: 100px;
+            height: 50px;
+            background: green;
+            color: transparent;
+            align-self: baseline;
+        }
+    </style>
+
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+    <div class="flex">
+        <div>A</div>
+        <!--The baseline of this child is different from the first, but because it
+            is orthogonal to the main axis of the flexbox, it does not affect the
+            positioning of the item, even with `baseline` alignment -->
+        <div style="font-size: 200%">A</div>
+    </div>
+</html>


### PR DESCRIPTION
When a baseline is orthogonal to the main flexbox axis, it should not
take part in baseline alignment. This change does that for column flex.
While there is no support for vertical writing modes, this change is
made to be as writing mode-agnostic as possible.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Oriol Brufau <obrufau@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
