### PR TITLE
Fix reordering of table-header-group and table-footer-group

### DIFF
--- a/tests/wpt/tests/css/CSS2/tables/table-footer-group-001.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-footer-group-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Table-footer-group</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-display" />
+        <link rel="match" href="table-row-group-001-ref.xht" />
         <meta name="assert" content="An element with 'display: table-footer-group' is rendered as if it were a table footer group." />
         <style type="text/css">
             .table

--- a/tests/wpt/tests/css/CSS2/tables/table-header-group-001.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-header-group-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Table-header-group</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-display" />
+        <link rel="match" href="table-row-group-001-ref.xht" />
         <meta name="assert" content="An element with 'display: table-header-group' is rendered as if it were a table header group." />
         <style type="text/css">
             .table

--- a/tests/wpt/tests/css/CSS2/tables/table-row-group-001-ref.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-row-group-001-ref.xht
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <body>
+        <p>Test passes if there is a square below, and the top half of the square is blue.</p>
+        <div style="width: 8em; height: 8em; border: 2px solid black">
+            <div style="height: 4em; background: blue"></div>
+        </div>
+    </body>
+</html>

--- a/tests/wpt/tests/css/CSS2/tables/table-row-group-001.xht
+++ b/tests/wpt/tests/css/CSS2/tables/table-row-group-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Table-row-group</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-display" />
+        <link rel="match" href="table-row-group-001-ref.xht" />
         <meta name="assert" content="An element with 'display: table-row-group' is rendered as if it were a table row group." />
         <style type="text/css">
             .table


### PR DESCRIPTION
We weren't moving a table-header-group to the front if it was the first row group. However, there might still be preceding rows that don't belong to any row group.

And similarly, we weren't moving a table-footer-group to the end if it was the last row group. However, there might still be following rows that don't belong to any row group.

This patch fixes the logic, and enables existing tests from Microsoft that were missing a reference.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
