### PR TITLE
Small improvements for table border collapse

### DIFF
--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -16,7 +16,9 @@ use style::properties::ComputedValues;
 use style::servo::selector_parser::PseudoElement;
 use style::values::computed::basic_shape::ClipPath;
 use style::values::computed::image::Image as ComputedImageLayer;
-use style::values::computed::{AlignItems, LengthPercentage, NonNegativeLengthPercentage, Size};
+use style::values::computed::{
+    AlignItems, BorderStyle, LengthPercentage, NonNegativeLengthPercentage, Size,
+};
 use style::values::generics::box_::Perspective;
 use style::values::generics::length::MaxSize;
 use style::values::generics::position::{GenericAspectRatio, PreferredRatio};
@@ -250,6 +252,8 @@ pub(crate) trait ComputedValuesExt {
         &self,
         containing_block_writing_mode: WritingMode,
     ) -> LogicalSides<&LengthPercentage>;
+    fn border_style(&self, containing_block_writing_mode: WritingMode)
+        -> LogicalSides<BorderStyle>;
     fn border_width(&self, containing_block_writing_mode: WritingMode) -> LogicalSides<Au>;
     fn margin(
         &self,
@@ -548,6 +552,22 @@ impl ComputedValuesExt for ComputedValues {
                 &padding.padding_right.0,
                 &padding.padding_bottom.0,
                 &padding.padding_left.0,
+            ),
+            containing_block_writing_mode,
+        )
+    }
+
+    fn border_style(
+        &self,
+        containing_block_writing_mode: WritingMode,
+    ) -> LogicalSides<BorderStyle> {
+        let border = self.get_border();
+        LogicalSides::from_physical(
+            &PhysicalSides::new(
+                border.border_top_style,
+                border.border_right_style,
+                border.border_bottom_style,
+                border.border_left_style,
             ),
             containing_block_writing_mode,
         )

--- a/tests/wpt/meta/css/CSS2/borders/border-conflict-style-101.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-conflict-style-101.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-style-101.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-conflict-style-102.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-conflict-style-102.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-style-102.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-conflict-style-103.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-conflict-style-103.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-style-103.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-conflict-style-104.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-conflict-style-104.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-style-104.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-conflict-style-105.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-conflict-style-105.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-style-105.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/borders/border-conflict-style-106.xht.ini
+++ b/tests/wpt/meta/css/CSS2/borders/border-conflict-style-106.xht.ini
@@ -1,2 +1,0 @@
-[border-conflict-style-106.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/border-writing-mode-dynamic-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/border-writing-mode-dynamic-001.html.ini
@@ -1,3 +1,0 @@
-[border-writing-mode-dynamic-001.html]
-  [Table borders track writing mode changes]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/col_removal.html.ini
+++ b/tests/wpt/meta/css/css-tables/col_removal.html.ini
@@ -1,3 +1,0 @@
-[col_removal.html]
-  [Table grid syncs after COL removal]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/rules-groups.html.ini
+++ b/tests/wpt/meta/css/css-tables/rules-groups.html.ini
@@ -1,0 +1,2 @@
+[rules-groups.html]
+  expected: FAIL


### PR DESCRIPTION
We were only collapsing the borders from adjacent cells. This patch also handles the borders from rows, row groups, columns, and column groups. Additionally, it takes the border style into account in order to decide which border wins.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
