### PR TITLE
fonts: Use `IpcSharedMemory` to send font data

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -10,8 +10,8 @@ use canvas_traits::canvas::*;
 use euclid::default::{Box2D, Point2D, Rect, Size2D, Transform2D, Vector2D};
 use euclid::point2;
 use fonts::{
-    ByteIndex, FontBaseline, FontCacheThread, FontContext, FontGroup, FontMetrics, FontRef,
-    GlyphInfo, GlyphStore, ShapingFlags, ShapingOptions, LAST_RESORT_GLYPH_ADVANCE,
+    ByteIndex, FontBaseline, FontContext, FontGroup, FontMetrics, FontRef, GlyphInfo, GlyphStore,
+    ShapingFlags, ShapingOptions, SystemFontServiceProxy, LAST_RESORT_GLYPH_ADVANCE,
 };
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use log::{debug, warn};
@@ -434,7 +434,7 @@ pub struct CanvasData<'a> {
     old_image_key: Option<ImageKey>,
     /// An old webrender image key that can be deleted when the current epoch ends.
     very_old_image_key: Option<ImageKey>,
-    font_context: Arc<FontContext<FontCacheThread>>,
+    font_context: Arc<FontContext<SystemFontServiceProxy>>,
 }
 
 fn create_backend() -> Box<dyn Backend> {
@@ -446,7 +446,7 @@ impl<'a> CanvasData<'a> {
         size: Size2D<u64>,
         webrender_api: Box<dyn WebrenderApi>,
         antialias: AntialiasMode,
-        font_context: Arc<FontContext<FontCacheThread>>,
+        font_context: Arc<FontContext<SystemFontServiceProxy>>,
     ) -> CanvasData<'a> {
         let backend = create_backend();
         let draw_target = backend.create_drawtarget(size);

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -555,7 +555,9 @@ impl GenericDrawTarget for raqote::DrawTarget {
             SHARED_FONT_CACHE.with(|font_cache| {
                 let identifier = template.identifier();
                 if !font_cache.borrow().contains_key(&identifier) {
-                    let Ok(font) = Font::from_bytes(template.data(), identifier.index()) else {
+                    let Ok(font) =
+                        Font::from_bytes(run.font.data.as_arc().clone(), identifier.index())
+                    else {
                         return;
                     };
                     font_cache.borrow_mut().insert(identifier.clone(), font);

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -895,12 +895,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             ForwardedToCompositorMsg::Font(FontToCompositorMsg::AddFont(
                 key_sender,
                 index,
-                bytes_receiver,
+                data,
             )) => {
                 let font_key = self.webrender_api.generate_font_key();
                 let mut transaction = Transaction::new();
-                let bytes = bytes_receiver.recv().unwrap_or_default();
-                transaction.add_raw_font(font_key, bytes, index);
+                transaction.add_raw_font(font_key, (**data).into(), index);
                 self.webrender_api
                     .send_transaction(self.webrender_document, transaction);
                 let _ = key_sender.send(font_key);

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -3,25 +3,72 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
+use ipc_channel::ipc::IpcSharedMemory;
 use log::warn;
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use style::stylesheets::DocumentStyleSheet;
 use style::values::computed::{FontStyle, FontWeight};
 use webrender_api::{FontInstanceFlags, FontInstanceKey, FontKey};
 
 use crate::font::FontDescriptor;
-use crate::font_cache_thread::{FontIdentifier, FontSource, LowercaseFontFamilyName};
 use crate::font_context::WebFontDownloadState;
 use crate::font_template::{FontTemplate, FontTemplateRef, FontTemplateRefMethods, IsOblique};
+use crate::system_font_service::{
+    FontIdentifier, LowercaseFontFamilyName, SystemFontServiceProxyTrait,
+};
+use crate::FontContext;
+
+/// A data structure to store data for fonts. If sent across IPC channels and only a
+/// [`IpcSharedMemory`] handle is sent, avoiding the overhead of serialization and
+/// deserialization. In addition, if a shared handle to data is requested
+/// (`Arc<Vec<u8>>`), the data is lazily copied out of shared memory once per
+/// [`FontData`].
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FontData {
+    /// The data of this font in shared memory. Suitable for sending across IPC channels.
+    shared_memory: Arc<IpcSharedMemory>,
+    /// A lazily-initialized copy of the data behind an [`Arc`] which can be used when
+    /// passing it to various APIs.
+    #[serde(skip)]
+    arc: OnceLock<Arc<Vec<u8>>>,
+}
+
+impl FontData {
+    pub fn from_bytes(data: Vec<u8>) -> FontData {
+        FontData {
+            shared_memory: Arc::new(IpcSharedMemory::from_bytes(&data)),
+            arc: Arc::new(data).into(),
+        }
+    }
+
+    /// Return a non-shared memory `Arc` view of this data. This may copy the data once
+    /// per [`FontData`], but subsequent calls will return the same shared view.
+    pub fn as_arc(&self) -> &Arc<Vec<u8>> {
+        self.arc
+            .get_or_init(|| Arc::new((**self.shared_memory).into()))
+    }
+
+    /// Return a the [`IpcSharedMemory`] view of this data suitable for sending directly across
+    /// an IPC channel if necessary. An `Arc` is returned to avoid the overhead of copying the
+    /// platform-specific shared memory handle.
+    pub(crate) fn as_ipc_shared_memory(&self) -> Arc<IpcSharedMemory> {
+        self.shared_memory.clone()
+    }
+}
 
 #[derive(Default)]
 pub struct FontStore {
     pub(crate) families: HashMap<LowercaseFontFamilyName, FontTemplates>,
     web_fonts_loading: Vec<(DocumentStyleSheet, usize)>,
+    /// The data for each [`FontIdentifier`]. This data might be used by
+    /// more than one [`FontTemplate`] as each identifier refers to a URL
+    /// or font that can contain more than a single font.
+    font_data: HashMap<FontIdentifier, Arc<FontData>>,
 }
 pub(crate) type CrossThreadFontStore = Arc<RwLock<FontStore>>;
 
@@ -78,27 +125,66 @@ impl FontStore {
     /// Handle a web font load finishing, adding the new font to the [`FontStore`]. If the web font
     /// load was canceled (for instance, if the stylesheet was removed), then do nothing and return
     /// false.
+    ///
+    /// In addition pass newly loaded data for this font. Add this data the cached [`FontData`] store
+    /// inside this [`FontStore`].
     pub(crate) fn handle_web_font_loaded(
         &mut self,
         state: &WebFontDownloadState,
         new_template: FontTemplate,
+        data: Arc<FontData>,
     ) -> bool {
         // Abort processing this web font if the originating stylesheet was removed.
         if self.font_load_cancelled_for_stylesheet(&state.stylesheet) {
             return false;
         }
-
         let family_name = state.css_font_face_descriptors.family_name.clone();
-        self.families
-            .entry(family_name)
-            .or_default()
-            .add_template(new_template);
+        self.add_template_and_data(family_name, new_template, data);
         self.remove_one_web_font_loading_for_stylesheet(&state.stylesheet);
         true
     }
 
+    pub(crate) fn add_template_and_data(
+        &mut self,
+        family_name: LowercaseFontFamilyName,
+        new_template: FontTemplate,
+        data: Arc<FontData>,
+    ) {
+        self.font_data.insert(new_template.identifier.clone(), data);
+        self.families
+            .entry(family_name)
+            .or_default()
+            .add_template(new_template);
+    }
+
     pub(crate) fn number_of_fonts_still_loading(&self) -> usize {
         self.web_fonts_loading.iter().map(|(_, count)| count).sum()
+    }
+
+    pub(crate) fn get_or_initialize_font_data(
+        &mut self,
+        identifier: &FontIdentifier,
+    ) -> &Arc<FontData> {
+        self.font_data
+            .entry(identifier.clone())
+            .or_insert_with(|| match identifier {
+                FontIdentifier::Local(local_identifier) => {
+                    Arc::new(FontData::from_bytes(local_identifier.read_data_from_file()))
+                },
+                FontIdentifier::Web(_) => unreachable!("Web fonts should always have data."),
+            })
+    }
+
+    pub(crate) fn get_font_data(&self, identifier: &FontIdentifier) -> Option<Arc<FontData>> {
+        self.font_data.get(identifier).cloned()
+    }
+
+    pub(crate) fn remove_all_font_data_for_identifiers(
+        &mut self,
+        identifiers: &HashSet<FontIdentifier>,
+    ) {
+        self.font_data
+            .retain(|font_identifier, _| identifiers.contains(font_identifier));
     }
 }
 
@@ -110,26 +196,32 @@ pub struct WebRenderFontStore {
 pub(crate) type CrossThreadWebRenderFontStore = Arc<RwLock<WebRenderFontStore>>;
 
 impl WebRenderFontStore {
-    pub(crate) fn get_font_instance<FCT: FontSource>(
+    pub(crate) fn get_font_instance<Proxy: SystemFontServiceProxyTrait>(
         &mut self,
-        font_cache_thread: &FCT,
+        font_context: &FontContext<Proxy>,
         font_template: FontTemplateRef,
         pt_size: Au,
         flags: FontInstanceFlags,
     ) -> FontInstanceKey {
         let webrender_font_key_map = &mut self.webrender_font_key_map;
         let identifier = font_template.identifier().clone();
+
         let font_key = *webrender_font_key_map
             .entry(identifier.clone())
             .or_insert_with(|| {
-                font_cache_thread.get_web_font(font_template.data(), identifier.index())
+                let data = font_context.get_font_data(&identifier);
+                font_context
+                    .system_font_service_proxy
+                    .get_web_font(data, identifier.index())
             });
 
         *self
             .webrender_font_instance_map
             .entry((font_key, pt_size))
             .or_insert_with(|| {
-                font_cache_thread.get_web_font_instance(font_key, pt_size.to_f32_px(), flags)
+                font_context
+                    .system_font_service_proxy
+                    .get_web_font_instance(font_key, pt_size.to_f32_px(), flags)
             })
     }
 
@@ -148,7 +240,7 @@ impl WebRenderFontStore {
 
     pub(crate) fn remove_all_fonts_for_identifiers(
         &mut self,
-        identifiers: HashSet<FontIdentifier>,
+        identifiers: &HashSet<FontIdentifier>,
     ) -> (Vec<FontKey>, Vec<FontInstanceKey>) {
         let mut removed_keys: HashSet<FontKey> = HashSet::new();
         self.webrender_font_key_map.retain(|identifier, font_key| {

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -5,7 +5,6 @@
 #![deny(unsafe_code)]
 
 mod font;
-mod font_cache_thread;
 mod font_context;
 mod font_store;
 mod font_template;
@@ -13,14 +12,15 @@ mod glyph;
 #[allow(unsafe_code)]
 pub mod platform;
 mod shaper;
+mod system_font_service;
 
 pub use font::*;
-pub use font_cache_thread::*;
 pub use font_context::*;
 pub use font_store::*;
 pub use font_template::*;
 pub use glyph::*;
 pub use shaper::*;
+pub use system_font_service::*;
 use unicode_properties::{emoji, EmojiStatus, UnicodeEmoji};
 
 /// Whether or not font fallback selection prefers the emoji or text representation

--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -452,7 +452,7 @@ impl FontList {
     }
 }
 
-// Functions used by FontCacheThread
+// Functions used by SystemFontSerivce
 pub fn for_each_available_family<F>(mut callback: F)
 where
     F: FnMut(String),

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -29,9 +29,9 @@ use crate::font::{
     FontMetrics, FontTableMethods, FontTableTag, FractionalPixel, PlatformFontMethods, GPOS, GSUB,
     KERN,
 };
-use crate::font_cache_thread::FontIdentifier;
 use crate::font_template::FontTemplateDescriptor;
 use crate::glyph::GlyphId;
+use crate::system_font_service::FontIdentifier;
 
 // This constant is not present in the freetype
 // bindings due to bindgen not handling the way

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -453,7 +453,7 @@ impl FontList {
     }
 }
 
-// Functions used by FontCacheThread
+// Functions used by SystemFontService
 pub fn for_each_available_family<F>(mut callback: F)
 where
     F: FnMut(String),

--- a/components/fonts/platform/macos/core_text_font_cache.rs
+++ b/components/fonts/platform/macos/core_text_font_cache.rs
@@ -16,7 +16,7 @@ use core_text::font::CTFont;
 use core_text::font_descriptor::kCTFontURLAttribute;
 use parking_lot::RwLock;
 
-use crate::font_cache_thread::FontIdentifier;
+use crate::system_font_service::FontIdentifier;
 
 /// A cache of `CTFont` to avoid having to create `CTFont` instances over and over. It is
 /// always possible to create a `CTFont` using a `FontTemplate` even if it isn't in this

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -11,7 +11,7 @@ use std::thread;
 
 use base::id::PipelineId;
 use fnv::FnvHasher;
-use fonts::{FontCacheThread, FontContext};
+use fonts::{FontContext, SystemFontServiceProxy};
 use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, UsePlaceholder,
 };
@@ -24,7 +24,7 @@ use style::context::{RegisteredSpeculativePainter, SharedStyleContext};
 
 use crate::display_list::items::{OpaqueNode, WebRenderImageInfo};
 
-pub type LayoutFontContext = FontContext<FontCacheThread>;
+pub type LayoutFontContext = FontContext<SystemFontServiceProxy>;
 
 type WebrenderImageCache =
     HashMap<(ServoUrl, UsePlaceholder), WebRenderImageInfo, BuildHasherDefault<FnvHasher>>;
@@ -44,7 +44,7 @@ pub struct LayoutContext<'a> {
     pub image_cache: Arc<dyn ImageCache>,
 
     /// A FontContext to be used during layout.
-    pub font_context: Arc<FontContext<FontCacheThread>>,
+    pub font_context: Arc<FontContext<SystemFontServiceProxy>>,
 
     /// A cache of WebRender image info.
     pub webrender_image_cache: Arc<RwLock<WebrenderImageCache>>,

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use base::id::PipelineId;
 use fnv::FnvHashMap;
-use fonts::{FontCacheThread, FontContext};
+use fonts::{FontContext, SystemFontServiceProxy};
 use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, UsePlaceholder,
 };
@@ -27,7 +27,7 @@ pub struct LayoutContext<'a> {
     pub style_context: SharedStyleContext<'a>,
 
     /// A FontContext to be used during layout.
-    pub font_context: Arc<FontContext<FontCacheThread>>,
+    pub font_context: Arc<FontContext<SystemFontServiceProxy>>,
 
     /// Reference to the script thread image cache.
     pub image_cache: Arc<dyn ImageCache>,

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 use app_units::Au;
 use base::text::is_bidi_control;
 use fonts::{
-    FontCacheThread, FontContext, FontRef, GlyphRun, ShapingFlags, ShapingOptions,
+    FontContext, FontRef, GlyphRun, ShapingFlags, ShapingOptions, SystemFontServiceProxy,
     LAST_RESORT_GLYPH_ADVANCE,
 };
 use fonts_traits::ByteIndex;
@@ -342,7 +342,7 @@ impl TextRun {
     pub(super) fn segment_and_shape(
         &mut self,
         formatting_context_text: &str,
-        font_context: &FontContext<FontCacheThread>,
+        font_context: &FontContext<SystemFontServiceProxy>,
         linebreaker: &mut LineBreaker,
         font_cache: &mut Vec<FontKeyAndMetrics>,
         bidi_info: &BidiInfo,
@@ -410,7 +410,7 @@ impl TextRun {
     fn segment_text_by_font(
         &mut self,
         formatting_context_text: &str,
-        font_context: &FontContext<FontCacheThread>,
+        font_context: &FontContext<SystemFontServiceProxy>,
         font_cache: &mut Vec<FontKeyAndMetrics>,
         bidi_info: &BidiInfo,
     ) -> Vec<(TextRunSegment, FontRef)> {
@@ -556,7 +556,7 @@ pub(super) fn add_or_get_font(font: &FontRef, ifc_fonts: &mut Vec<FontKeyAndMetr
 
 pub(super) fn get_font_for_first_font_for_style(
     style: &ComputedValues,
-    font_context: &FontContext<FontCacheThread>,
+    font_context: &FontContext<SystemFontServiceProxy>,
 ) -> Option<FontRef> {
     let font = font_context
         .font_group(style.clone_font())

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -24,7 +24,7 @@ use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use crossbeam_channel::Sender;
 use euclid::default::{Point2D, Rect};
 use euclid::Size2D;
-use fonts::FontCacheThread;
+use fonts::SystemFontServiceProxy;
 use ipc_channel::ipc::IpcSender;
 use libc::c_void;
 use malloc_size_of_derive::MallocSizeOf;
@@ -171,7 +171,7 @@ pub struct LayoutConfig {
     pub script_chan: IpcSender<ConstellationControlMsg>,
     pub image_cache: Arc<dyn ImageCache>,
     pub resource_threads: ResourceThreads,
-    pub font_cache_thread: FontCacheThread,
+    pub system_font_service: Arc<SystemFontServiceProxy>,
     pub time_profiler_chan: time::ProfilerChan,
     pub webrender_api_sender: WebRenderScriptApi,
     pub paint_time_metrics: PaintTimeMetrics,
@@ -277,7 +277,7 @@ pub trait ScriptThreadFactory {
     fn create(
         state: InitialScriptState,
         layout_factory: Arc<dyn LayoutFactory>,
-        font_cache_thread: FontCacheThread,
+        system_font_service: Arc<SystemFontServiceProxy>,
         load_data: LoadData,
         user_agent: Cow<'static, str>,
     );

--- a/components/shared/webrender/lib.rs
+++ b/components/shared/webrender/lib.rs
@@ -15,7 +15,7 @@ use crossbeam_channel::Sender;
 use display_list::{CompositorDisplayListInfo, ScrollTreeNodeId};
 use embedder_traits::Cursor;
 use euclid::default::Size2D;
-use ipc_channel::ipc::{self, IpcBytesReceiver, IpcSender};
+use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
 use libc::c_void;
 use log::warn;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -190,14 +190,14 @@ pub trait WebRenderFontApi {
         size: f32,
         flags: FontInstanceFlags,
     ) -> FontInstanceKey;
-    fn add_font(&self, data: Arc<Vec<u8>>, index: u32) -> FontKey;
+    fn add_font(&self, data: Arc<IpcSharedMemory>, index: u32) -> FontKey;
     fn add_system_font(&self, handle: NativeFontHandle) -> FontKey;
 
     /// Forward a `AddFont` message, sending it on to the compositor. This is used to get WebRender
     /// [`FontKey`]s for web fonts in the per-layout `FontContext`.
     fn forward_add_font_message(
         &self,
-        bytes_receiver: IpcBytesReceiver,
+        data: Arc<IpcSharedMemory>,
         font_index: u32,
         result_sender: IpcSender<FontKey>,
     );
@@ -219,7 +219,7 @@ pub enum CanvasToCompositorMsg {
 
 pub enum FontToCompositorMsg {
     AddFontInstance(FontKey, f32, FontInstanceFlags, Sender<FontInstanceKey>),
-    AddFont(Sender<FontKey>, u32, IpcBytesReceiver),
+    AddFont(Sender<FontKey>, u32, Arc<IpcSharedMemory>),
     AddSystemFont(Sender<FontKey>, NativeFontHandle),
 }
 


### PR DESCRIPTION
This changes modifes the way that font data is sent over IPC channels.
Instead of serializing the data or sending it via IPC byte senders, font
data is copied into shared memory and a copy of the handle is sent over
the channel.

There is also the idea of sending the file handle of the on disk data of
system fonts. This could be implemented as a further followup once there
is an abstraction in `ipc-channel` over file handles.

To accomplish this, a `FontData` abstraction is added, which also allows
caching an in-memory shared `Arc<Vec<u8>>` version of the data (neeeded
by some APIs). This could also be a place for caching font tables in the
future.

Finally, the `FontCacheThread` is renamed to the `SystemFontService`
while the proxy for this is now named `SystemFontServiceProxy`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Mukilan Thiyagarajan <mukilan@igalia.com>

Fixes #10230.
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change testable behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
