### PR TITLE
webxr: Implement reference space reset events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7968,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#5587c9236bac0a8b7b87b3a95b22882400461b46"
+source = "git+https://github.com/servo/webxr#845ae9c22c3eeb7b2ac3fcf9ed791879628256b3"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#5587c9236bac0a8b7b87b3a95b22882400461b46"
+source = "git+https://github.com/servo/webxr#845ae9c22c3eeb7b2ac3fcf9ed791879628256b3"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -337,6 +337,11 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         let _ = self.sender.send(MockDeviceMsg::SetBoundsGeometry(coords));
         Ok(())
     }
+
+    /// <https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-simulateresetpose>
+    fn SimulateResetPose(&self) {
+        let _ = self.sender.send(MockDeviceMsg::SimulateResetPose);
+    }
 }
 
 impl From<XRHandedness> for Handedness {

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -646,6 +646,7 @@ pub mod xrprojectionlayer;
 pub mod xrquadlayer;
 pub mod xrray;
 pub mod xrreferencespace;
+pub mod xrreferencespaceevent;
 pub mod xrrenderstate;
 pub mod xrrigidtransform;
 pub mod xrsession;

--- a/components/script/dom/webidls/FakeXRDevice.webidl
+++ b/components/script/dom/webidls/FakeXRDevice.webidl
@@ -17,7 +17,7 @@ interface FakeXRDevice {
   [Throws] undefined setFloorOrigin(FakeXRRigidTransformInit origin);
   undefined clearFloorOrigin();
   [Throws] undefined setBoundsGeometry(sequence<FakeXRBoundsPoint> boundsCoodinates);
-  // undefined simulateResetPose();
+  undefined simulateResetPose();
 
   // Simulates devices focusing and blurring sessions.
   undefined simulateVisibilityChange(XRVisibilityState state);

--- a/components/script/dom/webidls/XRReferenceSpace.webidl
+++ b/components/script/dom/webidls/XRReferenceSpace.webidl
@@ -16,5 +16,5 @@ enum XRReferenceSpaceType {
 interface XRReferenceSpace : XRSpace {
   [NewObject] XRReferenceSpace getOffsetReferenceSpace(XRRigidTransform originOffset);
 
-  // attribute EventHandler onreset;
+  attribute EventHandler onreset;
 };

--- a/components/script/dom/webidls/XRReferenceSpaceEvent.webidl
+++ b/components/script/dom/webidls/XRReferenceSpaceEvent.webidl
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://immersive-web.github.io/webxr/#xrreferencespaceevent-interface
+
+[SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
+interface XRReferenceSpaceEvent : Event {
+  [Throws] constructor(DOMString type, XRReferenceSpaceEventInit eventInitDict);
+  [SameObject] readonly attribute XRReferenceSpace referenceSpace;
+  [SameObject] readonly attribute XRRigidTransform? transform;
+};
+
+dictionary XRReferenceSpaceEventInit : EventInit {
+  required XRReferenceSpace referenceSpace;
+  XRRigidTransform? transform = null;
+};

--- a/components/script/dom/xrboundedreferencespace.rs
+++ b/components/script/dom/xrboundedreferencespace.rs
@@ -19,7 +19,7 @@ use crate::script_runtime::JSContext;
 
 #[dom_struct]
 pub struct XRBoundedReferenceSpace {
-    xrspace: XRReferenceSpace,
+    reference_space: XRReferenceSpace,
     offset: Dom<XRRigidTransform>,
 }
 
@@ -29,7 +29,7 @@ impl XRBoundedReferenceSpace {
         offset: &XRRigidTransform,
     ) -> XRBoundedReferenceSpace {
         XRBoundedReferenceSpace {
-            xrspace: XRReferenceSpace::new_inherited(
+            reference_space: XRReferenceSpace::new_inherited(
                 session,
                 offset,
                 XRReferenceSpaceType::Bounded_floor,
@@ -55,12 +55,16 @@ impl XRBoundedReferenceSpace {
             global,
         )
     }
+
+    pub fn reference_space(&self) -> &XRReferenceSpace {
+        &self.reference_space
+    }
 }
 
 impl XRBoundedReferenceSpaceMethods for XRBoundedReferenceSpace {
     /// <https://www.w3.org/TR/webxr/#dom-xrboundedreferencespace-boundsgeometry>
     fn BoundsGeometry(&self, cx: JSContext) -> JSVal {
-        if let Some(bounds) = self.xrspace.get_bounds() {
+        if let Some(bounds) = self.reference_space.get_bounds() {
             let points: Vec<DomRoot<DOMPointReadOnly>> = bounds
                 .into_iter()
                 .map(|point| {

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -85,6 +85,9 @@ impl XRReferenceSpaceMethods for XRReferenceSpace {
             &offset,
         )
     }
+
+    // https://www.w3.org/TR/webxr/#dom-xrreferencespace-onreset
+    event_handler!(reset, GetOnreset, SetOnreset);
 }
 
 impl XRReferenceSpace {

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -71,6 +71,10 @@ impl XRReferenceSpace {
         let offset = self.offset.transform();
         Space { base, offset }
     }
+
+    pub fn ty(&self) -> XRReferenceSpaceType {
+        self.ty
+    }
 }
 
 impl XRReferenceSpaceMethods for XRReferenceSpace {

--- a/components/script/dom/xrreferencespaceevent.rs
+++ b/components/script/dom/xrreferencespaceevent.rs
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::rust::HandleObject;
+use servo_atoms::Atom;
+
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceEventBinding::{
+    XRReferenceSpaceEventInit, XRReferenceSpaceEventMethods,
+};
+use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::reflector::{reflect_dom_object_with_proto, DomObject};
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::str::DOMString;
+use crate::dom::event::Event;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
+use crate::dom::xrreferencespace::XRReferenceSpace;
+use crate::dom::xrrigidtransform::XRRigidTransform;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+pub struct XRReferenceSpaceEvent {
+    event: Event,
+    space: Dom<XRReferenceSpace>,
+}
+
+impl XRReferenceSpaceEvent {
+    #[allow(crown::unrooted_must_root)]
+    fn new_inherited(space: &XRReferenceSpace) -> XRReferenceSpaceEvent {
+        XRReferenceSpaceEvent {
+            event: Event::new_inherited(),
+            space: Dom::from_ref(space),
+        }
+    }
+
+    pub fn new(
+        global: &GlobalScope,
+        type_: Atom,
+        bubbles: bool,
+        cancelable: bool,
+        space: &XRReferenceSpace,
+    ) -> DomRoot<XRReferenceSpaceEvent> {
+        Self::new_with_proto(
+            global,
+            None,
+            type_,
+            bubbles,
+            cancelable,
+            space,
+            CanGc::note(),
+        )
+    }
+
+    fn new_with_proto(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        type_: Atom,
+        bubbles: bool,
+        cancelable: bool,
+        space: &XRReferenceSpace,
+        can_gc: CanGc,
+    ) -> DomRoot<XRReferenceSpaceEvent> {
+        let trackevent = reflect_dom_object_with_proto(
+            Box::new(XRReferenceSpaceEvent::new_inherited(space)),
+            global,
+            proto,
+            can_gc,
+        );
+        {
+            let event = trackevent.upcast::<Event>();
+            event.init_event(type_, bubbles, cancelable);
+        }
+        trackevent
+    }
+
+    #[allow(non_snake_case)]
+    pub fn Constructor(
+        window: &Window,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+        type_: DOMString,
+        init: &XRReferenceSpaceEventInit,
+    ) -> Fallible<DomRoot<XRReferenceSpaceEvent>> {
+        Ok(XRReferenceSpaceEvent::new_with_proto(
+            &window.global(),
+            proto,
+            Atom::from(type_),
+            init.parent.bubbles,
+            init.parent.cancelable,
+            &init.referenceSpace,
+            can_gc,
+        ))
+    }
+}
+
+impl XRReferenceSpaceEventMethods for XRReferenceSpaceEvent {
+    /// <https://www.w3.org/TR/webxr/#dom-xrreferencespaceeventinit-session>
+    fn ReferenceSpace(&self) -> DomRoot<XRReferenceSpace> {
+        DomRoot::from_ref(&*self.space)
+    }
+
+    /// <https://www.w3.org/TR/webxr/#dom-xrreferencespaceevent-transform>
+    fn GetTransform(&self) -> Option<DomRoot<XRRigidTransform>> {
+        // TODO: Get transform from webxr crate
+        None
+    }
+
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}

--- a/components/script/dom/xrreferencespaceevent.rs
+++ b/components/script/dom/xrreferencespaceevent.rs
@@ -26,14 +26,19 @@ use crate::script_runtime::CanGc;
 pub struct XRReferenceSpaceEvent {
     event: Event,
     space: Dom<XRReferenceSpace>,
+    transform: Option<DomRoot<XRRigidTransform>>,
 }
 
 impl XRReferenceSpaceEvent {
     #[allow(crown::unrooted_must_root)]
-    fn new_inherited(space: &XRReferenceSpace) -> XRReferenceSpaceEvent {
+    fn new_inherited(
+        space: &XRReferenceSpace,
+        transform: &Option<DomRoot<XRRigidTransform>>,
+    ) -> XRReferenceSpaceEvent {
         XRReferenceSpaceEvent {
             event: Event::new_inherited(),
             space: Dom::from_ref(space),
+            transform: transform.clone(),
         }
     }
 
@@ -43,6 +48,7 @@ impl XRReferenceSpaceEvent {
         bubbles: bool,
         cancelable: bool,
         space: &XRReferenceSpace,
+        transform: &Option<DomRoot<XRRigidTransform>>,
     ) -> DomRoot<XRReferenceSpaceEvent> {
         Self::new_with_proto(
             global,
@@ -51,6 +57,7 @@ impl XRReferenceSpaceEvent {
             bubbles,
             cancelable,
             space,
+            transform,
             CanGc::note(),
         )
     }
@@ -62,10 +69,11 @@ impl XRReferenceSpaceEvent {
         bubbles: bool,
         cancelable: bool,
         space: &XRReferenceSpace,
+        transform: &Option<DomRoot<XRRigidTransform>>,
         can_gc: CanGc,
     ) -> DomRoot<XRReferenceSpaceEvent> {
         let trackevent = reflect_dom_object_with_proto(
-            Box::new(XRReferenceSpaceEvent::new_inherited(space)),
+            Box::new(XRReferenceSpaceEvent::new_inherited(space, transform)),
             global,
             proto,
             can_gc,
@@ -92,6 +100,7 @@ impl XRReferenceSpaceEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.referenceSpace,
+            &init.transform,
             can_gc,
         ))
     }
@@ -105,8 +114,7 @@ impl XRReferenceSpaceEventMethods for XRReferenceSpaceEvent {
 
     /// <https://www.w3.org/TR/webxr/#dom-xrreferencespaceevent-transform>
     fn GetTransform(&self) -> Option<DomRoot<XRRigidTransform>> {
-        // TODO: Get transform from webxr crate
-        None
+        self.transform.clone()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>

--- a/components/script/dom/xrreferencespaceevent.rs
+++ b/components/script/dom/xrreferencespaceevent.rs
@@ -26,19 +26,19 @@ use crate::script_runtime::CanGc;
 pub struct XRReferenceSpaceEvent {
     event: Event,
     space: Dom<XRReferenceSpace>,
-    transform: Option<DomRoot<XRRigidTransform>>,
+    transform: Option<Dom<XRRigidTransform>>,
 }
 
 impl XRReferenceSpaceEvent {
     #[allow(crown::unrooted_must_root)]
     fn new_inherited(
         space: &XRReferenceSpace,
-        transform: &Option<DomRoot<XRRigidTransform>>,
+        transform: Option<&XRRigidTransform>,
     ) -> XRReferenceSpaceEvent {
         XRReferenceSpaceEvent {
             event: Event::new_inherited(),
             space: Dom::from_ref(space),
-            transform: transform.clone(),
+            transform: transform.map(Dom::from_ref),
         }
     }
 
@@ -48,7 +48,7 @@ impl XRReferenceSpaceEvent {
         bubbles: bool,
         cancelable: bool,
         space: &XRReferenceSpace,
-        transform: &Option<DomRoot<XRRigidTransform>>,
+        transform: Option<&XRRigidTransform>,
     ) -> DomRoot<XRReferenceSpaceEvent> {
         Self::new_with_proto(
             global,
@@ -69,7 +69,7 @@ impl XRReferenceSpaceEvent {
         bubbles: bool,
         cancelable: bool,
         space: &XRReferenceSpace,
-        transform: &Option<DomRoot<XRRigidTransform>>,
+        transform: Option<&XRRigidTransform>,
         can_gc: CanGc,
     ) -> DomRoot<XRReferenceSpaceEvent> {
         let trackevent = reflect_dom_object_with_proto(
@@ -100,7 +100,7 @@ impl XRReferenceSpaceEvent {
             init.parent.bubbles,
             init.parent.cancelable,
             &init.referenceSpace,
-            &init.transform,
+            init.transform.as_deref(),
             can_gc,
         ))
     }
@@ -114,7 +114,11 @@ impl XRReferenceSpaceEventMethods for XRReferenceSpaceEvent {
 
     /// <https://www.w3.org/TR/webxr/#dom-xrreferencespaceevent-transform>
     fn GetTransform(&self) -> Option<DomRoot<XRRigidTransform>> {
-        self.transform.clone()
+        if let Some(ref transform) = self.transform {
+            Some(DomRoot::from_ref(&**transform))
+        } else {
+            None
+        }
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -111,7 +111,7 @@ pub struct XRSession {
     framerate: Cell<f32>,
     #[ignore_malloc_size_of = "promises are hard"]
     update_framerate_promise: DomRefCell<Option<Rc<Promise>>>,
-    reference_spaces: DomRefCell<Vec<DomRoot<XRReferenceSpace>>>,
+    reference_spaces: DomRefCell<Vec<Dom<XRReferenceSpace>>>,
 }
 
 impl XRSession {
@@ -401,7 +401,7 @@ impl XRSession {
                             false,
                             false,
                             space,
-                            &Some(offset),
+                            Some(&*offset),
                         );
                         event.upcast::<Event>().fire(space.upcast());
                     });
@@ -864,11 +864,11 @@ impl XRSessionMethods for XRSession {
                     let space = XRBoundedReferenceSpace::new(&self.global(), self);
                     self.reference_spaces
                         .borrow_mut()
-                        .push(DomRoot::from_ref(space.reference_space()));
+                        .push(Dom::from_ref(space.reference_space()));
                     p.resolve_native(&space);
                 } else {
                     let space = XRReferenceSpace::new(&self.global(), self, ty);
-                    self.reference_spaces.borrow_mut().push(space.clone());
+                    self.reference_spaces.borrow_mut().push(Dom::from_ref(&*space));
                     p.resolve_native(&space);
                 }
             },

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -868,7 +868,9 @@ impl XRSessionMethods for XRSession {
                     p.resolve_native(&space);
                 } else {
                     let space = XRReferenceSpace::new(&self.global(), self, ty);
-                    self.reference_spaces.borrow_mut().push(Dom::from_ref(&*space));
+                    self.reference_spaces
+                        .borrow_mut()
+                        .push(Dom::from_ref(&*space));
                     p.resolve_native(&space);
                 }
             },

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -862,7 +862,9 @@ impl XRSessionMethods for XRSession {
                 }
                 if ty == XRReferenceSpaceType::Bounded_floor {
                     let space = XRBoundedReferenceSpace::new(&self.global(), self);
-                    self.reference_spaces.borrow_mut().push(DomRoot::from_ref(space.reference_space()));
+                    self.reference_spaces
+                        .borrow_mut()
+                        .push(DomRoot::from_ref(space.reference_space()));
                     p.resolve_native(&space);
                 } else {
                     let space = XRReferenceSpace::new(&self.global(), self, ty);

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -862,6 +862,7 @@ impl XRSessionMethods for XRSession {
                 }
                 if ty == XRReferenceSpaceType::Bounded_floor {
                     let space = XRBoundedReferenceSpace::new(&self.global(), self);
+                    self.reference_spaces.borrow_mut().push(DomRoot::from_ref(space.reference_space()));
                     p.resolve_native(&space);
                 } else {
                     let space = XRReferenceSpace::new(&self.global(), self, ty);

--- a/tests/wpt/meta-legacy-layout/webxr/events_referenceSpace_reset_immersive.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/events_referenceSpace_reset_immersive.https.html.ini
@@ -1,7 +1,0 @@
-[events_referenceSpace_reset_immersive.https.html]
-  [XRSession resetpose from a device properly fires off the right events for immersive sessions - webgl2]
-    expected: FAIL
-
-  [XRSession resetpose from a device properly fires off the right events for immersive sessions - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/webxr/events_referenceSpace_reset_inline.https.html.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/events_referenceSpace_reset_inline.https.html.ini
@@ -1,7 +1,0 @@
-[events_referenceSpace_reset_inline.https.html]
-  [XRSession resetpose from a device properly fires off the right events for non-immersive sessions - webgl2]
-    expected: FAIL
-
-  [XRSession resetpose from a device properly fires off the right events for non-immersive sessions - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -5,28 +5,13 @@
   [XR interface: calling supportsSession(XRSessionMode) on navigator.xr with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRReferenceSpaceEvent interface: attribute referenceSpace]
-    expected: FAIL
-
   [XR interface: navigator.xr must inherit property "ondevicechange" with the proper type]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [XRRay interface object length]
     expected: FAIL
 
   [XRRay interface: attribute matrix]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface object length]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface object]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: attribute transform]
     expected: FAIL
 
   [XRRay interface: attribute direction]
@@ -39,12 +24,6 @@
     expected: FAIL
 
   [XRRay interface: existence and properties of interface object]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface object name]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's @@unscopables property]
     expected: FAIL
 
   [XRInputSource interface: attribute gamepad]
@@ -60,9 +39,6 @@
     expected: FAIL
 
   [XRRay interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
   [XR interface: operation requestSession(XRSessionMode, XRSessionInit)]

--- a/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/webxr/idlharness.https.window.js.ini
@@ -29,9 +29,6 @@
   [XRInputSource interface: attribute gamepad]
     expected: FAIL
 
-  [XRReferenceSpace interface: attribute onreset]
-    expected: FAIL
-
   [XRRay interface: attribute origin]
     expected: FAIL
 

--- a/tests/wpt/meta/webxr/events_referenceSpace_reset_immersive.https.html.ini
+++ b/tests/wpt/meta/webxr/events_referenceSpace_reset_immersive.https.html.ini
@@ -1,7 +1,0 @@
-[events_referenceSpace_reset_immersive.https.html]
-  [XRSession resetpose from a device properly fires off the right events for immersive sessions - webgl2]
-    expected: FAIL
-
-  [XRSession resetpose from a device properly fires off the right events for immersive sessions - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta/webxr/events_referenceSpace_reset_inline.https.html.ini
+++ b/tests/wpt/meta/webxr/events_referenceSpace_reset_inline.https.html.ini
@@ -1,7 +1,0 @@
-[events_referenceSpace_reset_inline.https.html]
-  [XRSession resetpose from a device properly fires off the right events for non-immersive sessions - webgl2]
-    expected: FAIL
-
-  [XRSession resetpose from a device properly fires off the right events for non-immersive sessions - webgl]
-    expected: FAIL
-

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -5,9 +5,6 @@
   [XRSession interface: calling requestReferenceSpace(XRReferenceSpaceType) on xrSession with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "visibilityState" with the proper type]
     expected: FAIL
 
@@ -20,13 +17,7 @@
   [XRWebGLLayer interface: calling getNativeFramebufferScaleFactor(XRSession) on xrWebGLLayer with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRReferenceSpaceEvent interface: attribute referenceSpace]
-    expected: FAIL
-
   [XRWebGLLayer interface: xrWebGLLayer must inherit property "antialias" with the proper type]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [XRSession interface: xrSession must inherit property "requestAnimationFrame(XRFrameRequestCallback)" with the proper type]
@@ -62,12 +53,6 @@
   [WebGLRenderingContext includes WebGLRenderingContextOverloads: member names are unique]
     expected: FAIL
 
-  [XRReferenceSpaceEvent interface object name]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface object length]
-    expected: FAIL
-
   [XRRenderState must be primary interface of xrRenderState]
     expected: FAIL
 
@@ -84,9 +69,6 @@
     expected: FAIL
 
   [XRReferenceSpace must be primary interface of xrReferenceSpace]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface object]
     expected: FAIL
 
   [XRPermissionStatus interface: attribute granted]
@@ -108,9 +90,6 @@
     expected: FAIL
 
   [idl_test setup]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: attribute transform]
     expected: FAIL
 
   [XRInputSourcesChangeEvent interface: xrInputSourcesChangeEvent must inherit property "added" with the proper type]
@@ -192,9 +171,6 @@
     expected: FAIL
 
   [Stringification of xrWebGLLayer]
-    expected: FAIL
-
-  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
   [Stringification of xrRenderState]

--- a/tests/wpt/meta/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/meta/webxr/idlharness.https.window.js.ini
@@ -155,9 +155,6 @@
   [XRInputSourcesChangeEvent interface: xrInputSourcesChangeEvent must inherit property "removed" with the proper type]
     expected: FAIL
 
-  [XRReferenceSpace interface: attribute onreset]
-    expected: FAIL
-
   [XRSession interface: xrSession must inherit property "onsqueeze" with the proper type]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13495,7 +13495,7 @@
      ]
     ],
     "interfaces.html": [
-     "dd0f564f708a2a0e8cf1ed571bd2bd45977fa469",
+     "086bc095b078efdcac4f51ef314f7851793dbb53",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -291,6 +291,7 @@ test_interfaces([
   "XRLayer",
   "XRPose",
   "XRReferenceSpace",
+  "XRReferenceSpaceEvent",
   "XRRay",
   "XRRenderState",
   "XRRigidTransform",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This adds support for reference space reset events, as well as support for simulating them via the test API.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
