### PR TITLE
Replace `.map_or(false` with `Option::is_some_and`

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -329,7 +329,7 @@ impl BluetoothManager {
         let adapter_valid = self
             .adapter
             .as_ref()
-            .map_or(false, |a| a.get_address().is_ok());
+            .is_some_and(|a| a.get_address().is_ok());
         if !adapter_valid {
             self.adapter = BluetoothAdapter::new().ok();
         }
@@ -471,9 +471,9 @@ impl BluetoothManager {
 
         services.retain(|s| {
             !uuid_is_blocklisted(&s.get_uuid().unwrap_or_default(), Blocklist::All) &&
-                self.allowed_services.get(device_id).map_or(false, |uuids| {
-                    uuids.contains(&s.get_uuid().unwrap_or_default())
-                })
+                self.allowed_services
+                    .get(device_id)
+                    .is_some_and(|uuids| uuids.contains(&s.get_uuid().unwrap_or_default()))
         });
         for service in &services {
             self.cached_services
@@ -727,7 +727,7 @@ impl BluetoothManager {
                     if !self
                         .allowed_services
                         .get(&id)
-                        .map_or(false, |s| s.contains(uuid))
+                        .is_some_and(|s| s.contains(uuid))
                     {
                         return Err(BluetoothError::Security);
                     }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4858,7 +4858,7 @@ where
             .webviews
             .focused_webview()
             .map(|(_, webview)| webview.focused_browsing_context_id);
-        focused_browsing_context_id.map_or(false, |focus_ctx_id| {
+        focused_browsing_context_id.is_some_and(|focus_ctx_id| {
             focus_ctx_id == browsing_context_id ||
                 self.fully_active_descendant_browsing_contexts_iter(browsing_context_id)
                     .any(|nested_ctx| nested_ctx.id == focus_ctx_id)

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -215,9 +215,10 @@ impl SimpleFamily {
 
     fn remove_templates_for_stylesheet(&mut self, stylesheet: &DocumentStyleSheet) {
         let remove_if_template_matches = |template: &mut Option<FontTemplateRef>| {
-            if template.as_ref().map_or(false, |template| {
-                template.borrow().stylesheet.as_ref() == Some(stylesheet)
-            }) {
+            if template
+                .as_ref()
+                .is_some_and(|template| template.borrow().stylesheet.as_ref() == Some(stylesheet))
+            {
                 *template = None;
             }
         };

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -505,9 +505,10 @@ impl<'a> DisplayListBuildState<'a> {
         // Properly order display items that make up a stacking context. "Steps" here
         // refer to the steps in CSS 2.1 Appendix E.
         // Steps 1 and 2: Borders and background for the root.
-        while child_items.last().map_or(false, |child| {
-            child.section() == DisplayListSection::BackgroundAndBorders
-        }) {
+        while child_items
+            .last()
+            .is_some_and(|child| child.section() == DisplayListSection::BackgroundAndBorders)
+        {
             list.push(child_items.pop().unwrap());
         }
 
@@ -515,31 +516,34 @@ impl<'a> DisplayListBuildState<'a> {
         let mut child_stacking_contexts = child_stacking_contexts.into_iter().peekable();
         while child_stacking_contexts
             .peek()
-            .map_or(false, |child| child.z_index < 0)
+            .is_some_and(|child| child.z_index < 0)
         {
             let context = child_stacking_contexts.next().unwrap();
             self.move_to_display_list_for_stacking_context(list, context);
         }
 
         // Step 4: Block backgrounds and borders.
-        while child_items.last().map_or(false, |child| {
-            child.section() == DisplayListSection::BlockBackgroundsAndBorders
-        }) {
+        while child_items
+            .last()
+            .is_some_and(|child| child.section() == DisplayListSection::BlockBackgroundsAndBorders)
+        {
             list.push(child_items.pop().unwrap());
         }
 
         // Step 5: Floats.
-        while child_stacking_contexts.peek().map_or(false, |child| {
-            child.context_type == StackingContextType::PseudoFloat
-        }) {
+        while child_stacking_contexts
+            .peek()
+            .is_some_and(|child| child.context_type == StackingContextType::PseudoFloat)
+        {
             let context = child_stacking_contexts.next().unwrap();
             self.move_to_display_list_for_stacking_context(list, context);
         }
 
         // Step 6 & 7: Content and inlines that generate stacking contexts.
-        while child_items.last().map_or(false, |child| {
-            child.section() == DisplayListSection::Content
-        }) {
+        while child_items
+            .last()
+            .is_some_and(|child| child.section() == DisplayListSection::Content)
+        {
             list.push(child_items.pop().unwrap());
         }
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -868,7 +868,7 @@ impl Fragment {
         node_address == self.node ||
             self.inline_context
                 .as_ref()
-                .map_or(false, |ctx| ctx.contains_node(node_address))
+                .is_some_and(|ctx| ctx.contains_node(node_address))
     }
 
     /// Adds a style to the inline context for this fragment. If the inline context doesn't exist
@@ -2750,9 +2750,7 @@ impl Fragment {
     /// Returns true if this fragment has a transform applied that causes it to take up no space.
     pub fn has_non_invertible_transform_or_zero_scale(&self) -> bool {
         self.transform_matrix(&Rect::default())
-            .map_or(false, |matrix| {
-                !matrix.is_invertible() || matrix.m11 == 0. || matrix.m22 == 0.
-            })
+            .is_some_and(|matrix| !matrix.is_invertible() || matrix.m11 == 0. || matrix.m22 == 0.)
     }
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.

--- a/components/layout/text_run.rs
+++ b/components/layout/text_run.rs
@@ -228,7 +228,7 @@ impl<'a> TextRun {
             // Split off any trailing whitespace into a separate glyph run.
             let mut whitespace = slice.end..slice.end;
             let mut rev_char_indices = word.char_indices().rev().peekable();
-            let ends_with_newline = rev_char_indices.peek().map_or(false, |&(_, c)| c == '\n');
+            let ends_with_newline = rev_char_indices.peek().is_some_and(|&(_, c)| c == '\n');
             if let Some((i, _)) = rev_char_indices
                 .take_while(|&(_, c)| char_is_whitespace(c))
                 .last()

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -219,7 +219,7 @@ fn construct_flows_at<'dom>(context: &LayoutContext, node: impl LayoutNode<'dom>
         if nonincremental_layout ||
             tnode.restyle_damage() != RestyleDamage::empty() ||
             node.as_element()
-                .map_or(false, |el| el.has_dirty_descendants())
+                .is_some_and(|el| el.has_dirty_descendants())
         {
             let mut flow_constructor = FlowConstructor::new(context);
             if nonincremental_layout || !flow_constructor.repair_if_possible(&tnode) {

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -678,7 +678,7 @@ impl StackingContext {
 
         // Steps 1 and 2: Borders and background for the root
         let mut contents = self.contents.iter().enumerate().peekable();
-        while contents.peek().map_or(false, |(_, child)| {
+        while contents.peek().is_some_and(|(_, child)| {
             child.section() == StackingContextSection::OwnBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
@@ -694,7 +694,7 @@ impl StackingContext {
             .peekable();
         while real_stacking_contexts_and_positioned_stacking_containers
             .peek()
-            .map_or(false, |(_, child)| child.z_index() < 0)
+            .is_some_and(|(_, child)| child.z_index() < 0)
         {
             let (i, child) = real_stacking_contexts_and_positioned_stacking_containers
                 .next()
@@ -707,7 +707,7 @@ impl StackingContext {
         }
 
         // Step 4: Block backgrounds and borders
-        while contents.peek().map_or(false, |(_, child)| {
+        while contents.peek().is_some_and(|(_, child)| {
             child.section() == StackingContextSection::DescendantBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
@@ -722,9 +722,10 @@ impl StackingContext {
         }
 
         // Steps 6 and 7: Fragments and inline stacking containers
-        while contents.peek().map_or(false, |(_, child)| {
-            child.section() == StackingContextSection::Foreground
-        }) {
+        while contents
+            .peek()
+            .is_some_and(|(_, child)| child.section() == StackingContextSection::Foreground)
+        {
             let (i, child) = contents.next().unwrap();
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
@@ -741,9 +742,10 @@ impl StackingContext {
         }
 
         // Step 10: Outline
-        while contents.peek().map_or(false, |(_, child)| {
-            child.section() == StackingContextSection::Outline
-        }) {
+        while contents
+            .peek()
+            .is_some_and(|(_, child)| child.section() == StackingContextSection::Outline)
+        {
             let (i, child) = contents.next().unwrap();
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);

--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -56,7 +56,7 @@ impl<'dom, Node: NodeExt<'dom>> NodeAndStyleInfo<Node> {
     }
 
     pub(crate) fn is_single_line_text_input(&self) -> bool {
-        self.node.map_or(false, |node| {
+        self.node.is_some_and(|node| {
             node.type_id() == LayoutNodeType::Element(LayoutElementType::HTMLInputElement)
         })
     }

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -230,7 +230,7 @@ impl TextRunSegment {
             let mut ends_with_whitespace = false;
             let ends_with_newline = rev_char_indices
                 .peek()
-                .map_or(false, |&(_, character)| character == '\n');
+                .is_some_and(|&(_, character)| character == '\n');
             if let Some((first_white_space_index, first_white_space_character)) = rev_char_indices
                 .take_while(|&(_, character)| char_is_whitespace(character))
                 .last()

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -70,9 +70,11 @@ impl BoxTree {
         let mut root_overflow = root_style.effective_overflow().y;
         if root_overflow == Overflow::Visible && !root_style.get_box().display.is_none() {
             for child in iter_child_nodes(root_element) {
-                if !child.to_threadsafe().as_element().map_or(false, |element| {
-                    element.is_body_element_of_html_element_root()
-                }) {
+                if !child
+                    .to_threadsafe()
+                    .as_element()
+                    .is_some_and(|element| element.is_body_element_of_html_element_root())
+                {
                     continue;
                 }
 

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -245,9 +245,9 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
     match fragment {
         Fragment::Box(box_fragment) => {
             !box_fragment.style.get_box().display.is_inline_flow() ||
-                fragment.base().map_or(false, |base| {
-                    base.flags.contains(FragmentFlags::IS_REPLACED)
-                })
+                fragment
+                    .base()
+                    .is_some_and(|base| base.flags.contains(FragmentFlags::IS_REPLACED))
         },
         Fragment::Float(_) |
         Fragment::Positioning(_) |

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1136,9 +1136,9 @@ impl<'a> TableLayout<'a> {
                 // configuration for whatever PositioningContext the contents are ultimately added to.
                 let collect_for_nearest_positioned_ancestor = parent_positioning_context
                     .collects_for_nearest_positioned_ancestor() ||
-                    self.table.rows.get(row_index).map_or(false, |row| {
+                    self.table.rows.get(row_index).is_some_and(|row| {
                         let row_group_collects_for_nearest_positioned_ancestor =
-                            row.group_index.map_or(false, |group_index| {
+                            row.group_index.is_some_and(|group_index| {
                                 self.table.row_groups[group_index]
                                     .style
                                     .establishes_containing_block_for_absolute_descendants(

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -93,7 +93,7 @@ impl HstsList {
 
     pub fn is_host_secure(&self, host: &str) -> bool {
         let base_domain = reg_suffix(host);
-        self.entries_map.get(base_domain).map_or(false, |entries| {
+        self.entries_map.get(base_domain).is_some_and(|entries| {
             entries.iter().any(|e| {
                 if e.include_subdomains {
                     e.matches_subdomain(host) || e.matches_domain(host)
@@ -105,15 +105,15 @@ impl HstsList {
     }
 
     fn has_domain(&self, host: &str, base_domain: &str) -> bool {
-        self.entries_map.get(base_domain).map_or(false, |entries| {
-            entries.iter().any(|e| e.matches_domain(host))
-        })
+        self.entries_map
+            .get(base_domain)
+            .is_some_and(|entries| entries.iter().any(|e| e.matches_domain(host)))
     }
 
     fn has_subdomain(&self, host: &str, base_domain: &str) -> bool {
-        self.entries_map.get(base_domain).map_or(false, |entries| {
-            entries.iter().any(|e| e.matches_subdomain(host))
-        })
+        self.entries_map
+            .get(base_domain)
+            .is_some_and(|entries| entries.iter().any(|e| e.matches_subdomain(host)))
     }
 
     pub fn push(&mut self, entry: HstsEntry) {
@@ -153,16 +153,16 @@ impl HstsList {
                 }) ||
                 (!pref!(network.enforce_tls.onion) &&
                     url.domain()
-                        .map_or(false, |domain| domain.ends_with(".onion")))
+                        .is_some_and(|domain| domain.ends_with(".onion")))
             {
                 url.domain()
-                    .map_or(false, |domain| self.is_host_secure(domain))
+                    .is_some_and(|domain| self.is_host_secure(domain))
             } else {
                 true
             }
         } else {
             url.domain()
-                .map_or(false, |domain| self.is_host_secure(domain))
+                .is_some_and(|domain| self.is_host_secure(domain))
         };
 
         if upgrade_scheme {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -802,7 +802,7 @@ pub async fn http_fetch(
         .actual_response()
         .status
         .as_ref()
-        .map_or(false, is_redirect_status)
+        .is_some_and(is_redirect_status)
     {
         // Substep 1.
         if response
@@ -992,7 +992,7 @@ pub async fn http_redirect_fetch(
         .status
         .as_ref()
         .map_or(true, |s| s.0 != StatusCode::SEE_OTHER) &&
-        request.body.as_ref().map_or(false, |b| b.source_is_null())
+        request.body.as_ref().is_some_and(|b| b.source_is_null())
     {
         return Response::network_error(NetworkError::Internal("Request body is not done".into()));
     }
@@ -1007,7 +1007,7 @@ pub async fn http_redirect_fetch(
         .actual_response()
         .status
         .as_ref()
-        .map_or(false, |(code, _)| {
+        .is_some_and(|(code, _)| {
             ((*code == StatusCode::MOVED_PERMANENTLY || *code == StatusCode::FOUND) &&
                 request.method == Method::POST) ||
                 (*code == StatusCode::SEE_OTHER &&
@@ -1450,7 +1450,7 @@ async fn http_network_or_cache_fetch(
             forward_response
                 .status
                 .as_ref()
-                .map_or(false, |s| s.0 == StatusCode::NOT_MODIFIED)
+                .is_some_and(|s| s.0 == StatusCode::NOT_MODIFIED)
         {
             if let Ok(mut http_cache) = context.state.http_cache.write() {
                 // Ensure done_chan is None,
@@ -1989,7 +1989,7 @@ async fn cors_preflight_fetch(
         response
             .status
             .as_ref()
-            .map_or(false, |(status, _)| status.is_success())
+            .is_some_and(|(status, _)| status.is_success())
     {
         // Substep 1
         let mut methods = if response

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -258,7 +258,7 @@ impl StorageManager {
         sender
             .send(
                 data.get_mut(&origin)
-                    .map_or(false, |&mut (ref mut total, ref mut entry)| {
+                    .is_some_and(|&mut (ref mut total, ref mut entry)| {
                         if !entry.is_empty() {
                             entry.clear();
                             *total = 0;

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1005,7 +1005,7 @@ impl CanvasState {
         if !x.is_finite() || !y.is_finite() {
             return;
         }
-        if max_width.map_or(false, |max_width| !max_width.is_finite() || max_width <= 0.) {
+        if max_width.is_some_and(|max_width| !max_width.is_finite() || max_width <= 0.) {
             return;
         }
         if self.state.borrow().font_style.is_none() {

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -598,7 +598,7 @@ pub unsafe fn cross_origin_has_own(
     // TODO: Once we have the slot for the holder, it'd be more efficient to
     //       use `ensure_cross_origin_property_holder`. We'll need `_proxy` to
     //       do that.
-    *bp = jsid_to_string(*cx, Handle::from_raw(id)).map_or(false, |key| {
+    *bp = jsid_to_string(*cx, Handle::from_raw(id)).is_some_and(|key| {
         cross_origin_properties.keys().any(|defined_key| {
             let defined_key = CStr::from_ptr(defined_key);
             defined_key.to_bytes() == key.as_bytes()
@@ -674,7 +674,7 @@ const ALLOWLISTED_SYMBOL_CODES: &[SymbolCode] = &[
 ];
 
 unsafe fn is_cross_origin_allowlisted_prop(cx: SafeJSContext, id: RawHandleId) -> bool {
-    if jsid_to_string(*cx, Handle::from_raw(id)).map_or(false, |st| st == "then") {
+    if jsid_to_string(*cx, Handle::from_raw(id)).is_some_and(|st| st == "then") {
         return true;
     }
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1266,7 +1266,7 @@ pub fn is_valid_custom_element_name(name: &str) -> bool {
     // PotentialCustomElementName ::= [a-z] (PCENChar)* '-' (PCENChar)*
 
     let mut chars = name.chars();
-    if !chars.next().map_or(false, |c| c.is_ascii_lowercase()) {
+    if !chars.next().is_some_and(|c| c.is_ascii_lowercase()) {
         return false;
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3595,7 +3595,7 @@ impl Document {
         if element.namespace() != &ns!(html) {
             return false;
         }
-        element.get_name().map_or(false, |n| *n == **name)
+        element.get_name().is_some_and(|n| *n == **name)
     }
 
     fn count_node_list<F: Fn(&Node) -> bool>(&self, callback: F) -> u32 {
@@ -3935,9 +3935,9 @@ impl Document {
                     true
                 } else {
                     // Step 3
-                    window.GetFrameElement().map_or(false, |el| {
-                        el.has_attribute(&local_name!("allowfullscreen"))
-                    })
+                    window
+                        .GetFrameElement()
+                        .is_some_and(|el| el.has_attribute(&local_name!("allowfullscreen")))
                 }
             },
         }
@@ -5064,7 +5064,7 @@ impl DocumentMethods for Document {
                     HTMLElementTypeId::HTMLFormElement | HTMLElementTypeId::HTMLIFrameElement => {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
-                    HTMLElementTypeId::HTMLImageElement => elem.get_name().map_or(false, |name| {
+                    HTMLElementTypeId::HTMLImageElement => elem.get_name().is_some_and(|name| {
                         name == *self.name ||
                             !name.is_empty() && elem.get_id().as_ref() == Some(&self.name)
                     }),
@@ -5217,7 +5217,7 @@ impl DocumentMethods for Document {
         // Step 5
         if self
             .get_current_parser()
-            .map_or(false, |parser| parser.is_active())
+            .is_some_and(|parser| parser.is_active())
         {
             return Ok(DomRoot::from_ref(self));
         }
@@ -5650,5 +5650,5 @@ fn is_named_element_with_id_attribute(elem: &Element) -> bool {
     // TODO handle <embed> and <object>; these depend on whether the element is
     // “exposed”, a concept that doesn’t fully make sense until embed/object
     // behaviour is actually implemented
-    elem.is::<HTMLImageElement>() && elem.get_name().map_or(false, |name| !name.is_empty())
+    elem.is::<HTMLImageElement>() && elem.get_name().is_some_and(|name| !name.is_empty())
 }

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -121,7 +121,7 @@ impl DOMTokenListMethods for DOMTokenList {
     /// <https://dom.spec.whatwg.org/#dom-domtokenlist-contains>
     fn Contains(&self, token: DOMString) -> bool {
         let token = Atom::from(token);
-        self.attribute().map_or(false, |attr| {
+        self.attribute().is_some_and(|attr| {
             attr.value()
                 .as_tokens()
                 .iter()

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -430,7 +430,7 @@ impl Element {
     // https://drafts.csswg.org/cssom-view/#css-layout-box
     pub fn has_css_layout_box(&self) -> bool {
         self.style()
-            .map_or(false, |s| !s.get_box().clone_display().is_none())
+            .is_some_and(|s| !s.get_box().clone_display().is_none())
     }
 
     // https://drafts.csswg.org/cssom-view/#potentially-scrollable
@@ -477,7 +477,7 @@ impl Element {
     fn has_scrolling_box(&self) -> bool {
         // TODO: scrolling mechanism, such as scrollbar (We don't have scrollbar yet)
         //       self.has_scrolling_mechanism()
-        self.style().map_or(false, |style| {
+        self.style().is_some_and(|style| {
             style.get_box().clone_overflow_x().is_scrollable() ||
                 style.get_box().clone_overflow_y().is_scrollable()
         })
@@ -658,7 +658,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
     #[inline]
     fn has_class_for_layout(self, name: &AtomIdent, case_sensitivity: CaseSensitivity) -> bool {
-        get_attr_for_layout(self, &ns!(), &local_name!("class")).map_or(false, |attr| {
+        get_attr_for_layout(self, &ns!(), &local_name!("class")).is_some_and(|attr| {
             attr.to_tokens()
                 .unwrap()
                 .iter()
@@ -1651,7 +1651,7 @@ impl Element {
 
     pub fn has_class(&self, name: &Atom, case_sensitivity: CaseSensitivity) -> bool {
         self.get_attribute(&ns!(), &local_name!("class"))
-            .map_or(false, |attr| {
+            .is_some_and(|attr| {
                 attr.value()
                     .as_tokens()
                     .iter()
@@ -3652,7 +3652,7 @@ impl SelectorsElement for DomRoot<Element> {
         match *ns {
             NamespaceConstraint::Specific(ns) => self
                 .get_attribute(ns, local_name)
-                .map_or(false, |attr| attr.value().eval_selector(operation)),
+                .is_some_and(|attr| attr.value().eval_selector(operation)),
             NamespaceConstraint::Any => self.attrs.borrow().iter().any(|attr| {
                 *attr.local_name() == **local_name && attr.value().eval_selector(operation)
             }),
@@ -3765,7 +3765,7 @@ impl SelectorsElement for DomRoot<Element> {
         self.id_attribute
             .borrow()
             .as_ref()
-            .map_or(false, |atom| case_sensitivity.eq_atom(id, atom))
+            .is_some_and(|atom| case_sensitivity.eq_atom(id, atom))
     }
 
     fn is_part(&self, _name: &AtomIdent) -> bool {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2836,12 +2836,12 @@ impl GlobalScope {
     ) -> Rc<Promise> {
         let in_realm_proof = AlreadyInRealm::assert();
         let p = Promise::new_in_current_realm(InRealm::Already(&in_realm_proof));
-        if options.resizeWidth.map_or(false, |w| w == 0) {
+        if options.resizeWidth.is_some_and(|w| w == 0) {
             p.reject_error(Error::InvalidState);
             return p;
         }
 
-        if options.resizeHeight.map_or(false, |w| w == 0) {
+        if options.resizeHeight.is_some_and(|w| w == 0) {
             p.reject_error(Error::InvalidState);
             return p;
         }

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -620,7 +620,7 @@ pub fn get_element_noopener(subject: &Element, target_attribute_value: Option<DO
     }
     let target_is_blank = target_attribute_value
         .as_ref()
-        .map_or(false, |target| target.to_lowercase() == "_blank");
+        .is_some_and(|target| target.to_lowercase() == "_blank");
     let link_types = match subject.get_attribute(&ns!(), &local_name!("rel")) {
         Some(rel) => rel.Value(),
         None => return target_is_blank,

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -383,8 +383,8 @@ impl HTMLCollectionMethods for HTMLCollection {
 
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_id().map_or(false, |id| id == key) ||
-                (elem.namespace() == &ns!(html) && elem.get_name().map_or(false, |id| id == key))
+            elem.get_id().is_some_and(|id| id == key) ||
+                (elem.namespace() == &ns!(html) && elem.get_name().is_some_and(|id| id == key))
         })
     }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -673,7 +673,7 @@ impl HTMLElement {
             .chars()
             .skip_while(|&ch| ch != '\u{2d}')
             .nth(1)
-            .map_or(false, |ch| ch.is_ascii_lowercase())
+            .is_some_and(|ch| ch.is_ascii_lowercase())
         {
             return Err(Error::Syntax);
         }

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -90,7 +90,7 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
         impl CollectionFilter for ElementsFilter {
             fn filter<'a>(&self, elem: &'a Element, _root: &'a Node) -> bool {
                 elem.downcast::<HTMLElement>()
-                    .map_or(false, HTMLElement::is_listed_element)
+                    .is_some_and(HTMLElement::is_listed_element)
             }
         }
         let filter = Box::new(ElementsFilter);
@@ -210,7 +210,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                             element.set_enabled_state(false);
                             if element
                                 .downcast::<HTMLElement>()
-                                .map_or(false, |h| h.is_form_associated_custom_element())
+                                .is_some_and(|h| h.is_form_associated_custom_element())
                             {
                                 ScriptThread::enqueue_callback_reaction(
                                     element,
@@ -231,7 +231,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                             if element.enabled_state() &&
                                 element
                                     .downcast::<HTMLElement>()
-                                    .map_or(false, |h| h.is_form_associated_custom_element())
+                                    .is_some_and(|h| h.is_form_associated_custom_element())
                             {
                                 ScriptThread::enqueue_callback_reaction(
                                     element,

--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -70,8 +70,8 @@ impl HTMLFormControlsCollectionMethods for HTMLFormControlsCollection {
         let name = Atom::from(name);
 
         let mut filter_map = self.collection.elements_iter().filter_map(|elem| {
-            if elem.get_name().map_or(false, |n| n == name) ||
-                elem.get_id().map_or(false, |i| i == name)
+            if elem.get_name().is_some_and(|n| n == name) ||
+                elem.get_id().is_some_and(|i| i == name)
             {
                 Some(elem)
             } else {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -144,9 +144,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .map_or(false, |c| c.is_listed_element()) &&
-                        (child.get_id().map_or(false, |i| i == *name) ||
-                            child.get_name().map_or(false, |n| n == *name))
+                        .is_some_and(|c| c.is_listed_element()) &&
+                        (child.get_id().is_some_and(|i| i == *name) ||
+                            child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -160,8 +160,8 @@ impl HTMLFormElement {
                 },
                 RadioListMode::Images => {
                     return child.is::<HTMLImageElement>() &&
-                        (child.get_id().map_or(false, |i| i == *name) ||
-                            child.get_name().map_or(false, |n| n == *name));
+                        (child.get_id().is_some_and(|i| i == *name) ||
+                            child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -511,7 +511,7 @@ impl HTMLFormElementMethods for HTMLFormElement {
         for child in controls.iter() {
             if child
                 .downcast::<HTMLElement>()
-                .map_or(false, |c| c.is_listed_element())
+                .is_some_and(|c| c.is_listed_element())
             {
                 if let Some(id_atom) = child.get_id() {
                     let entry = SourcedName {
@@ -1147,13 +1147,11 @@ impl HTMLFormElement {
             // An element can only have a dirname attribute if it is a textarea element
             // or an input element whose type attribute is in either the Text state or the Search state
             let child_element = child.downcast::<Element>().unwrap();
-            let input_matches =
-                child_element
-                    .downcast::<HTMLInputElement>()
-                    .map_or(false, |input| {
-                        input.input_type() == InputType::Text ||
-                            input.input_type() == InputType::Search
-                    });
+            let input_matches = child_element
+                .downcast::<HTMLInputElement>()
+                .is_some_and(|input| {
+                    matches!(input.input_type(), InputType::Text | InputType::Search)
+                });
             let textarea_matches = child_element.is::<HTMLTextAreaElement>();
             let dirname = child_element.get_string_attribute(&local_name!("dirname"));
             if (input_matches || textarea_matches) && !dirname.is_empty() {
@@ -1642,7 +1640,7 @@ pub trait FormControl: DomObject {
         if self.to_element().has_attribute(attr) {
             input(self)
         } else {
-            self.form_owner().map_or(false, |t| owner(&t))
+            self.form_owner().is_some_and(|t| owner(&t))
         }
     }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -975,7 +975,7 @@ impl HTMLImageElement {
         let is_parent_picture = elem
             .upcast::<Node>()
             .GetParentElement()
-            .map_or(false, |p| p.is::<HTMLPictureElement>());
+            .is_some_and(|p| p.is::<HTMLPictureElement>());
         if src_set.is_empty() && !is_parent_picture && !src.is_empty() {
             selected_source = Some(src.clone());
             pixel_density = Some(1_f64);
@@ -1295,7 +1295,7 @@ impl HTMLImageElement {
         let is_parent_picture = elem
             .upcast::<Node>()
             .GetParentElement()
-            .map_or(false, |p| p.is::<HTMLPictureElement>());
+            .is_some_and(|p| p.is::<HTMLPictureElement>());
         has_src || is_parent_picture
     }
 
@@ -1405,7 +1405,7 @@ impl HTMLImageElement {
             .find(|n| {
                 n.upcast::<Element>()
                     .get_name()
-                    .map_or(false, |n| *n == *last)
+                    .is_some_and(|n| *n == *last)
             });
 
         useMapElements.map(|mapElem| mapElem.get_area_elements())
@@ -1420,9 +1420,7 @@ impl HTMLImageElement {
             .borrow()
             .final_url
             .as_ref()
-            .map_or(false, |url| {
-                url.scheme() == "data" || url.origin().same_origin(origin)
-            })
+            .is_some_and(|url| url.scheme() == "data" || url.origin().same_origin(origin))
     }
 }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -756,7 +756,7 @@ impl HTMLInputElement {
             .traverse_preorder(ShadowIncluding::No)
             .find(|node| {
                 node.downcast::<Element>()
-                    .map_or(false, |e| e.Id() == list_string)
+                    .is_some_and(|e| e.Id() == list_string)
             });
         first_with_id
             .as_ref()

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2187,7 +2187,7 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
         if self
             .error
             .get()
-            .map_or(false, |e| e.Code() == MEDIA_ERR_SRC_NOT_SUPPORTED)
+            .is_some_and(|e| e.Code() == MEDIA_ERR_SRC_NOT_SUPPORTED)
         {
             promise.reject_error(Error::NotSupported);
             return promise;

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -825,7 +825,7 @@ impl HTMLScriptElement {
                 ScriptType::Classic => {
                     if was_parser_inserted &&
                         doc.get_current_parser()
-                            .map_or(false, |parser| parser.script_nesting_level() <= 1) &&
+                            .is_some_and(|parser| parser.script_nesting_level() <= 1) &&
                         doc.get_script_blocking_stylesheets_count() > 0
                     {
                         // Step 27.h: classic, has no src, was parser-inserted, is blocked on stylesheet.

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -283,7 +283,7 @@ impl HTMLStyleElementMethods for HTMLStyleElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-style-disabled>
     fn Disabled(&self) -> bool {
         self.get_cssom_stylesheet()
-            .map_or(false, |sheet| sheet.disabled())
+            .is_some_and(|sheet| sheet.disabled())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-style-disabled>

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -98,7 +98,7 @@ impl ImageData {
         }
 
         let height = len / width;
-        if opt_height.map_or(false, |x| height != x) {
+        if opt_height.is_some_and(|x| height != x) {
             return Err(Error::IndexSize);
         }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -783,7 +783,7 @@ impl Node {
         child
             .parent_node
             .get()
-            .map_or(false, |parent| &*parent == self)
+            .is_some_and(|parent| &*parent == self)
     }
 
     pub fn to_trusted_node_address(&self) -> TrustedNodeAddress {
@@ -825,10 +825,10 @@ impl Node {
         let viewport = Size2D::new(window.InnerWidth(), window.InnerHeight());
 
         let in_quirks_mode = document.quirks_mode() == QuirksMode::Quirks;
-        let is_root = self.downcast::<Element>().map_or(false, |e| e.is_root());
+        let is_root = self.downcast::<Element>().is_some_and(|e| e.is_root());
         let is_body_element = self
             .downcast::<HTMLBodyElement>()
-            .map_or(false, |e| e.is_the_html_body_element());
+            .is_some_and(|e| e.is_the_html_body_element());
 
         // "4. If the element is the root element and document is not in quirks mode
         // return max(viewport scrolling area width/height, viewport width/height)."
@@ -2180,7 +2180,7 @@ impl Node {
         parent.owner_doc().add_script_and_layout_blocker();
         assert!(node
             .GetParentNode()
-            .map_or(false, |node_parent| &*node_parent == parent));
+            .is_some_and(|node_parent| &*node_parent == parent));
         let cached_index = {
             if parent.ranges.is_empty() {
                 None
@@ -2809,7 +2809,7 @@ impl NodeMethods for Node {
                 }
                 while children
                     .peek()
-                    .map_or(false, |(_, sibling)| sibling.is::<Text>())
+                    .is_some_and(|(_, sibling)| sibling.is::<Text>())
                 {
                     let (index, sibling) = children.next().unwrap();
                     sibling

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -97,8 +97,7 @@ impl PerformanceEntryList {
         entry_type: DOMString,
     ) {
         self.entries.retain(|e| {
-            *e.entry_type() != *entry_type ||
-                name.as_ref().map_or(false, |name_| *e.name() != *name_)
+            *e.entry_type() != *entry_type || name.as_ref().is_some_and(|name_| *e.name() != *name_)
         });
     }
 

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -653,12 +653,12 @@ impl BodyMixin for Request {
         let body_stream = self.body_stream.get();
         body_stream
             .as_ref()
-            .map_or(false, |stream| stream.is_disturbed())
+            .is_some_and(|stream| stream.is_disturbed())
     }
 
     fn is_locked(&self) -> bool {
         let body_stream = self.body_stream.get();
-        body_stream.map_or(false, |stream| stream.is_locked())
+        body_stream.is_some_and(|stream| stream.is_locked())
     }
 
     fn body(&self) -> Option<DomRoot<ReadableStream>> {

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -235,13 +235,13 @@ impl BodyMixin for Response {
     fn is_disturbed(&self) -> bool {
         self.body_stream
             .get()
-            .map_or(false, |stream| stream.is_disturbed())
+            .is_some_and(|stream| stream.is_disturbed())
     }
 
     fn is_locked(&self) -> bool {
         self.body_stream
             .get()
-            .map_or(false, |stream| stream.is_locked())
+            .is_some_and(|stream| stream.is_locked())
     }
 
     fn body(&self) -> Option<DomRoot<ReadableStream>> {

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -159,7 +159,7 @@ struct SerializationIterator {
 }
 
 fn rev_children_iter(n: &Node) -> impl Iterator<Item = DomRoot<Node>> {
-    if n.downcast::<Element>().map_or(false, |e| e.is_void()) {
+    if n.downcast::<Element>().is_some_and(|e| e.is_void()) {
         return Node::new_document_node().rev_children();
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1294,7 +1294,7 @@ impl TreeSink for Sink {
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Dom<Node>) -> bool {
         let elem = handle.downcast::<Element>().unwrap();
         elem.get_attribute(&ns!(), &local_name!("encoding"))
-            .map_or(false, |attr| {
+            .is_some_and(|attr| {
                 attr.value().eq_ignore_ascii_case("text/html") ||
                     attr.value().eq_ignore_ascii_case("application/xhtml+xml")
             })

--- a/components/script/dom/vertexarrayobject.rs
+++ b/components/script/dom/vertexarrayobject.rs
@@ -194,7 +194,7 @@ impl VertexArrayObject {
         if self
             .element_array_buffer
             .get()
-            .map_or(false, |b| buffer == &*b)
+            .is_some_and(|b| buffer == &*b)
         {
             buffer.decrement_attached_counter(Operation::Infallible);
             self.element_array_buffer.set(None);
@@ -239,7 +239,7 @@ impl VertexArrayObject {
                     }
                 } else if max_vertices
                     .checked_mul(attrib.divisor)
-                    .map_or(false, |v| v < instance_count)
+                    .is_some_and(|v| v < instance_count)
                 {
                     return Err(WebGLError::InvalidOperation);
                 }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -350,7 +350,7 @@ impl WebGL2RenderingContext {
     }
 
     fn unbind_from(&self, slot: &MutNullableDom<WebGLBuffer>, buffer: &WebGLBuffer) {
-        if slot.get().map_or(false, |b| buffer == &*b) {
+        if slot.get().is_some_and(|b| buffer == &*b) {
             buffer.decrement_attached_counter(Operation::Infallible);
             slot.set(None);
         }
@@ -1452,10 +1452,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
         let src_is_elemarray = read_buffer
             .target()
-            .map_or(false, |t| t == constants::ELEMENT_ARRAY_BUFFER);
+            .is_some_and(|t| t == constants::ELEMENT_ARRAY_BUFFER);
         let dst_is_elemarray = write_buffer
             .target()
-            .map_or(false, |t| t == constants::ELEMENT_ARRAY_BUFFER);
+            .is_some_and(|t| t == constants::ELEMENT_ARRAY_BUFFER);
         if src_is_elemarray != dst_is_elemarray {
             return self.base.webgl_error(InvalidOperation);
         }
@@ -3424,7 +3424,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         if let Some(sampler) = sampler {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(sampler), return);
             for slot in self.samplers.iter() {
-                if slot.get().map_or(false, |s| sampler == &*s) {
+                if slot.get().is_some_and(|s| sampler == &*s) {
                     slot.set(None);
                 }
             }

--- a/components/script/dom/webgl_extensions/extensions.rs
+++ b/components/script/dom/webgl_extensions/extensions.rs
@@ -250,7 +250,7 @@ impl WebGLExtensions {
         self.extensions
             .borrow()
             .get(&name)
-            .map_or(false, |ext| ext.is_enabled())
+            .is_some_and(|ext| ext.is_enabled())
     }
 
     pub fn supports_gl_extension(&self, name: &str) -> bool {

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -430,7 +430,7 @@ impl WebGLFramebuffer {
         self.size.set(fb_size);
 
         if has_c || has_z || has_zs || has_s {
-            if self.size.get().map_or(false, |(w, h)| w != 0 && h != 0) {
+            if self.size.get().is_some_and(|(w, h)| w != 0 && h != 0) {
                 self.status.set(constants::FRAMEBUFFER_COMPLETE);
             } else {
                 self.status

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1208,7 +1208,7 @@ impl WebGLRenderingContext {
     }
 
     pub fn is_vertex_array(&self, vao: Option<&WebGLVertexArrayObjectOES>) -> bool {
-        vao.map_or(false, |vao| {
+        vao.is_some_and(|vao| {
             // The default vertex array has no id and should never be passed around.
             assert!(vao.id().is_some());
             self.validate_ownership(vao).is_ok() && vao.ever_bound() && !vao.is_deleted()
@@ -1216,7 +1216,7 @@ impl WebGLRenderingContext {
     }
 
     pub fn is_vertex_array_webgl2(&self, vao: Option<&WebGLVertexArrayObject>) -> bool {
-        vao.map_or(false, |vao| {
+        vao.is_some_and(|vao| {
             // The default vertex array has no id and should never be passed around.
             assert!(vao.id().is_some());
             self.validate_ownership(vao).is_ok() && vao.ever_bound() && !vao.is_deleted()
@@ -2913,11 +2913,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return;
         }
         self.current_vao().unbind_buffer(buffer);
-        if self
-            .bound_buffer_array
-            .get()
-            .map_or(false, |b| buffer == &*b)
-        {
+        if self.bound_buffer_array.get().is_some_and(|b| buffer == &*b) {
             self.bound_buffer_array.set(None);
             buffer.decrement_attached_counter(Operation::Infallible);
         }
@@ -3517,7 +3513,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
     fn IsBuffer(&self, buffer: Option<&WebGLBuffer>) -> bool {
-        buffer.map_or(false, |buf| {
+        buffer.is_some_and(|buf| {
             self.validate_ownership(buf).is_ok() && buf.target().is_some() && !buf.is_deleted()
         })
     }
@@ -3529,35 +3525,31 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
     fn IsFramebuffer(&self, frame_buffer: Option<&WebGLFramebuffer>) -> bool {
-        frame_buffer.map_or(false, |buf| {
+        frame_buffer.is_some_and(|buf| {
             self.validate_ownership(buf).is_ok() && buf.target().is_some() && !buf.is_deleted()
         })
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
     fn IsProgram(&self, program: Option<&WebGLProgram>) -> bool {
-        program.map_or(false, |p| {
-            self.validate_ownership(p).is_ok() && !p.is_deleted()
-        })
+        program.is_some_and(|p| self.validate_ownership(p).is_ok() && !p.is_deleted())
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
     fn IsRenderbuffer(&self, render_buffer: Option<&WebGLRenderbuffer>) -> bool {
-        render_buffer.map_or(false, |buf| {
+        render_buffer.is_some_and(|buf| {
             self.validate_ownership(buf).is_ok() && buf.ever_bound() && !buf.is_deleted()
         })
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
     fn IsShader(&self, shader: Option<&WebGLShader>) -> bool {
-        shader.map_or(false, |s| {
-            self.validate_ownership(s).is_ok() && !s.is_deleted()
-        })
+        shader.is_some_and(|s| self.validate_ownership(s).is_ok() && !s.is_deleted())
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
     fn IsTexture(&self, texture: Option<&WebGLTexture>) -> bool {
-        texture.map_or(false, |tex| {
+        texture.is_some_and(|tex| {
             self.validate_ownership(tex).is_ok() && tex.target().is_some() && !tex.is_invalid()
         })
     }
@@ -4850,7 +4842,7 @@ impl TextureUnit {
             (&self.tex_3d, WebGL2RenderingContextConstants::TEXTURE_3D),
         ];
         for &(slot, target) in &fields {
-            if slot.get().map_or(false, |t| texture == &*t) {
+            if slot.get().is_some_and(|t| texture == &*t) {
                 slot.set(None);
                 return Some(target);
             }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2020,7 +2020,7 @@ impl Window {
             // See http://testthewebforward.org/docs/reftests.html
             // and https://web-platform-tests.org/writing-tests/crashtest.html
             let html_element = document.GetDocumentElement();
-            let reftest_wait = html_element.map_or(false, |elem| {
+            let reftest_wait = html_element.is_some_and(|elem| {
                 elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive) ||
                     elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
             });
@@ -2516,7 +2516,7 @@ impl Window {
             .get()
             .as_ref()
             .and_then(|nav| nav.xr())
-            .map_or(false, |xr| xr.pending_or_active_session())
+            .is_some_and(|xr| xr.pending_or_active_session())
     }
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -507,7 +507,7 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
         match *ns {
             NamespaceConstraint::Specific(ns) => self
                 .get_attr_enum(ns, local_name)
-                .map_or(false, |value| value.eval_selector(operation)),
+                .is_some_and(|value| value.eval_selector(operation)),
             NamespaceConstraint::Any => self
                 .element
                 .get_attr_vals_for_layout(local_name)
@@ -637,7 +637,7 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
         unsafe {
             (*self.element.id_attribute())
                 .as_ref()
-                .map_or(false, |atom| case_sensitivity.eq_atom(atom, id))
+                .is_some_and(|atom| case_sensitivity.eq_atom(atom, id))
         }
     }
 
@@ -851,7 +851,7 @@ impl<'dom> ::selectors::Element for ServoThreadSafeLayoutElement<'dom> {
         match *ns {
             NamespaceConstraint::Specific(ns) => self
                 .get_attr_enum(ns, local_name)
-                .map_or(false, |value| value.eval_selector(operation)),
+                .is_some_and(|value| value.eval_selector(operation)),
             NamespaceConstraint::Any => self
                 .element
                 .element

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1097,7 +1097,7 @@ impl ScriptThread {
 
     pub fn is_user_interacting() -> bool {
         SCRIPT_THREAD_ROOT.with(|root| {
-            root.get().map_or(false, |script_thread| {
+            root.get().is_some_and(|script_thread| {
                 let script_thread = unsafe { &*script_thread };
                 script_thread.is_user_interacting.get()
             })

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -128,7 +128,7 @@ impl FetchResponseListener for StylesheetContext {
                 Some(meta) => meta,
                 None => return,
             };
-            let is_css = metadata.content_type.map_or(false, |ct| {
+            let is_css = metadata.content_type.is_some_and(|ct| {
                 let mime: Mime = ct.into_inner().into();
                 mime.type_() == mime::TEXT && mime.subtype() == mime::CSS
             });
@@ -202,7 +202,7 @@ impl FetchResponseListener for StylesheetContext {
 
             // FIXME: Revisit once consensus is reached at:
             // https://github.com/whatwg/html/issues/1142
-            successful = metadata.status.map_or(false, |(code, _)| code == 200);
+            successful = metadata.status.is_some_and(|(code, _)| code == 200);
         }
 
         let owner = elem

--- a/components/shared/bluetooth/blocklist.rs
+++ b/components/shared/bluetooth/blocklist.rs
@@ -37,7 +37,7 @@ impl BluetoothBlocklist {
     // https://webbluetoothcg.github.io/web-bluetooth/#blocklisted
     pub fn is_blocklisted(&self, uuid: &str) -> bool {
         match self.0 {
-            Some(ref map) => map.get(uuid).map_or(false, |et| et.eq(&Blocklist::All)),
+            Some(ref map) => map.get(uuid).is_some_and(|et| et.eq(&Blocklist::All)),
             None => false,
         }
     }
@@ -45,9 +45,9 @@ impl BluetoothBlocklist {
     // https://webbluetoothcg.github.io/web-bluetooth/#blocklisted-for-reads
     pub fn is_blocklisted_for_reads(&self, uuid: &str) -> bool {
         match self.0 {
-            Some(ref map) => map.get(uuid).map_or(false, |et| {
-                et.eq(&Blocklist::All) || et.eq(&Blocklist::Reads)
-            }),
+            Some(ref map) => map
+                .get(uuid)
+                .is_some_and(|et| et.eq(&Blocklist::All) || et.eq(&Blocklist::Reads)),
             None => false,
         }
     }
@@ -55,9 +55,9 @@ impl BluetoothBlocklist {
     // https://webbluetoothcg.github.io/web-bluetooth/#blocklisted-for-writes
     pub fn is_blocklisted_for_writes(&self, uuid: &str) -> bool {
         match self.0 {
-            Some(ref map) => map.get(uuid).map_or(false, |et| {
-                et.eq(&Blocklist::All) || et.eq(&Blocklist::Writes)
-            }),
+            Some(ref map) => map
+                .get(uuid)
+                .is_some_and(|et| et.eq(&Blocklist::All) || et.eq(&Blocklist::Writes)),
             None => false,
         }
     }


### PR DESCRIPTION
It's a common pattern in the codebase to call [`Option::map_or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map_or) with the default value `false`. Since rust `1.70`, one can use [`Option::is_some_and`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and) instead, which is more readable.

For example:
https://github.com/servo/servo/blob/679afe519591c3c36036154afb1e9b6d73ffa1ac/components/script/dom/request.rs#L654-L656
becomes
```rust
body_stream
    .as_ref()
    .is_some_and(|stream| stream.is_disturbed())
```



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behaviour 

