### PR TITLE
Allow `table-layout: fixed` to shrink cells to less than the border+padding

### DIFF
--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a01.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a01.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003a01.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a02.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a02.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003a02.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a03.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a03.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003a03.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a04.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a04.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003a04.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a05.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a05.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003a05.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a06.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003a06.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003a06.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d01.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d01.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003d01.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d02.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d02.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003d02.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d03.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d03.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003d03.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d04.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d04.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003d04.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d05.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d05.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003d05.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d06.xht.ini
+++ b/tests/wpt/meta/css/CSS2/tables/fixed-table-layout-003d06.xht.ini
@@ -1,2 +1,0 @@
-[fixed-table-layout-003d06.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed-padding.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed-padding.html.ini
@@ -1,7 +1,4 @@
 [table-width-redistribution-fixed-padding.html]
-  [table 6]
-    expected: FAIL
-
   [table 10]
     expected: FAIL
 


### PR DESCRIPTION
A table cell with `width: auto` in fixed layout will now have an outer min-content width of zero, even if it has borders or padding. In a way, this is like allowing the content-box width to become negative.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
