### PR TITLE
webxr: Update XRInputSource gamepad index to be -1

### DIFF
--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -96,6 +96,7 @@ impl Gamepad {
         axis_bounds: (f64, f64),
         button_bounds: (f64, f64),
         supported_haptic_effects: GamepadSupportedHapticEffects,
+        xr: bool,
     ) -> DomRoot<Gamepad> {
         Self::new_with_proto(
             global,
@@ -105,6 +106,7 @@ impl Gamepad {
             axis_bounds,
             button_bounds,
             supported_haptic_effects,
+            xr,
         )
     }
 
@@ -121,15 +123,17 @@ impl Gamepad {
         axis_bounds: (f64, f64),
         button_bounds: (f64, f64),
         supported_haptic_effects: GamepadSupportedHapticEffects,
+        xr: bool,
     ) -> DomRoot<Gamepad> {
         let button_list = GamepadButtonList::init_buttons(global);
         let vibration_actuator =
             GamepadHapticActuator::new(global, gamepad_id, supported_haptic_effects);
+        let index = if xr { -1 } else { 0 };
         let gamepad = reflect_dom_object_with_proto(
             Box::new(Gamepad::new_inherited(
                 gamepad_id,
                 id,
-                0,
+                index,
                 true,
                 0.,
                 mapping_type,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3236,7 +3236,8 @@ impl GlobalScope {
                             "standard".into(),
                             axis_bounds,
                             button_bounds,
-                            supported_haptic_effects
+                            supported_haptic_effects,
+                            false
                         );
                         navigator.set_gamepad(selected_index as usize, &gamepad);
                     }

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -55,6 +55,7 @@ impl XRInputSource {
                 supports_dual_rumble: false,
                 supports_trigger_rumble: false,
             },
+            true,
         );
         XRInputSource {
             reflector: Reflector::new(),

--- a/tests/wpt/meta-legacy-layout/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
@@ -1,7 +1,8 @@
 [xrInputSource_gamepad_disconnect.https.html]
+  expected: ERROR
   [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl2]
-    expected: FAIL
+    expected: NOTRUN
 
   [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/meta/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
+++ b/tests/wpt/meta/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
@@ -1,7 +1,8 @@
 [xrInputSource_gamepad_disconnect.https.html]
+  expected: ERROR
   [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl2]
-    expected: FAIL
+    expected: NOTRUN
 
   [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl]
-    expected: FAIL
+    expected: TIMEOUT
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Spec detail that wasn't implemented previously but gets checked during some WPT tests, needed before updating FakeXRInputController.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
