### PR TITLE
Stop using `time@0.1` in Servo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,6 @@ dependencies = [
  "servo_url",
  "style_traits",
  "surfman",
- "time 0.1.45",
  "tracing",
  "webrender",
  "webrender_api",
@@ -1352,7 +1351,6 @@ dependencies = [
  "malloc_size_of_derive",
  "serde",
  "servo_url",
- "time 0.1.45",
  "uuid",
 ]
 
@@ -4266,7 +4264,6 @@ dependencies = [
  "metrics",
  "profile_traits",
  "servo_url",
- "time 0.1.45",
 ]
 
 [[package]]
@@ -4545,7 +4542,7 @@ dependencies = [
  "servo_config",
  "servo_url",
  "sha2",
- "time 0.1.45",
+ "time 0.3.36",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -5774,7 +5771,6 @@ dependencies = [
  "swapper",
  "tempfile",
  "tendril",
- "time 0.1.45",
  "time 0.3.36",
  "unicode-bidi",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,8 +121,7 @@ surfman = { version = "0.9.8", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 thin-vec = "0.2.13"
-time = "0.1.41"
-time_03 = { package = "time", version = "0.3", features = ["large-dates", "serde"] }
+time_03 = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
 to_shmem = { git = "https://github.com/servo/stylo", branch = "2024-07-16" }
 tokio = "1"
 tokio-rustls = "0.24"

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -40,7 +40,6 @@ servo-media = { workspace = true }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 style_traits = { workspace = true }
-time = { workspace = true }
 tracing = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -9,7 +9,7 @@ use std::mem;
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 
-use devtools_traits::PreciseTime;
+use base::cross_process_instant::CrossProcessInstant;
 use log::{debug, warn};
 use serde_json::{Map, Value};
 
@@ -60,7 +60,7 @@ pub struct ActorRegistry {
     script_actors: RefCell<HashMap<String, String>>,
     shareable: Option<Arc<Mutex<ActorRegistry>>>,
     next: Cell<u32>,
-    start_stamp: PreciseTime,
+    start_stamp: CrossProcessInstant,
 }
 
 impl ActorRegistry {
@@ -73,7 +73,7 @@ impl ActorRegistry {
             script_actors: RefCell::new(HashMap::new()),
             shareable: None,
             next: Cell::new(0),
-            start_stamp: PreciseTime::now(),
+            start_stamp: CrossProcessInstant::now(),
         }
     }
 
@@ -104,7 +104,7 @@ impl ActorRegistry {
     }
 
     /// Get start stamp when registry was started
-    pub fn start_stamp(&self) -> PreciseTime {
+    pub fn start_stamp(&self) -> CrossProcessInstant {
         self.start_stamp
     }
 

--- a/components/hyper_serde/README.md
+++ b/components/hyper_serde/README.md
@@ -19,7 +19,6 @@ The supported types are:
 * `hyper::method::Method`
 * `hyper::Uri`
 * `mime::Mime`
-* `time::Tm`
 
 For more details, see the crate documentation.
 

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -56,8 +56,8 @@ servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 sha2 = "0.10"
-time = { workspace = true }
 chrono = { workspace = true }
+time_03 = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tokio-rustls = { workspace = true }
 tokio-stream = "0.1"

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -57,8 +57,6 @@ struct FileStoreEntry {
 #[derive(Clone)]
 struct FileMetaData {
     path: PathBuf,
-    /// Modified time in UNIX Epoch format
-    _modified: u64,
     size: u64,
 }
 
@@ -639,11 +637,6 @@ impl FileManagerStore {
         let modified = metadata
             .modified()
             .map_err(|e| FileSystemError(e.to_string()))?;
-        let elapsed = modified
-            .elapsed()
-            .map_err(|e| FileSystemError(e.to_string()))?;
-        // Unix Epoch: https://doc.servo.org/std/time/constant.UNIX_EPOCH.html
-        let modified_epoch = elapsed.as_secs() * 1000 + elapsed.subsec_nanos() as u64 / 1000000;
         let file_size = metadata.len();
         let file_name = file_path
             .file_name()
@@ -651,7 +644,6 @@ impl FileManagerStore {
 
         let file_impl = FileImpl::MetaDataOnly(FileMetaData {
             path: file_path.to_path_buf(),
-            _modified: modified_epoch,
             size: file_size,
         });
 
@@ -678,7 +670,7 @@ impl FileManagerStore {
         Ok(SelectedFile {
             id,
             filename: filename_path.to_path_buf(),
-            modified: modified_epoch,
+            modified,
             size: file_size,
             type_string,
         })

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -4,7 +4,9 @@
 
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::time::Duration;
 
+use base::cross_process_instant::CrossProcessInstant;
 use embedder_traits::resources::{self, Resource};
 use headers::{HeaderMapExt, StrictTransportSecurity};
 use http::HeaderMap;
@@ -19,15 +21,15 @@ use servo_url::{Host, ServoUrl};
 pub struct HstsEntry {
     pub host: String,
     pub include_subdomains: bool,
-    pub max_age: Option<u64>,
-    pub timestamp: Option<u64>,
+    pub max_age: Option<Duration>,
+    pub timestamp: Option<CrossProcessInstant>,
 }
 
 impl HstsEntry {
     pub fn new(
         host: String,
         subdomains: IncludeSubdomains,
-        max_age: Option<u64>,
+        max_age: Option<Duration>,
     ) -> Option<HstsEntry> {
         if host.parse::<Ipv4Addr>().is_ok() || host.parse::<Ipv6Addr>().is_ok() {
             None
@@ -36,16 +38,14 @@ impl HstsEntry {
                 host,
                 include_subdomains: (subdomains == IncludeSubdomains::Included),
                 max_age,
-                timestamp: Some(time::get_time().sec as u64),
+                timestamp: Some(CrossProcessInstant::now()),
             })
         }
     }
 
     pub fn is_expired(&self) -> bool {
         match (self.max_age, self.timestamp) {
-            (Some(max_age), Some(timestamp)) => {
-                (time::get_time().sec as u64) - timestamp >= max_age
-            },
+            (Some(max_age), Some(timestamp)) => CrossProcessInstant::now() - timestamp >= max_age,
 
             _ => false,
         }
@@ -187,11 +187,9 @@ impl HstsList {
                     IncludeSubdomains::NotIncluded
                 };
 
-                if let Some(entry) = HstsEntry::new(
-                    host.to_owned(),
-                    include_subdomains,
-                    Some(header.max_age().as_secs()),
-                ) {
+                if let Some(entry) =
+                    HstsEntry::new(host.to_owned(), include_subdomains, Some(header.max_age()))
+                {
                     info!("adding host {} to the strict transport security list", host);
                     info!("- max-age {}", header.max_age().as_secs());
                     if header.include_subdomains() {

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -104,7 +104,6 @@ style_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"
 tendril = { version = "0.4.1", features = ["encoding_rs"] }
-time = { workspace = true }
 time_03 = { workspace = true }
 unicode-bidi = { workspace = true }
 unicode-segmentation = { workspace = true }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::BrowsingContextId;
 use canvas_traits::webgl::{self, WebGLContextId, WebGLMsg};
+use chrono::Local;
 use content_security_policy::{self as csp, CspList};
 use cookie::Cookie;
 use cssparser::match_ignore_ascii_case;
@@ -4597,15 +4598,14 @@ impl DocumentMethods for Document {
 
     // https://html.spec.whatwg.org/multipage/#dom-document-lastmodified
     fn LastModified(&self) -> DOMString {
-        match self.last_modified {
-            Some(ref t) => DOMString::from(t.clone()),
-            None => DOMString::from(
-                time::now()
-                    .strftime("%m/%d/%Y %H:%M:%S")
-                    .unwrap()
-                    .to_string(),
-            ),
-        }
+        DOMString::from(self.last_modified.as_ref().cloned().unwrap_or_else(|| {
+            // Ideally this would get the local time using `time`, but `time` always fails to get the local
+            // timezone on Unix unless the application is single threaded unless the library is explicitly
+            // set to "unsound" mode. Maybe that's fine, but it needs more investigation. see
+            // https://nvd.nist.gov/vuln/detail/CVE-2020-26235
+            // When `time` supports a thread-safe way of getting the local time zone we could use it here.
+            Local::now().format("%m/%d/%Y %H:%M:%S").to_string()
+        }))
     }
 
     // https://dom.spec.whatwg.org/#dom-document-createrange

--- a/components/shared/base/cross_process_instant.rs
+++ b/components/shared/base/cross_process_instant.rs
@@ -61,6 +61,16 @@ impl Add<Duration> for CrossProcessInstant {
     }
 }
 
+impl Sub<Duration> for CrossProcessInstant {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        Self {
+            value: self.value - rhs.whole_nanoseconds() as u64,
+        }
+    }
+}
+
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
 mod platform {
     use libc::timespec;

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -19,5 +19,4 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 serde = { workspace = true }
 servo_url = { path = "../../url" }
-time = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -5,6 +5,7 @@
 use std::cmp::{max, min};
 use std::ops::Range;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 use embedder_traits::FilterPattern;
 use ipc_channel::ipc::IpcSender;
@@ -115,7 +116,7 @@ impl RelativePos {
 pub struct SelectedFile {
     pub id: Uuid,
     pub filename: PathBuf,
-    pub modified: u64,
+    pub modified: SystemTime,
     pub size: u64,
     // https://w3c.github.io/FileAPI/#dfn-type
     pub type_string: String,

--- a/tests/unit/metrics/Cargo.toml
+++ b/tests/unit/metrics/Cargo.toml
@@ -18,4 +18,3 @@ ipc-channel = { workspace = true }
 metrics = { path = "../../../components/metrics" }
 profile_traits = { workspace = true }
 servo_url = { path = "../../../components/url" }
-time = { workspace = true }


### PR DESCRIPTION
This removes the last few uses of `time@0.1` in Servo. There are still
dependencies from `style` and `webrender`, but they will be removed soon
as well. The uses of this version of `time` are replaced with
`std::time` types and `time@0.3` when negative `Duration` is necessary.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
