### PR TITLE
Update CustomEvent webidl interface

### DIFF
--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -11,7 +11,6 @@ use servo_atoms::Atom;
 use crate::dom::bindings::codegen::Bindings::CustomEventBinding;
 use crate::dom::bindings::codegen::Bindings::CustomEventBinding::CustomEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
-use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
@@ -75,8 +74,8 @@ impl CustomEvent {
         can_gc: CanGc,
         type_: DOMString,
         init: RootedTraceableBox<CustomEventBinding::CustomEventInit>,
-    ) -> Fallible<DomRoot<CustomEvent>> {
-        Ok(CustomEvent::new(
+    ) -> DomRoot<CustomEvent> {
+        CustomEvent::new(
             global,
             proto,
             Atom::from(type_),
@@ -84,7 +83,7 @@ impl CustomEvent {
             init.parent.cancelable,
             init.detail.handle(),
             can_gc,
-        ))
+        )
     }
 
     fn init_custom_event(

--- a/components/script/dom/webidls/CustomEvent.webidl
+++ b/components/script/dom/webidls/CustomEvent.webidl
@@ -13,12 +13,19 @@
  * http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
  */
 
-[Exposed=(Window,Worker)]
+// https://dom.spec.whatwg.org/#dom-customevent-initcustomevent
+[Exposed=*]
 interface CustomEvent : Event {
-  [Throws] constructor(DOMString type, optional CustomEventInit eventInitDict = {});
+  constructor(DOMString type, optional CustomEventInit eventInitDict = {});
+
   readonly attribute any detail;
 
-  undefined initCustomEvent(DOMString type, boolean bubbles, boolean cancelable, any detail);
+  undefined initCustomEvent(
+    DOMString type,
+    optional boolean bubbles = false,
+    optional boolean cancelable = false,
+    optional any detail = null
+  ); // legacy
 };
 
 dictionary CustomEventInit : EventInit {

--- a/components/script/dom/webidls/Event.webidl
+++ b/components/script/dom/webidls/Event.webidl
@@ -6,7 +6,7 @@
  * https://dom.spec.whatwg.org/#event
  */
 
-[Exposed=(Window,Worker)]
+[Exposed=*]
 interface Event {
   [Throws] constructor(DOMString type, optional EventInit eventInitDict = {});
   [Pure]

--- a/tests/wpt/meta/dom/events/CustomEvent.html.ini
+++ b/tests/wpt/meta/dom/events/CustomEvent.html.ini
@@ -1,3 +1,0 @@
-[CustomEvent.html]
-  [initCustomEvent's default parameter values.]
-    expected: FAIL

--- a/tests/wpt/meta/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/dom/idlharness.any.js.ini
@@ -11,9 +11,6 @@
   [Event interface: new Event("foo") must inherit property "composed" with the proper type]
     expected: FAIL
 
-  [CustomEvent interface: operation initCustomEvent(DOMString, optional boolean, optional boolean, optional any)]
-    expected: FAIL
-
   [Event interface: new CustomEvent("foo") must inherit property "composed" with the proper type]
     expected: FAIL
 

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -169,9 +169,6 @@
   [XPathExpression interface: existence and properties of interface prototype object]
     expected: FAIL
 
-  [CustomEvent interface: operation initCustomEvent(DOMString, optional boolean, optional boolean, optional any)]
-    expected: FAIL
-
   [XPathResult interface: constant ORDERED_NODE_ITERATOR_TYPE on interface object]
     expected: FAIL
 


### PR DESCRIPTION
The [idl interface](https://dom.spec.whatwg.org/#interface-customevent) and servo's implementation had diverged.

* Extra arguments to initCustomEvent are now optional (fixes WPT `dom/events/CustomEvent.html`)
* The CustomEvent constructor is infallible
* `[Exposed=*]` (and the same for the "Event" interface since it's CustomEvent's parent.)

<!-- Please describe your changes on the following line: -->

[try run](https://github.com/Wuelle/servo/actions/runs/10900636123)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes (wpt)


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
