### PR TITLE
CI: fix self-hosted runners in try-label builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,7 +108,7 @@ jobs:
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
         run: git fetch --depth=1 origin $env:GITHUB_SHA
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin refs/pull/${{ github.event_number }}/head
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
         # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
         # trees, in case the runner image was baked with a dirty working tree.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,7 +81,7 @@ jobs:
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
         run: git fetch --depth=1 origin $env:GITHUB_SHA
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin refs/pull/${{ github.event_number }}/head
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
         # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
         # trees, in case the runner image was baked with a dirty working tree.


### PR DESCRIPTION
The git fetch command we run on self-hosted runners for pull_request_target events was misspelled.

We should be fetching `${{ github.event.pull_request.head.sha }}` (e.g. in the non-self-hosted checkout steps above) or `refs/pull/${{ github.event.number }}/head` (with a dot, e.g. in try-label.yml).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33372