### PR TITLE
webgpu: Do one allocation less on presentation by keeping GPUBuffer mapped

### DIFF
--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -47,7 +47,7 @@ struct GPUPresentationBuffer {
     size: usize,
 }
 
-// This is safe because [`GPUPresentationBuffer`] is always wrapped in Arc Mutex of [`WGPUImageMap`]
+// This is safe because `GPUPresentationBuffer` holds exclusive access to ptr
 unsafe impl Send for GPUPresentationBuffer {}
 unsafe impl Sync for GPUPresentationBuffer {}
 
@@ -63,6 +63,7 @@ impl GPUPresentationBuffer {
             size: size as usize,
         }
     }
+
     fn slice(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.data.as_ptr(), self.size) }
     }

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -352,8 +352,9 @@ fn update_wr_image(
 ) {
     match result {
         Ok(()) => {
-            let presentation_buffer = GPUPresentationBuffer::new(global, buffer_id, buffer_size);
             if let Some(present_data) = wgpu_image_map.lock().unwrap().get_mut(&context_id) {
+                let presentation_buffer =
+                    GPUPresentationBuffer::new(global, buffer_id, buffer_size);
                 let old_presentation_buffer = present_data.data.replace(presentation_buffer);
                 let mut txn = Transaction::new();
                 txn.update_image(


### PR DESCRIPTION
Instead of mapping, cloning, unmapping `GPUBuffer` we simply keep it mapped (as `GPUPresentationBuffer`) until new GPUBuffer is ready.

We still do clone in `WebrenderExternalImageApi::lock` for now, because that would require more lock contention (between wr and map_async callback), so we will need to carefully evaluate such change.

This removes second allocation from https://github.com/servo/servo/issues/33368.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partial fix #33368
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
