### PR TITLE
android: publish nightly builds for aarch64

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -114,11 +114,21 @@ jobs:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+      - name: Generate artifact attestation for APK
+        if: ${{ inputs.upload }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
           path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
+      - name: Generate artifact attestation for AAR
+        if: ${{ inputs.upload }}
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
       - name: Upload AAR artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,13 @@ on:
         required: false
         default: "release"
         type: string
+      upload:
+        required: false
+        default: false
+        type: boolean
+      github-release-id:
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       profile:
@@ -28,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        arch: ['aarch64-linux-android', 'armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
+        target: ['aarch64-linux-android', 'armv7-linux-androideabi', 'i686-linux-android', 'x86_64-linux-android']
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -78,15 +85,15 @@ jobs:
           APK_SIGNING_KEY_STORE_PATH="${PWD}/servo_keystore.jks"
           echo "${KEYSTORE_BASE64}" | base64 -d > "${APK_SIGNING_KEY_STORE_PATH}"
           echo "APK_SIGNING_KEY_STORE_PATH=${APK_SIGNING_KEY_STORE_PATH}" >> ${GITHUB_ENV}
-      - name: Build (arch ${{ matrix.arch }} profile ${{ inputs.profile }})
+      - name: Build (arch ${{ matrix.target }} profile ${{ inputs.profile }})
         env:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
           APK_SIGNING_KEY_STORE_PASS: ${{ secrets.APK_SIGNING_KEY_STORE_PASS }}
           APK_SIGNING_KEY_ALIAS: ${{ secrets.APK_SIGNING_KEY_ALIAS }}
           APK_SIGNING_KEY_PASS: ${{ secrets.APK_SIGNING_KEY_PASS }}
         run: |
-          python3 ./mach build --use-crown --locked --target ${{ matrix.arch }} --${{ inputs.profile }}
-          cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.arch }}
+          python3 ./mach build --use-crown --locked --target ${{ matrix.target }} --${{ inputs.profile }}
+          cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.target }}
       # TODO: This is disabled since APK crashes during startup.
       # See https://github.com/servo/servo/issues/31134
       # - name: Script tests
@@ -94,11 +101,26 @@ jobs:
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:
-          name: cargo-timings-android-${{ matrix.arch }}
+          name: cargo-timings-android-${{ matrix.target }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
-      - name: Upload APK artifact for mach package
+      - name: Upload nightly
+        if: ${{ inputs.upload && contains(matrix.target, 'aarch64') }}
+        run: |
+          python3 ./mach upload-nightly android \
+            --secret-from-environment \
+            --github-release-id ${{ inputs.github-release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+      - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.profile }}-binary-android-${{ matrix.arch }}
-          path: target/android/${{ matrix.arch }}/${{ inputs.profile }}/servoapp.apk
+          name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
+          path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
+      - name: Upload AAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.profile }}-library-android-${{ matrix.target }}
+          path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,6 +119,9 @@ jobs:
     name: Upload nightly (Android)
     needs:
       - create-draft-release
+    permissions:
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/android.yml
     with:
       profile: "release"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,6 +72,7 @@ jobs:
       - upload-linux
       - upload-win
       - upload-mac
+      - upload-android
 
   upload-win:
     # This job is only useful when run on upstream servo.
@@ -108,6 +109,19 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       profile: "production"
+      upload: true
+      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+    secrets: inherit
+
+  upload-android:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    name: Upload nightly (Android)
+    needs:
+      - create-draft-release
+    uses: ./.github/workflows/android.yml
+    with:
+      profile: "release"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -42,8 +42,8 @@ from servo.util import delete, get_target_dir
 
 PACKAGES = {
     'android': [
-        'android/aarch64-linux-android/production/servoapp.apk',
-        'android/aarch64-linux-android/production/servoview.aar',
+        'android/aarch64-linux-android/release/servoapp.apk',
+        'android/aarch64-linux-android/release/servoview.aar',
     ],
     'linux': [
         'production/servo-tech-demo.tar.gz',

--- a/support/android/apk/build.gradle
+++ b/support/android/apk/build.gradle
@@ -1,3 +1,5 @@
+import java.text.SimpleDateFormat
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.0.1' apply false
@@ -78,4 +80,22 @@ ext.getSigningKeyInfo = { ->
     } else {
         return null
     }
+}
+
+ext {
+  // Generate unique version code based on the build date and time to support nightly
+  // builds.
+  //
+  // The version scheme is currently: yyyyMMddXX
+  // where
+  // yyyy is the 4 digit year (e.g 2024)
+  // MMdd is the 2 digit month followed by 2 digit day (e.g 0915 for September 15)
+  // XX is currently hardcoded to 00, but can be used to distinguish multiple builds within
+  // the same day.
+  //
+  // TODO: check if this interferes with caching of local builds and add option to use
+  // a static version.
+  def today = new Date()
+  def versionCodeString = new SimpleDateFormat("yyyyMMdd00").format(today)
+  generatedVersionCode = versionCodeString as int
 }

--- a/support/android/apk/servoapp/build.gradle
+++ b/support/android/apk/servoapp/build.gradle
@@ -17,8 +17,8 @@ android {
         applicationId "org.servo.servoshell"
         minSdk 30
         targetSdk 30
-        versionCode 1
-        versionName "1.0.0"
+        versionCode generatedVersionCode
+        versionName "0.0.1" // TODO: Parse Servo's TOML and add git SHA.
     }
 
     compileOptions {

--- a/support/android/apk/servoview/build.gradle
+++ b/support/android/apk/servoview/build.gradle
@@ -15,11 +15,12 @@ android {
     buildDir = rootDir.absolutePath + "/../../../target/android/gradle/servoview"
 
     ndkPath = getNdkDir()
+
     defaultConfig {
         minSdk 30
         targetSdk 30
-        versionCode 1
-        versionName "1.0"
+        versionCode generatedVersionCode
+        versionName "0.0.1" // TODO: Parse Servo's TOML and add git SHA.
     }
 
     compileOptions {


### PR DESCRIPTION
Publish the aarch64 apk and aar packages to both Github Releases
and S3 so that it can be linked from servo.org.

The focus is on getting a working version of the APK on the homepage,
so few issues are resolved with temporary solutions:
1) We publish the "release" profile instead of "production" since the
   latter will need changes in the gradle configuration (the changes
   required was previously blocked on #32720 which is now closed).
2) The scheme for the version code is simple and doesn't consider
   other factors such as API level and product variants discussed in the
   Android docs (https://developer.android.com/google/play/publishing/multiple-apks#VersionCodes)
   This should be fine for now as we don't publish to any store yet.

The change also makes it so that the 'Release nightly' workflow will
endup building all 4 variants for the Android target, but only aarch64
is uploaded. This is because GH Actions doesn't have a good way to skip
a specific job in a matrix and the additionally code complexity needed
to acheive it (either generating a JSON dynamically in a new job and using
`fromJSON` in the matrix definition or skipping each individual step
based on matrix.target and `inputs.upload`) didn't seem worth the cost
saved (this is executed only once a day).

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they modify just CI workflow definitions.

