### PR TITLE
webgpu: renovate gpucanvascontext and webgpu presentation to match the spec

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2951,7 +2951,7 @@ impl Document {
         self.dirty_webgpu_contexts
             .borrow_mut()
             .drain()
-            .for_each(|(_, context)| context.send_swap_chain_present());
+            .for_each(|(_, context)| context.update_rendering_of_webgpu_canvas());
     }
 
     pub fn id_map(&self) -> Ref<HashMapTracedValues<Atom, Vec<Dom<Element>>>> {

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -301,6 +301,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         self.replace_drawing_buffer();
 
         // Step 8
+        // Validate texture descriptor and create swapchain
         let mut buffer_ids = ArrayVec::<id::BufferId, PRESENTATION_BUFFER_COUNT>::new();
         for _ in 0..PRESENTATION_BUFFER_COUNT {
             buffer_ids.push(self.global().wgpu_id_hub().create_buffer_id());
@@ -331,7 +332,6 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         if configuration.is_some() {
             if let Err(e) = self.channel.0.send(WebGPURequest::DestroySwapChain {
                 context_id: self.context_id,
-                image_key: self.webrender_image,
             }) {
                 warn!(
                     "Failed to send DestroySwapChain-ImageKey({:?}) ({})",

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -160,6 +160,7 @@ impl GPUCanvasContext {
         GPUTextureDescriptor {
             format: configuration.format,
             // We need to add `COPY_SRC` so we can copy texture to presentation buffer
+            // causes FAIL on webgpu:web_platform,canvas,configure:usage:*
             usage: configuration.usage | GPUTextureUsageConstants::COPY_SRC,
             size: GPUExtent3D::GPUExtent3DDict(GPUExtent3DDict {
                 width: size.width as u32,

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::{Cell, RefCell};
+
 use arrayvec::ArrayVec;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
@@ -10,7 +12,7 @@ use script_layout_interface::HTMLCanvasDataSource;
 use webgpu::swapchain::WebGPUContextId;
 use webgpu::wgc::id;
 use webgpu::{WebGPU, WebGPURequest, WebGPUTexture, PRESENTATION_BUFFER_COUNT};
-use webrender_api::{units, ImageFormat, ImageKey};
+use webrender_api::{ImageFormat, ImageKey};
 
 use super::bindings::codegen::Bindings::WebGPUBinding::GPUTextureUsageConstants;
 use super::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
@@ -19,6 +21,7 @@ use super::bindings::root::MutNullableDom;
 use super::bindings::str::USVString;
 use super::gputexture::GPUTexture;
 use crate::dom::bindings::codegen::Bindings::HTMLCanvasElementBinding::HTMLCanvasElement_Binding::HTMLCanvasElementMethods;
+use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTexture_Binding::GPUTextureMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUCanvasConfiguration, GPUCanvasContextMethods, GPUDeviceMethods, GPUExtent3D,
     GPUExtent3DDict, GPUObjectDescriptorBase, GPUTextureDescriptor, GPUTextureDimension,
@@ -85,6 +88,12 @@ impl malloc_size_of::MallocSizeOf for HTMLCanvasElementOrOffscreenCanvas {
     }
 }
 
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf)]
+enum DrawingBuffer {
+    TransparentAlpha,
+    Wr,
+}
+
 #[dom_struct]
 pub struct GPUCanvasContext {
     reflector_: Reflector,
@@ -99,8 +108,15 @@ pub struct GPUCanvasContext {
     webrender_image: ImageKey,
     #[no_trace]
     context_id: WebGPUContextId,
+    #[ignore_malloc_size_of = "manual writing is hard"]
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configuration-slot>
+    configuration: RefCell<Option<GPUCanvasConfiguration>>,
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-texturedescriptor-slot>
+    texture_descriptor: RefCell<Option<GPUTextureDescriptor>>,
+    /// Conceptually <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-drawingbuffer-slot>
+    drawing_buffer: Cell<DrawingBuffer>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-currenttexture-slot>
-    texture: MutNullableDom<GPUTexture>,
+    current_texture: MutNullableDom<GPUTexture>,
 }
 
 impl GPUCanvasContext {
@@ -116,7 +132,10 @@ impl GPUCanvasContext {
             canvas,
             webrender_image,
             context_id: WebGPUContextId(external_id.0),
-            texture: MutNullableDom::default(),
+            drawing_buffer: Cell::new(DrawingBuffer::TransparentAlpha),
+            configuration: RefCell::new(None),
+            texture_descriptor: RefCell::new(None),
+            current_texture: MutNullableDom::default(),
         }
     }
 
@@ -131,17 +150,73 @@ impl GPUCanvasContext {
     }
 }
 
+// Abstract ops from spec
 impl GPUCanvasContext {
-    fn layout_handle(&self) -> HTMLCanvasDataSource {
-        HTMLCanvasDataSource::WebGPU(self.webrender_image)
+    /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-gputexturedescriptor-for-the-canvas-and-configuration>
+    fn texture_descriptor_for_canvas(
+        &self,
+        configuration: &GPUCanvasConfiguration,
+    ) -> GPUTextureDescriptor {
+        let size = self.size();
+        GPUTextureDescriptor {
+            format: configuration.format,
+            // We need to add `COPY_SRC` so we can copy texture to presentation buffer
+            usage: configuration.usage | GPUTextureUsageConstants::COPY_SRC,
+            size: GPUExtent3D::GPUExtent3DDict(GPUExtent3DDict {
+                width: size.width as u32,
+                height: size.height as u32,
+                depthOrArrayLayers: 1,
+            }),
+            viewFormats: configuration.viewFormats.clone(),
+            // other members to default
+            mipLevelCount: 1,
+            sampleCount: 1,
+            parent: GPUObjectDescriptorBase {
+                label: USVString::default(),
+            },
+            dimension: GPUTextureDimension::_2d,
+        }
     }
 
-    pub fn send_swap_chain_present(&self) {
-        let texture_id = self.texture_id().unwrap().0;
+    /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-expire-the-current-texture>
+    fn expire_current_texture(&self) {
+        if let Some(current_texture) = self.current_texture.take() {
+            // Make copy of texture content
+            self.send_swap_chain_present(current_texture.id());
+            // Step 1
+            current_texture.Destroy()
+        }
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-replace-the-drawing-buffer>
+    fn replace_drawing_buffer(&self) {
+        // Step 1
+        self.expire_current_texture();
+        // Step 2
+        //let configuration = self.configuration.borrow();
+        // Step 3
+        self.drawing_buffer.set(DrawingBuffer::TransparentAlpha);
+        // TODO: Configuration on drawing buffer
+        // here we should recreate swapchain
+        // expire does needless copy???
+    }
+}
+
+// Internal helper methods
+impl GPUCanvasContext {
+    fn layout_handle(&self) -> HTMLCanvasDataSource {
+        match self.drawing_buffer.get() {
+            DrawingBuffer::TransparentAlpha => HTMLCanvasDataSource::Empty,
+            DrawingBuffer::Wr => HTMLCanvasDataSource::WebGPU(self.webrender_image),
+        }
+    }
+
+    fn send_swap_chain_present(&self, texture_id: WebGPUTexture) {
+        self.drawing_buffer.set(DrawingBuffer::Wr);
         let encoder_id = self.global().wgpu_id_hub().create_command_encoder_id();
         if let Err(e) = self.channel.0.send(WebGPURequest::SwapChainPresent {
             context_id: self.context_id,
-            texture_id,
+            texture_id: texture_id.0,
             encoder_id,
         }) {
             warn!(
@@ -151,12 +226,21 @@ impl GPUCanvasContext {
         }
     }
 
+    fn size(&self) -> Size2D<u64> {
+        match &self.canvas {
+            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => {
+                Size2D::new(canvas.Width() as u64, canvas.Height() as u64)
+            },
+            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.get_size(),
+        }
+    }
+}
+
+// public methods for canvas handling
+// these methods should probably be behind trait for all canvases
+impl GPUCanvasContext {
     pub fn context_id(&self) -> WebGPUContextId {
         self.context_id
-    }
-
-    pub fn texture_id(&self) -> Option<WebGPUTexture> {
-        self.texture.get().map(|t| t.id())
     }
 
     pub fn mark_as_dirty(&self) {
@@ -165,15 +249,24 @@ impl GPUCanvasContext {
             let document = document_from_node(&**canvas);
             document.add_dirty_webgpu_canvas(self);
         }
-        // TODO(sagudev): offscreen canvas also dirty?
     }
 
-    fn size(&self) -> Size2D<u64> {
-        match &self.canvas {
-            HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => {
-                Size2D::new(canvas.Width() as u64, canvas.Height() as u64)
-            },
-            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => canvas.get_size(),
+    /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-updating-the-rendering-of-a-webgpu-canvas>
+    pub fn update_rendering_of_webgpu_canvas(&self) {
+        // Step 1
+        self.expire_current_texture();
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-update-the-canvas-size>
+    pub fn resize(&self) {
+        // Step 1
+        self.replace_drawing_buffer();
+        // Step 2
+        let configuration = self.configuration.borrow();
+        // Step 3
+        if let Some(configuration) = configuration.as_ref() {
+            self.texture_descriptor
+                .replace(Some(self.texture_descriptor_for_canvas(configuration)));
         }
     }
 }
@@ -223,27 +316,21 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         }
 
         // Step 4
-        let size = self.size();
-        let text_desc = GPUTextureDescriptor {
-            format: configuration.format,
-            mipLevelCount: 1,
-            sampleCount: 1,
-            // We need to add `COPY_SRC` so we can copy texture to presentation buffer
-            usage: configuration.usage | GPUTextureUsageConstants::COPY_SRC,
-            size: GPUExtent3D::GPUExtent3DDict(GPUExtent3DDict {
-                width: size.width as u32,
-                height: size.height as u32,
-                depthOrArrayLayers: 1,
-            }),
-            viewFormats: configuration.viewFormats.clone(),
-            // other members to default
-            parent: GPUObjectDescriptorBase {
-                label: USVString::default(),
-            },
-            dimension: GPUTextureDimension::_2d,
-        };
+        let descriptor = self.texture_descriptor_for_canvas(configuration);
+
+        // Step 5
+        self.configuration.replace(Some(configuration.clone()));
+
+        // Step 6
+        self.texture_descriptor.replace(Some(descriptor));
+
+        // Step 7
+        self.replace_drawing_buffer();
 
         // Step 8
+        // TODO: create dummy texture to trigger desc validation
+
+        // Eagerly create swapchain
         let mut buffer_ids = ArrayVec::<id::BufferId, PRESENTATION_BUFFER_COUNT>::new();
         for _ in 0..PRESENTATION_BUFFER_COUNT {
             buffer_ids.push(self.global().wgpu_id_hub().create_buffer_id());
@@ -258,20 +345,18 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
                 context_id: self.context_id,
                 image_key: self.webrender_image,
                 format,
-                size: units::DeviceIntSize::new(size.width as i32, size.height as i32),
+                size: self.size().cast().cast_unit(),
             })
             .expect("Failed to create WebGPU SwapChain");
-
-        self.texture.set(Some(
-            &configuration.device.CreateTexture(&text_desc).unwrap(),
-        ));
 
         Ok(())
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-unconfigure>
     fn Unconfigure(&self) {
-        if let Some(texture) = self.texture.take() {
+        self.current_texture.take();
+        let configuration = self.configuration.take();
+        if configuration.is_some() {
             if let Err(e) = self.channel.0.send(WebGPURequest::DestroySwapChain {
                 context_id: self.context_id,
                 image_key: self.webrender_image,
@@ -281,16 +366,34 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
                     self.webrender_image, e
                 );
             }
-            drop(texture);
         }
+        self.replace_drawing_buffer();
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getcurrenttexture>
     fn GetCurrentTexture(&self) -> Fallible<DomRoot<GPUTexture>> {
-        // Step 5.
+        // Step 1
+        let configuration = self.configuration.borrow();
+        let Some(configuration) = configuration.as_ref() else {
+            return Err(Error::InvalidState);
+        };
+        // Step 2
+        let texture_descriptor = self.texture_descriptor.borrow();
+        let texture_descriptor = texture_descriptor.as_ref().unwrap();
+        // Step 6
+        let current_texture = if let Some(current_texture) = self.current_texture.get() {
+            current_texture
+        } else {
+            // Step 3&4
+            self.replace_drawing_buffer();
+            let current_texture = configuration.device.CreateTexture(&texture_descriptor)?;
+            self.current_texture.set(Some(&current_texture));
+            current_texture
+        };
+        // Step 5
         self.mark_as_dirty();
-        // Step 6.
-        self.texture.get().ok_or(Error::InvalidState)
+        // Step 6
+        Ok(current_texture)
     }
 }
 

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 
 use arrayvec::ArrayVec;
@@ -343,7 +344,10 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         let descriptor = self.texture_descriptor_for_canvas(configuration);
 
         // Step 2&3
-        let (desc, _) = convert_texture_descriptor(&descriptor, &configuration.device)?;
+        let (mut desc, _) = convert_texture_descriptor(&descriptor, &configuration.device)?;
+        desc.label = Some(Cow::Borrowed(
+            "dummy texture for texture descriptor validation",
+        ));
 
         // Step 5
         self.configuration.replace(Some(configuration.clone()));

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -153,6 +153,10 @@ impl GPUDevice {
         self.device
     }
 
+    pub fn queue_id(&self) -> webgpu::WebGPUQueue {
+        self.default_queue.id()
+    }
+
     pub fn channel(&self) -> WebGPU {
         self.channel.clone()
     }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -105,7 +105,7 @@ impl HTMLCanvasElement {
                 },
                 CanvasContext::WebGL(ref context) => context.recreate(size),
                 CanvasContext::WebGL2(ref context) => context.recreate(size),
-                CanvasContext::WebGPU(_) => unimplemented!(),
+                CanvasContext::WebGPU(ref context) => context.resize(),
             }
         }
     }

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -164,7 +164,6 @@ pub enum WebGPURequest {
     DestroyTexture(id::TextureId),
     DestroySwapChain {
         context_id: WebGPUContextId,
-        image_key: ImageKey,
     },
     DropTexture(id::TextureId),
     DropAdapter(id::AdapterId),

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -138,6 +138,16 @@ pub enum WebGPURequest {
         format: ImageFormat,
         size: DeviceIntSize,
     },
+    ValidateTextureDescriptorAndCreateSwapChain {
+        device_id: id::DeviceId,
+        queue_id: id::QueueId,
+        buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
+        context_id: WebGPUContextId,
+        image_key: ImageKey,
+        size: DeviceIntSize,
+        texture_id: id::TextureId,
+        descriptor: TextureDescriptor<'static>,
+    },
     CreateTexture {
         device_id: id::DeviceId,
         texture_id: id::TextureId,

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -10,7 +10,7 @@ use base::id::PipelineId;
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use serde::{Deserialize, Serialize};
 use webrender_api::units::DeviceIntSize;
-use webrender_api::{ImageFormat, ImageKey};
+use webrender_api::ImageKey;
 use wgc::binding_model::{
     BindGroupDescriptor, BindGroupLayoutDescriptor, PipelineLayoutDescriptor,
 };
@@ -129,13 +129,9 @@ pub enum WebGPURequest {
         label: Option<String>,
         sender: IpcSender<WebGPUResponse>,
     },
-    CreateSwapChain {
-        device_id: id::DeviceId,
-        queue_id: id::QueueId,
+    ResizeSwapChain {
         buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
         context_id: WebGPUContextId,
-        image_key: ImageKey,
-        format: ImageFormat,
         size: DeviceIntSize,
     },
     ValidateTextureDescriptorAndCreateSwapChain {

--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -34,6 +34,14 @@ use crate::render_commands::RenderCommand;
 use crate::swapchain::WebGPUContextId;
 use crate::{Error, ErrorFilter, WebGPUResponse, PRESENTATION_BUFFER_COUNT};
 
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct ContextConfiguration {
+    pub device_id: id::DeviceId,
+    pub queue_id: id::QueueId,
+    pub format: wgt::TextureFormat,
+    pub is_opaque: bool,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebGPURequest {
     BufferMapAsync {
@@ -103,7 +111,6 @@ pub enum WebGPURequest {
         /// present only on ASYNC versions
         async_sender: Option<IpcSender<WebGPUResponse>>,
     },
-    CreateContext(IpcSender<(WebGPUContextId, ImageKey)>),
     CreatePipelineLayout {
         device_id: id::DeviceId,
         pipeline_layout_id: id::PipelineLayoutId,
@@ -129,20 +136,31 @@ pub enum WebGPURequest {
         label: Option<String>,
         sender: IpcSender<WebGPUResponse>,
     },
-    ResizeSwapChain {
+    /// Creates context
+    CreateContext {
         buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
-        context_id: WebGPUContextId,
         size: DeviceIntSize,
+        sender: IpcSender<(WebGPUContextId, ImageKey)>,
     },
-    ValidateTextureDescriptorAndCreateSwapChain {
-        device_id: id::DeviceId,
-        queue_id: id::QueueId,
-        buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
+    /// Recreates swapchain (if needed)
+    UpdateContext {
         context_id: WebGPUContextId,
-        image_key: ImageKey,
         size: DeviceIntSize,
+        configuration: Option<ContextConfiguration>,
+    },
+    /// Reads texture to swapchains buffer and maps it
+    SwapChainPresent {
+        context_id: WebGPUContextId,
+        texture_id: id::TextureId,
+        encoder_id: id::CommandEncoderId,
+    },
+    ValidateTextureDescriptor {
+        device_id: id::DeviceId,
         texture_id: id::TextureId,
         descriptor: TextureDescriptor<'static>,
+    },
+    DestroyContext {
+        context_id: WebGPUContextId,
     },
     CreateTexture {
         device_id: id::DeviceId,
@@ -158,9 +176,6 @@ pub enum WebGPURequest {
     DestroyBuffer(id::BufferId),
     DestroyDevice(id::DeviceId),
     DestroyTexture(id::TextureId),
-    DestroySwapChain {
-        context_id: WebGPUContextId,
-    },
     DropTexture(id::TextureId),
     DropAdapter(id::AdapterId),
     DropDevice(id::DeviceId),
@@ -258,11 +273,6 @@ pub enum WebGPURequest {
         device_id: id::DeviceId,
         queue_id: id::QueueId,
         command_buffers: Vec<id::CommandBufferId>,
-    },
-    SwapChainPresent {
-        context_id: WebGPUContextId,
-        texture_id: id::TextureId,
-        encoder_id: id::CommandEncoderId,
     },
     UnmapBuffer {
         buffer_id: id::BufferId,

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -4,7 +4,7 @@
 
 use log::warn;
 use swapchain::WGPUImageMap;
-pub use swapchain::{PresentationData, WGPUExternalImages};
+pub use swapchain::{ContextData, WGPUExternalImages};
 use webrender::RenderApiSender;
 use wgpu_thread::WGPU;
 pub use {wgpu_core as wgc, wgpu_types as wgt};

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -92,6 +92,7 @@ impl WebrenderExternalImageApi for WGPUExternalImages {
             data = if let Some(present_data) = &present_data.data {
                 present_data.slice().to_vec()
             } else {
+                // This should not happen!
                 present_data.dummy_data()
             };
         } else {
@@ -398,7 +399,10 @@ impl crate::WGPU {
             &copy_size,
         );
         let _ = global.command_encoder_finish(encoder_id, &wgt::CommandBufferDescriptor::default());
-        let _ = global.queue_submit(queue_id, &[encoder_id.into_command_buffer_id()]);
+        {
+            let _guard = self.poller.lock();
+            let _ = global.queue_submit(queue_id, &[encoder_id.into_command_buffer_id()]);
+        }
         let callback = {
             let global = Arc::clone(&self.global);
             let wgpu_image_map = Arc::clone(&self.wgpu_image_map);

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -540,7 +540,14 @@ fn update_wr_image(
             if let Some(context_data) = wgpu_image_map.lock().unwrap().get_mut(&context_id) {
                 let config_changed = image_desc != context_data.image_desc;
                 let buffer_state = context_data.get_buffer_state(buffer_id);
-                assert_eq!(*buffer_state, PresentationBufferState::Mapping);
+                match buffer_state {
+                    PresentationBufferState::Unassigned => {
+                        // throw away all work, because we are from old swapchain
+                        return;
+                    },
+                    PresentationBufferState::Mapping => {},
+                    _ => panic!("Unexpected presentation buffer state"),
+                }
                 if config_changed {
                     /*
                     This means that while mapasync was running, context got recreated

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -28,6 +28,7 @@ use wgpu_core::resource::{BufferAccessError, BufferMapCallback, BufferMapOperati
 use crate::{wgt, ContextConfiguration, Error, WebGPUMsg};
 
 pub const PRESENTATION_BUFFER_COUNT: usize = 10;
+const DEFAULT_IMAGE_FORMAT: ImageFormat = ImageFormat::RGBA8;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct WebGPUContextId(pub u64);
@@ -153,7 +154,7 @@ impl ContextData {
         buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
     ) -> Self {
         let image_desc = ImageDescriptor {
-            format: ImageFormat::RGBA8,
+            format: DEFAULT_IMAGE_FORMAT,
             size,
             stride: Some(stride(size)),
             offset: 0,
@@ -289,7 +290,7 @@ impl ContextData {
             *buffer_state = PresentationBufferState::Unassigned;
         }
         // set defaults back
-        self.update_image_desc(self.image_desc.size, ImageFormat::RGBA8, false)
+        self.update_image_desc(self.image_desc.size, DEFAULT_IMAGE_FORMAT, false)
     }
 
     fn destroy(

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -513,17 +513,11 @@ impl WGPU {
                         }
                         self.maybe_dispatch_wgpu_error(device_id, error);
                     },
-                    WebGPURequest::CreateSwapChain {
-                        device_id,
-                        queue_id,
+                    WebGPURequest::ResizeSwapChain {
                         buffer_ids,
                         context_id,
-                        image_key,
                         size,
-                        format,
-                    } => self.create_swapchain(
-                        device_id, queue_id, buffer_ids, context_id, format, size, image_key,
-                    ),
+                    } => self.resize_swapchain(context_id, buffer_ids, size),
                     WebGPURequest::ValidateTextureDescriptorAndCreateSwapChain {
                         device_id,
                         queue_id,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -534,6 +534,7 @@ impl WGPU {
                         texture_id,
                         descriptor,
                     } => {
+                        // https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure
                         // validating TextureDescriptor
                         let global = &self.global;
                         let (_, error) =
@@ -601,11 +602,8 @@ impl WGPU {
                         // Wake poller thread to trigger DeviceLostClosure
                         self.poller.wake();
                     },
-                    WebGPURequest::DestroySwapChain {
-                        context_id,
-                        image_key,
-                    } => {
-                        self.destroy_swapchain(context_id, image_key);
+                    WebGPURequest::DestroySwapChain { context_id } => {
+                        self.destroy_swapchain(context_id);
                     },
                     WebGPURequest::DestroyTexture(texture_id) => {
                         let global = &self.global;

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -530,7 +530,10 @@ impl WGPU {
                         texture_id,
                         encoder_id,
                     } => {
-                        self.swapchain_present(context_id, encoder_id, texture_id);
+                        let result = self.swapchain_present(context_id, encoder_id, texture_id);
+                        if let Err(e) = result {
+                            log::error!("Error occured in SwapChainPresent: {e:?}");
+                        }
                     },
                     WebGPURequest::ValidateTextureDescriptor {
                         device_id,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -534,6 +534,7 @@ impl WGPU {
                         let (_, error) =
                             global.device_create_texture(device_id, &descriptor, Some(texture_id));
                         global.texture_drop(texture_id);
+                        self.poller.wake();
                         if let Err(e) = self.script_sender.send(WebGPUMsg::FreeTexture(texture_id))
                         {
                             warn!("Unable to send FreeTexture({:?}) ({:?})", texture_id, e);

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -6,7 +6,6 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::ControlFlow;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
@@ -15,7 +14,7 @@ use ipc_channel::ipc::{IpcReceiver, IpcSender, IpcSharedMemory};
 use log::{info, warn};
 use servo_config::pref;
 use webrender::{RenderApi, RenderApiSender};
-use webrender_api::{DocumentId, ImageFormat};
+use webrender_api::{DocumentId, ExternalImageId};
 use webrender_traits::{WebrenderExternalImageRegistry, WebrenderImageHandlerType};
 use wgc::command::{ComputePass, ComputePassDescriptor, RenderPass};
 use wgc::device::queue::SubmittedWorkDoneClosure;
@@ -404,17 +403,6 @@ impl WGPU {
                             self.maybe_dispatch_wgpu_error(device_id, error);
                         }
                     },
-                    WebGPURequest::CreateContext(sender) => {
-                        let id = self
-                            .external_images
-                            .lock()
-                            .expect("Lock poisoned?")
-                            .next_id(WebrenderImageHandlerType::WebGPU);
-                        let image_key = self.webrender_api.lock().unwrap().generate_image_key();
-                        if let Err(e) = sender.send((WebGPUContextId(id.0), image_key)) {
-                            warn!("Failed to send ExternalImageId to new context ({})", e);
-                        };
-                    },
                     WebGPURequest::CreatePipelineLayout {
                         device_id,
                         pipeline_layout_id,
@@ -513,23 +501,44 @@ impl WGPU {
                         }
                         self.maybe_dispatch_wgpu_error(device_id, error);
                     },
-                    WebGPURequest::ResizeSwapChain {
+                    WebGPURequest::CreateContext {
                         buffer_ids,
+                        size,
+                        sender,
+                    } => {
+                        let id = self
+                            .external_images
+                            .lock()
+                            .expect("Lock poisoned?")
+                            .next_id(WebrenderImageHandlerType::WebGPU);
+                        let image_key = self.webrender_api.lock().unwrap().generate_image_key();
+                        let context_id = WebGPUContextId(id.0);
+                        if let Err(e) = sender.send((context_id, image_key)) {
+                            warn!("Failed to send ExternalImageId to new context ({})", e);
+                        };
+                        self.create_context(context_id, image_key, size, buffer_ids);
+                    },
+                    WebGPURequest::UpdateContext {
                         context_id,
                         size,
-                    } => self.resize_swapchain(context_id, buffer_ids, size),
-                    WebGPURequest::ValidateTextureDescriptorAndCreateSwapChain {
+                        configuration,
+                    } => {
+                        self.update_context(context_id, size, configuration);
+                    },
+                    WebGPURequest::SwapChainPresent {
+                        context_id,
+                        texture_id,
+                        encoder_id,
+                    } => {
+                        self.swapchain_present(context_id, encoder_id, texture_id);
+                    },
+                    WebGPURequest::ValidateTextureDescriptor {
                         device_id,
-                        queue_id,
-                        buffer_ids,
-                        context_id,
-                        image_key,
-                        size,
                         texture_id,
                         descriptor,
                     } => {
                         // https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure
-                        // validating TextureDescriptor
+                        // validating TextureDescriptor by creating dummy texture
                         let global = &self.global;
                         let (_, error) =
                             global.device_create_texture(device_id, &descriptor, Some(texture_id));
@@ -544,21 +553,23 @@ impl WGPU {
                             continue;
                         }
                         // Supported context formats
-                        let format = match descriptor.format {
-                            wgt::TextureFormat::Bgra8Unorm => ImageFormat::BGRA8,
-                            wgt::TextureFormat::Rgba8Unorm => ImageFormat::RGBA8,
-                            // TODO: wgt::TextureFormat::Rgba16Float, when wr supports HDR
-                            _ => {
-                                self.dispatch_error(
-                                    device_id,
-                                    Error::Validation("Unsupported context format".to_string()),
-                                );
-                                continue;
-                            },
-                        };
-                        self.create_swapchain(
-                            device_id, queue_id, buffer_ids, context_id, format, size, image_key,
-                        )
+                        // TODO: wgt::TextureFormat::Rgba16Float, when wr supports HDR
+                        if !matches!(
+                            descriptor.format,
+                            wgt::TextureFormat::Bgra8Unorm | wgt::TextureFormat::Rgba8Unorm
+                        ) {
+                            self.dispatch_error(
+                                device_id,
+                                Error::Validation("Unsupported context format".to_string()),
+                            );
+                        }
+                    },
+                    WebGPURequest::DestroyContext { context_id } => {
+                        self.destroy_context(context_id);
+                        self.external_images
+                            .lock()
+                            .expect("Lock poisoned?")
+                            .remove(&ExternalImageId(context_id.0));
                     },
                     WebGPURequest::CreateTexture {
                         device_id,
@@ -596,9 +607,6 @@ impl WGPU {
                         global.device_destroy(device);
                         // Wake poller thread to trigger DeviceLostClosure
                         self.poller.wake();
-                    },
-                    WebGPURequest::DestroySwapChain { context_id } => {
-                        self.destroy_swapchain(context_id);
                     },
                     WebGPURequest::DestroyTexture(texture_id) => {
                         let global = &self.global;
@@ -997,17 +1005,6 @@ impl WGPU {
                                 .map_err(Error::from_error)
                         };
                         self.maybe_dispatch_error(device_id, result.err());
-                    },
-                    WebGPURequest::SwapChainPresent {
-                        context_id,
-                        texture_id,
-                        encoder_id,
-                    } => {
-                        if let ControlFlow::Break(_) =
-                            self.swapchain_present(context_id, encoder_id, texture_id)
-                        {
-                            continue;
-                        }
                     },
                     WebGPURequest::UnmapBuffer {
                         buffer_id,

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_clear.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_clear.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_clear.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
-    if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_colorspace_rgba16float.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
     if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_complex_rgba16float_copy.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
     if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_complex_rgba16float_draw.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
     if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_complex_rgba16float_store.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
-    if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_complex_rgba8unorm_store.https.html]
   expected:
-    if os == "linux" and not debug: [PASS, FAIL]
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: [CRASH, PASS, FAIL]
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: FAIL
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html.ini
@@ -1,2 +1,2 @@
 [canvas_composite_alpha_bgra8unorm_opaque_draw.https.html]
-  expected: [CRASH, PASS, FAIL]
+  expected: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html.ini
@@ -1,2 +1,2 @@
 [canvas_composite_alpha_bgra8unorm_opaque_draw.https.html]
-  expected: FAIL
+  expected: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html.ini
@@ -1,2 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html]
-  expected: FAIL
+  expected:
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html.ini
@@ -1,2 +1,3 @@
 [canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html]
-  expected: FAIL
+  expected:
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_composite_alpha_rgba16float_opaque_copy.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
-    if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_composite_alpha_rgba16float_opaque_draw.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
-    if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_composite_alpha_rgba16float_premultiplied_copy.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
-    if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html.ini
@@ -1,6 +1,3 @@
 [canvas_composite_alpha_rgba16float_premultiplied_draw.https.html]
   expected:
-    if os == "win": CRASH
-    if os == "linux" and debug: CRASH
-    if os == "linux" and not debug: TIMEOUT
-    if os == "mac": CRASH
+    if os == "linux" and not debug: FAIL

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_opaque_copy.https.html]
   expected:
-    if os == "linux" and not debug: [CRASH, PASS, FAIL]
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html.ini
@@ -1,3 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_opaque_draw.https.html]
   expected:
-    if os == "linux" and not debug: [PASS, FAIL]
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html.ini
@@ -1,2 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html]
-  expected: FAIL
+  expected:
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html.ini
@@ -1,2 +1,3 @@
 [canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html]
-  expected: [CRASH, FAIL]
+  expected:
+    if os == "linux" and not debug: PASS

--- a/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/delay_get_texture.https.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/webgpu/web_platform/reftests/delay_get_texture.https.html.ini
@@ -1,6 +1,3 @@
 [delay_get_texture.https.html]
   expected:
-    if os == "win": FAIL
-    if os == "linux" and debug: FAIL
-    if os == "linux" and not debug: [PASS, FAIL]
-    if os == "mac": FAIL
+    if os == "linux" and not debug: PASS


### PR DESCRIPTION
When I started working on servo's webgpu about a year ago in https://github.com/servo/servo/pull/29795, I dreaded the day when I will be fixing presentation of webgpu canvas. I spent whole month studying specs and our current impl and now its time for this big renovation.

All reconfiguration/recreation of wr image desc (format, size) now happens as part of `replace_drawing_buffer` (we support resize now), and we read texture to `GPUPresentationBuffer` before we destroy texture in `expire_current_texture`. There are some configuration options that are not really respected (like color space and tone mapping) due too missing support in wr.

Interestingly enough Firefox implementation is roughly equally behind spec as our old impl.

NOT reviewable per commit.

FOLLOWUPs:
submission index for mapasync: https://github.com/servo/servo/pull/33521#discussion_r1778570921
html event loop integration: https://github.com/servo/servo/pull/33521#discussion_r1780420725
obtain pixel data
support rgba16float with clamping in wr (later proper hdr support)
other configuration options
[`preferred_color_formats`](https://docs.rs/webrender/0.61.0/webrender/struct.Device.html#method.preferred_color_formats) for `getPreferredCanvasFormat`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes closes #30386
- [x] There are tests for these changes WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
