### PR TITLE
CI: fix self-hosted runner timeout detection

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/self-hosted-runner-timeout.yml
     secrets: inherit
     with:
-      selected-runner-label: ${{ needs.runner-select.outputs.selected-runner-label }}
+      unique-id: ${{ needs.runner-select.outputs.unique-id }}
       is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
 
   build:

--- a/.github/workflows/self-hosted-runner-timeout.yml
+++ b/.github/workflows/self-hosted-runner-timeout.yml
@@ -2,7 +2,7 @@ name: Detect Self-hosted Runner Timeout
 on:
   workflow_call:
     inputs:
-      selected-runner-label:
+      unique-id:
         required: true
         type: string
       is-self-hosted:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
     uses: ./.github/workflows/self-hosted-runner-timeout.yml
     secrets: inherit
     with:
-      selected-runner-label: ${{ needs.runner-select.outputs.selected-runner-label }}
+      unique-id: ${{ needs.runner-select.outputs.unique-id }}
       is-self-hosted: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
 
   build:


### PR DESCRIPTION
#33321 [plumbed](https://github.com/servo/servo/pull/33321/files#diff-21364b2e6fae1f2875cee1ab3daefb0685403687eaf8bc32b5c6eacda351c9d3R82-R83) [in](https://github.com/servo/servo/pull/33321/files#diff-53d5b46b0729b29b726a72bcf1a42b2b96240fd4c014b179a89226fc825a07a1R5-R10) the [wrong](https://github.com/servo/servo/pull/33321/files#diff-53d5b46b0729b29b726a72bcf1a42b2b96240fd4c014b179a89226fc825a07a1R16) [inputs](https://github.com/servo/servo/pull/33321/files#diff-53d5b46b0729b29b726a72bcf1a42b2b96240fd4c014b179a89226fc825a07a1R29) from the runner select job to the runner timeout job, causing a regression where we no longer actually detect any self-hosted runner timeouts. This in turn interacts with servo/ci-runners#8 (now mitigated), causing a job to hang in #33470.

This patch fixes the timeout detection by plumbing in the correct inputs.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially address #33470

<!-- Either: -->
- [x] Self-hosted runner test plan
  - [x] Self-hosted runner case without timeout: timeout job has UUID, does not cancel run
    - <https://github.com/delan/servo/actions/runs/10901721105/job/30252108833#step:3:6>
  - [x] Self-hosted runner case with timeout: timeout job has UUID, cancels run and fails
    - <https://github.com/delan/servo/actions/runs/10901425259/job/30251172417#step:3:6>
  - [x] GitHub-hosted runner case: timeout job skipped
    - <https://github.com/delan/servo/actions/runs/10901463242/job/30251288366>

Timeout scenario staged by making the monitor lie about reserving a runner:

```diff
diff --git a/reserve-runner.sh b/reserve-runner.sh
index 8ac8999..c2bf988 100755
--- a/reserve-runner.sh
+++ b/reserve-runner.sh
@@ -6,6 +6,7 @@ github_runner_id=$1; shift
 unique_id=$1; shift
 reserved_by=$1; shift

+exit
 reserved_since=$(date +\%s)
 gh api "$SERVO_CI_GITHUB_API_SCOPE/actions/runners/$github_runner_id/labels" \
     -f "labels[]=reserved-for:$unique_id" \
```