### PR TITLE
Bump mozjs to 128.0-xx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#d90edd169aae1e16c1ef8b7bd4b2e0d93dda8ba2"
+source = "git+https://github.com/jschwe/mozjs?branch=jschwender/reconfigure#8605a56ae7b28f144d05324927dbba2052058aa6"
 dependencies = [
  "bindgen",
  "cc",
@@ -4396,8 +4396,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.0-9"
-source = "git+https://github.com/servo/mozjs#d90edd169aae1e16c1ef8b7bd4b2e0d93dda8ba2"
+version = "0.128.0-10"
+source = "git+https://github.com/jschwe/mozjs?branch=jschwender/reconfigure#8605a56ae7b28f144d05324927dbba2052058aa6"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -63,7 +63,7 @@ image = { workspace = true }
 indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 itertools = { workspace = true }
-js = { package = "mozjs", git = "https://github.com/servo/mozjs", features = ["streams"] }
+js = { package = "mozjs", git = "https://github.com/jschwe/mozjs", features = ["streams"], branch = "jschwender/reconfigure" }
 jstraceable_derive = { path = "../jstraceable_derive" }
 keyboard-types = { workspace = true }
 libc = { workspace = true }


### PR DESCRIPTION
Companion PR to https://github.com/servo/mozjs/pull/506 (Reconfigure mozjs if configure inputs changed)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix building servo/mozjs when changing inputs such as the compiler.

