### PR TITLE
Don't allow servoshell tab titles to be empty

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -359,8 +359,8 @@ impl Minibrowser {
                     |ui| {
                         for (webview_id, webview) in webviews.webviews().into_iter() {
                             let label = match (&webview.title, &webview.url) {
-                                (Some(title), _) => title,
-                                (None, Some(url)) => &url.to_string(),
+                                (Some(title), _) if !title.is_empty() => title,
+                                (_, Some(url)) => &url.to_string(),
                                 _ => "New Tab",
                             };
                             if let Some(event) =


### PR DESCRIPTION
Hey, merging #33244 accidentally overwrote the changes introduced in #33229 so we can still get empty tab labels. This PR reintroduces the changes by @Wuelle

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because Minibrowser
