### PR TITLE
webxr: Update XRInputSource Gamepad handling, FakeXRInputController

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7958,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#1a2186a5b33ae9e2e0b4fc15e9dc6095ae2e5fd0"
+source = "git+https://github.com/servo/webxr#5587c9236bac0a8b7b87b3a95b22882400461b46"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#1a2186a5b33ae9e2e0b4fc15e9dc6095ae2e5fd0"
+source = "git+https://github.com/servo/webxr#5587c9236bac0a8b7b87b3a95b22882400461b46"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -11,8 +11,8 @@ use ipc_channel::ipc::IpcSender;
 use ipc_channel::router::ROUTER;
 use profile_traits::ipc;
 use webxr_api::{
-    EntityType, Handedness, InputId, InputSource, MockDeviceMsg, MockInputInit, MockRegion,
-    MockViewInit, MockViewsInit, MockWorld, TargetRayMode, Triangle, Visibility,
+    EntityType, Handedness, InputId, InputSource, MockButton, MockDeviceMsg, MockInputInit,
+    MockRegion, MockViewInit, MockViewsInit, MockWorld, TargetRayMode, Triangle, Visibility,
 };
 
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
@@ -30,7 +30,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::fakexrinputcontroller::FakeXRInputController;
+use crate::dom::fakexrinputcontroller::{init_to_mock_buttons, FakeXRInputController};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::task_source::TaskSource;
@@ -267,7 +267,10 @@ impl FakeXRDeviceMethods for FakeXRDevice {
 
         let profiles = init.profiles.iter().cloned().map(String::from).collect();
 
-        // XXXManishearth deal with supportedButtons and selection*
+        let mut supported_buttons = vec![];
+        if let Some(ref buttons) = init.supportedButtons {
+            supported_buttons.extend(init_to_mock_buttons(buttons));
+        }
 
         let source = InputSource {
             handedness,
@@ -282,6 +285,7 @@ impl FakeXRDeviceMethods for FakeXRDevice {
             source,
             pointer_origin,
             grip_origin,
+            supported_buttons,
         };
 
         let global = self.global();

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -156,7 +156,10 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
             return Err(Error::Type("Pressed value must be non-negative".into()));
         }
 
-        // TODO: Hook into gamepad state
+        // TODO: Steps 3-5 of updateButtonState
+        // Passing the one WPT test that utilizes this will require additional work
+        // to specify gamepad button/axes list lengths, as well as passing that info
+        // to the constructor of XRInputSource
 
         Ok(())
     }
@@ -174,9 +177,10 @@ impl From<FakeXRButtonType> for MockButtonType {
     }
 }
 
-pub fn init_to_mock_buttons(buttons: &Vec<FakeXRButtonStateInit>) -> Vec<MockButton> {
+/// <https://immersive-web.github.io/webxr-test-api/#parse-supported-buttons>
+pub fn init_to_mock_buttons(buttons: &[FakeXRButtonStateInit]) -> Vec<MockButton> {
     let supported: Vec<MockButton> = buttons
-        .into_iter()
+        .iter()
         .map(|b| MockButton {
             button_type: b.buttonType.into(),
             pressed: b.pressed,

--- a/components/script/dom/webidls/FakeXRInputController.webidl
+++ b/components/script/dom/webidls/FakeXRInputController.webidl
@@ -23,8 +23,8 @@ interface FakeXRInputController {
   undefined endSelection();
   undefined simulateSelect();
 
-  // void setSupportedButtons(sequence<FakeXRButtonStateInit> supportedButtons);
-  // void updateButtonState(FakeXRButtonStateInit buttonState);
+  undefined setSupportedButtons(sequence<FakeXRButtonStateInit> supportedButtons);
+  [Throws] undefined updateButtonState(FakeXRButtonStateInit buttonState);
 };
 
 dictionary FakeXRInputSourceInit {

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -110,6 +110,10 @@ impl XRInputSource {
             self.gamepad.map_and_normalize_axes(i, *value as f64);
         });
     }
+
+    pub fn gamepad(&self) -> &DomRoot<Gamepad> {
+        &self.gamepad
+    }
 }
 
 impl XRInputSourceMethods for XRInputSource {

--- a/components/script/dom/xrinputsourcearray.rs
+++ b/components/script/dom/xrinputsourcearray.rs
@@ -69,6 +69,7 @@ impl XRInputSourceArray {
         let mut input_sources = self.input_sources.borrow_mut();
         let global = self.global();
         let removed = if let Some(i) = input_sources.iter().find(|i| i.id() == id) {
+            i.gamepad().update_connected(false, false);
             [DomRoot::from_ref(&**i)]
         } else {
             return;
@@ -94,6 +95,7 @@ impl XRInputSourceArray {
         let global = self.global();
         let root;
         let removed = if let Some(i) = input_sources.iter().find(|i| i.id() == id) {
+            i.gamepad().update_connected(false, false);
             root = [DomRoot::from_ref(&**i)];
             &root as &[_]
         } else {

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -33,6 +33,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::Wind
 use crate::dom::bindings::codegen::Bindings::XRHitTestSourceBinding::{
     XRHitTestOptionsInit, XRHitTestTrackableType,
 };
+use crate::dom::bindings::codegen::Bindings::XRInputSourceArrayBinding::XRInputSourceArray_Binding::XRInputSourceArrayMethods;
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::{
     XRRenderStateInit, XRRenderStateMethods,
@@ -867,6 +868,11 @@ impl XRSessionMethods for XRSession {
         self.ended.set(true);
         global.as_window().Navigator().Xr().end_session(self);
         self.session.borrow_mut().end_session();
+        // Disconnect any still-attached XRInputSources
+        for source in 0..self.input_sources.Length() {
+            self.input_sources
+                .remove_input_source(self, InputId(source));
+        }
         p
     }
 

--- a/tests/wpt/meta-legacy-layout/webxr/events_session_squeeze.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/events_session_squeeze.https.html.ini
@@ -1,5 +1,5 @@
 [events_session_squeeze.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [XRInputSources primary input presses properly fires off the right events - webgl]
     expected: TIMEOUT
 

--- a/tests/wpt/meta-legacy-layout/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
@@ -1,8 +1,0 @@
-[xrInputSource_gamepad_disconnect.https.html]
-  expected: ERROR
-  [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl2]
-    expected: NOTRUN
-
-  [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/webxr/events_session_squeeze.https.html.ini
+++ b/tests/wpt/meta/webxr/events_session_squeeze.https.html.ini
@@ -1,5 +1,5 @@
 [events_session_squeeze.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [XRInputSources primary input presses properly fires off the right events - webgl]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
+++ b/tests/wpt/meta/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
@@ -1,8 +1,0 @@
-[xrInputSource_gamepad_disconnect.https.html]
-  expected: ERROR
-  [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl2]
-    expected: NOTRUN
-
-  [WebXR InputSource's gamepad gets disconnected when the input source is removed - webgl]
-    expected: TIMEOUT
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This ensures that any gamepads attached to a removed XRInputSource should no longer read as connected. It also adds two of the missing functions for FakeXRInputController. I've left a TODO in updateButtonState for now, as passing the one test that currently utilizes this would require some more involved refactoring of both XRInputSource and Gamepad.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
