### PR TITLE
Bring `http_network_or_cache_fetch` closer to the spec

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1104,7 +1104,7 @@ async fn http_network_or_cache_fetch(
 
     // TODO: Step 8. Run these steps, but abort when fetchParams is canceled:
     // Step 8.1: If request’s window is "no-window" and request’s redirect mode is "error", then set
-    //           httpFetchParams to fetchParams and httpRequest to request.
+    // httpFetchParams to fetchParams and httpRequest to request.
     let request_has_no_window = request.window == RequestWindow::NoWindow;
 
     let http_request = if request_has_no_window && request.redirect_mode == RedirectMode::Error {
@@ -1133,11 +1133,11 @@ async fn http_network_or_cache_fetch(
     };
 
     // Step 8.4: If Cross-Origin-Embedder-Policy allows credentials with request returns false, then
-    //           set includeCredentials to false.
+    // set includeCredentials to false.
     // TODO: Requires request's client object
 
     // Step 8.5 Let contentLength be httpRequest’s body’s length, if httpRequest’s body is non-null;
-    //          otherwise null.
+    // otherwise null.
     let content_length = http_request
         .body
         .as_ref()
@@ -1148,19 +1148,19 @@ async fn http_network_or_cache_fetch(
     let mut content_length_header_value = None;
 
     // Step 8.7 If httpRequest’s body is null and httpRequest’s method is `POST` or `PUT`,
-    //          then set contentLengthHeaderValue to `0`.
+    // then set contentLengthHeaderValue to `0`.
     if http_request.body.is_none() && matches!(http_request.method, Method::POST | Method::PUT) {
         content_length_header_value = Some(0);
     }
 
     // Step 8.8 If contentLength is non-null, then set contentLengthHeaderValue to contentLength,
-    //          serialized and isomorphic encoded.
+    // serialized and isomorphic encoded.
     if let Some(content_length) = content_length {
         content_length_header_value = Some(content_length);
     };
 
     // Step 8.9 If contentLengthHeaderValue is non-null, then append (`Content-Length`, contentLengthHeaderValue)
-    //          to httpRequest’s header list.
+    // to httpRequest’s header list.
     if let Some(content_length_header_value) = content_length_header_value {
         http_request
             .headers
@@ -1198,7 +1198,7 @@ async fn http_network_or_cache_fetch(
     // TODO Implement Sec-Fetch-* headers
 
     // Step 8.14: If httpRequest’s initiator is "prefetch", then set a structured field value given
-    //            (`Sec-Purpose`, the token "prefetch") in httpRequest’s header list.
+    // (`Sec-Purpose`, the token "prefetch") in httpRequest’s header list.
     if http_request.initiator == Initiator::Prefetch {
         if let Ok(value) = HeaderValue::from_str("prefetch") {
             http_request.headers.insert("Sec-Purpose", value);
@@ -1206,7 +1206,7 @@ async fn http_network_or_cache_fetch(
     }
 
     // Step 8.15: If httpRequest’s header list does not contain `User-Agent`, then user agents
-    //            should append (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
+    // should append (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
     if !http_request.headers.contains_key(header::USER_AGENT) {
         let user_agent = context.user_agent.clone().into_owned();
         http_request
@@ -1490,13 +1490,13 @@ async fn http_network_or_cache_fetch(
         }
 
         // Step 10.2 Let forwardResponse be the result of running HTTP-network fetch given httpFetchParams,
-        //           includeCredentials, and isNewConnectionFetch.
+        // includeCredentials, and isNewConnectionFetch.
         let forward_response =
             http_network_fetch(http_request, include_credentials, done_chan, context).await;
 
         // Step 10.3 If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399,
-        //           inclusive, invalidate appropriate stored responses in httpCache, as per the
-        //           "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
+        // inclusive, invalidate appropriate stored responses in httpCache, as per the
+        // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
         if forward_response.status.in_range(200..=399) && !http_request.method.is_safe() {
             if let Ok(mut http_cache) = context.state.http_cache.write() {
                 http_cache.invalidate(http_request, &forward_response);
@@ -1551,8 +1551,7 @@ async fn http_network_or_cache_fetch(
     // TODO: Step 13 Set response’s request-includes-credentials to includeCredentials.
 
     // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors",
-    //          includeCredentials is true, and request’s window is an environment settings object, then:
-
+    // includeCredentials is true, and request’s window is an environment settings object, then:
     // TODO: Figure out what to do with request window objects
     if let (Some(StatusCode::UNAUTHORIZED), false, true) =
         (response.status.try_code(), cors_flag, include_credentials)
@@ -1603,7 +1602,7 @@ async fn http_network_or_cache_fetch(
 
         // FIXME: Step 15.3 If fetchParams is canceled, then return the appropriate network error for fetchParams.
         // FIXME: Step 15.4 Prompt the end user as appropriate in request’s window and store the
-        //                  result as a proxy-authentication entry.
+        // result as a proxy-authentication entry.
 
         // Step 15.5 Set response to the result of running HTTP-network-or-cache fetch given fetchParams.
 
@@ -1614,11 +1613,10 @@ async fn http_network_or_cache_fetch(
     }
 
     // TODO: Step 16. If all of the following are true:
-    //                 * response’s status is 421
-    //                 * isNewConnectionFetch is false
-    //                 * request’s body is null, or request’s body is non-null and request’s body’s
-    //                   source is non-null
-    //                 then: [..]
+    // * response’s status is 421
+    // * isNewConnectionFetch is false
+    // * request’s body is null, or request’s body is non-null and request’s body’s source is non-null
+    // then: [..]
 
     // Step 17. If isAuthenticationFetch is true, then create an authentication entry for request and the given realm.
     if authentication_fetch_flag {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2344,7 +2344,7 @@ pub fn append_a_request_origin_header(request: &mut Request) {
                     }
                 },
                 _ => {
-                    // Do nothing.
+                    // Otherwise, do nothing.
                 },
             };
         }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1136,7 +1136,8 @@ async fn http_network_or_cache_fetch(
     //           set includeCredentials to false.
     // TODO: Requires request's client object
 
-    // Step 8.5 Let contentLength be httpRequest’s body’s length, if httpRequest’s body is non-null; otherwise null.
+    // Step 8.5 Let contentLength be httpRequest’s body’s length, if httpRequest’s body is non-null;
+    //          otherwise null.
     let content_length = http_request
         .body
         .as_ref()
@@ -1146,17 +1147,20 @@ async fn http_network_or_cache_fetch(
     // Step 8.6 Let contentLengthHeaderValue be null.
     let mut content_length_header_value = None;
 
-    // Step 8.7 If httpRequest’s body is null and httpRequest’s method is `POST` or `PUT`, then set contentLengthHeaderValue to `0`.
+    // Step 8.7 If httpRequest’s body is null and httpRequest’s method is `POST` or `PUT`,
+    //          then set contentLengthHeaderValue to `0`.
     if http_request.body.is_none() && matches!(http_request.method, Method::POST | Method::PUT) {
         content_length_header_value = Some(0);
     }
 
-    // Step 8.8 If contentLength is non-null, then set contentLengthHeaderValue to contentLength, serialized and isomorphic encoded.
+    // Step 8.8 If contentLength is non-null, then set contentLengthHeaderValue to contentLength,
+    //          serialized and isomorphic encoded.
     if let Some(content_length) = content_length {
         content_length_header_value = Some(content_length);
     };
 
-    // Step 8.9 If contentLengthHeaderValue is non-null, then append (`Content-Length`, contentLengthHeaderValue) to httpRequest’s header list.
+    // Step 8.9 If contentLengthHeaderValue is non-null, then append (`Content-Length`, contentLengthHeaderValue)
+    //          to httpRequest’s header list.
     if let Some(content_length_header_value) = content_length_header_value {
         http_request
             .headers
@@ -1546,8 +1550,8 @@ async fn http_network_or_cache_fetch(
     // FIXME: Step 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
     // FIXME: Step 13 Set response’s request-includes-credentials to includeCredentials.
 
-    // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors", includeCredentials is true,
-    //          and request’s window is an environment settings object, then:
+    // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors",
+    //          includeCredentials is true, and request’s window is an environment settings object, then:
     // FIXME: Figure out what to do with request window objects
     if let (Some(StatusCode::UNAUTHORIZED), false, true) =
         (response.status.try_code(), cors_flag, include_credentials)
@@ -1611,7 +1615,8 @@ async fn http_network_or_cache_fetch(
     // FIXME: Step 16. If all of the following are true:
     //                 * response’s status is 421
     //                 * isNewConnectionFetch is false
-    //                 * request’s body is null, or request’s body is non-null and request’s body’s source is non-null
+    //                 * request’s body is null, or request’s body is non-null and request’s body’s
+    //                   source is non-null
     //                 then: [..]
 
     // Step 17. If isAuthenticationFetch is true, then create an authentication entry for request and the given realm.

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1091,7 +1091,7 @@ async fn http_network_or_cache_fetch(
     context: &FetchContext,
 ) -> Response {
     // Step 1. Let request be fetchParams’s request.
-    // NOTE: We get request as an argument
+    // NOTE: We get request as an argument (Fetchparams are not implemented, see #33616)
 
     // Step 3. Let httpRequest be null.
     let mut http_request;
@@ -1102,7 +1102,7 @@ async fn http_network_or_cache_fetch(
     // Step 7. Let the revalidatingFlag be unset.
     let mut revalidating_flag = false;
 
-    // TODO: Step 8. Run these steps, but abort when fetchParams is canceled:
+    // TODO(#33616): Step 8. Run these steps, but abort when fetchParams is canceled:
     // Step 8.1: If request’s window is "no-window" and request’s redirect mode is "error", then set
     // httpFetchParams to fetchParams and httpRequest to request.
     let request_has_no_window = request.window == RequestWindow::NoWindow;
@@ -1115,7 +1115,7 @@ async fn http_network_or_cache_fetch(
         // Step 8.2.1: Set httpRequest to a clone of request.
         http_request = request.clone();
 
-        // TODO: Step 8.2.2-8.2.3
+        // TODO(#33616): Step 8.2.2-8.2.3
         &mut http_request
     };
 
@@ -1134,7 +1134,7 @@ async fn http_network_or_cache_fetch(
 
     // Step 8.4: If Cross-Origin-Embedder-Policy allows credentials with request returns false, then
     // set includeCredentials to false.
-    // TODO: Requires request's client object
+    // TODO(#33616): Requires request's client object
 
     // Step 8.5 Let contentLength be httpRequest’s body’s length, if httpRequest’s body is non-null;
     // otherwise null.
@@ -1170,7 +1170,7 @@ async fn http_network_or_cache_fetch(
 
     // Step 8.10 If contentLength is non-null and httpRequest’s keepalive is true, then:
     if content_length.is_some() && http_request.keep_alive {
-        // TODO Keepalive requires request's client object's fetch group
+        // TODO(#33616) Keepalive requires request's client object's fetch group
     }
 
     // Step 8.11: If httpRequest’s referrer is a URL, then:
@@ -1196,7 +1196,7 @@ async fn http_network_or_cache_fetch(
     append_a_request_origin_header(http_request);
 
     // Step 8.13 Append the Fetch metadata headers for httpRequest.
-    // TODO Implement Sec-Fetch-* headers
+    // TODO(#33616) Implement Sec-Fetch-* headers
 
     // Step 8.14: If httpRequest’s initiator is "prefetch", then set a structured field value given
     // (`Sec-Purpose`, the token "prefetch") in httpRequest’s header list.
@@ -1317,7 +1317,7 @@ async fn http_network_or_cache_fetch(
         }
     }
 
-    // FIXME Step 8.22 If there’s a proxy-authentication entry, use it as appropriate.
+    // TODO(#33616) Step 8.22 If there’s a proxy-authentication entry, use it as appropriate.
 
     // If the cache is not ready to construct a response, wait.
     //
@@ -1354,7 +1354,8 @@ async fn http_network_or_cache_fetch(
             }
         }
 
-        // TODO: Step 8.23 Set httpCache to the result of determining the HTTP cache partition, given httpRequest.
+        // TODO(#33616): Step 8.23 Set httpCache to the result of determining the
+        // HTTP cache partition, given httpRequest.
         if let Ok(http_cache) = context.state.http_cache.read() {
             // Step 8.25.1 Set storedResponse to the result of selecting a response from the httpCache,
             //              possibly needing validation, as per the "Constructing Responses from Caches"
@@ -1476,7 +1477,7 @@ async fn http_network_or_cache_fetch(
 
     wait_for_cached_response(done_chan, &mut response).await;
 
-    // TODO: Step 9. If aborted, then return the appropriate network error for fetchParams.
+    // TODO(#33616): Step 9. If aborted, then return the appropriate network error for fetchParams.
 
     // Step 10. If response is null, then:
     if response.is_none() {
@@ -1537,7 +1538,7 @@ async fn http_network_or_cache_fetch(
     let mut response = response.unwrap();
 
     // FIXME: The spec doesn't tell us to do this *here*, but if we don't do it then
-    //        tests fail. Where should we do it instead?
+    // tests fail. Where should we do it instead? See also #33615
     if http_request.response_tainting != ResponseTainting::CorsTainting &&
         cross_origin_resource_policy_check(http_request, &response) ==
             CrossOriginResourcePolicy::Blocked
@@ -1547,13 +1548,14 @@ async fn http_network_or_cache_fetch(
         ));
     }
 
-    // TODO: Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
-    // TODO: Step 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
-    // TODO: Step 13 Set response’s request-includes-credentials to includeCredentials.
+    // TODO(#33616): Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
+    // TODO(#33616): Step 12. If httpRequest’s header list contains `Range`,
+    // then set response’s range-requested flag.
+    // TODO(#33616): Step 13 Set response’s request-includes-credentials to includeCredentials.
 
     // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors",
     // includeCredentials is true, and request’s window is an environment settings object, then:
-    // TODO: Figure out what to do with request window objects
+    // TODO(#33616): Figure out what to do with request window objects
     if let (Some(StatusCode::UNAUTHORIZED), false, true) =
         (response.status.try_code(), cors_flag, include_credentials)
     {
@@ -1566,11 +1568,11 @@ async fn http_network_or_cache_fetch(
 
         // Step 14.3 If request’s use-URL-credentials flag is unset or isAuthenticationFetch is true, then:
         if !http_request.use_url_credentials || authentication_fetch_flag {
-            // FIXME: Prompt the user for username and password from the window
+            // TODO(#33616, #27439): Prompt the user for username and password from the window
 
             // Wrong, but will have to do until we are able to prompt the user
             // otherwise this creates an infinite loop
-            // We basically pretend that the user declined to enter credentials
+            // We basically pretend that the user declined to enter credentials (#33616)
             return response;
         }
 
@@ -1601,19 +1603,20 @@ async fn http_network_or_cache_fetch(
 
         // (Step 15.2 does not exist, requires testing on Proxy-Authenticate headers)
 
-        // FIXME: Step 15.3 If fetchParams is canceled, then return the appropriate network error for fetchParams.
-        // FIXME: Step 15.4 Prompt the end user as appropriate in request’s window and store the
+        // TODO(#33616): Step 15.3 If fetchParams is canceled, then return
+        // the appropriate network error for fetchParams.
+        // TODO(#33616): Step 15.4 Prompt the end user as appropriate in request’s window and store the
         // result as a proxy-authentication entry.
 
         // Step 15.5 Set response to the result of running HTTP-network-or-cache fetch given fetchParams.
 
         // Wrong, but will have to do until we are able to prompt the user
         // otherwise this creates an infinite loop
-        // We basically pretend that the user declined to enter credentials
+        // We basically pretend that the user declined to enter credentials (#33616)
         return response;
     }
 
-    // TODO: Step 16. If all of the following are true:
+    // TODO(#33616): Step 16. If all of the following are true:
     // * response’s status is 421
     // * isNewConnectionFetch is false
     // * request’s body is null, or request’s body is non-null and request’s body’s source is non-null
@@ -1621,7 +1624,7 @@ async fn http_network_or_cache_fetch(
 
     // Step 17. If isAuthenticationFetch is true, then create an authentication entry for request and the given realm.
     if authentication_fetch_flag {
-        // TODO
+        // TODO(#33616)
     }
 
     // Step 18. Return response.
@@ -1637,7 +1640,7 @@ enum CrossOriginResourcePolicy {
     Blocked,
 }
 
-// TODO: Judging from the name, this appears to be https://fetch.spec.whatwg.org/#cross-origin-resource-policy-check,
+// TODO(#33615): Judging from the name, this appears to be https://fetch.spec.whatwg.org/#cross-origin-resource-policy-check,
 //       but the steps aren't even close to the spec. Perhaps this needs to be rewritten?
 fn cross_origin_resource_policy_check(
     request: &Request,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1354,7 +1354,7 @@ async fn http_network_or_cache_fetch(
             }
         }
 
-        // Step 8.23 Set httpCache to the result of determining the HTTP cache partition, given httpRequest.
+        // TODO: Step 8.23 Set httpCache to the result of determining the HTTP cache partition, given httpRequest.
         if let Ok(http_cache) = context.state.http_cache.read() {
             // Step 8.25.1 Set storedResponse to the result of selecting a response from the httpCache,
             //              possibly needing validation, as per the "Constructing Responses from Caches"

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2290,8 +2290,9 @@ fn serialize_request_origin(request: &Request) -> headers::Origin {
     match origin {
         ImmutableOrigin::Opaque(_) => headers::Origin::NULL,
         ImmutableOrigin::Tuple(scheme, host, port) => {
+            // TODO: Ensure that hyper/servo don't disagree about valid origin headers
             headers::Origin::try_from_parts(scheme, &host.to_string(), *port)
-                .expect("servo and hyper disagree about valid origins")
+                .unwrap_or(headers::Origin::NULL)
         },
     }
 }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1155,6 +1155,7 @@ async fn http_network_or_cache_fetch(
 
     // Step 8.8 If contentLength is non-null, then set contentLengthHeaderValue to contentLength,
     // serialized and isomorphic encoded.
+    // NOTE: The header will later be serialized using HeaderMap::typed_insert
     if let Some(content_length) = content_length {
         content_length_header_value = Some(content_length);
     };

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1519,11 +1519,11 @@ async fn http_network_or_cache_fetch(
             // Step 10.5.1 Set response to forwardResponse.
             let forward_response = response.insert(forward_response);
 
+            // Per https://httpwg.org/specs/rfc9111.html#response.cacheability we must not cache responses
+            // if the No-Store directive is present
             if http_request.cache_mode != CacheMode::NoStore {
                 // Step 10.5.2 Store httpRequest and forwardResponse in httpCache, as per the
                 //             "Storing Responses in Caches" chapter of HTTP Caching.
-                // TODO: The spec doesn't explicitly tell us to check for CacheMode::NoStore.
-                //       Is this correct?
                 if let Ok(mut http_cache) = context.state.http_cache.write() {
                     http_cache.store(http_request, forward_response);
                 }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1102,7 +1102,7 @@ async fn http_network_or_cache_fetch(
     // Step 7. Let the revalidatingFlag be unset.
     let mut revalidating_flag = false;
 
-    // Step 8. Run these steps, but abort when fetchParams is canceled:
+    // TODO: Step 8. Run these steps, but abort when fetchParams is canceled:
     // Step 8.1: If request’s window is "no-window" and request’s redirect mode is "error", then set
     //           httpFetchParams to fetchParams and httpRequest to request.
     let request_has_no_window = request.window == RequestWindow::NoWindow;
@@ -1115,7 +1115,7 @@ async fn http_network_or_cache_fetch(
         // Step 8.2.1: Set httpRequest to a clone of request.
         http_request = request.clone();
 
-        // FIXME: Step 8.2.2-8.2.3
+        // TODO: Step 8.2.2-8.2.3
         &mut http_request
     };
 
@@ -1475,9 +1475,9 @@ async fn http_network_or_cache_fetch(
 
     wait_for_cached_response(done_chan, &mut response).await;
 
-    // Step 9 If aborted, then return the appropriate network error for fetchParams.
+    // TODO: Step 9. If aborted, then return the appropriate network error for fetchParams.
 
-    // Step 10 If response is null, then:
+    // Step 10. If response is null, then:
     if response.is_none() {
         // Step 10.1 If httpRequest’s cache mode is "only-if-cached", then return a network error.
         if http_request.cache_mode == CacheMode::OnlyIfCached {
@@ -1546,13 +1546,14 @@ async fn http_network_or_cache_fetch(
         ));
     }
 
-    // FIXME: Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
-    // FIXME: Step 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
-    // FIXME: Step 13 Set response’s request-includes-credentials to includeCredentials.
+    // TODO: Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
+    // TODO: Step 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
+    // TODO: Step 13 Set response’s request-includes-credentials to includeCredentials.
 
     // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors",
     //          includeCredentials is true, and request’s window is an environment settings object, then:
-    // FIXME: Figure out what to do with request window objects
+
+    // TODO: Figure out what to do with request window objects
     if let (Some(StatusCode::UNAUTHORIZED), false, true) =
         (response.status.try_code(), cors_flag, include_credentials)
     {
@@ -1612,7 +1613,7 @@ async fn http_network_or_cache_fetch(
         return response;
     }
 
-    // FIXME: Step 16. If all of the following are true:
+    // TODO: Step 16. If all of the following are true:
     //                 * response’s status is 421
     //                 * isNewConnectionFetch is false
     //                 * request’s body is null, or request’s body is non-null and request’s body’s

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -136,7 +136,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
     }
 }
 
-// https://fetch.spec.whatwg.org/#fetch-method
+/// <https://fetch.spec.whatwg.org/#fetch-method>
 #[allow(crown::unrooted_must_root, non_snake_case)]
 pub fn Fetch(
     global: &GlobalScope,
@@ -146,33 +146,45 @@ pub fn Fetch(
 ) -> Rc<Promise> {
     let core_resource_thread = global.core_resource_thread();
 
-    // Step 1
+    // Step 1. Let p be a new promise.
     let promise = Promise::new_in_current_realm(comp);
+
+    // Step 7. Let responseObject be null.
+    // NOTE: We do step 7 earlier so we can use it to track errors
     let response = Response::new(global);
 
-    // Step 2
+    // Step 2. Let requestObject be the result of invoking the initial value of Request as constructor
+    //         with input and init as arguments. If this throws an exception, reject p with it and return p.
     let request = match Request::Constructor(global, None, CanGc::note(), input, init) {
         Err(e) => {
             response.error_stream(e.clone());
             promise.reject_error(e);
             return promise;
         },
-        Ok(r) => r.get_request(),
+        Ok(r) => {
+            // Step 3. Let request be requestObject’s request.
+            r.get_request()
+        },
     };
     let timing_type = request.timing_type();
 
     let mut request_init = request_init_from_request(request);
     request_init.csp_list.clone_from(&global.get_csp_list());
 
-    // Step 3
+    // FIXME: Step 4. If requestObject’s signal is aborted, then: [..]
+
+    // Step 5. Let globalObject be request’s client’s global object.
+    // NOTE:   We already get the global object as an argument
+
+    // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s service-workers mode to "none".
     if global.downcast::<ServiceWorkerGlobalScope>().is_some() {
         request_init.service_workers_mode = ServiceWorkersMode::None;
     }
 
-    // Step 4
-    response.Headers().set_guard(Guard::Immutable);
+    // FIXME: Steps 8-11, abortcontroller stuff
 
-    // Step 5
+    // Step 12. Set controller to the result of calling fetch given request and processResponse given response being these steps:
+    //          [..]
     let (action_sender, action_receiver) = ipc::channel().unwrap();
     let fetch_context = Arc::new(Mutex::new(FetchContext {
         fetch_promise: Some(TrustedPromise::new(promise.clone())),
@@ -198,6 +210,7 @@ pub fn Fetch(
         ))
         .unwrap();
 
+    // Step 13. Return p.
     promise
 }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -150,8 +150,9 @@ pub fn Fetch(
     let promise = Promise::new_in_current_realm(comp);
 
     // Step 7. Let responseObject be null.
-    // NOTE: We do step 7 earlier so we can use it to track errors
+    // NOTE: We do initialize the object earlier earlier so we can use it to track errors
     let response = Response::new(global);
+    response.Headers().set_guard(Guard::Immutable);
 
     // Step 2. Let requestObject be the result of invoking the initial value of Request as constructor
     //         with input and init as arguments. If this throws an exception, reject p with it and return p.
@@ -274,6 +275,7 @@ impl FetchResponseListener for FetchContext {
                 },
             },
         }
+
         // Step 4.3
         promise.resolve_native(&self.response_object.root());
         self.fetch_promise = Some(TrustedPromise::new(promise));

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -177,15 +177,16 @@ pub fn Fetch(
     // Step 5. Let globalObject be request’s client’s global object.
     // NOTE:   We already get the global object as an argument
 
-    // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s service-workers mode to "none".
+    // Step 6. If globalObject is a ServiceWorkerGlobalScope object, then set request’s
+    //         service-workers mode to "none".
     if global.downcast::<ServiceWorkerGlobalScope>().is_some() {
         request_init.service_workers_mode = ServiceWorkersMode::None;
     }
 
     // FIXME: Steps 8-11, abortcontroller stuff
 
-    // Step 12. Set controller to the result of calling fetch given request and processResponse given response being these steps:
-    //          [..]
+    // Step 12. Set controller to the result of calling fetch given request and
+    //           processResponse given response being these steps: [..]
     let (action_sender, action_receiver) = ipc::channel().unwrap();
     let fetch_context = Arc::new(Mutex::new(FetchContext {
         fetch_promise: Some(TrustedPromise::new(promise.clone())),

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -172,7 +172,7 @@ pub fn Fetch(
     let mut request_init = request_init_from_request(request);
     request_init.csp_list.clone_from(&global.get_csp_list());
 
-    // FIXME: Step 4. If requestObject’s signal is aborted, then: [..]
+    // TODO: Step 4. If requestObject’s signal is aborted, then: [..]
 
     // Step 5. Let globalObject be request’s client’s global object.
     // NOTE:   We already get the global object as an argument
@@ -183,7 +183,7 @@ pub fn Fetch(
         request_init.service_workers_mode = ServiceWorkersMode::None;
     }
 
-    // FIXME: Steps 8-11, abortcontroller stuff
+    // TODO: Steps 8-11, abortcontroller stuff
 
     // Step 12. Set controller to the result of calling fetch given request and
     //           processResponse given response being these steps: [..]

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -679,8 +679,8 @@ impl Request {
                         ReferrerPolicy::StrictOrigin |
                         ReferrerPolicy::StrictOriginWhenCrossOrigin,
                     ) => {
-                        // If request’s origin is a tuple origin, its scheme is "https", and request’s current URL’s scheme is not "https",
-                        // then set serializedOrigin to `null`.
+                        // If request’s origin is a tuple origin, its scheme is "https", and
+                        // request’s current URL’s scheme is not "https", then set serializedOrigin to `null`.
                         if let ImmutableOrigin::Tuple(scheme, _, _) = &request_origin {
                             if scheme == "https" && self.current_url().scheme() != "https" {
                                 serialized_origin = headers::Origin::NULL;
@@ -688,7 +688,8 @@ impl Request {
                         }
                     },
                     Some(ReferrerPolicy::SameOrigin) => {
-                        // If request’s origin is not same origin with request’s current URL’s origin, then set serializedOrigin to `null`.
+                        // If request’s origin is not same origin with request’s current URL’s origin,
+                        // then set serializedOrigin to `null`.
                         if *request_origin != self.current_url().origin() {
                             serialized_origin = headers::Origin::NULL;
                         }
@@ -859,7 +860,7 @@ pub fn convert_header_names_to_sorted_lowercase_set(
     ordered_set.into_iter().cloned().collect()
 }
 
-/// <https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin>
+/// <https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin>
 fn immutable_origin_to_hyper_origin(origin: &ImmutableOrigin) -> headers::Origin {
     match origin {
         ImmutableOrigin::Opaque(_) => headers::Origin::NULL,

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use base::id::PipelineId;
 use content_security_policy::{self as csp, CspList};
+use headers::HeaderMapExt;
 use http::header::{HeaderName, AUTHORIZATION};
 use http::{HeaderMap, Method};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
@@ -598,6 +599,110 @@ impl Request {
             ResourceTimingType::Resource
         }
     }
+
+    /// <https://fetch.spec.whatwg.org/#concept-request-tainted-origin>
+    fn has_redirect_tainted_origin(&self) -> bool {
+        // https://github.com/whatwg/fetch/issues/1773
+        let Origin::Origin(request_origin) = &self.origin else {
+            panic!("origin cannot be \"client\" at this point in time");
+        };
+
+        // Step 1. Let lastURL be null.
+        let mut last_url = None;
+
+        // Step 2. For each url of request’s URL list:
+        for url in &self.url_list {
+            // Step 2.1 If lastURL is null, then set lastURL to url and continue.
+            let Some(last_url) = &mut last_url else {
+                last_url = Some(url);
+                continue;
+            };
+
+            // Step 2.2 If url’s origin is not same origin with lastURL’s origin and
+            //          request’s origin is not same origin with lastURL’s origin, then return true.
+            if url.origin() != last_url.origin() && *request_origin != last_url.origin() {
+                return true;
+            }
+
+            // Step 2.3 Set lastURL to url.
+            *last_url = url;
+        }
+
+        // Step 3. Return false.
+        false
+    }
+
+    /// <https://fetch.spec.whatwg.org/#serializing-a-request-origin>
+    fn serialize_request_origin(&self) -> headers::Origin {
+        // 1. If request has a redirect-tainted origin, then return "null".
+        if self.has_redirect_tainted_origin() {
+            return headers::Origin::NULL;
+        }
+
+        // 2. Return request’s origin, serialized.
+        // NOTE: https://github.com/whatwg/fetch/issues/1773
+        let Origin::Origin(origin) = &self.origin else {
+            panic!("origin cannot be \"client\" at this point in time");
+        };
+
+        immutable_origin_to_hyper_origin(origin)
+    }
+
+    /// <https://fetch.spec.whatwg.org/#append-a-request-origin-header>
+    pub fn append_a_request_origin_header(&mut self) {
+        // https://github.com/whatwg/fetch/issues/1773
+        let Origin::Origin(request_origin) = &self.origin else {
+            panic!("origin cannot be \"client\" at this point in time");
+        };
+
+        // Step 1. Let serializedOrigin be the result of byte-serializing a request origin with request.
+        let mut serialized_origin = self.serialize_request_origin();
+
+        // Step 2. If request’s response tainting is "cors" or request’s mode is "websocket",
+        //         then append (`Origin`, serializedOrigin) to request’s header list.
+        if self.response_tainting == ResponseTainting::CorsTainting ||
+            matches!(self.mode, RequestMode::WebSocket { .. })
+        {
+            self.headers.typed_insert(serialized_origin);
+        }
+        // Step 3. Otherwise, if request’s method is neither `GET` nor `HEAD`, then:
+        else if !matches!(self.method, Method::GET | Method::HEAD) {
+            // Step 3.1 If request’s mode is not "cors", then switch on request’s referrer policy:
+            if self.mode != RequestMode::CorsMode {
+                match self.referrer_policy {
+                    Some(ReferrerPolicy::NoReferrer) => {
+                        // Set serializedOrigin to `null`.
+                        serialized_origin = headers::Origin::NULL;
+                    },
+                    Some(
+                        ReferrerPolicy::NoReferrerWhenDowngrade |
+                        ReferrerPolicy::StrictOrigin |
+                        ReferrerPolicy::StrictOriginWhenCrossOrigin,
+                    ) => {
+                        // If request’s origin is a tuple origin, its scheme is "https", and request’s current URL’s scheme is not "https",
+                        // then set serializedOrigin to `null`.
+                        if let ImmutableOrigin::Tuple(scheme, _, _) = &request_origin {
+                            if scheme == "https" && self.current_url().scheme() != "https" {
+                                serialized_origin = headers::Origin::NULL;
+                            }
+                        }
+                    },
+                    Some(ReferrerPolicy::SameOrigin) => {
+                        // If request’s origin is not same origin with request’s current URL’s origin, then set serializedOrigin to `null`.
+                        if *request_origin != self.current_url().origin() {
+                            serialized_origin = headers::Origin::NULL;
+                        }
+                    },
+                    _ => {
+                        // Do nothing.
+                    },
+                };
+            }
+
+            // Step 3.2. Append (`Origin`, serializedOrigin) to request’s header list.
+            self.headers.typed_insert(serialized_origin);
+        }
+    }
 }
 
 impl Referrer {
@@ -752,4 +857,15 @@ pub fn convert_header_names_to_sorted_lowercase_set(
     ordered_set.sort_by(|a, b| a.as_str().partial_cmp(b.as_str()).unwrap());
     ordered_set.dedup();
     ordered_set.into_iter().cloned().collect()
+}
+
+/// <https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin>
+fn immutable_origin_to_hyper_origin(origin: &ImmutableOrigin) -> headers::Origin {
+    match origin {
+        ImmutableOrigin::Opaque(_) => headers::Origin::NULL,
+        ImmutableOrigin::Tuple(scheme, host, port) => {
+            headers::Origin::try_from_parts(scheme, &host.to_string(), *port)
+                .expect("servo and hyper disagree about valid origins")
+        },
+    }
 }

--- a/tests/wpt/meta/fetch/origin/assorted.window.js.ini
+++ b/tests/wpt/meta/fetch/origin/assorted.window.js.ini
@@ -1,13 +1,4 @@
 [assorted.window.html]
-  [Origin header and 308 redirect]
-    expected: FAIL
-
-  [Origin header and POST cross-origin fetch no-cors mode with Referrer-Policy no-referrer]
-    expected: FAIL
-
-  [Origin header and POST same-origin fetch no-cors mode with Referrer-Policy no-referrer]
-    expected: FAIL
-
   [Origin header and POST cross-origin navigation with Referrer-Policy origin-when-cross-origin]
     expected: FAIL
 
@@ -17,16 +8,7 @@
   [Origin header and POST navigation]
     expected: FAIL
 
-  [Origin header and POST cross-origin navigation with Referrer-Policy no-referrer]
-    expected: FAIL
-
   [Origin header and POST cross-origin navigation with Referrer-Policy same-origin]
-    expected: FAIL
-
-  [Origin header and POST cross-origin fetch no-cors mode with Referrer-Policy same-origin]
-    expected: FAIL
-
-  [Origin header and POST same-origin navigation with Referrer-Policy no-referrer]
     expected: FAIL
 
   [Origin header and POST cross-origin navigation with Referrer-Policy no-referrer-when-downgrade]


### PR DESCRIPTION
This adds spec steps for the [ `http_network_or_cache_fetch`](https://fetch.spec.whatwg.org#http-network-or-cache-fetch) algorithm and implements the missing [`append_a_request_origin_header`](https://fetch.spec.whatwg.org/#append-a-request-origin-header) method, fixing a few WPT subtests in the process.

Draft because I would like to get https://github.com/whatwg/fetch/pull/1776 merged first and update the spec steps accordingly, but apart from that this is ready for review.

[try run](https://github.com/simonwuelker/servo/actions/runs/11013561747)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes 

