### PR TITLE
Add `HTMLCanvasDataSource::Empty` that represent transparent black instead of `HTMLCanvasDataSource::Image(None)`

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -1944,20 +1944,18 @@ impl Fragment {
                 let image_key = match canvas_fragment_info.source {
                     CanvasFragmentSource::WebGL(image_key) => image_key,
                     CanvasFragmentSource::WebGPU(image_key) => image_key,
-                    CanvasFragmentSource::Image(ref ipc_renderer) => match *ipc_renderer {
-                        Some(ref ipc_renderer) => {
-                            let ipc_renderer = ipc_renderer.lock().unwrap();
-                            let (sender, receiver) = ipc::channel().unwrap();
-                            ipc_renderer
-                                .send(CanvasMsg::FromLayout(
-                                    FromLayoutMsg::SendData(sender),
-                                    canvas_fragment_info.canvas_id,
-                                ))
-                                .unwrap();
-                            receiver.recv().unwrap().image_key
-                        },
-                        None => return,
+                    CanvasFragmentSource::Image(ref ipc_renderer) => {
+                        let ipc_renderer = ipc_renderer.lock().unwrap();
+                        let (sender, receiver) = ipc::channel().unwrap();
+                        ipc_renderer
+                            .send(CanvasMsg::FromLayout(
+                                FromLayoutMsg::SendData(sender),
+                                canvas_fragment_info.canvas_id,
+                            ))
+                            .unwrap();
+                        receiver.recv().unwrap().image_key
                     },
+                    CanvasFragmentSource::Empty => return,
                 };
 
                 let base = create_base_display_item(state);

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -353,8 +353,10 @@ impl InlineAbsoluteFragmentInfo {
 #[derive(Clone)]
 pub enum CanvasFragmentSource {
     WebGL(ImageKey),
-    Image(Option<Arc<Mutex<IpcSender<CanvasMsg>>>>),
+    Image(Arc<Mutex<IpcSender<CanvasMsg>>>),
     WebGPU(ImageKey),
+    /// Transparent black
+    Empty,
 }
 
 #[derive(Clone)]
@@ -369,10 +371,11 @@ impl CanvasFragmentInfo {
     pub fn new(data: HTMLCanvasData) -> CanvasFragmentInfo {
         let source = match data.source {
             HTMLCanvasDataSource::WebGL(texture_id) => CanvasFragmentSource::WebGL(texture_id),
-            HTMLCanvasDataSource::Image(ipc_sender) => CanvasFragmentSource::Image(
-                ipc_sender.map(|renderer| Arc::new(Mutex::new(renderer))),
-            ),
+            HTMLCanvasDataSource::Image(ipc_sender) => {
+                CanvasFragmentSource::Image(Arc::new(Mutex::new(ipc_sender)))
+            },
             HTMLCanvasDataSource::WebGPU(image_key) => CanvasFragmentSource::WebGPU(image_key),
+            HTMLCanvasDataSource::Empty => CanvasFragmentSource::Empty,
         };
 
         CanvasFragmentInfo {

--- a/components/layout_2020/dom.rs
+++ b/components/layout_2020/dom.rs
@@ -149,9 +149,10 @@ where
         let source = match canvas_data.source {
             HTMLCanvasDataSource::WebGL(texture_id) => CanvasSource::WebGL(texture_id),
             HTMLCanvasDataSource::Image(ipc_sender) => {
-                CanvasSource::Image(ipc_sender.map(|renderer| Arc::new(Mutex::new(renderer))))
+                CanvasSource::Image(Arc::new(Mutex::new(ipc_sender)))
             },
             HTMLCanvasDataSource::WebGPU(image_key) => CanvasSource::WebGPU(image_key),
+            HTMLCanvasDataSource::Empty => CanvasSource::Empty,
         };
         Some((
             CanvasInfo {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -137,12 +137,12 @@ impl LayoutHTMLCanvasElementHelpers for LayoutDom<'_, HTMLCanvasElement> {
         let source = unsafe {
             match self.unsafe_get().context.borrow_for_layout().as_ref() {
                 Some(CanvasContext::Context2d(context)) => {
-                    HTMLCanvasDataSource::Image(Some(context.to_layout().get_ipc_renderer()))
+                    HTMLCanvasDataSource::Image(context.to_layout().get_ipc_renderer())
                 },
                 Some(CanvasContext::WebGL(context)) => context.to_layout().canvas_data_source(),
                 Some(CanvasContext::WebGL2(context)) => context.to_layout().canvas_data_source(),
                 Some(CanvasContext::WebGPU(context)) => context.to_layout().canvas_data_source(),
-                None => HTMLCanvasDataSource::Image(None),
+                None => HTMLCanvasDataSource::Empty,
             }
         };
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -665,7 +665,7 @@ impl WebGLRenderingContext {
                     HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
                         document_from_node(&**canvas)
                     },
-                    HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(ref canvas) => {
+                    HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(ref _canvas) => {
                         // TODO: Support retrieving image pixels here for OffscreenCanvas
                         return Ok(None);
                     },

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -116,8 +116,10 @@ pub enum LayoutElementType {
 
 pub enum HTMLCanvasDataSource {
     WebGL(ImageKey),
-    Image(Option<IpcSender<CanvasMsg>>),
+    Image(IpcSender<CanvasMsg>),
     WebGPU(ImageKey),
+    /// transparent black
+    Empty,
 }
 
 pub struct HTMLCanvasData {


### PR DESCRIPTION
I think this makes more sense than encoding it in Image variant, especially because I plan to use it in gpucanvascontext when it's not configured.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are just refactors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
