### PR TITLE
mach: remove python2 compatibility code

### DIFF
--- a/python/mach/mach/config.py
+++ b/python/mach/mach/config.py
@@ -19,10 +19,8 @@ from __future__ import absolute_import, unicode_literals
 import collections
 import os
 import sys
-import six
 from functools import wraps
-from six.moves.configparser import RawConfigParser, NoSectionError
-from six import string_types
+from configparser import RawConfigParser, NoSectionError
 
 
 class ConfigException(Exception):
@@ -62,7 +60,7 @@ class ConfigType(object):
 class StringType(ConfigType):
     @staticmethod
     def validate(value):
-        if not isinstance(value, string_types):
+        if not isinstance(value, str):
             raise TypeError()
 
     @staticmethod
@@ -109,7 +107,7 @@ class PositiveIntegerType(IntegerType):
 class PathType(StringType):
     @staticmethod
     def validate(value):
-        if not isinstance(value, string_types):
+        if not isinstance(value, str):
             raise TypeError()
 
     @staticmethod
@@ -140,7 +138,7 @@ def reraise_attribute_error(func):
             return func(*args, **kwargs)
         except KeyError:
             exc_class, exc, tb = sys.exc_info()
-            six.reraise(AttributeError().__class__, exc, tb)
+            raise(AttributeError().__class__, exc, tb)
     return _
 
 
@@ -337,7 +335,7 @@ class ConfigSettings(collections.abc.Mapping):
             extra -- A dict of additional key/value pairs to add to the
                 setting metadata.
         """
-        if isinstance(type_cls, string_types):
+        if isinstance(type_cls, str):
             type_cls = TYPE_CLASSES[type_cls]
 
         meta = {

--- a/python/mach/mach/main.py
+++ b/python/mach/mach/main.py
@@ -550,7 +550,7 @@ To see more help for a specific command, run:
                 if os.path.isfile(path):
                     return path
 
-        files = map(find_in_dir, self.settings_paths)
+        files = map(find_in_dir, paths)
         files = filter(bool, files)
 
         self.settings.load_files(files)

--- a/python/mach/mach/main.py
+++ b/python/mach/mach/main.py
@@ -18,8 +18,6 @@ import traceback
 import uuid
 from collections.abc import Iterable
 
-from six import string_types
-
 from .base import (
     CommandContext,
     MachError,
@@ -538,7 +536,7 @@ To see more help for a specific command, run:
 
             machrc, .machrc
         """
-        if isinstance(paths, string_types):
+        if isinstance(paths, str):
             paths = [paths]
 
         valid_names = ('machrc', '.machrc')

--- a/python/mach/mach/registrar.py
+++ b/python/mach/mach/registrar.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import time
 
-import six
-
 from .base import MachError
 
 INVALID_COMMAND_CONTEXT = r'''
@@ -111,7 +109,7 @@ class MachRegistrar(object):
         end_time = time.time()
 
         result = result or 0
-        assert isinstance(result, six.integer_types)
+        assert isinstance(result, int)
 
         if context and not debug_command:
             postrun = getattr(context, 'post_dispatch_handler', None)

--- a/python/mach/mach/terminal.py
+++ b/python/mach/mach/terminal.py
@@ -13,8 +13,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import sys
 
-from six.moves import range
-
 
 class LoggingHandler(logging.Handler):
     """Custom logging handler that works with terminal window dressing.

--- a/python/mach/mach/util.py
+++ b/python/mach/mach/util.py
@@ -7,8 +7,6 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
-from six import text_type
-
 
 def setenv(key, value):
     """Compatibility shim to ensure the proper string type is used with
@@ -17,9 +15,9 @@ def setenv(key, value):
     encoding = "mbcs" if sys.platform == "win32" else "utf-8"
 
     if sys.version_info[0] == 2:
-        if isinstance(key, text_type):
+        if isinstance(key, str):
             key = key.encode(encoding)
-        if isinstance(value, text_type):
+        if isinstance(value, str):
             value = value.encode(encoding)
     else:
         if isinstance(key, bytes):

--- a/python/mach/setup.py
+++ b/python/mach/setup.py
@@ -26,8 +26,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.10',
     ],
     install_requires=[
         'blessings',

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -19,7 +19,6 @@ import urllib.request
 import zipfile
 from typing import Dict, List, Union
 
-import six
 from io import BufferedIOBase, BytesIO
 from socket import error as socket_error
 
@@ -188,7 +187,7 @@ def append_paths_to_env(env: Dict[str, str], key: str, paths: Union[str, List[st
 
     existing_value = env.get(key, None)
     if existing_value:
-        new_value = six.ensure_str(existing_value) + os.pathsep + paths
+        new_value = str(existing_value) + os.pathsep + paths
     else:
         new_value = paths
     env[key] = new_value
@@ -201,7 +200,7 @@ def prepend_paths_to_env(env: Dict[str, str], key: str, paths: Union[str, List[s
     existing_value = env.get(key, None)
     new_value = paths
     if existing_value:
-        new_value += os.pathsep + six.ensure_str(existing_value)
+        new_value += os.pathsep + str(existing_value)
     env[key] = new_value
 
 


### PR DESCRIPTION
- Removes `six` from our mach code, and just uses the python3 builtins, since we don't support python2 anymore.
- There is still a bunch of `six` usage in the wpt test code, so we still need to install six.
- Fix a bug with `--settings` being ignored. (not tested, but the code is very straight forward)

Note: The conversions are very straightforward: https://six.readthedocs.io/ 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33409