### PR TITLE
layout: Use `Au` in `display_list`

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -24,7 +24,7 @@ use style::properties::style_structs::Border;
 use style::properties::ComputedValues;
 use style::values::computed::image::Image;
 use style::values::computed::{
-    BorderImageSideWidth, BorderImageWidth, BorderStyle, Color, Length, LengthPercentage,
+    BorderImageSideWidth, BorderImageWidth, BorderStyle, Color, LengthPercentage,
     LengthPercentageOrAuto, NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle,
 };
 use style::values::generics::rect::Rect;
@@ -495,19 +495,19 @@ struct BuilderForBoxFragment<'a> {
 
 impl<'a> BuilderForBoxFragment<'a> {
     fn new(fragment: &'a BoxFragment, containing_block: &'a PhysicalRect<Au>) -> Self {
-        let border_rect: units::LayoutRect = fragment
+        let border_rect = fragment
             .border_rect()
-            .translate(containing_block.origin.to_vector())
-            .to_webrender();
+            .translate(containing_block.origin.to_vector());
 
+        let webrender_border_rect = border_rect.to_webrender();
         let border_radius = {
-            let resolve = |radius: &LengthPercentage, box_size: f32| {
-                radius.percentage_relative_to(Length::new(box_size)).px()
+            let resolve = |radius: &LengthPercentage, box_size: Au| {
+                radius.to_used_value(box_size).to_f32_px()
             };
             let corner = |corner: &style::values::computed::BorderCornerRadius| {
                 Size2D::new(
-                    resolve(&corner.0.width.0, border_rect.size().width),
-                    resolve(&corner.0.height.0, border_rect.size().height),
+                    resolve(&corner.0.width.0, border_rect.size.width),
+                    resolve(&corner.0.height.0, border_rect.size.height),
                 )
             };
             let b = fragment.style.get_border();
@@ -517,14 +517,15 @@ impl<'a> BuilderForBoxFragment<'a> {
                 bottom_right: corner(&b.border_bottom_right_radius),
                 bottom_left: corner(&b.border_bottom_left_radius),
             };
-            normalize_radii(&border_rect, &mut radius);
+
+            normalize_radii(&webrender_border_rect, &mut radius);
             radius
         };
 
         Self {
             fragment,
             containing_block,
-            border_rect,
+            border_rect: webrender_border_rect,
             border_radius,
             margin_rect: OnceCell::new(),
             padding_rect: OnceCell::new(),
@@ -1344,14 +1345,14 @@ pub(super) fn compute_margin_box_radius(
         let width = margin
             .width
             .auto_is(LengthPercentage::zero)
-            .resolve(Length::new(layout_rect.width));
+            .to_used_value(Au::from_f32_px(layout_rect.width));
         let height = margin
             .height
             .auto_is(LengthPercentage::zero)
-            .resolve(Length::new(layout_rect.height));
+            .to_used_value(Au::from_f32_px(layout_rect.height));
         LayoutSize::new(
-            adjust_radius(radius.width, width.px()),
-            adjust_radius(radius.height, height.px()),
+            adjust_radius(radius.width, width.to_f32_px()),
+            adjust_radius(radius.height, height.to_f32_px()),
         )
     };
     wr::BorderRadius {

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -1363,23 +1363,15 @@ impl BoxFragment {
         // nearest scroll frame instead of the containing block like for other types
         // of positioning.
         let position = self.style.get_position();
+        let scroll_frame_height = Au::from_f32_px(scroll_frame_size_for_resolve.height);
+        let scroll_frame_width = Au::from_f32_px(scroll_frame_size_for_resolve.width);
         let offsets = PhysicalSides::<AuOrAuto>::new(
-            position.top.map(|v| {
-                v.resolve(Length::new(scroll_frame_size_for_resolve.height))
-                    .into()
-            }),
-            position.right.map(|v| {
-                v.resolve(Length::new(scroll_frame_size_for_resolve.width))
-                    .into()
-            }),
-            position.bottom.map(|v| {
-                v.resolve(Length::new(scroll_frame_size_for_resolve.height))
-                    .into()
-            }),
-            position.left.map(|v| {
-                v.resolve(Length::new(scroll_frame_size_for_resolve.width))
-                    .into()
-            }),
+            position.top.map(|v| v.to_used_value(scroll_frame_height)),
+            position.right.map(|v| v.to_used_value(scroll_frame_width)),
+            position
+                .bottom
+                .map(|v| v.to_used_value(scroll_frame_height)),
+            position.left.map(|v| v.to_used_value(scroll_frame_width)),
         );
         self.resolved_sticky_insets = Some(offsets);
 

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -1268,6 +1268,6 @@ impl SequentialLayoutState {
                 .size
                 .to_logical(container_writing_mode),
         }
-        .to_physical(Some(&containing_block));
+        .to_physical(Some(containing_block));
     }
 }

--- a/components/layout_2020/flow/inline/line.rs
+++ b/components/layout_2020/flow/inline/line.rs
@@ -9,7 +9,6 @@ use itertools::Either;
 use servo_arc::Arc;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::properties::ComputedValues;
-use style::values::computed::Length;
 use style::values::generics::box_::{GenericVerticalAlign, VerticalAlignKeyword};
 use style::values::generics::font::LineHeight;
 use style::values::specified::align::AlignFlags;
@@ -433,7 +432,7 @@ impl<'layout_data, 'layout> LineItemLayout<'layout_data, 'layout> {
         let inline_box_containing_block = ContainingBlock {
             inline_size: content_rect.size.inline,
             block_size: AuOrAuto::Auto,
-            style: &self.layout.containing_block.style,
+            style: self.layout.containing_block.style,
         };
         let fragments = inner_state
             .fragments
@@ -515,11 +514,11 @@ impl<'layout_data, 'layout> LineItemLayout<'layout_data, 'layout> {
         // baseline, so we need to make it relative to the line block start.
         match inline_box_state.base.style.clone_vertical_align() {
             GenericVerticalAlign::Keyword(VerticalAlignKeyword::Top) => {
-                let line_height: Au = line_height(style, font_metrics).into();
+                let line_height: Au = line_height(style, font_metrics);
                 (line_height - line_gap).scale_by(0.5)
             },
             GenericVerticalAlign::Keyword(VerticalAlignKeyword::Bottom) => {
-                let line_height: Au = line_height(style, font_metrics).into();
+                let line_height: Au = line_height(style, font_metrics);
                 let half_leading = (line_height - line_gap).scale_by(0.5);
                 self.line_metrics.block_size - line_height + half_leading
             },
@@ -875,13 +874,13 @@ pub(super) struct FloatLineItem {
     pub needs_placement: bool,
 }
 
-fn line_height(parent_style: &ComputedValues, font_metrics: &FontMetrics) -> Length {
+fn line_height(parent_style: &ComputedValues, font_metrics: &FontMetrics) -> Au {
     let font = parent_style.get_font();
     let font_size = font.font_size.computed_size();
     match font.line_height {
-        LineHeight::Normal => Length::from(font_metrics.line_gap),
-        LineHeight::Number(number) => font_size * number.0,
-        LineHeight::Length(length) => length.0,
+        LineHeight::Normal => font_metrics.line_gap,
+        LineHeight::Number(number) => (font_size * number.0).into(),
+        LineHeight::Length(length) => length.0.into(),
     }
 }
 

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1685,7 +1685,7 @@ impl InlineFormattingContext {
 
         FlowLayout {
             fragments: layout.fragments,
-            content_block_size: content_block_size.into(),
+            content_block_size: content_block_size,
             collapsible_margins_in_children,
             baselines: layout.baselines,
         }
@@ -1865,18 +1865,12 @@ impl InlineContainerState {
                 VerticalAlign::Keyword(VerticalAlignKeyword::Baseline) |
                 VerticalAlign::Keyword(VerticalAlignKeyword::Top) |
                 VerticalAlign::Keyword(VerticalAlignKeyword::Bottom) => Au::zero(),
-                VerticalAlign::Keyword(VerticalAlignKeyword::Sub) => Au::from_f32_px(
-                    block_size
-                        .resolve()
-                        .scale_by(FONT_SUBSCRIPT_OFFSET_RATIO)
-                        .to_f32_px(),
-                ),
-                VerticalAlign::Keyword(VerticalAlignKeyword::Super) => -Au::from_f32_px(
-                    block_size
-                        .resolve()
-                        .scale_by(FONT_SUPERSCRIPT_OFFSET_RATIO)
-                        .to_f32_px(),
-                ),
+                VerticalAlign::Keyword(VerticalAlignKeyword::Sub) => {
+                    block_size.resolve().scale_by(FONT_SUBSCRIPT_OFFSET_RATIO)
+                },
+                VerticalAlign::Keyword(VerticalAlignKeyword::Super) => {
+                    -block_size.resolve().scale_by(FONT_SUPERSCRIPT_OFFSET_RATIO)
+                },
                 VerticalAlign::Keyword(VerticalAlignKeyword::TextTop) => {
                     child_block_size.size_for_baseline_positioning.ascent - self.font_metrics.ascent
                 },
@@ -1893,7 +1887,7 @@ impl InlineContainerState {
                         child_block_size.size_for_baseline_positioning.descent
                 },
                 VerticalAlign::Length(length_percentage) => {
-                    (-length_percentage.resolve(child_block_size.line_height.into())).into()
+                    -length_percentage.to_used_value(child_block_size.line_height)
                 },
             }
     }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -13,7 +13,7 @@ use servo_arc::Arc;
 use style::computed_values::clear::T as Clear;
 use style::computed_values::float::T as Float;
 use style::properties::ComputedValues;
-use style::values::computed::{Length, Size};
+use style::values::computed::Size;
 use style::values::specified::align::AlignFlags;
 use style::values::specified::{Display, TextAlignKeyword};
 use style::Zero;
@@ -196,7 +196,7 @@ impl BlockLevelBox {
 
 pub(crate) struct FlowLayout {
     pub fragments: Vec<Fragment>,
-    pub content_block_size: Length,
+    pub content_block_size: Au,
     pub collapsible_margins_in_children: CollapsedBlockMargins,
     /// The offset of the baselines in this layout in the content area, if there were some. This is
     /// used to propagate inflow baselines to the ancestors of `display: inline-block` elements
@@ -285,7 +285,7 @@ impl OutsideMarker {
             },
             size: LogicalVec2 {
                 inline: max_inline_size,
-                block: flow_layout.content_block_size.into(),
+                block: flow_layout.content_block_size,
             },
         };
 
@@ -341,7 +341,7 @@ impl BlockFormattingContext {
 
         IndependentLayout {
             fragments: flow_layout.fragments,
-            content_block_size: Au::from(flow_layout.content_block_size) +
+            content_block_size: flow_layout.content_block_size +
                 flow_layout.collapsible_margins_in_children.end.solve() +
                 clearance.unwrap_or_default(),
             content_inline_size_for_table: None,
@@ -856,7 +856,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         sequential_layout_state.as_deref_mut(),
         CollapsibleWithParentStartMargin(start_margin_can_collapse_with_children),
     );
-    let mut content_block_size: Au = flow_layout.content_block_size.into();
+    let mut content_block_size: Au = flow_layout.content_block_size;
 
     // Update margins.
     let mut block_margins_collapsed_with_children = CollapsedBlockMargins::from_margin(&margin);
@@ -1842,7 +1842,7 @@ impl<'container> PlacementState<'container> {
         }
     }
 
-    fn finish(mut self) -> (Length, CollapsedBlockMargins, Baselines) {
+    fn finish(mut self) -> (Au, CollapsedBlockMargins, Baselines) {
         if !self.last_in_flow_margin_collapses_with_parent_end_margin {
             self.current_block_direction_position += self.current_margin.solve();
             self.current_margin = CollapsedMargin::zero();
@@ -1861,7 +1861,7 @@ impl<'container> PlacementState<'container> {
         };
 
         (
-            total_block_size.into(),
+            total_block_size,
             CollapsedBlockMargins {
                 collapsed_through,
                 start: self.start_margin,

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -507,8 +507,8 @@ impl HoistedAbsolutelyPositionedBox {
             box_offsets: inline_box_offsets,
             static_position_rect_axis: static_position_rect.get_axis(AxisDirection::Inline),
             alignment: inline_alignment,
-            flip_anchor: !(shared_fragment.original_parent_writing_mode.is_bidi_ltr() ==
-                indefinite_containing_block.style.writing_mode.is_bidi_ltr()),
+            flip_anchor: shared_fragment.original_parent_writing_mode.is_bidi_ltr() !=
+                indefinite_containing_block.style.writing_mode.is_bidi_ltr(),
         };
 
         // When the "static-position rect" doesn't come into play, we re-resolve "align-self"

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1160,8 +1160,7 @@ impl<'a> TableLayout<'a> {
                             .unwrap_or_else(|| {
                                 cell.style
                                     .border_width(containing_block_for_table.style.writing_mode)
-                            })
-                            .into();
+                            });
 
                         let padding: LogicalSides<Au> = cell
                             .style

--- a/tests/wpt/meta/css/CSS2/floats-clear/clear-on-replaced-element.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/clear-on-replaced-element.html.ini
@@ -1,0 +1,2 @@
+[clear-on-replaced-element.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-images/infinite-radial-gradient-refcrash.html.ini
+++ b/tests/wpt/meta/css/css-images/infinite-radial-gradient-refcrash.html.ini
@@ -1,2 +1,0 @@
-[infinite-radial-gradient-refcrash.html]
-  expected: FAIL


### PR DESCRIPTION
This change uses app units in `display_list`

Co-authored-by: Martin Robinson <mrobinson@igalia.com>
Signed-off-by: atbrakhi <atbrakhi@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29819
