### PR TITLE
libservo: Improve finding python

### DIFF
--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -67,7 +67,7 @@ impl<'a> phf_shared::PhfHash for Bytes<'a> {
 /// Tries to find a suitable python
 ///
 /// Algorithm
-/// 1. Trying to find python3/python in $VIRTUAL_ENV (this should be from servos venv)
+/// 1. Trying to find python3/python in $VIRTUAL_ENV (this should be from Servo's venv)
 /// 2. Checking PYTHON3 (set by mach)
 /// 3. Falling back to the system installation.
 ///
@@ -75,13 +75,13 @@ impl<'a> phf_shared::PhfHash for Bytes<'a> {
 fn find_python() -> PathBuf {
     let mut candidates = vec![];
     if let Some(venv) = env::var_os("VIRTUAL_ENV") {
-        let base = PathBuf::from(venv);
-        let bin = base.join("bin");
-        let python = bin.join("python");
-        let python3 = bin.join("python3");
+        let bin_directory = PathBuf::from(venv).join("bin");
+
+        let python3 = bin_directory.join("python3");
         if python3.exists() {
             candidates.push(python3);
         }
+        let python = bin_directory.join("python");
         if python.exists() {
             candidates.push(python);
         }
@@ -111,7 +111,7 @@ fn find_python() -> PathBuf {
         .map(|c| c.into_os_string())
         .collect::<Vec<_>>();
     panic!(
-        "Can't find python (tried {:?})! Try enabling servos python venv, \
+        "Can't find python (tried {:?})! Try enabling Servo's Python venv, \
         setting the PYTHON3 env var or adding python3 to PATH.",
         candidates.join(", ".as_ref())
     )

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -64,26 +64,55 @@ impl<'a> phf_shared::PhfHash for Bytes<'a> {
     }
 }
 
-fn find_python() -> String {
-    env::var("PYTHON3").ok().unwrap_or_else(|| {
-        let candidates = if cfg!(windows) {
-            ["python.exe", "python"]
-        } else {
-            ["python3", "python"]
-        };
-        for &name in &candidates {
-            if Command::new(name)
-                .arg("--version")
-                .output()
-                .ok()
-                .map_or(false, |out| out.status.success())
-            {
-                return name.to_owned();
-            }
+/// Tries to find a suitable python
+///
+/// Algorithm
+/// 1. Trying to find python3/python in $VIRTUAL_ENV (this should be from servos venv)
+/// 2. Checking PYTHON3 (set by mach)
+/// 3. Falling back to the system installation.
+///
+/// Note: This function should be kept in sync with the version in `components/servo/build.rs`
+fn find_python() -> PathBuf {
+    let mut candidates = vec![];
+    if let Some(venv) = env::var_os("VIRTUAL_ENV") {
+        let base = PathBuf::from(venv);
+        let bin = base.join("bin");
+        let python = bin.join("python");
+        let python3 = bin.join("python3");
+        if python3.exists() {
+            candidates.push(python3);
         }
-        panic!(
-            "Can't find python (tried {})! Try fixing PATH or setting the PYTHON3 env var",
-            candidates.join(", ")
-        )
-    })
+        if python.exists() {
+            candidates.push(python);
+        }
+    };
+    if let Some(python3) = env::var_os("PYTHON3") {
+        let python3 = PathBuf::from(python3);
+        if python3.exists() {
+            candidates.push(python3);
+        }
+    }
+
+    let system_python = ["python3", "python"].map(PathBuf::from);
+    candidates.extend_from_slice(&system_python);
+
+    for name in &candidates {
+        // Command::new() allows us to omit the `.exe` suffix on windows
+        if Command::new(&name)
+            .arg("--version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+        {
+            return name.to_owned();
+        }
+    }
+    let candidates = candidates
+        .into_iter()
+        .map(|c| c.into_os_string())
+        .collect::<Vec<_>>();
+    panic!(
+        "Can't find python (tried {:?})! Try enabling servos python venv, \
+        setting the PYTHON3 env var or adding python3 to PATH.",
+        candidates.join(", ".as_ref())
+    )
 }

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -34,22 +34,14 @@ fn main() {
 fn find_python() -> PathBuf {
     let mut candidates = vec![];
     if let Some(venv) = env::var_os("VIRTUAL_ENV") {
-        let bin_directory = PathBuf::from(venv).join("bin");
-
-        let python3 = bin_directory.join("python3");
-        if python3.exists() {
-            candidates.push(python3);
-        }
-        let python = bin_directory.join("python");
-        if python.exists() {
-            candidates.push(python);
-        }
-    };
+        // See: https://docs.python.org/3/library/venv.html#how-venvs-work
+        let bin_dir = if cfg!(windows) { "Scripts" } else { "bin" };
+        let bin_directory = PathBuf::from(venv).join(bin_dir);
+        candidates.push(bin_directory.join("python3"));
+        candidates.push(bin_directory.join("python"));
+    }
     if let Some(python3) = env::var_os("PYTHON3") {
-        let python3 = PathBuf::from(python3);
-        if python3.exists() {
-            candidates.push(python3);
-        }
+        candidates.push(PathBuf::from(python3));
     }
 
     let system_python = ["python3", "python"].map(PathBuf::from);

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -34,13 +34,13 @@ fn main() {
 fn find_python() -> PathBuf {
     let mut candidates = vec![];
     if let Some(venv) = env::var_os("VIRTUAL_ENV") {
-        let base = PathBuf::from(venv);
-        let bin = base.join("bin");
-        let python = bin.join("python");
-        let python3 = bin.join("python3");
+        let bin_directory = PathBuf::from(venv).join("bin");
+
+        let python3 = bin_directory.join("python3");
         if python3.exists() {
             candidates.push(python3);
         }
+        let python = bin_directory.join("python");
         if python.exists() {
             candidates.push(python);
         }
@@ -70,7 +70,7 @@ fn find_python() -> PathBuf {
         .map(|c| c.into_os_string())
         .collect::<Vec<_>>();
     panic!(
-        "Can't find python (tried {:?})! Try enabling servos python venv, \
+        "Can't find python (tried {:?})! Try enabling Servo's Python venv, \
         setting the PYTHON3 env var or adding python3 to PATH.",
         candidates.join(", ".as_ref())
     )

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs};
 
@@ -23,26 +23,53 @@ fn main() {
     fs::write(path, output.stdout).unwrap();
 }
 
-fn find_python() -> String {
-    env::var("PYTHON3").ok().unwrap_or_else(|| {
-        let candidates = if cfg!(windows) {
-            ["python3.8.exe", "python38.exe", "python.exe"]
-        } else {
-            ["python3.8", "python3", "python"]
-        };
-        for &name in &candidates {
-            if Command::new(name)
-                .arg("--version")
-                .output()
-                .ok()
-                .map_or(false, |out| out.status.success())
-            {
-                return name.to_owned();
-            }
+/// Tries to find a suitable python
+///
+/// Algorithm
+/// 1. Trying to find python3/python in $VIRTUAL_ENV (this should be from servos venv)
+/// 2. Checking PYTHON3 (set by mach)
+/// 3. Falling back to the system installation.
+fn find_python() -> PathBuf {
+    let mut candidates = vec![];
+    if let Some(venv) = env::var_os("VIRTUAL_ENV") {
+        let base = PathBuf::from(venv);
+        let bin = base.join("bin");
+        let python = bin.join("python");
+        let python3 = bin.join("python3");
+        if python3.exists() {
+            candidates.push(python3);
         }
-        panic!(
-            "Can't find python (tried {})! Try fixing PATH or setting the PYTHON3 env var",
-            candidates.join(", ")
-        )
-    })
+        if python.exists() {
+            candidates.push(python);
+        }
+    };
+    if let Some(python3) = env::var_os("PYTHON3") {
+        let python3 = PathBuf::from(python3);
+        if python3.exists() {
+            candidates.push(python3);
+        }
+    }
+
+    let system_python = ["python3", "python"].map(PathBuf::from);
+    candidates.extend_from_slice(&system_python);
+
+    for name in &candidates {
+        // Command::new() allows us to omit the `.exe` suffix on windows
+        if Command::new(&name)
+            .arg("--version")
+            .output()
+            .is_ok_and(|out| out.status.success())
+        {
+            return name.to_owned();
+        }
+    }
+    let candidates = candidates
+        .into_iter()
+        .map(|c| c.into_os_string())
+        .collect::<Vec<_>>();
+    panic!(
+        "Can't find python (tried {:?})! Try enabling servos python venv, \
+        setting the PYTHON3 env var or adding python3 to PATH.",
+        candidates.join(", ".as_ref())
+    )
 }

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -29,6 +29,8 @@ fn main() {
 /// 1. Trying to find python3/python in $VIRTUAL_ENV (this should be from servos venv)
 /// 2. Checking PYTHON3 (set by mach)
 /// 3. Falling back to the system installation.
+///
+/// Note: This function should be kept in sync with the version in `components/script/build.rs`
 fn find_python() -> PathBuf {
     let mut candidates = vec![];
     if let Some(venv) = env::var_os("VIRTUAL_ENV") {


### PR DESCRIPTION
Servo is built in a virtual environment, which sets [`VIRTUAL_ENV`](https://docs.python.org/3/library/venv.html) to the base path of the venv.
PYTHON3 is only set if mach or the user set it.

Additional changes:

- Use Path / var_os for Paths instead of strings. In General using Path APIs is preferable, since in rare cases valid paths may not be valid utf-8.
- Don't search for python 3.8 anymore, since we require a newer version anyway.
- Don't add the .exe suffix anymore, since Command::new() [will take care of that](https://doc.rust-lang.org/std/process/struct.Command.html#platform-specific-behavior).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix `cargo build` failing when python3.8 is installed (building without mach)
