### PR TITLE
layout: `<th>` should have `text-align: center` when the child of an element with `text-align: initial`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -6198,7 +6198,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6207,7 +6207,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6425,7 +6425,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "static_assertions",
 ]
@@ -6566,7 +6566,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 
 [[package]]
 name = "strck"
@@ -6619,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "lazy_static",
 ]
@@ -6685,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "darling",
  "derive_common",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7096,7 +7096,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e70c56124cdb7064ebafcd3bf3392d48b5aa3de8"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#f1f1ce0e737ae8f99522cc52c47e2c6363789e28"
 dependencies = [
  "darling",
  "derive_common",

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -296,7 +296,10 @@ table {
   text-indent: initial;
 }
 td, th { padding: 1px; }
-th { font-weight: bold; }
+th {
+  font-weight: bold;
+  text-align: -moz-center-or-inherit;
+}
 
 thead, tbody, tfoot, table > tr { vertical-align: middle; }
 tr, td, th { vertical-align: inherit; }

--- a/tests/wpt/meta/css/css-tables/th-text-align.html.ini
+++ b/tests/wpt/meta/css/css-tables/th-text-align.html.ini
@@ -1,2 +1,0 @@
-[th-text-align.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-attribute.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-attribute.html.ini
@@ -113,12 +113,6 @@
   [table td align attribute justify is correct]
     expected: FAIL
 
-  [table th align attribute center is correct]
-    expected: FAIL
-
-  [table th align attribute middle is correct]
-    expected: FAIL
-
   [table th align attribute left is correct]
     expected: FAIL
 
@@ -144,7 +138,4 @@
     expected: FAIL
 
   [table cellpadding attribute is correct]
-    expected: FAIL
-
-  [th default align attribute is center]
     expected: FAIL


### PR DESCRIPTION
This behavior is enabled via a special CSS value that we can share with
Gecko.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
