### PR TITLE
Propagate `CanGc` from `Document::new()`

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -13,7 +13,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::realms::enter_realm;
-use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptPort};
+use crate::script_runtime::{CanGc, CommonScriptMsg, ScriptChan, ScriptPort};
 use crate::task_queue::{QueuedTaskConversion, TaskQueue};
 
 /// A ScriptChan that can be cloned freely and will silently send a TrustedWorkerAddress with
@@ -101,6 +101,7 @@ pub trait WorkerEventLoopMethods {
 pub fn run_worker_event_loop<T, WorkerMsg, Event>(
     worker_scope: &T,
     worker: Option<&TrustedWorkerAddress>,
+    _can_gc: CanGc,
 ) where
     WorkerMsg: QueuedTaskConversion + Send,
     T: WorkerEventLoopMethods<WorkerMsg = WorkerMsg, Event = Event>
@@ -155,7 +156,7 @@ pub fn run_worker_event_loop<T, WorkerMsg, Event>(
         };
         worker_scope
             .upcast::<GlobalScope>()
-            .perform_a_microtask_checkpoint();
+            .perform_a_microtask_checkpoint(CanGc::note());
     }
     worker_scope
         .upcast::<GlobalScope>()

--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -40,6 +40,7 @@ DOMInterfaces = {
 
 'Range': {
     'weakReferenceable': True,
+    'canGc': ['CreateContextualFragment', 'ExtractContents', 'CloneContents', 'CloneRange', 'SurroundContents'],
 },
 
 'EventSource': {
@@ -70,6 +71,7 @@ DOMInterfaces = {
 
 'Window': {
     'inRealms': ['Fetch', 'GetOpener'],
+    'canGc': ['Stop'],
 },
 
 'WorkerGlobalScope': {
@@ -90,6 +92,7 @@ DOMInterfaces = {
 
 'HTMLMediaElement': {
     'inRealms': ['Play'],
+    'canGc': ['Play', 'Pause', 'Load', 'SetSrcObject'],
 },
 
 'BluetoothRemoteGATTDescriptor': {
@@ -180,6 +183,39 @@ DOMInterfaces = {
 
 'GamepadHapticActuator': {
     'inRealms': ['PlayEffect', 'Reset']
-}
+},
+
+'DOMParser': {
+    'canGc': ['ParseFromString'],
+},
+
+'XMLHttpRequest': {
+    'canGc': ['Response', 'GetResponseXML'],
+},
+
+'DOMImplementation': {
+    'canGc': ['CreateHTMLDocument', 'CreateDocument'],
+},
+
+'HTMLTemplateElement': {
+    'canGc': ['Content'],
+},
+
+'Element': {
+    'canGc': ['SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML'],
+},
+
+'Selection': {
+    'canGc': ['Extend', 'SetBaseAndExtent', 'SelectAllChildren', 'Collapse', 'SetPosition', 
+              'CollapseToStart', 'CollapseToEnd'],
+},
+
+'Document': {
+    'canGc': ['Write', 'Writeln', 'Close', 'SetTitle', 'CreateElementNS', 'CreateElement', 'ImportNode'],
+},
+
+'Node': {
+    'canGc': ['CloneNode'],
+},
 
 }

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3725,7 +3725,7 @@ class CGCallGenerator(CGThing):
         ]))
 
         if hasCEReactions:
-            self.cgRoot.append(CGGeneric("pop_current_element_queue();\n"))
+            self.cgRoot.append(CGGeneric("pop_current_element_queue(CanGc::note());\n"))
 
         if isFallible:
             if static:

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3700,6 +3700,8 @@ class CGCallGenerator(CGThing):
             args.prepend(CGGeneric("cx"))
         if nativeMethodName in descriptor.inRealmMethods:
             args.append(CGGeneric("InRealm::already(&AlreadyInRealm::assert_for_cx(cx))"))
+        if nativeMethodName in descriptor.canGcMethods:
+            args.append(CGGeneric("CanGc::note()"))
 
         # Build up our actual call
         self.cgRoot = CGList([], "\n")
@@ -6263,7 +6265,7 @@ class CGInterfaceTrait(CGThing):
     def __init__(self, descriptor):
         CGThing.__init__(self)
 
-        def attribute_arguments(needCx, argument=None, inRealm=False):
+        def attribute_arguments(needCx, argument=None, inRealm=False, canGc=False):
             if needCx:
                 yield "cx", "SafeJSContext"
 
@@ -6272,6 +6274,9 @@ class CGInterfaceTrait(CGThing):
 
             if inRealm:
                 yield "_comp", "InRealm"
+
+            if canGc:
+                yield "_can_gc", "CanGc"
 
         def members():
             for m in descriptor.interface.members:
@@ -6283,7 +6288,8 @@ class CGInterfaceTrait(CGThing):
                     infallible = 'infallible' in descriptor.getExtendedAttributes(m)
                     for idx, (rettype, arguments) in enumerate(m.signatures()):
                         arguments = method_arguments(descriptor, rettype, arguments,
-                                                     inRealm=name in descriptor.inRealmMethods)
+                                                     inRealm=name in descriptor.inRealmMethods,
+                                                     canGc=name in descriptor.canGcMethods)
                         rettype = return_type(descriptor, rettype, infallible)
                         yield f"{name}{'_' * idx}", arguments, rettype
                 elif m.isAttr() and not m.isStatic():
@@ -6292,7 +6298,8 @@ class CGInterfaceTrait(CGThing):
                     yield (name,
                            attribute_arguments(
                                typeNeedsCx(m.type, True),
-                               inRealm=name in descriptor.inRealmMethods
+                               inRealm=name in descriptor.inRealmMethods,
+                               canGc=name in descriptor.canGcMethods
                            ),
                            return_type(descriptor, m.type, infallible))
 
@@ -6307,7 +6314,8 @@ class CGInterfaceTrait(CGThing):
                                attribute_arguments(
                                    typeNeedsCx(m.type, False),
                                    m.type,
-                                   inRealm=name in descriptor.inRealmMethods
+                                   inRealm=name in descriptor.inRealmMethods,
+                                   canGc=name in descriptor.canGcMethods
                                ),
                                rettype)
 
@@ -6324,7 +6332,8 @@ class CGInterfaceTrait(CGThing):
                         if not rettype.nullable():
                             rettype = IDLNullableType(rettype.location, rettype)
                         arguments = method_arguments(descriptor, rettype, arguments,
-                                                     inRealm=name in descriptor.inRealmMethods)
+                                                     inRealm=name in descriptor.inRealmMethods,
+                                                     canGc=name in descriptor.canGcMethods)
 
                         # If this interface 'supports named properties', then we
                         # should be able to access 'supported property names'
@@ -6335,7 +6344,8 @@ class CGInterfaceTrait(CGThing):
                             yield "SupportedPropertyNames", [], "Vec<DOMString>"
                     else:
                         arguments = method_arguments(descriptor, rettype, arguments,
-                                                     inRealm=name in descriptor.inRealmMethods)
+                                                     inRealm=name in descriptor.inRealmMethods,
+                                                     canGc=name in descriptor.canGcMethods)
                     rettype = return_type(descriptor, rettype, infallible)
                     yield name, arguments, rettype
 
@@ -7123,7 +7133,8 @@ def argument_type(descriptorProvider, ty, optional=False, defaultValue=None, var
     return declType.define()
 
 
-def method_arguments(descriptorProvider, returnType, arguments, passJSBits=True, trailing=None, inRealm=False):
+def method_arguments(descriptorProvider, returnType, arguments, passJSBits=True, trailing=None,
+                     inRealm=False, canGc=False):
     if needCx(returnType, arguments, passJSBits):
         yield "cx", "SafeJSContext"
 
@@ -7137,6 +7148,9 @@ def method_arguments(descriptorProvider, returnType, arguments, passJSBits=True,
 
     if inRealm:
         yield "_comp", "InRealm"
+
+    if canGc:
+        yield "_can_gc", "CanGc"
 
 
 def return_type(descriptorProvider, rettype, infallible):

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -232,6 +232,7 @@ class Descriptor(DescriptorProvider):
         self.register = desc.get('register', True)
         self.path = desc.get('path', pathDefault)
         self.inRealmMethods = [name for name in desc.get('inRealms', [])]
+        self.canGcMethods = [name for name in desc.get('canGc', [])]
         self.bindingPath = f"{getModuleFromObject(self.interface)}::{ifaceName}_Binding"
         self.outerObjectHook = desc.get('outerObjectHook', 'None')
         self.proxy = False

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -51,7 +51,7 @@ use crate::dom::element::{Element, ElementCreator};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::window::Window;
-use crate::script_runtime::{JSContext, JSContext as SafeJSContext};
+use crate::script_runtime::{CanGc, JSContext, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
 // https://html.spec.whatwg.org/multipage/#htmlconstructor
@@ -369,8 +369,8 @@ pub fn get_constructor_object_from_local_name(
     }
 }
 
-pub fn pop_current_element_queue() {
-    ScriptThread::pop_current_element_queue();
+pub fn pop_current_element_queue(can_gc: CanGc) {
+    ScriptThread::pop_current_element_queue(can_gc);
 }
 
 pub fn push_new_element_queue() {

--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -11,6 +11,7 @@ use js::rust::Runtime;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
 
 thread_local!(static STACK: RefCell<Vec<StackEntry>> = const { RefCell::new(Vec::new()) });
 
@@ -76,7 +77,7 @@ impl Drop for AutoEntryScript {
 
         // Step 5
         if !thread::panicking() && incumbent_global().is_none() {
-            self.global.perform_a_microtask_checkpoint();
+            self.global.perform_a_microtask_checkpoint(CanGc::note());
         }
     }
 }

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -86,6 +86,7 @@ use crate::dom::htmlvideoelement::HTMLVideoElement;
 use crate::dom::svgelement::SVGElement;
 use crate::dom::svgsvgelement::SVGSVGElement;
 use crate::realms::{enter_realm, InRealm};
+use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
 fn create_svg_element(
@@ -127,6 +128,7 @@ fn create_html_element(
     creator: ElementCreator,
     mode: CustomElementCreationMode,
     proto: Option<HandleObject>,
+    can_gc: CanGc,
 ) -> DomRoot<Element> {
     assert_eq!(name.ns, ns!(html));
 
@@ -150,7 +152,7 @@ fn create_html_element(
                 CustomElementCreationMode::Synchronous => {
                     let local_name = name.local.clone();
                     //TODO(jdm) Pass proto to create_element?
-                    return match definition.create_element(document, prefix.clone()) {
+                    return match definition.create_element(document, prefix.clone(), can_gc) {
                         Ok(element) => {
                             element.set_custom_element_definition(definition.clone());
                             element
@@ -185,7 +187,9 @@ fn create_html_element(
             element.set_custom_element_state(CustomElementState::Undefined);
             match mode {
                 // Step 5.3
-                CustomElementCreationMode::Synchronous => upgrade_element(definition, &element),
+                CustomElementCreationMode::Synchronous => {
+                    upgrade_element(definition, &element, can_gc)
+                },
                 // Step 5.4
                 CustomElementCreationMode::Asynchronous => {
                     ScriptThread::enqueue_upgrade_reaction(&element, definition)
@@ -395,10 +399,11 @@ pub fn create_element(
     creator: ElementCreator,
     mode: CustomElementCreationMode,
     proto: Option<HandleObject>,
+    can_gc: CanGc,
 ) -> DomRoot<Element> {
     let prefix = name.prefix.clone();
     match name.ns {
-        ns!(html) => create_html_element(name, prefix, is, document, creator, mode, proto),
+        ns!(html) => create_html_element(name, prefix, is, document, creator, mode, proto, can_gc),
         ns!(svg) => create_svg_element(name, prefix, document, proto),
         _ => Element::new(name.local, name.ns, prefix, document, proto),
     }

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -28,6 +28,7 @@ use crate::dom::htmltitleelement::HTMLTitleElement;
 use crate::dom::node::Node;
 use crate::dom::text::Text;
 use crate::dom::xmldocument::XMLDocument;
+use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#domimplementation
 #[dom_struct]
@@ -74,6 +75,7 @@ impl DOMImplementationMethods for DOMImplementation {
         maybe_namespace: Option<DOMString>,
         qname: DOMString,
         maybe_doctype: Option<&DocumentType>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLDocument>> {
         let win = self.document.window();
         let loader = DocumentLoader::new(&self.document.loader());
@@ -108,7 +110,7 @@ impl DOMImplementationMethods for DOMImplementation {
                 });
             match doc
                 .upcast::<Document>()
-                .CreateElementNS(maybe_namespace, qname, options)
+                .CreateElementNS(maybe_namespace, qname, options, can_gc)
             {
                 Err(error) => return Err(error),
                 Ok(elem) => Some(elem),
@@ -137,7 +139,7 @@ impl DOMImplementationMethods for DOMImplementation {
     }
 
     // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-    fn CreateHTMLDocument(&self, title: Option<DOMString>) -> DomRoot<Document> {
+    fn CreateHTMLDocument(&self, title: Option<DOMString>, can_gc: CanGc) -> DomRoot<Document> {
         let win = self.document.window();
         let loader = DocumentLoader::new(&self.document.loader());
 
@@ -157,6 +159,7 @@ impl DOMImplementationMethods for DOMImplementation {
             None,
             None,
             Default::default(),
+            can_gc,
         );
 
         {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -62,6 +62,7 @@ impl DOMParserMethods for DOMParser {
         &self,
         s: DOMString,
         ty: DOMParserBinding::SupportedType,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<Document>> {
         let url = self.window.get_url();
         let content_type = ty
@@ -87,8 +88,9 @@ impl DOMParserMethods for DOMParser {
                     None,
                     None,
                     Default::default(),
+                    can_gc,
                 );
-                ServoParser::parse_html_document(&document, Some(s), url);
+                ServoParser::parse_html_document(&document, Some(s), url, CanGc::note());
                 document.set_ready_state(DocumentReadyState::Complete);
                 Ok(document)
             },
@@ -108,8 +110,9 @@ impl DOMParserMethods for DOMParser {
                     None,
                     None,
                     Default::default(),
+                    can_gc,
                 );
-                ServoParser::parse_xml_document(&document, Some(s), url);
+                ServoParser::parse_xml_document(&document, Some(s), url, CanGc::note());
                 document.set_ready_state(DocumentReadyState::Complete);
                 Ok(document)
             },

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -120,7 +120,8 @@ use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
 use crate::script_module::{DynamicModuleList, ModuleScript, ModuleTree, ScriptFetchOptions};
 use crate::script_runtime::{
-    CommonScriptMsg, ContextForRequestInterrupt, JSContext as SafeJSContext, ScriptChan, ScriptPort,
+    CanGc, CommonScriptMsg, ContextForRequestInterrupt, JSContext as SafeJSContext, ScriptChan,
+    ScriptPort,
 };
 use crate::script_thread::{MainThreadScriptChan, ScriptThread};
 use crate::security_manager::CSPViolationReporter;
@@ -2952,13 +2953,14 @@ impl GlobalScope {
     }
 
     /// Perform a microtask checkpoint.
-    pub fn perform_a_microtask_checkpoint(&self) {
+    pub fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
         // Only perform the checkpoint if we're not shutting down.
         if self.can_continue_running() {
             self.microtask_queue.checkpoint(
                 GlobalScope::get_cx(),
                 |_| Some(DomRoot::from_ref(self)),
                 vec![DomRoot::from_ref(self)],
+                can_gc,
             );
         }
     }

--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -56,7 +56,7 @@ impl HTMLAudioElement {
     pub fn Audio(
         window: &Window,
         proto: Option<HandleObject>,
-        _can_gc: CanGc,
+        can_gc: CanGc,
         src: Option<DOMString>,
     ) -> Fallible<DomRoot<HTMLAudioElement>> {
         let element = Element::create(
@@ -66,6 +66,7 @@ impl HTMLAudioElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
+            can_gc,
         );
 
         let audio = DomRoot::downcast::<HTMLAudioElement>(element).unwrap();

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -87,7 +87,7 @@ impl HTMLOptionElement {
     pub fn Option(
         window: &Window,
         proto: Option<HandleObject>,
-        _can_gc: CanGc,
+        can_gc: CanGc,
         text: DOMString,
         value: Option<DOMString>,
         default_selected: bool,
@@ -100,6 +100,7 @@ impl HTMLOptionElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
+            can_gc,
         );
 
         let option = DomRoot::downcast::<HTMLOptionElement>(element).unwrap();

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -19,6 +19,7 @@ use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::htmlmediaelement::HTMLMediaElement;
 use crate::dom::node::{BindContext, Node, UnbindContext};
 use crate::dom::virtualmethods::VirtualMethods;
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct HTMLSourceElement {
@@ -54,10 +55,11 @@ impl HTMLSourceElement {
 
     fn iterate_next_html_image_element_siblings(
         next_siblings_iterator: impl Iterator<Item = Root<Dom<Node>>>,
+        _can_gc: CanGc,
     ) {
         for next_sibling in next_siblings_iterator {
             if let Some(html_image_element_sibling) = next_sibling.downcast::<HTMLImageElement>() {
-                html_image_element_sibling.update_the_image_data();
+                html_image_element_sibling.update_the_image_data(CanGc::note());
             }
         }
     }
@@ -76,7 +78,10 @@ impl VirtualMethods for HTMLSourceElement {
             &local_name!("media") |
             &local_name!("type") => {
                 let next_sibling_iterator = self.upcast::<Node>().following_siblings();
-                HTMLSourceElement::iterate_next_html_image_element_siblings(next_sibling_iterator);
+                HTMLSourceElement::iterate_next_html_image_element_siblings(
+                    next_sibling_iterator,
+                    CanGc::note(),
+                );
             },
             _ => {},
         }
@@ -87,17 +92,23 @@ impl VirtualMethods for HTMLSourceElement {
         self.super_type().unwrap().bind_to_tree(context);
         let parent = self.upcast::<Node>().GetParentNode().unwrap();
         if let Some(media) = parent.downcast::<HTMLMediaElement>() {
-            media.handle_source_child_insertion();
+            media.handle_source_child_insertion(CanGc::note());
         }
         let next_sibling_iterator = self.upcast::<Node>().following_siblings();
-        HTMLSourceElement::iterate_next_html_image_element_siblings(next_sibling_iterator);
+        HTMLSourceElement::iterate_next_html_image_element_siblings(
+            next_sibling_iterator,
+            CanGc::note(),
+        );
     }
 
     fn unbind_from_tree(&self, context: &UnbindContext) {
         self.super_type().unwrap().unbind_from_tree(context);
         if let Some(next_sibling) = context.next_sibling {
             let next_sibling_iterator = next_sibling.inclusively_following_siblings();
-            HTMLSourceElement::iterate_next_html_image_element_siblings(next_sibling_iterator);
+            HTMLSourceElement::iterate_next_html_image_element_siblings(
+                next_sibling_iterator,
+                CanGc::note(),
+            );
         }
     }
 }

--- a/components/script/dom/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/mediaelementaudiosourcenode.rs
@@ -32,6 +32,7 @@ impl MediaElementAudioSourceNode {
     fn new_inherited(
         context: &AudioContext,
         media_element: &HTMLMediaElement,
+        can_gc: CanGc,
     ) -> Fallible<MediaElementAudioSourceNode> {
         let node = AudioNode::new_inherited(
             AudioNodeInit::MediaElementSourceNode,
@@ -45,7 +46,7 @@ impl MediaElementAudioSourceNode {
             MediaElementSourceNodeMessage::GetAudioRenderer(sender),
         ));
         let audio_renderer = receiver.recv().unwrap();
-        media_element.set_audio_renderer(audio_renderer);
+        media_element.set_audio_renderer(audio_renderer, can_gc);
         let media_element = Dom::from_ref(media_element);
         Ok(MediaElementAudioSourceNode {
             node,
@@ -69,12 +70,12 @@ impl MediaElementAudioSourceNode {
         media_element: &HTMLMediaElement,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        let node = MediaElementAudioSourceNode::new_inherited(context, media_element)?;
+        let node = MediaElementAudioSourceNode::new_inherited(context, media_element, can_gc)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            CanGc::note(),
         ))
     }
 

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -28,6 +28,7 @@ use crate::dom::htmlmediaelement::HTMLMediaElement;
 use crate::dom::mediametadata::MediaMetadata;
 use crate::dom::window::Window;
 use crate::realms::{enter_realm, InRealm};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct MediaSession {
@@ -67,7 +68,7 @@ impl MediaSession {
         self.media_instance.set(Some(media_instance));
     }
 
-    pub fn handle_action(&self, action: MediaSessionActionType) {
+    pub fn handle_action(&self, action: MediaSessionActionType, can_gc: CanGc) {
         debug!("Handle media session action {:?}", action);
 
         if let Some(handler) = self.action_handlers.borrow().get(&action) {
@@ -82,10 +83,10 @@ impl MediaSession {
             match action {
                 MediaSessionActionType::Play => {
                     let realm = enter_realm(self);
-                    media.Play(InRealm::Entered(&realm));
+                    media.Play(InRealm::Entered(&realm), can_gc);
                 },
                 MediaSessionActionType::Pause => {
-                    media.Pause();
+                    media.Pause(can_gc);
                 },
                 MediaSessionActionType::SeekBackward => {},
                 MediaSessionActionType::SeekForward => {},

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -45,7 +45,7 @@ use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::load_whole_resource;
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
 use crate::script_runtime::{
-    new_rt_and_cx, CommonScriptMsg, ContextForRequestInterrupt, JSContext as SafeJSContext,
+    new_rt_and_cx, CanGc, CommonScriptMsg, ContextForRequestInterrupt, JSContext as SafeJSContext,
     Runtime, ScriptChan,
 };
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
@@ -295,6 +295,7 @@ impl ServiceWorkerGlobalScope {
         control_receiver: Receiver<ServiceWorkerControlMsg>,
         context_sender: Sender<ContextForRequestInterrupt>,
         closing: Arc<AtomicBool>,
+        _can_gc: CanGc,
     ) -> JoinHandle<()> {
         let ScopeThings {
             script_url,
@@ -398,7 +399,7 @@ impl ServiceWorkerGlobalScope {
                             // which happens after the closing flag is set to true,
                             // or until the worker has run beyond its allocated time.
                             while !scope.is_closing() && !global.has_timed_out() {
-                                run_worker_event_loop(&*global, None);
+                                run_worker_event_loop(&*global, None, CanGc::note());
                             }
                         },
                         reporter_name,

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -30,6 +30,7 @@ use crate::dom::htmltemplateelement::HTMLTemplateElement;
 use crate::dom::node::Node;
 use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::servoparser::{ParsingAlgorithm, Sink};
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[crown::unrooted_must_root_lint::must_root]
@@ -163,7 +164,7 @@ fn rev_children_iter(n: &Node) -> impl Iterator<Item = DomRoot<Node>> {
     }
 
     match n.downcast::<HTMLTemplateElement>() {
-        Some(t) => t.Content().upcast::<Node>().rev_children(),
+        Some(t) => t.Content(CanGc::note()).upcast::<Node>().rev_children(),
         None => n.rev_children(),
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -144,7 +144,7 @@ use crate::layout_image::fetch_image_for_layout;
 use crate::microtask::MicrotaskQueue;
 use crate::realms::InRealm;
 use crate::script_runtime::{
-    CommonScriptMsg, JSContext, Runtime, ScriptChan, ScriptPort, ScriptThreadEventCategory,
+    CanGc, CommonScriptMsg, JSContext, Runtime, ScriptChan, ScriptPort, ScriptThreadEventCategory,
 };
 use crate::script_thread::{
     ImageCacheMsg, MainThreadScriptChan, MainThreadScriptMsg, ScriptThread,
@@ -676,10 +676,10 @@ impl WindowMethods for Window {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window-stop
-    fn Stop(&self) {
+    fn Stop(&self, can_gc: CanGc) {
         // TODO: Cancel ongoing navigation.
         let doc = self.Document();
-        doc.abort();
+        doc.abort(can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-open

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -159,6 +159,7 @@ impl Worker {
             global.wgpu_id_hub(),
             control_receiver,
             context_sender,
+            CanGc::note(),
         );
 
         let context = context_receiver

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -72,7 +72,7 @@ use crate::dom::window::Window;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
 use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::task::TaskBox;
 use crate::task_source::TaskSourceName;
 
@@ -1091,7 +1091,7 @@ impl FetchResponseListener for ModuleContext {
         if let Some(window) = global.downcast::<Window>() {
             window
                 .Document()
-                .finish_load(LoadType::Script(self.url.clone()));
+                .finish_load(LoadType::Script(self.url.clone()), CanGc::note());
         }
 
         // Step 9-1 & 9-2.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -145,8 +145,8 @@ use crate::microtask::{Microtask, MicrotaskQueue};
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{
-    get_reports, new_rt_and_cx, CommonScriptMsg, ContextForRequestInterrupt, JSContext, Runtime,
-    ScriptChan, ScriptPort, ScriptThreadEventCategory,
+    get_reports, new_rt_and_cx, CanGc, CommonScriptMsg, ContextForRequestInterrupt, JSContext,
+    Runtime, ScriptChan, ScriptPort, ScriptThreadEventCategory,
 };
 use crate::task_manager::TaskManager;
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
@@ -840,7 +840,7 @@ impl ScriptThreadFactory for ScriptThread {
                 let reporter_name = format!("script-reporter-{:?}", id);
                 mem_profiler_chan.run_with_memory_reporting(
                     || {
-                        script_thread.start();
+                        script_thread.start(CanGc::note());
                         let _ = script_thread.content_process_shutdown_chan.send(());
                     },
                     reporter_name,
@@ -935,10 +935,11 @@ impl ScriptThread {
     pub fn page_headers_available(
         id: &PipelineId,
         metadata: Option<Metadata>,
+        can_gc: CanGc,
     ) -> Option<DomRoot<ServoParser>> {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
-            script_thread.handle_page_headers_available(id, metadata)
+            script_thread.handle_page_headers_available(id, metadata, can_gc)
         })
     }
 
@@ -1208,13 +1209,13 @@ impl ScriptThread {
         })
     }
 
-    pub fn pop_current_element_queue() {
+    pub fn pop_current_element_queue(can_gc: CanGc) {
         SCRIPT_THREAD_ROOT.with(|root| {
             if let Some(script_thread) = root.get() {
                 let script_thread = unsafe { &*script_thread };
                 script_thread
                     .custom_element_reaction_stack
-                    .pop_current_element_queue();
+                    .pop_current_element_queue(can_gc);
             }
         })
     }
@@ -1245,13 +1246,13 @@ impl ScriptThread {
         })
     }
 
-    pub fn invoke_backup_element_queue() {
+    pub fn invoke_backup_element_queue(can_gc: CanGc) {
         SCRIPT_THREAD_ROOT.with(|root| {
             if let Some(script_thread) = root.get() {
                 let script_thread = unsafe { &*script_thread };
                 script_thread
                     .custom_element_reaction_stack
-                    .invoke_backup_element_queue();
+                    .invoke_backup_element_queue(can_gc);
             }
         })
     }
@@ -1447,9 +1448,9 @@ impl ScriptThread {
 
     /// Starts the script thread. After calling this method, the script thread will loop receiving
     /// messages on its port.
-    pub fn start(&self) {
+    pub fn start(&self, _can_gc: CanGc) {
         debug!("Starting script thread.");
-        while self.handle_msgs() {
+        while self.handle_msgs(CanGc::note()) {
             // Go on...
             debug!("Running script thread.");
         }
@@ -1781,7 +1782,7 @@ impl ScriptThread {
     }
 
     /// Handle incoming messages from other tasks and the task queue.
-    fn handle_msgs(&self) -> bool {
+    fn handle_msgs(&self, _can_gc: CanGc) -> bool {
         use self::MixedMessage::{
             FromConstellation, FromDevtools, FromImageCache, FromScript, FromWebGPUServer,
         };
@@ -1893,7 +1894,7 @@ impl ScriptThread {
                     // Run the "update the rendering" task.
                     task.run_box();
                     // Always perform a microtrask checkpoint after running a task.
-                    self.perform_a_microtask_checkpoint();
+                    self.perform_a_microtask_checkpoint(CanGc::note());
                 },
                 FromScript(MainThreadScriptMsg::Inactive) => {
                     // An event came-in from a document that is not fully-active, it has been stored by the task-queue.
@@ -1948,14 +1949,18 @@ impl ScriptThread {
                 // If we've received the closed signal from the BHM, only handle exit messages.
                 match msg {
                     FromConstellation(ConstellationControlMsg::ExitScriptThread) => {
-                        self.handle_exit_script_thread_msg();
+                        self.handle_exit_script_thread_msg(CanGc::note());
                         return false;
                     },
                     FromConstellation(ConstellationControlMsg::ExitPipeline(
                         pipeline_id,
                         discard_browsing_context,
                     )) => {
-                        self.handle_exit_pipeline_msg(pipeline_id, discard_browsing_context);
+                        self.handle_exit_pipeline_msg(
+                            pipeline_id,
+                            discard_browsing_context,
+                            CanGc::note(),
+                        );
                     },
                     _ => {},
                 }
@@ -1965,10 +1970,12 @@ impl ScriptThread {
             let result = self.profile_event(category, pipeline_id, move || {
                 match msg {
                     FromConstellation(ConstellationControlMsg::ExitScriptThread) => {
-                        self.handle_exit_script_thread_msg();
+                        self.handle_exit_script_thread_msg(CanGc::note());
                         return Some(false);
                     },
-                    FromConstellation(inner_msg) => self.handle_msg_from_constellation(inner_msg),
+                    FromConstellation(inner_msg) => {
+                        self.handle_msg_from_constellation(inner_msg, CanGc::note())
+                    },
                     FromScript(inner_msg) => self.handle_msg_from_script(inner_msg),
                     FromDevtools(inner_msg) => self.handle_msg_from_devtools(inner_msg),
                     FromImageCache(inner_msg) => self.handle_msg_from_image_cache(inner_msg),
@@ -1984,7 +1991,7 @@ impl ScriptThread {
 
             // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 6
             // TODO(#32003): A microtask checkpoint is only supposed to be performed after running a task.
-            self.perform_a_microtask_checkpoint();
+            self.perform_a_microtask_checkpoint(CanGc::note());
         }
 
         {
@@ -2246,7 +2253,7 @@ impl ScriptThread {
         value
     }
 
-    fn handle_msg_from_constellation(&self, msg: ConstellationControlMsg) {
+    fn handle_msg_from_constellation(&self, msg: ConstellationControlMsg, can_gc: CanGc) {
         match msg {
             ConstellationControlMsg::StopDelayingLoadEventsMode(pipeline_id) => {
                 self.handle_stop_delaying_load_events_mode(pipeline_id)
@@ -2273,6 +2280,7 @@ impl ScriptThread {
                 browsing_context_id,
                 load_data,
                 replace,
+                can_gc,
             ),
             ConstellationControlMsg::UnloadDocument(pipeline_id) => {
                 self.handle_unload_document(pipeline_id)
@@ -2325,6 +2333,7 @@ impl ScriptThread {
                 top_level_browsing_context_id,
                 new_pipeline_id,
                 reason,
+                can_gc,
             ),
             ConstellationControlMsg::UpdateHistoryState(pipeline_id, history_state_id, url) => {
                 self.handle_update_history_state_msg(pipeline_id, history_state_id, url)
@@ -2345,7 +2354,7 @@ impl ScriptThread {
                 target: browsing_context_id,
                 parent: parent_id,
                 child: child_id,
-            } => self.handle_iframe_load_event(parent_id, browsing_context_id, child_id),
+            } => self.handle_iframe_load_event(parent_id, browsing_context_id, child_id, can_gc),
             ConstellationControlMsg::DispatchStorageEvent(
                 pipeline_id,
                 storage,
@@ -2359,13 +2368,13 @@ impl ScriptThread {
             },
             ConstellationControlMsg::Reload(pipeline_id) => self.handle_reload(pipeline_id),
             ConstellationControlMsg::ExitPipeline(pipeline_id, discard_browsing_context) => {
-                self.handle_exit_pipeline_msg(pipeline_id, discard_browsing_context)
+                self.handle_exit_pipeline_msg(pipeline_id, discard_browsing_context, can_gc)
             },
             ConstellationControlMsg::PaintMetric(pipeline_id, metric_type, metric_value) => {
                 self.handle_paint_metric(pipeline_id, metric_type, metric_value)
             },
             ConstellationControlMsg::MediaSessionAction(pipeline_id, action) => {
-                self.handle_media_session_action(pipeline_id, action)
+                self.handle_media_session_action(pipeline_id, action, can_gc)
             },
             ConstellationControlMsg::SetWebGPUPort(port) => {
                 if self.webgpu_port.borrow().is_some() {
@@ -3050,13 +3059,14 @@ impl ScriptThread {
         top_level_browsing_context_id: TopLevelBrowsingContextId,
         new_pipeline_id: PipelineId,
         reason: UpdatePipelineIdReason,
+        can_gc: CanGc,
     ) {
         let frame_element = self
             .documents
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
         if let Some(frame_element) = frame_element {
-            frame_element.update_pipeline_id(new_pipeline_id, reason);
+            frame_element.update_pipeline_id(new_pipeline_id, reason, can_gc);
         }
 
         if let Some(window) = self.documents.borrow().find_window(new_pipeline_id) {
@@ -3123,6 +3133,7 @@ impl ScriptThread {
         &self,
         id: &PipelineId,
         metadata: Option<Metadata>,
+        _can_gc: CanGc,
     ) -> Option<DomRoot<ServoParser>> {
         let idx = self
             .incomplete_loads
@@ -3161,7 +3172,7 @@ impl ScriptThread {
                 };
 
                 let load = self.incomplete_loads.borrow_mut().remove(idx);
-                metadata.map(|meta| self.load(meta, load))
+                metadata.map(|meta| self.load(meta, load, CanGc::note()))
             },
             None => {
                 assert!(self.closed_pipelines.borrow().contains(id));
@@ -3244,7 +3255,12 @@ impl ScriptThread {
     }
 
     /// Handles a request to exit a pipeline and shut down layout.
-    fn handle_exit_pipeline_msg(&self, id: PipelineId, discard_bc: DiscardBrowsingContext) {
+    fn handle_exit_pipeline_msg(
+        &self,
+        id: PipelineId,
+        discard_bc: DiscardBrowsingContext,
+        can_gc: CanGc,
+    ) {
         debug!("{id}: Starting pipeline exit.");
 
         self.closed_pipelines.borrow_mut().insert(id);
@@ -3261,7 +3277,7 @@ impl ScriptThread {
                 .any(|load| load.pipeline_id == id));
 
             if let Some(parser) = document.get_current_parser() {
-                parser.abort();
+                parser.abort(can_gc);
             }
 
             debug!("{id}: Shutting down layout");
@@ -3298,7 +3314,7 @@ impl ScriptThread {
     }
 
     /// Handles a request to exit the script thread and shut down layout.
-    fn handle_exit_script_thread_msg(&self) {
+    fn handle_exit_script_thread_msg(&self, _can_gc: CanGc) {
         debug!("Exiting script thread.");
 
         let mut pipeline_ids = Vec::new();
@@ -3318,7 +3334,7 @@ impl ScriptThread {
         );
 
         for pipeline_id in pipeline_ids {
-            self.handle_exit_pipeline_msg(pipeline_id, DiscardBrowsingContext::Yes);
+            self.handle_exit_pipeline_msg(pipeline_id, DiscardBrowsingContext::Yes, CanGc::note());
         }
 
         self.background_hang_monitor.unregister();
@@ -3399,13 +3415,14 @@ impl ScriptThread {
         parent_id: PipelineId,
         browsing_context_id: BrowsingContextId,
         child_id: PipelineId,
+        can_gc: CanGc,
     ) {
         let iframe = self
             .documents
             .borrow()
             .find_iframe(parent_id, browsing_context_id);
         match iframe {
-            Some(iframe) => iframe.iframe_load_event_steps(child_id),
+            Some(iframe) => iframe.iframe_load_event_steps(child_id, can_gc),
             None => warn!("Message sent to closed pipeline {}.", parent_id),
         }
     }
@@ -3547,7 +3564,12 @@ impl ScriptThread {
 
     /// The entry point to document loading. Defines bindings, sets up the window and document
     /// objects, parses HTML and CSS, and kicks off initial layout.
-    fn load(&self, metadata: Metadata, incomplete: InProgressLoad) -> DomRoot<ServoParser> {
+    fn load(
+        &self,
+        metadata: Metadata,
+        incomplete: InProgressLoad,
+        can_gc: CanGc,
+    ) -> DomRoot<ServoParser> {
         let final_url = metadata.final_url.clone();
         {
             self.script_sender
@@ -3736,6 +3758,7 @@ impl ScriptThread {
             referrer_policy,
             Some(status_code),
             incomplete.canceller,
+            CanGc::note(),
         );
         document.set_ready_state(DocumentReadyState::Loading);
 
@@ -3758,6 +3781,7 @@ impl ScriptThread {
                 window_proxy.top_level_browsing_context_id(),
                 incomplete.pipeline_id,
                 UpdatePipelineIdReason::Navigation,
+                can_gc,
             );
         }
 
@@ -3776,9 +3800,9 @@ impl ScriptThread {
         document.set_navigation_start(incomplete.navigation_start);
 
         if is_html_document == IsHTMLDocument::NonHTMLDocument {
-            ServoParser::parse_xml_document(&document, None, final_url);
+            ServoParser::parse_xml_document(&document, None, final_url, CanGc::note());
         } else {
-            ServoParser::parse_html_document(&document, None, final_url);
+            ServoParser::parse_html_document(&document, None, final_url, CanGc::note());
         }
 
         if incomplete.activity == DocumentActivity::FullyActive {
@@ -3901,13 +3925,14 @@ impl ScriptThread {
         browsing_context_id: BrowsingContextId,
         load_data: LoadData,
         replace: HistoryEntryReplacement,
+        can_gc: CanGc,
     ) {
         let iframe = self
             .documents
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
         if let Some(iframe) = iframe {
-            iframe.navigate_or_reload_child_browsing_context(load_data, replace);
+            iframe.navigate_or_reload_child_browsing_context(load_data, replace, can_gc);
         }
     }
 
@@ -4179,10 +4204,15 @@ impl ScriptThread {
         }
     }
 
-    fn handle_media_session_action(&self, pipeline_id: PipelineId, action: MediaSessionActionType) {
+    fn handle_media_session_action(
+        &self,
+        pipeline_id: PipelineId,
+        action: MediaSessionActionType,
+        can_gc: CanGc,
+    ) {
         if let Some(window) = self.documents.borrow().find_window(pipeline_id) {
             let media_session = window.Navigator().MediaSession();
-            media_session.handle_action(action);
+            media_session.handle_action(action, can_gc);
         } else {
             warn!("No MediaSession for this pipeline ID");
         };
@@ -4197,7 +4227,7 @@ impl ScriptThread {
         });
     }
 
-    fn perform_a_microtask_checkpoint(&self) {
+    fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
         // Only perform the checkpoint if we're not shutting down.
         if self.can_continue_running_inner() {
             let globals = self
@@ -4211,6 +4241,7 @@ impl ScriptThread {
                 self.get_cx(),
                 |id| self.documents.borrow().find_global(id),
                 globals,
+                can_gc,
             )
         }
     }

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -29,7 +29,7 @@ use crate::dom::serviceworkerglobalscope::{
     ServiceWorkerControlMsg, ServiceWorkerGlobalScope, ServiceWorkerScriptMsg,
 };
 use crate::dom::serviceworkerregistration::longest_prefix_match;
-use crate::script_runtime::ContextForRequestInterrupt;
+use crate::script_runtime::{CanGc, ContextForRequestInterrupt};
 
 enum Message {
     FromResource(CustomResponseMediator),
@@ -250,10 +250,12 @@ impl ServiceWorkerManager {
         None
     }
 
-    fn handle_message(&mut self) {
+    fn handle_message(&mut self, _can_gc: CanGc) {
         while let Ok(message) = self.receive_message() {
             let should_continue = match message {
-                Message::FromConstellation(msg) => self.handle_message_from_constellation(msg),
+                Message::FromConstellation(msg) => {
+                    self.handle_message_from_constellation(msg, CanGc::note())
+                },
                 Message::FromResource(msg) => self.handle_message_from_resource(msg),
             };
             if !should_continue {
@@ -288,7 +290,7 @@ impl ServiceWorkerManager {
         }
     }
 
-    fn handle_message_from_constellation(&mut self, msg: ServiceWorkerMsg) -> bool {
+    fn handle_message_from_constellation(&mut self, msg: ServiceWorkerMsg, can_gc: CanGc) -> bool {
         match msg {
             ServiceWorkerMsg::Timeout(_scope) => {
                 // TODO: https://w3c.github.io/ServiceWorker/#terminate-service-worker
@@ -305,7 +307,7 @@ impl ServiceWorkerManager {
                     self.handle_register_job(job);
                 },
                 JobType::Update => {
-                    self.handle_update_job(job);
+                    self.handle_update_job(job, can_gc);
                 },
                 JobType::Unregister => {
                     // TODO: https://w3c.github.io/ServiceWorker/#unregister-algorithm
@@ -380,7 +382,7 @@ impl ServiceWorkerManager {
     }
 
     /// <https://w3c.github.io/ServiceWorker/#update>
-    fn handle_update_job(&mut self, job: Job) {
+    fn handle_update_job(&mut self, job: Job, can_gc: CanGc) {
         // Step 1: Get registation
         if let Some(registration) = self.registrations.get_mut(&job.scope_url) {
             // Step 3.
@@ -403,8 +405,12 @@ impl ServiceWorkerManager {
 
             // Very roughly steps 5 to 18.
             // TODO: implement all steps precisely.
-            let (new_worker, join_handle, control_sender, context, closing) =
-                update_serviceworker(self.own_sender.clone(), job.scope_url.clone(), scope_things);
+            let (new_worker, join_handle, control_sender, context, closing) = update_serviceworker(
+                self.own_sender.clone(),
+                job.scope_url.clone(),
+                scope_things,
+                can_gc,
+            );
 
             // Since we've just started the worker thread, ensure we can shut it down later.
             registration.note_worker_thread(join_handle, control_sender, context, closing);
@@ -443,6 +449,7 @@ fn update_serviceworker(
     own_sender: IpcSender<ServiceWorkerMsg>,
     scope_url: ServoUrl,
     scope_things: ScopeThings,
+    can_gc: CanGc,
 ) -> (
     ServiceWorker,
     JoinHandle<()>,
@@ -468,6 +475,7 @@ fn update_serviceworker(
         control_receiver,
         context_sender,
         closing.clone(),
+        can_gc,
     );
 
     let context = context_receiver
@@ -504,7 +512,7 @@ impl ServiceWorkerManagerFactory for ServiceWorkerManager {
                 resource_port,
                 constellation_sender,
             )
-            .handle_message()
+            .handle_message(CanGc::note())
         };
         if thread::Builder::new()
             .name("SvcWorkerManager".to_owned())

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -44,6 +44,7 @@ use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::fetch::create_a_potential_cors_request;
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
+use crate::script_runtime::CanGc;
 
 pub trait StylesheetOwner {
     /// Returns whether this element was inserted by the parser (i.e., it should
@@ -213,7 +214,7 @@ impl FetchResponseListener for StylesheetContext {
             document.decrement_script_blocking_stylesheet_count();
         }
 
-        document.finish_load(LoadType::Stylesheet(self.url.clone()));
+        document.finish_load(LoadType::Stylesheet(self.url.clone()), CanGc::note());
 
         if let Some(any_failed) = owner.load_finished(successful) {
             let event = if any_failed {


### PR DESCRIPTION
Following https://github.com/servo/servo/issues/33140 and #33144, more work on marking functions that can transitively trigger a GC to easier recognize hazards.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #33140  (GitHub issue number if applicable)
- [x] These changes do not require tests because there are no functional changes