### PR TITLE
Use `ContentSizes::shrink_to_fit` when possible

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -1737,9 +1737,8 @@ impl FlexItem<'_> {
                                 self.content_max_size.cross,
                             )
                         });
-                    (containing_block.inline_size - self.pbm_auto_is_zero.cross)
-                        .min(content_contributions.max_content)
-                        .max(content_contributions.min_content)
+                    content_contributions
+                        .shrink_to_fit(containing_block.inline_size - self.pbm_auto_is_zero.cross)
                 }),
                 // The main size of a flex item is considered to be definite if its flex basis is definite
                 // or the flex container has a definite main size.
@@ -2513,10 +2512,8 @@ impl FlexItemBox {
                                 flex_context.layout_context,
                                 &containing_block_for_children,
                             );
-
-                            containing_block_inline_size_minus_pbm
-                                .min(inline_content_sizes.max_content)
-                                .max(inline_content_sizes.min_content)
+                            inline_content_sizes
+                                .shrink_to_fit(containing_block_inline_size_minus_pbm)
                         }
                     })
                     .clamp_between_extremums(min_size.inline, max_size.inline);

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -92,9 +92,15 @@ impl AddAssign for ContentSizes {
 }
 
 impl ContentSizes {
+    /// Clamps the provided amount to be between the min-content and the max-content.
+    /// This is called "shrink-to-fit" in CSS2, and "fit-content" in CSS Sizing.
     /// <https://drafts.csswg.org/css2/visudet.html#shrink-to-fit-float>
+    /// <https://drafts.csswg.org/css-sizing/#funcdef-width-fit-content>
     pub fn shrink_to_fit(&self, available_size: Au) -> Au {
-        available_size.max(self.min_content).min(self.max_content)
+        // This formula is slightly different than what the spec says,
+        // to ensure that the minimum wins for a malformed ContentSize
+        // whose min_content is larger than its max_content.
+        available_size.min(self.max_content).max(self.min_content)
     }
 }
 


### PR DESCRIPTION
And ensure that the minimum wins for malformed ContentSizes
whose min_content is larger than its max_content.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there should be no change in behavior (assuming we never create malformed `ContentSizes`)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
