### PR TITLE
Set empty object as `console` prototype

### DIFF
--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -5,8 +5,7 @@
 // https://console.spec.whatwg.org/
 
 [ClassString="Console",
- Exposed=(Window,Worker,Worklet),
- ProtoObjectHack]
+ Exposed=(Window,Worker,Worklet)]
 namespace console {
   // Logging
   undefined log(any... messages);

--- a/tests/wpt/meta/console/console-is-a-namespace.any.js.ini
+++ b/tests/wpt/meta/console/console-is-a-namespace.any.js.ini
@@ -1,12 +1,2 @@
-[console-is-a-namespace.any.worker.html]
-  [The prototype chain must be correct]
-    expected: FAIL
-
-
-[console-is-a-namespace.any.html]
-  [The prototype chain must be correct]
-    expected: FAIL
-
-
 [console-is-a-namespace.any.shadowrealm.html]
   expected: ERROR

--- a/tests/wpt/meta/console/idlharness.any.js.ini
+++ b/tests/wpt/meta/console/idlharness.any.js.ini
@@ -1,7 +1,4 @@
 [idlharness.any.html]
-  [console namespace: [[Prototype\]\] is Object.prototype]
-    expected: FAIL
-
   [console namespace: operation assert(optional boolean, any...)]
     expected: FAIL
 
@@ -28,9 +25,6 @@
 
 
 [idlharness.any.worker.html]
-  [console namespace: [[Prototype\]\] is Object.prototype]
-    expected: FAIL
-
   [console namespace: operation assert(optional boolean, any...)]
     expected: FAIL
 


### PR DESCRIPTION
The console object has an empty object as its prototype, not the realm object prototype.

[Specification](https://console.spec.whatwg.org/#console-namespace):
> For historical web-compatibility reasons, the [namespace object](https://webidl.spec.whatwg.org/#dfn-namespace-object) for [console](https://console.spec.whatwg.org/#namespacedef-console) must have as its [[Prototype]] an empty object, created as if by [ObjectCreate](https://tc39.github.io/ecma262/#sec-objectcreate)([%ObjectPrototype%](https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object)), instead of [%ObjectPrototype%](https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object).

[try-run](https://github.com/Wuelle/servo/actions/runs/10754666399)


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (wpt)


