### PR TITLE
Fix inset box-shadow to use the padding box

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -1028,18 +1028,17 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         // NB: According to CSS-BACKGROUNDS, box shadows render in *reverse* order (front to back).
-        let border_rect = self.border_rect;
         let common = builder.common_properties(MaxRect::max_rect(), &self.fragment.style);
         for box_shadow in box_shadows.iter().rev() {
-            let clip_mode = if box_shadow.inset {
-                BoxShadowClipMode::Inset
+            let (rect, clip_mode) = if box_shadow.inset {
+                (*self.padding_rect(), BoxShadowClipMode::Inset)
             } else {
-                BoxShadowClipMode::Outset
+                (self.border_rect, BoxShadowClipMode::Outset)
             };
 
             builder.wr().push_box_shadow(
                 &common,
-                border_rect,
+                rect,
                 LayoutVector2D::new(
                     box_shadow.base.horizontal.px(),
                     box_shadow.base.vertical.px(),

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow-041.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow-041.html.ini
@@ -1,2 +1,0 @@
-[box-shadow-041.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow-042.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow-042.html.ini
@@ -1,2 +1,0 @@
-[box-shadow-042.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/box-shadow-inset-without-border-radius.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/box-shadow-inset-without-border-radius.html.ini
@@ -1,2 +1,0 @@
-[box-shadow-inset-without-border-radius.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/box-shadow-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/box-shadow-001.html.ini
@@ -1,2 +1,0 @@
-[box-shadow-001.html]
-  expected: FAIL


### PR DESCRIPTION
As specified in https://drafts.csswg.org/css-backgrounds-3/#shadow-shape

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
