### PR TITLE
layout: Use `Au` in `ComputedValuesExt`

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -1507,12 +1507,12 @@ impl BoxFragment {
         let transform_origin = &self.style.get_box().transform_origin;
         let transform_origin_x = transform_origin
             .horizontal
-            .percentage_relative_to(border_rect.size.width.into())
-            .px();
+            .to_used_value(border_rect.size.width)
+            .to_f32_px();
         let transform_origin_y = transform_origin
             .vertical
-            .percentage_relative_to(border_rect.size.height.into())
-            .px();
+            .to_used_value(border_rect.size.height)
+            .to_f32_px();
         let transform_origin_z = transform_origin.depth.px();
 
         let pre_transform = LayoutTransform::translation(

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -15,7 +15,6 @@ use style::properties::longhands::box_sizing::computed_value::T as BoxSizing;
 use style::properties::longhands::flex_wrap::computed_value::T as FlexWrap;
 use style::properties::ComputedValues;
 use style::values::computed::length::Size;
-use style::values::computed::Length;
 use style::values::generics::flex::GenericFlexBasis as FlexBasis;
 use style::values::generics::length::{GenericLengthPercentageOrAuto, LengthPercentageOrNormal};
 use style::values::specified::align::AlignFlags;
@@ -938,15 +937,12 @@ impl FlexContainer {
         let min_box_size = self
             .style
             .content_min_box_size(containing_block_for_container, &pbm)
-            .auto_is(Length::zero);
+            .auto_is(Au::zero);
 
         let max_box_size = self.config.flex_axis.vec2_to_flex_relative(max_box_size);
         let min_box_size = self.config.flex_axis.vec2_to_flex_relative(min_box_size);
 
-        (
-            min_box_size.cross.into(),
-            max_box_size.cross.map(Into::into),
-        )
+        (min_box_size.cross, max_box_size.cross.map(Into::into))
     }
 }
 
@@ -1042,7 +1038,7 @@ impl<'a> FlexItem<'a> {
 
         let item_with_auto_cross_size_stretches_to_container_size = flex_context
             .config
-            .item_with_auto_cross_size_stretches_to_container_size(&box_.style(), &margin);
+            .item_with_auto_cross_size_stretches_to_container_size(box_.style(), &margin);
 
         let flex_relative_content_box_size = flex_context.vec2_to_flex_relative(content_box_size);
         let flex_relative_content_max_size = flex_context.vec2_to_flex_relative(max_size);
@@ -2361,8 +2357,8 @@ impl FlexItemBox {
                     Some(container_definite_main_size) => {
                         let length = length_percentage
                             .0
-                            .percentage_relative_to(container_definite_main_size.into());
-                        FlexBasis::Size(apply_box_sizing(length.into()))
+                            .to_used_value(container_definite_main_size);
+                        FlexBasis::Size(apply_box_sizing(length))
                     },
                     None => {
                         if let Some(length) = length_percentage.0.to_length() {

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -370,12 +370,9 @@ impl<'layout_data, 'layout> LineItemLayout<'layout_data, 'layout> {
 
         let ifc_writing_mode = self.layout.containing_block.effective_writing_mode();
         for fragment in inner_state.fragments.iter_mut() {
-            match fragment {
-                Fragment::Float(box_fragment) => {
-                    box_fragment.content_rect.origin -=
-                        pbm_sums.start_offset().to_physical_size(ifc_writing_mode);
-                },
-                _ => {},
+            if let Fragment::Float(box_fragment) = fragment {
+                box_fragment.content_rect.origin -=
+                    pbm_sums.start_offset().to_physical_size(ifc_writing_mode);
             }
         }
 

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -96,7 +96,7 @@ use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::context::QuirksMode;
 use style::properties::style_structs::InheritedText;
 use style::properties::ComputedValues;
-use style::values::computed::{Clear, Length};
+use style::values::computed::Clear;
 use style::values::generics::box_::VerticalAlignKeyword;
 use style::values::generics::font::LineHeight;
 use style::values::specified::box_::BaselineSource;
@@ -2298,7 +2298,7 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                 // https://drafts.csswg.org/css-sizing-3/#min-percentage-contribution
                 let inline_box = inline_formatting_context.inline_boxes.get(identifier);
                 let inline_box = (*inline_box).borrow();
-                let zero = Length::zero();
+                let zero = Au::zero();
                 let padding = inline_box
                     .style
                     .padding(self.containing_block.style.writing_mode)
@@ -2310,14 +2310,14 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                     .style
                     .margin(self.containing_block.style.writing_mode)
                     .percentages_relative_to(zero)
-                    .auto_is(Length::zero);
+                    .auto_is(Au::zero);
 
                 let pbm = margin + padding + border;
                 if inline_box.is_first_fragment {
-                    self.add_inline_size(pbm.inline_start.into());
+                    self.add_inline_size(pbm.inline_start);
                 }
                 if inline_box.is_last_fragment {
-                    self.ending_inline_pbm_stack.push(pbm.inline_end.into());
+                    self.ending_inline_pbm_stack.push(pbm.inline_end);
                 } else {
                     self.ending_inline_pbm_stack.push(Au::zero());
                 }

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -287,7 +287,7 @@ impl NonReplacedFormattingContext {
             .insert((
                 containing_block_for_children.size.block,
                 self.contents
-                    .inline_content_sizes(layout_context, &containing_block_for_children),
+                    .inline_content_sizes(layout_context, containing_block_for_children),
             ))
             .1
     }

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -67,7 +67,7 @@ impl<'a> IndefiniteContainingBlock<'a> {
         auto_minimum: &LogicalVec2<Au>,
     ) -> Self {
         let (content_box_size, content_min_size, content_max_size, _) =
-            style.content_box_sizes_and_padding_border_margin(&self);
+            style.content_box_sizes_and_padding_border_margin(self);
         let block_size = content_box_size.block.map(|v| {
             v.clamp_between_extremums(
                 content_min_size.block.auto_is(|| auto_minimum.block),

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -371,14 +371,14 @@ impl ReplacedContent {
             // We need to clamp to zero here to obtain the proper aspect
             // ratio when box-sizing is border-box and the inner box size
             // would otherwise be negative.
-            .map(|v| v.map(|v| Au::from(v).max(Au::zero())));
+            .map(|value| value.map(|value| value.max(Au::zero())));
         let min_box_size = style
             .content_min_box_size(containing_block, pbm)
-            .map(|v| v.map(Au::from))
+            .map(|value| value.map(Au::from))
             .auto_is(Au::zero);
         let max_box_size = style
             .content_max_box_size(containing_block, pbm)
-            .map(|v| v.map(Au::from));
+            .map(|value| value.map(Au::from));
         self.used_size_as_if_inline_element_from_content_box_sizes(
             containing_block,
             style,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -374,11 +374,8 @@ impl ReplacedContent {
             .map(|value| value.map(|value| value.max(Au::zero())));
         let min_box_size = style
             .content_min_box_size(containing_block, pbm)
-            .map(|value| value.map(Au::from))
             .auto_is(Au::zero);
-        let max_box_size = style
-            .content_max_box_size(containing_block, pbm)
-            .map(|value| value.map(Au::from));
+        let max_box_size = style.content_max_box_size(containing_block, pbm);
         self.used_size_as_if_inline_element_from_content_box_sizes(
             containing_block,
             style,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -541,7 +541,6 @@ impl ComputedValuesExt for ComputedValues {
         writing_mode: WritingMode,
         containing_block_inline_size: Au,
     ) -> PaddingBorderMargin {
-        let containing_block_inline_size = containing_block_inline_size;
         let padding = self
             .padding(writing_mode)
             .percentages_relative_to(containing_block_inline_size);

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -377,8 +377,12 @@ impl ComputedValuesExt for ComputedValues {
             BoxSizing::BorderBox => LogicalVec2 {
                 // These may be negative, but will later be clamped by `min-width`/`min-height`
                 // which is clamped to zero.
-                inline: box_size.inline.map(|value| value - pbm.padding_border_sums.inline),
-                block: box_size.block.map(|value| value - pbm.padding_border_sums.block),
+                inline: box_size
+                    .inline
+                    .map(|value| value - pbm.padding_border_sums.inline),
+                block: box_size
+                    .block
+                    .map(|value| value - pbm.padding_border_sums.block),
             },
         }
     }


### PR DESCRIPTION
This change uses `Au` in `ComputedValuesExt` and also converts `border_width` to use `Au`

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Signed-off-by: atbrakhi <atbrakhi@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
