### PR TITLE
webgpu: reuse ImageKey in GPUCanvasContext

### DIFF
--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -103,7 +103,7 @@ pub enum WebGPURequest {
         /// present only on ASYNC versions
         async_sender: Option<IpcSender<WebGPUResponse>>,
     },
-    CreateContext(IpcSender<WebGPUContextId>),
+    CreateContext(IpcSender<(WebGPUContextId, ImageKey)>),
     CreatePipelineLayout {
         device_id: id::DeviceId,
         pipeline_layout_id: id::PipelineLayoutId,
@@ -134,7 +134,7 @@ pub enum WebGPURequest {
         queue_id: id::QueueId,
         buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
         context_id: WebGPUContextId,
-        sender: IpcSender<ImageKey>,
+        image_key: ImageKey,
         format: ImageFormat,
         size: DeviceIntSize,
     },

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::ops::ControlFlow;
 use std::ptr::NonNull;
 use std::slice;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 use arrayvec::ArrayVec;
 use euclid::default::Size2D;
@@ -234,7 +234,6 @@ impl crate::WGPU {
         format: ImageFormat,
         size: DeviceIntSize,
         image_key: ImageKey,
-        mut wr: MutexGuard<RenderApi>,
     ) {
         let image_desc = ImageDescriptor {
             format,
@@ -265,7 +264,10 @@ impl crate::WGPU {
 
         let mut txn = Transaction::new();
         txn.add_image(image_key, image_desc, image_data, None);
-        wr.send_transaction(self.webrender_document, txn);
+        self.webrender_api
+            .lock()
+            .unwrap()
+            .send_transaction(self.webrender_document, txn);
     }
 
     /// Copies data async from provided texture using encoder_id to available staging presentation buffer


### PR DESCRIPTION
Before we requested new ImageKey on each `configure()` call, but if we request it together with `ExtrnalImageId` on creation of `GPUCanvasContext` we do not need to `recv()` in configure anymore.

Similar was also done for WebGL in https://github.com/servo/servo/pull/18332

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
