### PR TITLE
CI: fix self-hosted runners in Linux builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,7 +106,7 @@ jobs:
 
       # Faster checkout for self-hosted runner that uses prebaked repo.
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=1 origin $env:GITHUB_SHA
+        run: git fetch --depth=1 origin $GITHUB_SHA
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && github.event_name == 'pull_request_target' }}
         run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
       - if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}


### PR DESCRIPTION
The git fetch command we use on Linux self-hosted runners for non-pull_request_target events was misspelled.

We should be fetching `$GITHUB_SHA` (sh syntax), not `$env:GITHUB_SHA` (PowerShell syntax).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33382

The test plan below includes all of the known ways our self-hosted runner builds can misbehave or regress, including simultaneous builds (#33276), try-label builds (#33372), and non-pull_request_target builds (#33388). To save time, only the build linked at the very bottom includes WPT tests.
- [x] main branch push builds — must be done in a fork, since we need to make workflow code changes on main
  - [x] main.yml build before: <https://github.com/delan/servo/actions/runs/10786263182/job/29912869413#step:5:1>
  - [x] main.yml build after: <https://github.com/delan/servo/actions/runs/10786277861/job/29912904962#step:5:1>
- [x] Same-repo pull_request_target builds — must be done in a fork, since we need to make workflow code changes on main (pull_request_target uses workflow code from the destination branch)
  - [x] try-label.yml build (T-linux T-windows): <https://github.com/delan/servo/actions/runs/10786707785/job/29914051257#step:6:1>
- [x] Different-repo pull_request builds — workflow code comes from pull request
  - [x] main.yml build: <https://github.com/delan/servo/actions/runs/10786277861/job/29912904962#step:5:1>
- [x] Same-repo pull_request builds — workflow code comes from pull request
  - [x] main.yml build: <https://github.com/servo/servo/actions/runs/10787185487/job/29915389750#step:5:1>
- [x] try branch push builds — workflow code comes from try
  - [x] try.yml build (`mach try linux-wpt win`): <https://github.com/servo/servo/actions/runs/10787328547/job/29915814930#step:5:1>