### PR TITLE
script: Added missing spec step in `Location::SetHash`

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -315,13 +315,19 @@ impl LocationMethods for Location {
             // Step 5: Set copyURL's fragment to the empty string.
             // Step 6: Basic URL parse input, with copyURL as url and fragment state as
             // state override.
-            copy_url.as_mut_url().set_fragment(match value.0.as_str() {
+            let new_fragment = match value.0.as_str() {
                 "" => Some("#"),
                 _ if value.0.starts_with('#') => Some(&value.0[1..]),
-                _ => Some(&value.0),
-            });
+                _ => Some(value.0.as_str()),
+            };
+            // Step 7: If copyURL's fragment is this's url's fragment, then return.
+            if copy_url.fragment() == new_fragment {
+                Ok(None)
+            } else {
+                copy_url.as_mut_url().set_fragment(new_fragment);
 
-            Ok(Some(copy_url))
+                Ok(Some(copy_url))
+            }
         })
     }
 

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -315,10 +315,10 @@ impl LocationMethods for Location {
             // Step 5: Set copyURL's fragment to the empty string.
             // Step 6: Basic URL parse input, with copyURL as url and fragment state as
             // state override.
-            let new_fragment = match value.0.as_str() {
-                "" => Some("#"),
-                _ if value.0.starts_with('#') => Some(&value.0[1..]),
-                _ => Some(value.0.as_str()),
+            let new_fragment = if value.0.starts_with('#') {
+                Some(&value.0[1..])
+            } else {
+                Some(value.0.as_str())
             };
             // Step 7: If copyURL's fragment is this's url's fragment, then return.
             if copy_url.fragment() == new_fragment {

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/location_hash_set_empty_string.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set window.location.hash to an empty string</title>
+<link rel="author" href="mailto:cristianb@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-location-hash">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const orig_location = window.location.href;
+
+window.location.hash = '';
+
+test(() => {
+    assert_true(window.location.hash === '');
+    assert_true(window.location.href === orig_location + '#');
+}, 'window.location.hash is an empty string');
+</script>

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/location_hashchange_infinite_loop.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set window.location.hash to same value while handling event hashchange</title>
+<link rel="author" href="mailto:cristianb@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-location-hash">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let count = 0;
+
+window.onhashchange = () => {
+    count += 1;
+    window.location.hash = 'running';
+}
+
+promise_test(async t => {
+    window.location.hash = 'running';
+
+    await t.step_wait(() => count === 1);
+}, 'Setting window.location.hash to same value while handling hashchange event shouldn\'t cause an infinite loop.');
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added check if the new fragment is different when updating location hash. Also, fixes wrong location hash (it was set to #) when `window.location.hash` was set to an empty string.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33353

<!-- Either: -->
- [X] There are tests for these changes

I did a [try wpt-2020 run](https://github.com/crbrz/servo/actions/runs/10772645732/job/29872675832) but no test results changed so I added new WPT tests for these changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
