### PR TITLE
Add perfetto tracing events to fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "smallvec",
  "style",
  "surfman",
+ "tracing",
  "truetype",
  "unicode-bidi",
  "unicode-properties",

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -41,6 +41,7 @@ servo_url = { path = "../url" }
 smallvec = { workspace = true, features = ["union"] }
 surfman = { workspace = true }
 style = { workspace = true }
+tracing = { workspace = true }
 unicode-bidi = { workspace = true, features = ["with_serde"] }
 unicode-properties = { workspace = true }
 unicode-script = { workspace = true }

--- a/components/fonts/font_cache_thread.rs
+++ b/components/fonts/font_cache_thread.rs
@@ -149,8 +149,11 @@ impl FontCache {
                             .font_data
                             .entry(identifier)
                             .or_insert_with(|| font_template.data());
-                        let span =
-                            span!(Level::TRACE, "FontTemplates send", servo_profiling = true);
+                        let span = span!(
+                            Level::TRACE,
+                            "GetFontTemplates send",
+                            servo_profiling = true
+                        );
                         let _span = span.enter();
                         let _ = bytes_sender.send(data);
                     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -89,6 +89,7 @@ use surfman::platform::generic::multi::context::NativeContext as LinuxNativeCont
 use surfman::{GLApi, GLVersion};
 #[cfg(all(target_os = "linux", not(target_env = "ohos")))]
 use surfman::{NativeConnection, NativeContext};
+use tracing::{span, Level};
 use webgpu::swapchain::WGPUImageMap;
 use webrender::{RenderApiSender, ShaderPrecacheFlags, UploadMethod, ONE_TIME_USAGE_HINT};
 use webrender_api::{
@@ -1104,6 +1105,7 @@ impl WebRenderFontApi for WebRenderFontApiCompositorProxy {
         receiver.recv().unwrap()
     }
 
+    #[tracing::instrument(skip(self), fields(servo_profiling = true))]
     fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey {
         let (sender, receiver) = unbounded();
         let (bytes_sender, bytes_receiver) =
@@ -1112,7 +1114,11 @@ impl WebRenderFontApi for WebRenderFontApiCompositorProxy {
             .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
                 FontToCompositorMsg::AddFont(sender, index, bytes_receiver),
             )));
-        let _ = bytes_sender.send(&data);
+        {
+            let span = span!(Level::TRACE, "add_font send", servo_profiling = true);
+            let _span = span.enter();
+            let _ = bytes_sender.send(&data);
+        }
         receiver.recv().unwrap()
     }
 


### PR DESCRIPTION
This changes extends perfetto events to trace fonts as well

Co-authored-by:Delan Azabani <dazabani@igalia.com>
Signed-off-by: atbrakhi <atbrakhi@igalia.com>

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
