### PR TITLE
layout: Ensure that `<caption>` supports `position: relative`

### DIFF
--- a/tests/wpt/meta/css/CSS2/abspos/table-caption-is-containing-block-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/abspos/table-caption-is-containing-block-001.html.ini
@@ -1,2 +1,0 @@
-[table-caption-is-containing-block-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-relative-table-caption.html.ini
+++ b/tests/wpt/meta/css/css-position/position-relative-table-caption.html.ini
@@ -1,2 +1,0 @@
-[position-relative-table-caption.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-tables/caption-relative-positioning.html
+++ b/tests/wpt/tests/css/css-tables/caption-relative-positioning.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+    <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+    <title>&lt;caption&gt; elements can be relatively positioned</title>
+    <meta name="assert" content="The caption is positioned relatively to the table wrapper">
+    <link rel="help" href="https://drafts.csswg.org/css2/#relative-positioning">
+    <link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+    <style>
+        caption {
+            position: relative;
+            background: green;
+            width: 100px;
+            height: 100px;
+            margin-left: 200px;
+            left: -200px;
+        }
+   </style>
+
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <div style="width: 100px; background: red;">
+        <table>
+            <caption></caption>
+        </table>
+    </div>
+</html>


### PR DESCRIPTION
This change adds support for `position: relative` to table `<caption>`.
In addition to adjusting their position according to inset values, table
captions must also establish containing blocks for descendants that are
absolutely positioned.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
