### PR TITLE
Add a profiling build profile in Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,9 +163,11 @@ inherits = "production"
 strip = true
 
 [profile.profiling]
-inherits = "production"
+inherits = "release"
+debug-assertions = false
 debug = true
 lto = false
+codegen-units = 1
 
 [profile.profiling2]
 inherits = "production"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,49 +169,6 @@ debug = true
 lto = false
 codegen-units = 1
 
-[profile.profiling2]
-inherits = "production"
-debug = true
-lto = true
-
-[profile.profiling3]
-inherits = "production"
-debug = true
-
-[profile.profiling4]
-inherits = "production"
-debug = true
-codegen-units = 16
-
-[profile.profiling5]
-inherits = "production"
-debug = true
-lto = false
-codegen-units = 16
-
-[profile.profiling6]
-inherits = "production"
-debug = true
-lto = true
-codegen-units = 16
-
-[profile.profiling7]
-inherits = "production"
-debug = true
-lto = true
-codegen-units = 9999999
-
-[profile.profiling8]
-inherits = "production"
-debug = true
-codegen-units = 9999999
-
-[profile.profiling9]
-inherits = "production"
-debug = true
-lto = false
-codegen-units = 9999999
-
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ strip = true
 inherits = "release"
 debug-assertions = false
 debug = true
-lto = false
+lto = "thin"
 codegen-units = 1
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,9 +151,6 @@ xml5ever = "0.20"
 [profile.release]
 opt-level = 3
 debug-assertions = true
-# Uncomment to profile on Linux:
-# debug = true
-# lto = false
 
 [profile.production]
 inherits = "release"
@@ -164,6 +161,54 @@ codegen-units = 1
 [profile.production-stripped]
 inherits = "production"
 strip = true
+
+[profile.profiling]
+inherits = "production"
+debug = true
+lto = false
+
+[profile.profiling2]
+inherits = "production"
+debug = true
+lto = true
+
+[profile.profiling3]
+inherits = "production"
+debug = true
+
+[profile.profiling4]
+inherits = "production"
+debug = true
+codegen-units = 16
+
+[profile.profiling5]
+inherits = "production"
+debug = true
+lto = false
+codegen-units = 16
+
+[profile.profiling6]
+inherits = "production"
+debug = true
+lto = true
+codegen-units = 16
+
+[profile.profiling7]
+inherits = "production"
+debug = true
+lto = true
+codegen-units = 9999999
+
+[profile.profiling8]
+inherits = "production"
+debug = true
+codegen-units = 9999999
+
+[profile.profiling9]
+inherits = "production"
+debug = true
+lto = false
+codegen-units = 9999999
 
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream


### PR DESCRIPTION
This patch adds a Cargo profile for things like profiling and perf bots.

The configuration we use is based on the `production` profile, to model the performance of our actual nightlies as closely as possible. Notably, unlike the `release` profile, debug assertions are disabled. But in the manifest, we define it in terms of the `release` profile, because inheriting from `production` may wrongly imply that we’re also inheriting the production resource loading logic ([#30509](https://github.com/servo/servo/pull/30509)).

Our deviations from `production` were informed by the [The Rust Performance Book](https://nnethercote.github.io/perf-book/build-configuration.html), with some more thoughts below.

LTO may not interfere with profiling [[1]](https://doc.rust-lang.org/cargo/reference/profiles.html#lto)[[2]](https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization)[[3]](https://nnethercote.github.io/perf-book/profiling.html#debug-info), and only modestly slows build times when set to `"thin"` (see table below), so we leave it that way. I did not try [thin-local LTO](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_session/src/session.rs#L655-L718), which ~~requires removing the `lto` option altogether~~, but it has no effect [unless we have multiple codegen units](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_session/src/config.rs#L108-L110).

**Update 2024-09-20:** in rustc, thin local LTO requires [removing `-C lto` altogether](https://doc.rust-lang.org/rustc/codegen-options/index.html#lto), but in Cargo, it requires [`lto = false`](https://doc.rust-lang.org/cargo/reference/profiles.html#lto), which may not be the same. In both cases, it also requires `codegen-units = 1` and `opt-level > 0`.

[Codegen units](https://internals.rust-lang.org/t/lets-talk-about-parallel-codegen/2759/1) (2015) have a much bigger impact on build times, but we stick to `codegen-units = 1` to avoid having code changes cause unpredictable effects on runtime perf. If we can’t trust our profiling data or perf measurements, then we can’t trust our inferences or decisions.

CGUs are how Rust gets around the one crate = one compilation unit problem, trading optimisation for build time by allowing LLVM to parallelise crate compilation. `codegen-units` controls how many CGUs to split each crate into, where each CGU is an LLVM “module”. I’m not a rustc engineer, but my reasoning is as follows:

1. [One comment](https://github.com/rust-lang/rust/blob/d0985bb5240317daaf7c7f8790479e5f08ac0dd5/compiler/rustc_session/src/session.rs#L859-L875) in rustc suggests that ThinLTO recovers the runtime perf lost due to inability to inline across codegen units, but this was not reflected in our measurements (see table below)
2. CGUs are initially split by Rust module (1x “stable” + 1x “volatile” for each module) [[4]](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_session/src/session.rs#L655-L718)[[5]](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_monomorphize/src/partitioning.rs#L1-L93), which is nice and predictable
3. But they always get merged until there are no more CGUs than `codegen-units` [[6]](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_monomorphize/src/partitioning.rs#L329-L381), not to mention extra merging done when `codegen-units` is unset [[7]](https://github.com/rust-lang/rust/blob/2e367d94f05f3c6170f4d49f5e387cfaa0c42c32/compiler/rustc_monomorphize/src/partitioning.rs#383-L417)
4. LLVM can’t optimise across CGU boundaries [[8]](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_monomorphize/src/partitioning.rs#L29-L32), except for [link-time optimisation](https://llvm.org/docs/LinkTimeOptimization.html), so moving a CGU boundary can harm runtime perf
5. So in theory, the safest approach is to explicitly set `codegen-units` to `1` (boundaries nowhere) or a massive number (boundaries everywhere)
  - The former is slow to build (7m06s for `1` vs 3m41s for `16`, with `lto = "thin"`)
  - The latter breaks inlining across modules, which would probably hugely distort runtime perf
    - Except with fat LTO, where I measured similar runtime perf, but that builds even slower
    - With thin LTO, Servo doesn’t even build (“Argument list too long”)
    - With no LTO, Servo builds in 4m43s <!-- max 1264, avg 1212, stdev 31.0 -->
6. Merging codegen units is not done arbitrarily, it’s done in order of “greatest overlap of inlined items” between codegen units of adjacent size [[6]](https://github.com/rust-lang/rust/blob/c8dff289a0c931e138350f3baef0fab6d3309f80/compiler/rustc_monomorphize/src/partitioning.rs#L329-L381), which seems fairly stable
7. But it’s still possible to change code in one place and disrupt runtime perf in another
  - For example, say we have `codegen-units = 4`, but we have (largest first) A-B-C-D-E
  - If the best candidate for merging is B-C, we may end up with BC-A-D-E
  - But if D gains a bunch of inlined items and wins, we may end up with A-CD-B-E
  - This may hurt the runtime performance of B, even though B did not change

| Cargo profile (in 709a63d0deebbfadddd7f52cbe54fb892640cb7c) | `codegen-units` | `lto` | Build time | Blink perf_tests/layout/many-block-children-rebuild-box-tree.html |
|---|---|---|---|---|
| profiling | `1` | `false` | 6m08s | 1353 runs/s max (1294 mean, 34.3 stdev)<br>1360 runs/s max (1299 mean, 35.5 stdev) |
| profiling3 | `1` | `"thin"` | 7m06s | 1454 runs/s max (1389 mean, 38.9 stdev) |
| profiling2 | `1` | `true` | 13m20s | 1497 runs/s max (1432 mean, 40.3 stdev) |
| profiling5 | `16` | `false` | 3m35s | 1267 runs/s max (1218 mean, 33.0 stdev) |
| profiling4 | `16` | `"thin"` | 3m41s | 1365 runs/s max (1310 mean, 31.9 stdev) |
| profiling6 | `16` | `true` | 14m48s | 1514 runs/s max (1445 mean, 42.3 stdev) |
| profiling9 | `9999999` | `false` | 4m43s | 1253 runs/s max (1206 mean, 30.6 stdev) |
| profiling8 | `9999999` | `"thin"` | 4m43s (lol) | did not build |
| profiling7 | `9999999` | `true` | 24m45s | 1504 runs/s max (1434 mean, 42.7 stdev) |

- We report max (best) results because [microbenchmarking calls for idealised conditions](https://lemire.me/blog/2018/01/16/microbenchmarking-calls-for-idealized-conditions/)
- Linux 6.11.0-rc6, AMD 7950X, `mach build --features tracing-perfetto --profile <profile>`
- Build times are taken under a default environment
- Runtime perf is taken after [disabling CPU frequency boost](https://wiki.archlinux.org/title/CPU_frequency_scaling#Setting_via_sysfs_(other_scaling_drivers)) and dedicating CPUs to Servo with [this script](https://testbit.eu/2023/cgroup-cpuset) ([`isolcpus`](https://wiki.linuxfoundation.org/realtime/documentation/howto/tools/cpu-partitioning/isolcpus) breaks multicore scheduling and `cset shield` [no](https://unix.stackexchange.com/a/692558/341134) [longer](https://forum.proxmox.com/threads/cset-failing-pve7.95613/) [works](https://superuser.com/q/1786095)), except we dedicate 8 through 15 and offline 24 through 31, rather than 6 through 9 and 22 through 25
- This actually controls noise very well, but there’s still a high stdev, because this test steadily decreases in perf over 20 runs

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors