### PR TITLE
Accept zero values on some `width`/`height` attributes on table elements

### DIFF
--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -101,7 +101,7 @@ impl VirtualMethods for HTMLTableColElement {
                 }
                 attr
             },
-            local_name!("width") => AttrValue::from_nonzero_dimension(value.into()),
+            local_name!("width") => AttrValue::from_dimension(value.into()),
             _ => self
                 .super_type()
                 .unwrap()

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -521,7 +521,7 @@ impl VirtualMethods for HTMLTableElement {
         match *local_name {
             local_name!("border") => AttrValue::from_u32(value.into(), 1),
             local_name!("width") => AttrValue::from_nonzero_dimension(value.into()),
-            local_name!("height") => AttrValue::from_nonzero_dimension(value.into()),
+            local_name!("height") => AttrValue::from_dimension(value.into()),
             local_name!("bgcolor") => AttrValue::from_legacy_color(value.into()),
             _ => self
                 .super_type()

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -182,7 +182,7 @@ impl VirtualMethods for HTMLTableRowElement {
     fn parse_plain_attribute(&self, local_name: &LocalName, value: DOMString) -> AttrValue {
         match *local_name {
             local_name!("bgcolor") => AttrValue::from_legacy_color(value.into()),
-            local_name!("height") => AttrValue::from_nonzero_dimension(value.into()),
+            local_name!("height") => AttrValue::from_dimension(value.into()),
             _ => self
                 .super_type()
                 .unwrap()

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -120,7 +120,7 @@ impl VirtualMethods for HTMLTableSectionElement {
     fn parse_plain_attribute(&self, local_name: &LocalName, value: DOMString) -> AttrValue {
         match *local_name {
             local_name!("bgcolor") => AttrValue::from_legacy_color(value.into()),
-            local_name!("height") => AttrValue::from_nonzero_dimension(value.into()),
+            local_name!("height") => AttrValue::from_dimension(value.into()),
             _ => self
                 .super_type()
                 .unwrap()

--- a/tests/wpt/meta/html/rendering/dimension-attributes.html.ini
+++ b/tests/wpt/meta/html/rendering/dimension-attributes.html.ini
@@ -1702,30 +1702,3 @@
 
   [<source height="0px"> mapping to <img> height property]
     expected: FAIL
-
-  [<table height="0"> mapping to <table> height property]
-    expected: FAIL
-
-  [<table height="0%"> mapping to <table> height property]
-    expected: FAIL
-
-  [<table height="0px"> mapping to <table> height property]
-    expected: FAIL
-
-  [<tr height="0"> mapping to <tr> height property]
-    expected: FAIL
-
-  [<tr height="0%"> mapping to <tr> height property]
-    expected: FAIL
-
-  [<tr height="0px"> mapping to <tr> height property]
-    expected: FAIL
-
-  [<col width="0"> mapping to <col> width property]
-    expected: FAIL
-
-  [<col width="0%"> mapping to <col> width property]
-    expected: FAIL
-
-  [<col width="0px"> mapping to <col> width property]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-column-width.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-column-width.html.ini
@@ -1,2 +1,0 @@
-[table-column-width.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-row-height.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-row-height.html.ini
@@ -1,2 +1,0 @@
-[table-row-height.html]
-  expected: FAIL


### PR DESCRIPTION
We were incorrectly using `AttrValue::from_nonzero_dimension` to parse some attributes, instead of `AttrValue::from_dimension`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
