### PR TITLE
Upgrade to html5ever 0.29 and xml5ever 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff6858c1f7e2a470c5403091866fa95b36fe0dbac5d771f932c15e5ff1ee501"
+checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
 dependencies = [
  "log",
  "mac",
@@ -4167,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d581ff8be69d08a2efa23a959d81aa22b739073f749f067348bd4f4ba4b69195"
+checksum = "82c88c6129bd24319e62a0359cb6b958fa7e8be6e19bb1663bc396b90883aca5"
 dependencies = [
  "log",
  "phf 0.11.2",
@@ -8650,9 +8650,9 @@ checksum = "539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601"
 
 [[package]]
 name = "xml5ever"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b906d34d867d216b2d79fb0e9470aaa7f4948ea86b44c27846efedd596076c"
+checksum = "2278b4bf33071ba8e30368a59436c65eec8e01c49d5c29b3dfeb0cdc45331383"
 dependencies = [
  "log",
  "mac",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3933,7 +3933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -4137,7 +4137,6 @@ dependencies = [
  "smallvec",
  "string_cache",
  "thin-vec",
- "time 0.1.45",
  "tokio",
  "url",
  "uuid",
@@ -5911,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -5923,7 +5922,6 @@ dependencies = [
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
- "size_of_test",
  "smallvec",
  "to_shmem",
  "to_shmem_derive",
@@ -6200,7 +6198,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6209,7 +6207,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6427,7 +6425,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "static_assertions",
 ]
@@ -6568,7 +6566,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 
 [[package]]
 name = "strck"
@@ -6621,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6667,7 +6665,6 @@ dependencies = [
  "style_derive",
  "style_traits",
  "thin-vec",
- "time 0.1.45",
  "to_shmem",
  "to_shmem_derive",
  "uluru",
@@ -6680,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "lazy_static",
 ]
@@ -6688,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "darling",
  "derive_common",
@@ -6719,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -6732,7 +6729,6 @@ dependencies = [
  "serde",
  "servo_arc",
  "servo_atoms",
- "size_of_test",
  "thin-vec",
  "to_shmem",
  "to_shmem_derive",
@@ -7087,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7100,7 +7096,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#65f8d1316a0966401bcfb9fa7dd5e3659a1605b2"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
 dependencies = [
  "darling",
  "derive_common",
@@ -8114,7 +8110,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ gstreamer-sys = "0.22"
 gstreamer-video = "0.22"
 headers = "0.3"
 hitrace = "0.1.4"
-html5ever = "0.28"
+html5ever = "0.29"
 http = "0.2"
 hyper = "0.14"
 hyper-rustls = { version = "0.24", default-features = false, features = ["acceptor", "http1", "http2", "logging", "tls12", "webpki-tokio"] }
@@ -146,7 +146,7 @@ wgpu-core = { git = "https://github.com/gfx-rs/wgpu", rev = "0e352f5b3448236b6cb
 wgpu-types = { git = "https://github.com/gfx-rs/wgpu", rev = "0e352f5b3448236b6cbebcd146d0606b00cb3806" }
 windows-sys = "0.59"
 xi-unicode = "0.3.0"
-xml5ever = "0.19"
+xml5ever = "0.20"
 
 [profile.release]
 opt-level = 3

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -694,6 +694,7 @@ impl TreeSink for Sink {
     }
 
     type Handle = ParseNode;
+    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
 
     fn get_document(&self) -> Self::Handle {
         self.document_node.clone()

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1085,6 +1085,7 @@ impl TreeSink for Sink {
     }
 
     type Handle = Dom<Node>;
+    type ElemName<'a> = ExpandedName<'a> where Self: 'a;
 
     #[allow(crown::unrooted_must_root)]
     fn get_document(&self) -> Dom<Node> {


### PR DESCRIPTION
Upgrade to the latest version of html5ever/xml5ever

- Depends on https://github.com/servo/stylo/pull/72

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the changes in dependency version are minor / non-functional.
<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
