### PR TITLE
android: make aarch64 the default target

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -694,7 +694,7 @@ class CommandBase(object):
 
         #  Set the default Android target
         if android and not target_triple:
-            target_triple = "armv7-linux-androideabi"
+            target_triple = "aarch64-linux-android"
 
         self.target = BuildTarget.from_triple(target_triple)
 

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -43,8 +43,8 @@ from servo.util import delete, get_target_dir
 
 PACKAGES = {
     'android': [
-        'android/armv7-linux-androideabi/production/servoapp.apk',
-        'android/armv7-linux-androideabi/production/servoview.aar',
+        'android/aarch64-linux-android/production/servoapp.apk',
+        'android/aarch64-linux-android/production/servoview.aar',
     ],
     'linux': [
         'production/servo-tech-demo.tar.gz',


### PR DESCRIPTION
Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just switch the default android target in mach
