### PR TITLE
Allow breaking line after space with `white-space: break-spaces`

### DIFF
--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -225,6 +225,7 @@ impl TextRunSegment {
             let mut whitespace = slice.end..slice.end;
             let mut rev_char_indices = word.char_indices().rev().peekable();
 
+            let mut ends_with_whitespace = false;
             let ends_with_newline = rev_char_indices
                 .peek()
                 .map_or(false, |&(_, character)| character == '\n');
@@ -232,6 +233,7 @@ impl TextRunSegment {
                 .take_while(|&(_, character)| char_is_whitespace(character))
                 .last()
             {
+                ends_with_whitespace = true;
                 whitespace.start = slice.start + first_white_space_index;
 
                 // If line breaking for a piece of text that has `white-space-collapse: break-spaces` there
@@ -252,10 +254,7 @@ impl TextRunSegment {
 
             // If there's no whitespace and `word-break` is set to `keep-all`, try increasing the slice.
             // TODO: This should only happen for CJK text.
-            let can_break_anywhere = text_style.word_break == WordBreak::BreakAll ||
-                text_style.overflow_wrap == OverflowWrap::Anywhere ||
-                text_style.overflow_wrap == OverflowWrap::BreakWord;
-            if whitespace.is_empty() &&
+            if !ends_with_whitespace &&
                 *break_index != self.range.end &&
                 text_style.word_break == WordBreak::KeepAll &&
                 !can_break_anywhere

--- a/tests/wpt/tests/css/css-text/white-space/break-spaces-with-word-break-001.html
+++ b/tests/wpt/tests/css/css-text/white-space/break-spaces-with-word-break-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: white-space:break-spaces + word-break:keep-all</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#valdef-white-space-collapse-break-spaces">
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#valdef-word-break-keep-all">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="break-spaces + keep-all does allow a break after space.">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+div {
+  font: 50px/1 Ahem;
+  white-space: break-spaces;
+  word-break: keep-all;
+  width: 100px;
+  height: 100px;
+  background: red;
+  color: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div>XX XX</div>


### PR DESCRIPTION
`white-space: break-spaces` should allow a soft wrap opportunity *after* every preserved white space. Then, to avoid breaking before the first white space, `TextRunSegment::shape_text()` has some logic to separate it from the following spaces and put it with the preceding text instead.

The problem was that, when combined with `word-break: keep-all`, we were then only checking whether there were more white spaces afterwards, ignoring the soft wrap opportunity after the first one.

Also removing a duplicated `can_break_anywhere` variable.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
