### PR TITLE
Do not remove extra columns at the end of the table

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -799,7 +799,9 @@ impl<'a> TableLayout<'a> {
     /// Distribute width to columns, performing step 2.4 of table layout from
     /// <https://drafts.csswg.org/css-tables/#table-layout-algorithm>.
     fn distribute_width_to_columns(&self) -> Vec<Au> {
-        if self.table.slots.is_empty() {
+        // No need to do anything if there is no column.
+        // Note that tables without rows may still have columns.
+        if self.table.size.width.is_zero() {
             return Vec::new();
         }
 
@@ -929,7 +931,7 @@ impl<'a> TableLayout<'a> {
                     "A deviation of more than one Au per column is unlikely to be caused by float imprecision"
                 );
 
-                // We checked if the table was empty at the top of the function, so there
+                // We checked if the table had columns at the top of the function, so there
                 // always is a first column
                 widths[0] += remaining_assignable_width;
             }

--- a/tests/wpt/meta/css/css-tables/column-track-merging.html.ini
+++ b/tests/wpt/meta/css/css-tables/column-track-merging.html.ini
@@ -5,10 +5,13 @@
   [main table 4]
     expected: FAIL
 
-  [main table 10]
+  [main table 6]
     expected: FAIL
 
-  [main table 11]
+  [main table 7]
+    expected: FAIL
+
+  [main table 8]
     expected: FAIL
 
   [main table 12]
@@ -18,4 +21,7 @@
     expected: FAIL
 
   [main table 3]
+    expected: FAIL
+
+  [main table 13]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-1.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-1.html.ini
@@ -1,9 +1,3 @@
 [html5-table-formatting-1.html]
-  [Table-columns are taken into account after missing cells are generated (empty line)]
-    expected: FAIL
-
-  [Table-columns are taken into account after missing cells are generated (partially empty line)]
-    expected: FAIL
-
   [Empty tables do not take table-rows into account]
     expected: FAIL

--- a/tests/wpt/meta/css/css-tables/html5-table-formatting-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/html5-table-formatting-2.html.ini
@@ -1,9 +1,0 @@
-[html5-table-formatting-2.html]
-  [Explicitely defined columns are not merged]
-    expected: FAIL
-
-  [Border-spacing is added between any two unmerged columns (1)]
-    expected: FAIL
-
-  [Border-spacing is added between any two unmerged columns (5)]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
@@ -11,9 +11,6 @@
   [Replaced elements inside a table cannot be table-row and are considered inline -- input elements (top)]
     expected: FAIL
 
-  [Replaced elements inside a table cannot be table-column and are considered inline -- input elements (top)]
-    expected: FAIL
-
   [Replaced elements outside a table cannot be table-row and are considered inline -- input=file elements]
     expected: FAIL
 


### PR DESCRIPTION
`<col>` and `<colgroup>` elements can be used to create extra columns that have no cell. We were removing these columns and column groups, but in general we shouldn't do that.

Now we will only remove them if the table has no row nor row group. matching WebKit and the expectations of some tests. But note that Gecko and Blink never remove them.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
