### PR TITLE
webgpu: Support more `TextureFormat`s in `GPUCanvasContext.configure()`

### DIFF
--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -201,26 +201,26 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure>
-    fn Configure(&self, descriptor: &GPUCanvasConfiguration) -> Fallible<()> {
+    fn Configure(&self, configuration: &GPUCanvasConfiguration) -> Fallible<()> {
         // Step 1 is let
         // Step 2
-        descriptor
+        configuration
             .device
-            .validate_texture_format_required_features(&descriptor.format)?;
-        let format = match descriptor.format {
+            .validate_texture_format_required_features(&configuration.format)?;
+        let format = match configuration.format {
             GPUTextureFormat::Rgba8unorm | GPUTextureFormat::Rgba8unorm_srgb => ImageFormat::RGBA8,
             GPUTextureFormat::Bgra8unorm | GPUTextureFormat::Bgra8unorm_srgb => ImageFormat::BGRA8,
             _ => {
                 return Err(Error::Type(format!(
                     "SwapChain format({:?}) not supported",
-                    descriptor.format
+                    configuration.format
                 )))
             },
         };
 
         // Step 3
-        for view_format in &descriptor.viewFormats {
-            descriptor
+        for view_format in &configuration.viewFormats {
+            configuration
                 .device
                 .validate_texture_format_required_features(view_format)?;
         }
@@ -228,16 +228,17 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         // Step 4
         let size = self.size();
         let text_desc = GPUTextureDescriptor {
-            format: descriptor.format,
+            format: configuration.format,
             mipLevelCount: 1,
             sampleCount: 1,
-            usage: descriptor.usage | GPUTextureUsageConstants::COPY_SRC, // TODO: specs
+            // We need to add `COPY_SRC` so we can copy texture to presentation buffer
+            usage: configuration.usage | GPUTextureUsageConstants::COPY_SRC,
             size: GPUExtent3D::GPUExtent3DDict(GPUExtent3DDict {
                 width: size.width as u32,
                 height: size.height as u32,
                 depthOrArrayLayers: 1,
             }),
-            viewFormats: descriptor.viewFormats.clone(),
+            viewFormats: configuration.viewFormats.clone(),
             // other members to default
             parent: GPUObjectDescriptorBase {
                 label: USVString::default(),
@@ -253,15 +254,15 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
             buffer_ids.push(
                 self.global()
                     .wgpu_id_hub()
-                    .create_buffer_id(descriptor.device.id().0.backend()),
+                    .create_buffer_id(configuration.device.id().0.backend()),
             );
         }
 
         self.channel
             .0
             .send(WebGPURequest::CreateSwapChain {
-                device_id: descriptor.device.id().0,
-                queue_id: descriptor.device.GetQueue().id().0,
+                device_id: configuration.device.id().0,
+                queue_id: configuration.device.GetQueue().id().0,
                 buffer_ids,
                 context_id: self.context_id,
                 sender,
@@ -270,8 +271,9 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
             })
             .expect("Failed to create WebGPU SwapChain");
 
-        self.texture
-            .set(Some(&descriptor.device.CreateTexture(&text_desc).unwrap()));
+        self.texture.set(Some(
+            &configuration.device.CreateTexture(&text_desc).unwrap(),
+        ));
 
         self.webrender_image.set(Some(receiver.recv().unwrap()));
         Ok(())

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -207,9 +207,16 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         configuration
             .device
             .validate_texture_format_required_features(&configuration.format)?;
+        // Mapping between wr and wgpu can be determined by inspecting
+        // https://github.com/gfx-rs/wgpu/blob/9b36a3e129da04b018257564d5129caff240cb75/wgpu-hal/src/gles/conv.rs#L10
+        // https://github.com/servo/webrender/blob/1e73f384a7a86e413f91e9e430436a9bd83381cd/webrender/src/device/gl.rs#L4064
         let format = match configuration.format {
-            GPUTextureFormat::Rgba8unorm | GPUTextureFormat::Rgba8unorm_srgb => ImageFormat::RGBA8,
+            GPUTextureFormat::R8unorm => ImageFormat::R8,
             GPUTextureFormat::Bgra8unorm | GPUTextureFormat::Bgra8unorm_srgb => ImageFormat::BGRA8,
+            GPUTextureFormat::Rgba8unorm | GPUTextureFormat::Rgba8unorm_srgb => ImageFormat::RGBA8,
+            GPUTextureFormat::Rgba32float => ImageFormat::RGBAF32,
+            GPUTextureFormat::Rgba32sint => ImageFormat::RGBAI32,
+            GPUTextureFormat::Rg8unorm => ImageFormat::RG8,
             _ => {
                 return Err(Error::Type(format!(
                     "SwapChain format({:?}) not supported",


### PR DESCRIPTION
We can present all textures formats that webrender supports.

Mappings were determined by checking how wr/wgpu formats maps to gl
https://github.com/gfx-rs/wgpu/blob/9b36a3e129da04b018257564d5129caff240cb75/wgpu-hal/src/gles/conv.rs#L10
https://github.com/servo/webrender/blob/1e73f384a7a86e413f91e9e430436a9bd83381cd/webrender/src/device/gl.rs#L4064


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
