### PR TITLE
webgpu: Use `PresentationBufferState` instead of bucketing buffer_ids per state

### DIFF
--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -114,7 +114,7 @@ impl WebrenderExternalImageApi for WGPUExternalImages {
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum PresentationBufferState {
     /// Initial state, buffer has yet to be created,
-    /// only it's id is reserved
+    /// only its id is reserved
     #[default]
     Unassigned,
     /// Buffer is already created and ready to be used immediately
@@ -218,7 +218,7 @@ impl PresentationData {
 
     fn unmap_old_buffer(&mut self, presentation_buffer: GPUPresentationBuffer) {
         let buffer_state = self.get_buffer_state(presentation_buffer.buffer_id);
-        assert!(*buffer_state == PresentationBufferState::Mapped);
+        assert_eq!(*buffer_state, PresentationBufferState::Mapped);
         *buffer_state = PresentationBufferState::Available;
         drop(presentation_buffer);
     }
@@ -373,7 +373,7 @@ impl crate::WGPU {
         for (buffer_id, buffer_state) in present_data.buffer_ids {
             match buffer_state {
                 PresentationBufferState::Unassigned => {
-                    /* These buffer where not allocated in wgpu */
+                    /* These buffer were not yet created in wgpu */
                 },
                 _ => {
                     self.global.buffer_drop(buffer_id);
@@ -406,7 +406,7 @@ fn update_wr_image(
         Ok(()) => {
             if let Some(present_data) = wgpu_image_map.lock().unwrap().get_mut(&context_id) {
                 let buffer_state = present_data.get_buffer_state(buffer_id);
-                assert!(*buffer_state == PresentationBufferState::Mapping);
+                assert_eq!(*buffer_state, PresentationBufferState::Mapping);
                 *buffer_state = PresentationBufferState::Mapped;
                 let presentation_buffer =
                     GPUPresentationBuffer::new(global, buffer_id, buffer_size);


### PR DESCRIPTION
I think having id's associated with their state makes much more sense than moving id's between buckets. Some new states are also introduced to make things more clear.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
