### PR TITLE
compositor: Do not allow script to scroll past maximum scroll node offsets

### DIFF
--- a/components/shared/webrender/display_list.rs
+++ b/components/shared/webrender/display_list.rs
@@ -91,7 +91,16 @@ impl ScrollTreeNode {
     pub fn set_offset(&mut self, new_offset: LayoutVector2D) -> bool {
         match self.scroll_info {
             Some(ref mut info) => {
-                info.offset = new_offset;
+                let scrollable_width = info.scrollable_size.width;
+                let scrollable_height = info.scrollable_size.height;
+
+                if scrollable_width > 0. {
+                    info.offset.x = (new_offset.x).min(0.0).max(-scrollable_width);
+                }
+
+                if scrollable_height > 0. {
+                    info.offset.y = (new_offset.y).min(0.0).max(-scrollable_height);
+                }
                 true
             },
             _ => false,

--- a/tests/wpt/meta/css/css-flexbox/flexbox_flex-formatting-interop.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_flex-formatting-interop.html.ini
@@ -1,2 +1,0 @@
-[flexbox_flex-formatting-interop.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/sticky-content.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/sticky-content.html.ini
@@ -1,2 +1,0 @@
-[sticky-content.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
