### PR TITLE
Bump Stylo from 6059306e6 to 25daa6b91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4119,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5912,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -6427,7 +6427,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "static_assertions",
 ]
@@ -6568,7 +6568,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 
 [[package]]
 name = "strck"
@@ -6621,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6679,7 +6679,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "lazy_static",
 ]
@@ -6687,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "darling",
  "derive_common",
@@ -6718,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -7085,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-09-02#6059306e6c2cbd8c76473b545bfbfd2be4062de4"
+source = "git+https://github.com/servo/stylo?branch=2024-09-02#25daa6b91d77ced8498f0a729d311e4292328313"
 dependencies = [
  "darling",
  "derive_common",


### PR DESCRIPTION
https://github.com/servo/stylo/compare/6059306e6c2cbd8c76473b545bfbfd2be4062de4...25daa6b91d77ced8498f0a729d311e4292328313

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's just a dependency upgrade

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
