### PR TITLE
fetch: add Accept-Encoding header when the Range header exists

### DIFF
--- a/tests/wpt/meta-legacy-layout/fetch/range/general.any.js.ini
+++ b/tests/wpt/meta-legacy-layout/fetch/range/general.any.js.ini
@@ -5,9 +5,6 @@
   [general]
     expected: FAIL
 
-  [Fetch with range header will be sent with Accept-Encoding: identity]
-    expected: FAIL
-
   [Cross Origin Fetch with safe range header]
     expected: FAIL
 
@@ -17,9 +14,6 @@
     expected: FAIL
 
   [general]
-    expected: FAIL
-
-  [Fetch with range header will be sent with Accept-Encoding: identity]
     expected: FAIL
 
   [Cross Origin Fetch with safe range header]

--- a/tests/wpt/meta-legacy-layout/fetch/range/general.window.js.ini
+++ b/tests/wpt/meta-legacy-layout/fetch/range/general.window.js.ini
@@ -4,6 +4,3 @@
 
   [general]
     expected: FAIL
-
-  [Fetch with range header will be sent with Accept-Encoding: identity]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/range/general.any.js.ini
+++ b/tests/wpt/meta/fetch/range/general.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [general.any.html]
-  [Fetch with range header will be sent with Accept-Encoding: identity]
-    expected: FAIL
-
   [Cross Origin Fetch with safe range header]
     expected: FAIL
 
@@ -13,8 +10,5 @@
   expected: ERROR
 
 [general.any.worker.html]
-  [Fetch with range header will be sent with Accept-Encoding: identity]
-    expected: FAIL
-
   [Cross Origin Fetch with safe range header]
     expected: FAIL

--- a/tests/wpt/meta/fetch/range/general.window.js.ini
+++ b/tests/wpt/meta/fetch/range/general.window.js.ini
@@ -1,3 +1,0 @@
-[general.window.html]
-  [Fetch with range header will be sent with Accept-Encoding: identity]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implements step 8.19 of the fetch spec for https://fetch.spec.whatwg.org/#http-network-or-cache-fetch.

Also some tidying of surrounding documentation an numbering fixes.

WPT results in my fork: https://github.com/shanehandley/servo/actions/runs/10937450208

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
