### PR TITLE
Fix intermittency of child-document-raf-order test

### DIFF
--- a/tests/wpt/tests/html/webappapis/update-rendering/child-document-raf-order.html
+++ b/tests/wpt/tests/html/webappapis/update-rendering/child-document-raf-order.html
@@ -47,6 +47,17 @@ callbacks for each.
 
 <script>
 
+// Split array into chunks of len.
+function chunk (arr, len) {
+  var chunks = [],
+    i = 0,
+    n = arr.length;
+  while (i < n) {
+    chunks.push(arr.slice(i, i += len));
+  }
+  return chunks;
+}
+
 async_test(function (t) {
   step_timeout(setup, 0);
 
@@ -108,9 +119,20 @@ async_test(function (t) {
   });
 
   let finish = t.step_func(function() {
-    assert_array_equals(notification_sequence,
-                        ["parent_raf", "first_child_raf", "second_child_raf"],
-                        "expected order of notifications");
+
+    // The test requests rafs recursively,
+    // but since all three rafs run as part of the same "update the rendering" task,
+    // they should always come in a triplet.
+    assert_equals(notification_sequence.length % 3, 0);
+
+    let chunks = chunk(notification_sequence, 3);
+    for (var i = 0; i < chunks.length; i++) {
+      // Assert correct ordering per triplet of rafs.
+      assert_array_equals(chunks[i],
+                          ["parent_raf", "first_child_raf", "second_child_raf"],
+                          "expected order of notifications");
+    }
+
     t.done();
   });
 });


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fix intermittency of `/html/webappapis/update-rendering/child-document-raf-order.html`, as discussed in https://github.com/web-platform-tests/wpt/issues/48153

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #33028 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
