### PR TITLE
android/ohos: Fix wrong production cfg

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -131,6 +131,3 @@ sig = "1.0"
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
 libservo = { path = "../../components/servo", features = ["no-wgl"] }
-
-[lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(production)'] }

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -122,7 +122,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
 
     // We only redirect stdout and stderr for non-production builds, since it is
     // only used for debugging purposes. This saves us one thread in production.
-    #[cfg(not(production))]
+    #[cfg(not(servo_production))]
     if let Err(e) = super::log::redirect_stdout_and_stderr() {
         error!("Failed to redirect stdout and stderr to logcat due to: {e:?}");
     }

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -342,7 +342,7 @@ fn initialize_logging_once() {
 
         // We only redirect stdout and stderr for non-production builds, since it is
         // only used for debugging purposes. This saves us one thread in production.
-        #[cfg(not(production))]
+        #[cfg(not(servo_production))]
         if let Err(e) = super::log::redirect_stdout_and_stderr() {
             error!("Failed to redirect stdout and stderr to hilog due to: {e:?}");
         }


### PR DESCRIPTION
Our build script sets `servo_production` and not `production`.
See https://github.com/servo/servo/blob/632d83270498f6cb2e9d284503d86607f250b80e/ports/servoshell/build.rs#L39


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

