### PR TITLE
Fix precision issue with line heights

### DIFF
--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1815,8 +1815,12 @@ impl InlineContainerState {
             ascent = font_metrics_of_first_font.ascent;
             descent = font_metrics_of_first_font.descent;
             let half_leading = (line_height - (ascent + descent)).scale_by(0.5);
+            // We want the sum of `ascent` and `descent` to equal `line_height`.
+            // If we just add `half_leading` to both, then we may not get `line_height`
+            // due to precision limitations of `Au`. Instead, we set `descent` to
+            // the value that will guarantee the correct sum.
             ascent += half_leading;
-            descent += half_leading;
+            descent = line_height - ascent;
         }
 
         LineBlockSizes {

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b01.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b01.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b01.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b02.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b02.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b02.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b03.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b03.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b03.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b04.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b04.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b04.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b05.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b05.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b05.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b06.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b06.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b06.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b07.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b07.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b07.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b08.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b08.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b08.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b09.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b09.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b09.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b10.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b10.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b10.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b11.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b11.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b11.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b12.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003b12.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003b12.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c01.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c01.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c01.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c02.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c02.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c02.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c03.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c03.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c03.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c04.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c04.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c04.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c05.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c05.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c05.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c06.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c06.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c06.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c07.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c07.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c07.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c08.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003c08.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003c08.xht]
-  expected: FAIL


### PR DESCRIPTION
When computing the ascent and descent in an inline formatting context, we weren't taking into account that app units have precision limitations. Therefore, in some cases we were getting a line height that was slightly taller than the value specified in `line-height`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
