### PR TITLE
Let table-related boxes adjust their `overflow` values

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -1287,8 +1287,7 @@ impl BoxFragment {
         parent_clip_id: &wr::ClipChainId,
         containing_block_rect: &PhysicalRect<Au>,
     ) -> Option<(ScrollTreeNodeId, wr::ClipChainId, LayoutSize)> {
-        let overflow_x = self.style.get_box().overflow_x;
-        let overflow_y = self.style.get_box().overflow_y;
+        let overflow = self.style.effective_overflow();
         if !self.style.establishes_scroll_container() {
             return None;
         }
@@ -1318,7 +1317,7 @@ impl BoxFragment {
         );
 
         let sensitivity =
-            if ComputedOverflow::Hidden == overflow_x && ComputedOverflow::Hidden == overflow_y {
+            if ComputedOverflow::Hidden == overflow.x && ComputedOverflow::Hidden == overflow.y {
                 ScrollSensitivity::Script
             } else {
                 ScrollSensitivity::ScriptAndInputEvents

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -67,7 +67,7 @@ impl BoxTree {
         // TODO: This should handle when different overflow is set multiple axes, which requires the
         // compositor scroll tree to allow setting a value per axis.
         let root_style = root_element.style(context);
-        let mut root_overflow = root_style.get_box().overflow_y;
+        let mut root_overflow = root_style.effective_overflow().y;
         if root_overflow == Overflow::Visible && !root_style.get_box().display.is_none() {
             for child in iter_child_nodes(root_element) {
                 if !child.to_threadsafe().as_element().map_or(false, |element| {
@@ -78,7 +78,7 @@ impl BoxTree {
 
                 let style = child.style(context);
                 if !style.get_box().display.is_none() {
-                    root_overflow = style.get_box().overflow_y;
+                    root_overflow = style.effective_overflow().y;
                     break;
                 }
             }

--- a/components/layout_2020/fragment_tree/box_fragment.rs
+++ b/components/layout_2020/fragment_tree/box_fragment.rs
@@ -240,7 +240,7 @@ impl BoxFragment {
                 \nclearance={:?}\
                 \nscrollable_overflow={:?}\
                 \nbaselines={:?}\
-                \noverflow={:?} / {:?}",
+                \noverflow={:?}",
             self.base,
             self.content_rect,
             self.padding_rect(),
@@ -249,8 +249,7 @@ impl BoxFragment {
             self.clearance,
             self.scrollable_overflow(),
             self.baselines,
-            self.style.get_box().overflow_x,
-            self.style.get_box().overflow_y,
+            self.style.effective_overflow(),
         ));
 
         for child in &self.children {
@@ -273,12 +272,13 @@ impl BoxFragment {
             overflow.max_y().max(scrollable_overflow.max_y()),
         );
 
-        if self.style.get_box().overflow_y == ComputedOverflow::Visible {
+        let overflow_style = self.style.effective_overflow();
+        if overflow_style.y == ComputedOverflow::Visible {
             overflow.origin.y = overflow.origin.y.min(scrollable_overflow.origin.y);
             overflow.size.height = bottom_right.y - overflow.origin.y;
         }
 
-        if self.style.get_box().overflow_x == ComputedOverflow::Visible {
+        if overflow_style.x == ComputedOverflow::Visible {
             overflow.origin.x = overflow.origin.x.min(scrollable_overflow.origin.x);
             overflow.size.width = bottom_right.x - overflow.origin.x;
         }

--- a/tests/wpt/meta/css/css-tables/tentative/paint/overflow-hidden-table.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/paint/overflow-hidden-table.html.ini
@@ -1,2 +1,0 @@
-[overflow-hidden-table.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-ui/text-overflow-025.html.ini
+++ b/tests/wpt/meta/css/css-ui/text-overflow-025.html.ini
@@ -1,2 +1,0 @@
-[text-overflow-025.html]
-  expected: FAIL


### PR DESCRIPTION
The `overflow` property doesn't apply to table track and track groups, and table elements only accept a few `overflow` values.

Therefore, this patch adds an `effective_overflow()` method to get the actual value that needs to be used.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
