### PR TITLE
script: Implement `TextEncoder::encodeInto()`

### DIFF
--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -98,7 +98,7 @@ impl TextEncoderMethods for TextEncoder {
         // Step 3, 4, 5, 6
         // Turn the source into a queue of scalar values.
         // Iterate over the source values.
-        for result in  source.0.chars() {
+        for result in source.0.chars() {
             let utf8_len = result.len_utf8();
             if available - written >= utf8_len {
                 // Step 6.4.1

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -95,13 +95,10 @@ impl TextEncoderMethods for TextEncoder {
 
         let dest = unsafe { destination.as_mut_slice() };
 
-        // Step 3, 4, 5
+        // Step 3, 4, 5, 6
         // Turn the source into a queue of scalar values.
-        let mut chars = source.0.chars();
-
-        // Step 6
         // Iterate over the source values.
-        for result in chars {
+        for result in  source.0.chars() {
             let utf8_len = result.len_utf8();
             if available - written >= utf8_len {
                 // Step 6.4.1

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -5,12 +5,16 @@
 use std::ptr;
 
 use dom_struct::dom_struct;
+use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
+use js::typedarray;
 use js::typedarray::Uint8Array;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
-use crate::dom::bindings::codegen::Bindings::TextEncoderBinding::TextEncoderMethods;
+use crate::dom::bindings::codegen::Bindings::TextEncoderBinding::{
+    TextEncoderEncodeIntoResult, TextEncoderMethods,
+};
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, Reflector};
 use crate::dom::bindings::root::DomRoot;
@@ -43,7 +47,7 @@ impl TextEncoder {
         )
     }
 
-    // https://encoding.spec.whatwg.org/#dom-textencoder
+    /// <https://encoding.spec.whatwg.org/#dom-textencoder>
     #[allow(non_snake_case)]
     pub fn Constructor(
         global: &GlobalScope,
@@ -55,17 +59,71 @@ impl TextEncoder {
 }
 
 impl TextEncoderMethods for TextEncoder {
-    // https://encoding.spec.whatwg.org/#dom-textencoder-encoding
+    /// <https://encoding.spec.whatwg.org/#dom-textencoder-encoding>
     fn Encoding(&self) -> DOMString {
         DOMString::from("utf-8")
     }
 
-    // https://encoding.spec.whatwg.org/#dom-textencoder-encode
+    /// <https://encoding.spec.whatwg.org/#dom-textencoder-encode>
     fn Encode(&self, cx: JSContext, input: USVString) -> Uint8Array {
         let encoded = input.0.as_bytes();
 
         rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
         create_buffer_source(cx, encoded, js_object.handle_mut())
             .expect("Converting input to uint8 array should never fail")
+    }
+
+    /// <https://encoding.spec.whatwg.org/#dom-textencoder-encodeinto>
+    #[allow(unsafe_code)]
+    fn EncodeInto(
+        &self,
+        source: USVString,
+        mut destination: CustomAutoRooterGuard<typedarray::Uint8Array>,
+    ) -> TextEncoderEncodeIntoResult {
+        let available = destination.len();
+
+        // Bail out if the destination has no space available.
+        if available == 0 {
+            return TextEncoderEncodeIntoResult {
+                read: Some(0),
+                written: Some(0),
+            };
+        }
+
+        let mut read = 0;
+        let mut written = 0;
+
+        let dest = unsafe { destination.as_mut_slice() };
+
+        // Step 3, 4, 5
+        // Turn the source into a queue of scalar values.
+        let mut chars = source.0.chars();
+
+        // Step 6
+        // Iterate over the source values.
+        for result in chars {
+            let utf8_len = result.len_utf8();
+            if available - written >= utf8_len {
+                // Step 6.4.1
+                // If destination’s byte length − written is greater than or equal to the number of bytes in result
+                read += if result > '\u{FFFF}' { 2 } else { 1 };
+
+                // Write the bytes in result into destination, with startingOffset set to written.
+                let target = &mut dest[written..written + utf8_len];
+                result.encode_utf8(target);
+
+                // Increment written by the number of bytes in result.
+                written += utf8_len;
+            } else {
+                // Step 6.4.2
+                // Bail out when destination buffer is full.
+                break;
+            }
+        }
+
+        TextEncoderEncodeIntoResult {
+            read: Some(read),
+            written: Some(written as _),
+        }
     }
 }

--- a/components/script/dom/webidls/TextEncoder.webidl
+++ b/components/script/dom/webidls/TextEncoder.webidl
@@ -3,10 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* https://encoding.spec.whatwg.org/#interface-textencoder */
+
+dictionary TextEncoderEncodeIntoResult {
+  unsigned long long read;
+  unsigned long long written;
+};
+
 [Exposed=(Window,Worker)]
 interface TextEncoder {
    [Throws] constructor();
    readonly attribute DOMString encoding;
    [NewObject]
    Uint8Array encode(optional USVString input = "");
+   TextEncoderEncodeIntoResult encodeInto(USVString source, [AllowShared] Uint8Array destination);
 };

--- a/tests/wpt/meta/encoding/encodeInto.any.js.ini
+++ b/tests/wpt/meta/encoding/encodeInto.any.js.ini
@@ -1,251 +1,125 @@
 [encodeInto.any.html]
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler random]
@@ -282,9 +156,6 @@
     expected: FAIL
 
   [Invalid encodeInto() destination: Float64Array, backed by: SharedArrayBuffer]
-    expected: FAIL
-
-  [encodeInto() and a detached output buffer]
     expected: FAIL
 
   [Invalid encodeInto() destination: Float16Array, backed by: ArrayBuffer]
@@ -298,253 +169,127 @@
   expected: ERROR
 
 [encodeInto.any.worker.html]
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with Hi and destination length 0, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with Hi and destination length 0, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with A and destination length 10, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with A and destination length 10, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆 and destination length 4, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆 and destination length 4, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with 𝌆A and destination length 3, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with 𝌆A and destination length 3, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with U+d834AU+df06A¥Hi and destination length 10, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with AU+df06 and destination length 4, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with AU+df06 and destination length 4, offset 4, filler random]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler 0]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler 0]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler 0]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler 128]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler 128]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler 128]
     expected: FAIL
 
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 0, filler random]
-    expected: FAIL
-
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 0, filler random]
-    expected: FAIL
-
-  [encodeInto() into ArrayBuffer with ¥¥ and destination length 4, offset 4, filler random]
     expected: FAIL
 
   [encodeInto() into SharedArrayBuffer with ¥¥ and destination length 4, offset 4, filler random]
@@ -581,9 +326,6 @@
     expected: FAIL
 
   [Invalid encodeInto() destination: Float64Array, backed by: SharedArrayBuffer]
-    expected: FAIL
-
-  [encodeInto() and a detached output buffer]
     expected: FAIL
 
   [Invalid encodeInto() destination: Float16Array, backed by: ArrayBuffer]

--- a/tests/wpt/meta/encoding/idlharness.any.js.ini
+++ b/tests/wpt/meta/encoding/idlharness.any.js.ini
@@ -5,15 +5,6 @@
   expected: ERROR
 
 [idlharness.any.html]
-  [TextEncoder interface: operation encodeInto(USVString, Uint8Array)]
-    expected: FAIL
-
-  [TextEncoder interface: new TextEncoder() must inherit property "encodeInto(USVString, Uint8Array)" with the proper type]
-    expected: FAIL
-
-  [TextEncoder interface: calling encodeInto(USVString, Uint8Array) on new TextEncoder() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [TextDecoderStream interface: existence and properties of interface object]
     expected: FAIL
 
@@ -64,15 +55,6 @@
 
 
 [idlharness.any.worker.html]
-  [TextEncoder interface: operation encodeInto(USVString, Uint8Array)]
-    expected: FAIL
-
-  [TextEncoder interface: new TextEncoder() must inherit property "encodeInto(USVString, Uint8Array)" with the proper type]
-    expected: FAIL
-
-  [TextEncoder interface: calling encodeInto(USVString, Uint8Array) on new TextEncoder() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [TextDecoderStream interface: existence and properties of interface object]
     expected: FAIL
 


### PR DESCRIPTION
This implements https://encoding.spec.whatwg.org/#dom-textencoder-encodeinto

@mrobinson This is the same patch with your comments addressed. I switched to a new PR because I had issues rebasing some wpt manifests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes (wpt expectations are updated)


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
