### PR TITLE
use rerun-if-changed in script/build.rs

### DIFF
--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -23,7 +23,7 @@ fn main() {
     println!("cargo::rerun-if-changed=dom/bindings/codegen");
     println!("cargo::rerun-if-changed={}", css_properties_json.display());
     println!("cargo::rerun-if-changed=../../third_party/WebIDL/WebIDL.py");
-    // we assume no changes in third_party/ply
+    // NB: We aren't handling changes in `third_party/ply` here.
 
     let status = Command::new(find_python())
         .arg("dom/bindings/codegen/run.py")

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -16,11 +16,17 @@ fn main() {
     let start = Instant::now();
 
     let style_out_dir = PathBuf::from(env::var_os("DEP_SERVO_STYLE_CRATE_OUT_DIR").unwrap());
+    let css_properties_json = style_out_dir.join("css-properties.json");
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    println!("cargo::rerun-if-changed=dom/webidls");
+    println!("cargo::rerun-if-changed=dom/bindings/codegen");
+    println!("cargo::rerun-if-changed={}", css_properties_json.display());
+    // FIXME: rerun-if-changed third_party/{ply, WebIDL}
 
     let status = Command::new(find_python())
         .arg("dom/bindings/codegen/run.py")
-        .arg(style_out_dir.join("css-properties.json"))
+        .arg(&css_properties_json)
         .arg(&out_dir)
         .status()
         .unwrap();

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -22,7 +22,8 @@ fn main() {
     println!("cargo::rerun-if-changed=dom/webidls");
     println!("cargo::rerun-if-changed=dom/bindings/codegen");
     println!("cargo::rerun-if-changed={}", css_properties_json.display());
-    // FIXME: rerun-if-changed third_party/{ply, WebIDL}
+    println!("cargo::rerun-if-changed=../../third_party/WebIDL/WebIDL.py");
+    // we assume no changes in third_party/ply
 
     let status = Command::new(find_python())
         .arg("dom/bindings/codegen/run.py")


### PR DESCRIPTION
Per https://github.com/servo/servo/pull/33416#issuecomment-2363118154 I think we can avoid some reruns of script/build.rs by specifying `rerun-if-changed` for appropriate files (if not specified all crate files are checked).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are about rebuilding

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
