### PR TITLE
Raf delivery: run rafs for all pipeline if tick received for any.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3335,10 +3335,17 @@ impl Document {
         self.pending_animation_ticks.borrow_mut().extend(tick_type);
     }
 
+    /// Whether this document has received an animation tick for rafs.
+    pub fn has_received_raf_tick(&self) -> bool {
+        self.pending_animation_ticks
+            .borrow()
+            .contains(AnimationTickType::REQUEST_ANIMATION_FRAME)
+    }
+
     /// As part of a `update_the_rendering` task, tick all pending animations.
-    pub fn tick_all_animations(&self) {
+    pub fn tick_all_animations(&self, should_run_rafs: bool) {
         let tick_type = mem::take(&mut *self.pending_animation_ticks.borrow_mut());
-        if tick_type.contains(AnimationTickType::REQUEST_ANIMATION_FRAME) {
+        if should_run_rafs {
             self.run_the_animation_frame_callbacks();
         }
         if tick_type.contains(AnimationTickType::CSS_ANIMATIONS_AND_TRANSITIONS) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1647,6 +1647,14 @@ impl ScriptThread {
             return;
         }
 
+        // Run rafs for all pipeline, if a raf tick was received for any.
+        // This ensures relative ordering of rafs between parent doc and iframes.
+        let should_run_rafs = self
+            .documents
+            .borrow()
+            .iter()
+            .any(|(_, doc)| doc.has_received_raf_tick());
+
         // TODO: The specification says to filter out non-renderable documents,
         // as well as those for which a rendering update would be unnecessary,
         // but this isn't happening here.
@@ -1708,7 +1716,7 @@ impl ScriptThread {
             // https://html.spec.whatwg.org/multipage/#context-lost-steps.
 
             // Run the animation frame callbacks.
-            document.tick_all_animations();
+            document.tick_all_animations(should_run_rafs);
 
             // Run the resize observer steps.
             let _realm = enter_realm(&*document);

--- a/tests/wpt/meta/html/webappapis/update-rendering/child-document-raf-order.html.ini
+++ b/tests/wpt/meta/html/webappapis/update-rendering/child-document-raf-order.html.ini
@@ -1,3 +1,0 @@
-[child-document-raf-order.html]
-  [Ordering of steps in "Update the Rendering" - child document requestAnimationFrame order]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The first commits ensures the ordering of running rafs between parent and child docs, by running rafs for all pipeline if a tick was received for any(see #33251).

The second commits prevents a sequence of "update the rendering" tasks from running one after the other and starving other script tasks(see https://github.com/servo/servo/pull/33395#issuecomment-2343431208). 

For the first commit there is a TLA spec modelling the idea at https://gist.github.com/gterzian/1f297aa22393ea8604ad14ca6a5cfff6

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #33251 and fix #33028 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
