### PR TITLE
crypto: Add checks for BigInt/BigUint in getRandomValues

### DIFF
--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -83,6 +83,8 @@ fn is_integer_buffer(array_type: Type) -> bool {
             Type::Uint16 |
             Type::Int16 |
             Type::Uint32 |
-            Type::Int32
+            Type::Int32 |
+            Type::BigInt64 |
+            Type::BigUint64
     )
 }

--- a/tests/wpt/meta/WebCryptoAPI/getRandomValues.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/getRandomValues.any.js.ini
@@ -1,56 +1,7 @@
 [getRandomValues.any.worker.html]
-  [Integer array: BigInt64Array]
-    expected: FAIL
-
-  [Large length: BigInt64Array]
-    expected: FAIL
-
-  [Null arrays: BigInt64Array]
-    expected: FAIL
-
-  [Integer array: BigUint64Array]
-    expected: FAIL
-
-  [Large length: BigUint64Array]
-    expected: FAIL
-
-  [Null arrays: BigUint64Array]
-    expected: FAIL
-
   [Float16 arrays]
     expected: FAIL
-
-  [Subclass of BigInt64Array]
-    expected: FAIL
-
-  [Subclass of BigUint64Array]
-    expected: FAIL
-
 
 [getRandomValues.any.html]
-  [Integer array: BigInt64Array]
-    expected: FAIL
-
-  [Large length: BigInt64Array]
-    expected: FAIL
-
-  [Null arrays: BigInt64Array]
-    expected: FAIL
-
-  [Integer array: BigUint64Array]
-    expected: FAIL
-
-  [Large length: BigUint64Array]
-    expected: FAIL
-
-  [Null arrays: BigUint64Array]
-    expected: FAIL
-
   [Float16 arrays]
-    expected: FAIL
-
-  [Subclass of BigInt64Array]
-    expected: FAIL
-
-  [Subclass of BigUint64Array]
     expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`Crypto.getRandomValues()` was missing checks for BigInt64 and BigUint64. The only failing subtest now is for Float16Arrays, which I don't believe are exposed from mozjs currently.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
