### PR TITLE
layout: Reverse `space-between` alignment for absolute children of flex containers

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -892,6 +892,8 @@ impl FlexContainer {
                         AlignFlags::END | AlignFlags::SAFE
                     },
                     (AlignFlags::STRETCH, false) => AlignFlags::START | AlignFlags::SAFE,
+                    (AlignFlags::SPACE_BETWEEN, false) => AlignFlags::START | AlignFlags::SAFE,
+                    (AlignFlags::SPACE_BETWEEN, true) => AlignFlags::END | AlignFlags::SAFE,
                     _ => value,
                 };
             let cross = make_flex_only_values_directional_for_absolutes(

--- a/tests/wpt/meta/css/css-flexbox/abspos/position-absolute-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/position-absolute-001.html.ini
@@ -1,10 +1,4 @@
 [position-absolute-001.html]
-  [.flexbox 39]
-    expected: FAIL
-
-  [.flexbox 34]
-    expected: FAIL
-
   [.flexbox 89]
     expected: FAIL
 
@@ -78,9 +72,6 @@
     expected: FAIL
 
   [.flexbox 118]
-    expected: FAIL
-
-  [.flexbox 119]
     expected: FAIL
 
   [.flexbox 70]
@@ -185,9 +176,6 @@
   [.flexbox 55]
     expected: FAIL
 
-  [.flexbox 24]
-    expected: FAIL
-
   [.flexbox 120]
     expected: FAIL
 
@@ -195,9 +183,6 @@
     expected: FAIL
 
   [.flexbox 71]
-    expected: FAIL
-
-  [.flexbox 29]
     expected: FAIL
 
   [.flexbox 47]
@@ -212,5 +197,8 @@
   [.flexbox 76]
     expected: FAIL
 
-  [.flexbox 109]
+  [.flexbox 69]
+    expected: FAIL
+
+  [.flexbox 74]
     expected: FAIL


### PR DESCRIPTION
We assume that absolutely positioned children are the only flex item, and `space-between` requires more than 1 item, so we use the fallback position, which is `safe flex-start`, and then we need to resolve `flex-start` to either `start` or `end`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
