### PR TITLE
ohos: Support product flavors

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -59,7 +59,7 @@ class MachCommands(CommandBase):
                      help="Command-line arguments to be passed through to Cargo")
     @CommandBase.common_command_arguments(build_configuration=True, build_type=True)
     def build(self, build_type: BuildType, jobs=None, params=None, no_package=False,
-              verbose=False, very_verbose=False, with_asan=False, **kwargs):
+              verbose=False, very_verbose=False, with_asan=False, flavor=None, **kwargs):
         opts = params or []
 
         if build_type.is_release():
@@ -134,7 +134,7 @@ class MachCommands(CommandBase):
             built_binary = self.get_binary_path(build_type, asan=with_asan)
 
             if not no_package and self.target.needs_packaging():
-                rv = Registrar.dispatch("package", context=self.context, build_type=build_type, flavor=None)
+                rv = Registrar.dispatch("package", context=self.context, build_type=build_type, flavor=flavor)
                 if rv:
                     return rv
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -531,7 +531,11 @@ class CommandBase(object):
                                 help='Build in release mode without debug assertions'),
                 CommandArgument('--profile', group="Build Type",
                                 help='Build with custom Cargo profile'),
-                CommandArgument('--with-asan', action='store_true', help="Build with AddressSanitizer")
+                CommandArgument('--with-asan', action='store_true', help="Build with AddressSanitizer"),
+                CommandArgument(
+                    '--flavor', default=None,
+                    help='Product flavor to be used when packaging with Gradle/Hvigor (android/ohos).'
+                ),
             ]
 
         if build_configuration:
@@ -612,6 +616,7 @@ class CommandBase(object):
                     kwargs.pop('dev', None)
                     kwargs.pop('prod', None)
                     kwargs.pop('profile', None)
+                    self.flavor = kwargs.get('flavor', None)
 
                 if build_configuration:
                     self.configure_build_target(kwargs)

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -533,7 +533,7 @@ class CommandBase(object):
                                 help='Build with custom Cargo profile'),
                 CommandArgument('--with-asan', action='store_true', help="Build with AddressSanitizer"),
                 CommandArgument(
-                    '--flavor', default=None,
+                    '--flavor', default=None, group="Build Type",
                     help='Product flavor to be used when packaging with Gradle/Hvigor (android/ohos).'
                 ),
             ]
@@ -616,7 +616,6 @@ class CommandBase(object):
                     kwargs.pop('dev', None)
                     kwargs.pop('prod', None)
                     kwargs.pop('profile', None)
-                    self.flavor = kwargs.get('flavor', None)
 
                 if build_configuration:
                     self.configure_build_target(kwargs)

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -382,11 +382,13 @@ class OpenHarmonyTarget(CrossBuildTarget):
     def needs_packaging(self) -> bool:
         return True
 
-    def get_package_path(self, build_type_directory: str) -> str:
+    def get_package_path(self, build_type_directory: str, flavor: Optional[str] = None) -> str:
         base_path = util.get_target_dir()
         base_path = path.join(base_path, "openharmony", self.triple())
         hap_name = "servoshell-default-signed.hap"
-        build_output_path = path.join("entry", "build", "default", "outputs", "default")
+        if not flavor:
+            flavor = "default"
+        build_output_path = path.join("entry", "build", flavor, "outputs", "default")
         return path.join(base_path, build_type_directory, build_output_path, hap_name)
 
     def abi_string(self) -> str:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -806,7 +806,7 @@ tests/wpt/mozilla/tests for Servo-only tests""" % reference_path)
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Servo")
     @CommandBase.common_command_arguments(binary_selection=True)
-    def smoketest(self, servo_binary: str, params):
+    def smoketest(self, servo_binary: str, params, **kwargs):
         # We pass `-f` here so that any thread panic will cause Servo to exit,
         # preventing a panic from hanging execution. This means that these kind
         # of panics won't cause timeouts on CI.

--- a/support/openharmony/build-profile.json5
+++ b/support/openharmony/build-profile.json5
@@ -11,7 +11,7 @@
       },
       {
         "name": "harmonyos",
-        "signingConfig": "default",
+        "signingConfig": "hos",
         "compatibleSdkVersion": "4.1.0(11)",
         "targetSdkVersion": "4.1.0(11)",
         "runtimeOS": "HarmonyOS"


### PR DESCRIPTION
Support different product flavors (e.g. with different signing configurations) by supporting --flavor on ohos.
The flavor influences the package path for OH packages, so allow the flavor parameter on build + package + install.
This allows using mach to build for HarmonyOS by passing `--flavor=harmonyos` to build / package / install.


---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix packaging and installing for HarmonyOS 

