### PR TITLE
script: fixed document title being set to Some("") instead of None

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1234,10 +1234,10 @@ impl Document {
         }
     }
 
-    /// Return the title if one is specified
-    ///
-    /// https://html.spec.whatwg.org/multipage/#document.title
-    fn get_title(&self) -> Option<DOMString> {
+    /// Determine the title of the [`Document`] according to the specification at:
+    /// <https://html.spec.whatwg.org/multipage/#document.title>. The difference
+    /// here is that when the title isn't specified `None` is returned.
+    fn title(&self) -> Option<DOMString> {
         let title = self.GetDocumentElement().and_then(|root| {
             if root.namespace() == &ns!(svg) && root.local_name() == &local_name!("svg") {
                 // Step 1.
@@ -1266,7 +1266,7 @@ impl Document {
     pub fn send_title_to_embedder(&self) {
         let window = self.window();
         if window.is_top_level() {
-            let title = self.get_title().map(String::from);
+            let title = self.title().map(String::from);
             self.send_to_embedder(EmbedderMsg::ChangePageTitle(title));
         }
     }
@@ -4655,7 +4655,7 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/multipage/#document.title
     fn Title(&self) -> DOMString {
-        self.get_title().unwrap_or_else(|| DOMString::from(""))
+        self.title().unwrap_or_else(|| DOMString::from(""))
     }
 
     // https://html.spec.whatwg.org/multipage/#document.title

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1234,11 +1234,39 @@ impl Document {
         }
     }
 
+    /// Return the title if one is specified
+    ///
+    /// https://html.spec.whatwg.org/multipage/#document.title
+    fn get_title(&self) -> Option<DOMString> {
+        let title = self.GetDocumentElement().and_then(|root| {
+            if root.namespace() == &ns!(svg) && root.local_name() == &local_name!("svg") {
+                // Step 1.
+                root.upcast::<Node>()
+                    .child_elements()
+                    .find(|node| {
+                        node.namespace() == &ns!(svg) && node.local_name() == &local_name!("title")
+                    })
+                    .map(DomRoot::upcast::<Node>)
+            } else {
+                // Step 2.
+                root.upcast::<Node>()
+                    .traverse_preorder(ShadowIncluding::No)
+                    .find(|node| node.is::<HTMLTitleElement>())
+            }
+        });
+
+        title.map(|title| {
+            // Steps 3-4.
+            let value = title.child_text_content();
+            DOMString::from(str_join(split_html_space_chars(&value), " "))
+        })
+    }
+
     /// Sends this document's title to the constellation.
     pub fn send_title_to_embedder(&self) {
         let window = self.window();
         if window.is_top_level() {
-            let title = Some(String::from(self.Title()));
+            let title = self.get_title().map(String::from);
             self.send_to_embedder(EmbedderMsg::ChangePageTitle(title));
         }
     }
@@ -4627,31 +4655,7 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/multipage/#document.title
     fn Title(&self) -> DOMString {
-        let title = self.GetDocumentElement().and_then(|root| {
-            if root.namespace() == &ns!(svg) && root.local_name() == &local_name!("svg") {
-                // Step 1.
-                root.upcast::<Node>()
-                    .child_elements()
-                    .find(|node| {
-                        node.namespace() == &ns!(svg) && node.local_name() == &local_name!("title")
-                    })
-                    .map(DomRoot::upcast::<Node>)
-            } else {
-                // Step 2.
-                root.upcast::<Node>()
-                    .traverse_preorder(ShadowIncluding::No)
-                    .find(|node| node.is::<HTMLTitleElement>())
-            }
-        });
-
-        match title {
-            None => DOMString::new(),
-            Some(ref title) => {
-                // Steps 3-4.
-                let value = title.child_text_content();
-                DOMString::from(str_join(split_html_space_chars(&value), " "))
-            },
-        }
+        self.get_title().unwrap_or_else(|| DOMString::from(""))
     }
 
     // https://html.spec.whatwg.org/multipage/#document.title


### PR DESCRIPTION
I suppose this wasn't really an issue before but since we use the
title as a label for the tab it's a bit inconvenient, since pages
without a <title> get an empty label because of this, instead of
falling back to the URL as other browsers do.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
