### PR TITLE
Add `rust-version` to all `Cargo.toml` files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 edition = "2021"
 publish = false
+rust-version = "1.80.1"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.0"

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "background_hang_monitor"

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "bluetooth"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "canvas"

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "compositing"

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servo_config"

--- a/components/config_plugins/Cargo.toml
+++ b/components/config_plugins/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servo_config_plugins"

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "constellation"

--- a/components/deny_public_fields/Cargo.toml
+++ b/components/deny_public_fields/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "devtools"

--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 quote = { workspace = true }

--- a/components/domobject_derive/Cargo.toml
+++ b/components/domobject_derive/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "fonts"

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servo_geometry"

--- a/components/jstraceable_derive/Cargo.toml
+++ b/components/jstraceable_derive/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "layout_2013"

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "layout_2020"

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "layout_thread_2013"

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "layout_thread_2020"

--- a/components/media/Cargo.toml
+++ b/components/media/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "media"

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "metrics"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 autotests = false # Inhibit lookup for tests/*.rs without [[test]] sections
 
 [lib]

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "pixels"

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "profile"

--- a/components/rand/Cargo.toml
+++ b/components/rand/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servo_rand"

--- a/components/range/Cargo.toml
+++ b/components/range/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "range"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "script"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servo"

--- a/components/shared/background_hang_monitor/Cargo.toml
+++ b/components/shared/background_hang_monitor/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "background_hang_monitor_api"

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "base"

--- a/components/shared/bluetooth/Cargo.toml
+++ b/components/shared/bluetooth/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "bluetooth_traits"

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "canvas_traits"

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "compositing_traits"

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "devtools_traits"

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "embedder_traits"

--- a/components/shared/fonts/Cargo.toml
+++ b/components/shared/fonts/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "fonts_traits"

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "net_traits"

--- a/components/shared/profile/Cargo.toml
+++ b/components/shared/profile/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "profile_traits"

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "script_traits"

--- a/components/shared/script_layout/Cargo.toml
+++ b/components/shared/script_layout/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "script_layout_interface"

--- a/components/shared/webrender/Cargo.toml
+++ b/components/shared/webrender/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "webrender_traits"

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servo_url"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "webdriver_server"

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "webgpu"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "servoshell"

--- a/support/rust-task_info/Cargo.toml
+++ b/support/rust-task_info/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 build = "build.rs"
 
 [build-dependencies]

--- a/tests/unit/deny_public_fields/Cargo.toml
+++ b/tests/unit/deny_public_fields/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/tests/unit/malloc_size_of/Cargo.toml
+++ b/tests/unit/malloc_size_of/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/tests/unit/metrics/Cargo.toml
+++ b/tests/unit/metrics/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "metrics_tests"

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "profile_tests"

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "script_tests"

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "style_tests"
-version = "0.0.1"
-authors = ["The Servo Project Developers"]
-license = "MPL-2.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "style_tests"


### PR DESCRIPTION
This is another step preparing for building Servo without `mach`.

Fixes #33430.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they don't change any observable behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
