### PR TITLE
Replace IPC channel with GenericChannel in Bluetooth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
 name = "bluetooth"
 version = "0.0.1"
 dependencies = [
+ "base",
  "bitflags 2.6.0",
  "bluetooth_traits",
  "blurdroid",

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -12,6 +12,7 @@ name = "bluetooth"
 path = "lib.rs"
 
 [dependencies]
+base = { workspace = true }
 bitflags = { workspace = true }
 bluetooth_traits = { workspace = true }
 blurmock = { version = "0.1.2", optional = true }

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -76,7 +76,8 @@ pub trait BluetoothThreadFactory {
 
 impl BluetoothThreadFactory for GenericSender<BluetoothRequest> {
     fn new(embedder_proxy: EmbedderProxy) -> GenericSender<BluetoothRequest> {
-        let (sender, receiver) = base::generic_channel::channel(servo_config::opts::multiprocess()).unwrap();
+        let (sender, receiver) =
+            base::generic_channel::channel(servo_config::opts::multiprocess()).unwrap();
         let adapter = if pref!(dom.bluetooth.enabled) {
             BluetoothAdapter::new()
         } else {
@@ -408,14 +409,15 @@ impl BluetoothManager {
             ]);
         }
 
-        let (ipc_sender, ipc_receiver) = ipc::channel().expect("Failed to create IPC channel!");
+        let (sender, receiver) =
+            base::generic_channel::channel(servo_config::opts::multiprocess()).unwrap();
         let msg = (
             None,
-            EmbedderMsg::GetSelectedBluetoothDevice(dialog_rows, ipc_sender),
+            EmbedderMsg::GetSelectedBluetoothDevice(dialog_rows, sender),
         );
         self.embedder_proxy.send(msg);
 
-        match ipc_receiver.recv() {
+        match receiver.recv() {
             Ok(result) => result,
             Err(e) => {
                 warn!("Failed to receive files from embedder ({:?}).", e);

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -355,7 +355,7 @@ pub struct Constellation<STF, SWF> {
 
     /// An IPC channel for the constellation to send messages to the
     /// bluetooth thread.
-    bluetooth_ipc_sender:  GenericSender<BluetoothRequest>,
+    bluetooth_sender: GenericSender<BluetoothRequest>,
 
     /// A map of origin to sender to a Service worker manager.
     sw_managers: HashMap<ImmutableOrigin, IpcSender<ServiceWorkerMsg>>,
@@ -514,7 +514,7 @@ pub struct InitialConstellationState {
     pub devtools_sender: Option<Sender<DevtoolsControlMsg>>,
 
     /// A channel to the bluetooth thread.
-    pub bluetooth_thread:  GenericSender<BluetoothRequest>,
+    pub bluetooth_thread: GenericSender<BluetoothRequest>,
 
     /// A channel to the font cache thread.
     pub font_cache_thread: FontCacheThread,
@@ -760,7 +760,7 @@ where
                     compositor_proxy: state.compositor_proxy,
                     webviews: WebViewManager::default(),
                     devtools_sender: state.devtools_sender,
-                    bluetooth_ipc_sender: state.bluetooth_thread,
+                    bluetooth_sender: state.bluetooth_thread,
                     public_resource_threads: state.public_resource_threads,
                     private_resource_threads: state.private_resource_threads,
                     font_cache_thread: state.font_cache_thread,
@@ -1041,7 +1041,7 @@ where
             scheduler_chan: self.scheduler_ipc_sender.clone(),
             compositor_proxy: self.compositor_proxy.clone(),
             devtools_sender: self.devtools_sender.clone(),
-            bluetooth_thread: self.bluetooth_ipc_sender.clone(),
+            bluetooth_thread: self.bluetooth_sender.clone(),
             swmanager_thread: self.swmanager_ipc_sender.clone(),
             font_cache_thread: self.font_cache_thread.clone(),
             resource_threads,
@@ -2705,7 +2705,7 @@ where
         }
 
         debug!("Exiting bluetooth thread.");
-        if let Err(e) = self.bluetooth_ipc_sender.send(BluetoothRequest::Exit) {
+        if let Err(e) = self.bluetooth_sender.send(BluetoothRequest::Exit) {
             warn!("Exit bluetooth thread failed ({})", e);
         }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -97,6 +97,7 @@ use background_hang_monitor::HangMonitorRegister;
 use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
 };
+use base::generic_channel::GenericSender;
 use base::id::{
     BroadcastChannelRouterId, BrowsingContextGroupId, BrowsingContextId, HistoryStateId,
     MessagePortId, MessagePortRouterId, PipelineId, PipelineNamespace, PipelineNamespaceId,
@@ -354,7 +355,7 @@ pub struct Constellation<STF, SWF> {
 
     /// An IPC channel for the constellation to send messages to the
     /// bluetooth thread.
-    bluetooth_ipc_sender: IpcSender<BluetoothRequest>,
+    bluetooth_ipc_sender:  GenericSender<BluetoothRequest>,
 
     /// A map of origin to sender to a Service worker manager.
     sw_managers: HashMap<ImmutableOrigin, IpcSender<ServiceWorkerMsg>>,
@@ -513,7 +514,7 @@ pub struct InitialConstellationState {
     pub devtools_sender: Option<Sender<DevtoolsControlMsg>>,
 
     /// A channel to the bluetooth thread.
-    pub bluetooth_thread: IpcSender<BluetoothRequest>,
+    pub bluetooth_thread:  GenericSender<BluetoothRequest>,
 
     /// A channel to the font cache thread.
     pub font_cache_thread: FontCacheThread,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -6,11 +6,12 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
-use base::generic_channel::GenericSender;
+
 use background_hang_monitor::HangMonitorRegister;
 use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
 };
+use base::generic_channel::GenericSender;
 use base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, PipelineNamespaceId,
     PipelineNamespaceRequest, TopLevelBrowsingContextId,
@@ -148,7 +149,7 @@ pub struct InitialPipelineState {
     pub devtools_sender: Option<Sender<DevtoolsControlMsg>>,
 
     /// A channel to the bluetooth thread.
-    pub bluetooth_thread:  GenericSender<BluetoothRequest>,
+    pub bluetooth_thread: GenericSender<BluetoothRequest>,
 
     /// A channel to the service worker manager thread
     pub swmanager_thread: IpcSender<SWManagerMsg>,
@@ -485,7 +486,7 @@ pub struct UnprivilegedPipelineContent {
     layout_to_constellation_chan: IpcSender<LayoutMsg>,
     scheduler_chan: IpcSender<TimerSchedulerMsg>,
     devtools_ipc_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
-    bluetooth_thread:  GenericSender<BluetoothRequest>,
+    bluetooth_thread: GenericSender<BluetoothRequest>,
     swmanager_thread: IpcSender<SWManagerMsg>,
     font_cache_thread: FontCacheThread,
     resource_threads: ResourceThreads,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
-
+use base::generic_channel::GenericSender;
 use background_hang_monitor::HangMonitorRegister;
 use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
@@ -148,7 +148,7 @@ pub struct InitialPipelineState {
     pub devtools_sender: Option<Sender<DevtoolsControlMsg>>,
 
     /// A channel to the bluetooth thread.
-    pub bluetooth_thread: IpcSender<BluetoothRequest>,
+    pub bluetooth_thread:  GenericSender<BluetoothRequest>,
 
     /// A channel to the service worker manager thread
     pub swmanager_thread: IpcSender<SWManagerMsg>,
@@ -485,7 +485,7 @@ pub struct UnprivilegedPipelineContent {
     layout_to_constellation_chan: IpcSender<LayoutMsg>,
     scheduler_chan: IpcSender<TimerSchedulerMsg>,
     devtools_ipc_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
-    bluetooth_thread: IpcSender<BluetoothRequest>,
+    bluetooth_thread:  GenericSender<BluetoothRequest>,
     swmanager_thread: IpcSender<SWManagerMsg>,
     font_cache_thread: FontCacheThread,
     resource_threads: ResourceThreads,

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -43,6 +43,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
+use base::generic_channel::GenericSender;
 
 const KEY_CONVERSION_ERROR: &str =
     "This `manufacturerData` key can not be parsed as unsigned short:";
@@ -151,7 +152,7 @@ impl Bluetooth {
         reflect_dom_object(Box::new(Bluetooth::new_inherited()), global)
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -152,7 +152,7 @@ impl Bluetooth {
         reflect_dom_object(Box::new(Bluetooth::new_inherited()), global)
     }
 
-    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{
     BluetoothCharacteristicMsg, BluetoothDescriptorMsg, BluetoothRequest, BluetoothResponse,
     BluetoothServiceMsg,
@@ -13,7 +14,6 @@ use bluetooth_traits::{
 use dom_struct::dom_struct;
 use profile_traits::ipc;
 
-use base::generic_channel::GenericSender;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
@@ -182,7 +182,7 @@ impl BluetoothDevice {
         bt_descriptor
     }
 
-    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -11,9 +11,9 @@ use bluetooth_traits::{
     BluetoothServiceMsg,
 };
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 use profile_traits::ipc;
 
+use base::generic_channel::GenericSender;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
@@ -182,7 +182,7 @@ impl BluetoothDevice {
         bt_descriptor
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -4,9 +4,9 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom_struct::dom_struct;
-
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::BluetoothPermissionResultMethods;
@@ -15,7 +15,6 @@ use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::Permission
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionName, PermissionState,
 };
-use base::generic_channel::GenericSender;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
@@ -59,7 +58,7 @@ impl BluetoothPermissionResult {
         self.global().as_window().Navigator().Bluetooth()
     }
 
-    pub fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    pub fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetoothpermissionresult.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
+
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::BluetoothPermissionResultMethods;
@@ -15,6 +15,7 @@ use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::Permission
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::{
     PermissionName, PermissionState,
 };
+use base::generic_channel::GenericSender;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
@@ -58,7 +59,7 @@ impl BluetoothPermissionResult {
         self.global().as_window().Navigator().Bluetooth()
     }
 
-    pub fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    pub fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -4,10 +4,10 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::blocklist::{uuid_is_blocklisted, Blocklist};
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 use dom_struct::dom_struct;
-
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::BluetoothCharacteristicPropertiesMethods;
@@ -18,7 +18,6 @@ use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
 use crate::dom::bindings::error::Error::{
     self, InvalidModification, Network, NotSupported, Security,
 };
-use base::generic_channel::GenericSender;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -82,7 +81,7 @@ impl BluetoothRemoteGATTCharacteristic {
         )
     }
 
-    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use bluetooth_traits::blocklist::{uuid_is_blocklisted, Blocklist};
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
+
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::BluetoothCharacteristicPropertiesMethods;
@@ -18,6 +18,7 @@ use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
 use crate::dom::bindings::error::Error::{
     self, InvalidModification, Network, NotSupported, Security,
 };
+use base::generic_channel::GenericSender;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -81,7 +82,7 @@ impl BluetoothRemoteGATTCharacteristic {
         )
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -4,10 +4,11 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::blocklist::{uuid_is_blocklisted, Blocklist};
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom_struct::dom_struct;
-use base::generic_channel::GenericSender;
+
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::BluetoothRemoteGATTCharacteristicMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding::BluetoothRemoteGATTDescriptorMethods;
@@ -67,7 +68,7 @@ impl BluetoothRemoteGATTDescriptor {
         )
     }
 
-    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -7,8 +7,7 @@ use std::rc::Rc;
 use bluetooth_traits::blocklist::{uuid_is_blocklisted, Blocklist};
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
-
+use base::generic_channel::GenericSender;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::BluetoothRemoteGATTCharacteristicMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding::BluetoothRemoteGATTDescriptorMethods;
@@ -68,7 +67,7 @@ impl BluetoothRemoteGATTDescriptor {
         )
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -5,9 +5,10 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 use dom_struct::dom_struct;
-use base::generic_channel::GenericSender;
+
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
@@ -47,7 +48,7 @@ impl BluetoothRemoteGATTServer {
         )
     }
 
-    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -7,8 +7,7 @@ use std::rc::Rc;
 
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
-
+use base::generic_channel::GenericSender;
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
@@ -48,7 +47,7 @@ impl BluetoothRemoteGATTServer {
         )
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/testrunner.rs
+++ b/components/script/dom/testrunner.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::BluetoothRequest;
 use dom_struct::dom_struct;
-use base::generic_channel::GenericSender;
 use profile_traits::ipc;
 
 use crate::dom::bindings::codegen::Bindings::TestRunnerBinding::TestRunnerMethods;
@@ -31,7 +31,7 @@ impl TestRunner {
         reflect_dom_object(Box::new(TestRunner::new_inherited()), global)
     }
 
-    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 }

--- a/components/script/dom/testrunner.rs
+++ b/components/script/dom/testrunner.rs
@@ -4,7 +4,7 @@
 
 use bluetooth_traits::BluetoothRequest;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
+use base::generic_channel::GenericSender;
 use profile_traits::ipc;
 
 use crate::dom::bindings::codegen::Bindings::TestRunnerBinding::TestRunnerMethods;
@@ -31,7 +31,7 @@ impl TestRunner {
         reflect_dom_object(Box::new(TestRunner::new_inherited()), global)
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -18,6 +18,7 @@ use std::{cmp, env};
 use app_units::Au;
 use backtrace::Backtrace;
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId};
 use base64::Engine;
 use bluetooth_traits::BluetoothRequest;
@@ -59,7 +60,6 @@ use script_traits::{
     ScriptToConstellationChan, ScrollState, StructuredSerializedData, TimerEventId,
     TimerSchedulerMsg, WindowSizeData, WindowSizeType,
 };
-use base::generic_channel::GenericSender;
 use selectors::attr::CaseSensitivity;
 use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
@@ -240,7 +240,7 @@ pub struct Window {
     /// A handle for communicating messages to the bluetooth thread.
     #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
-    bluetooth_thread:  GenericSender<BluetoothRequest>,
+    bluetooth_thread: GenericSender<BluetoothRequest>,
 
     bluetooth_extra_permission_data: BluetoothExtraPermissionData,
 
@@ -465,7 +465,7 @@ impl Window {
         })
     }
 
-    pub fn bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
+    pub fn bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.bluetooth_thread.clone()
     }
 
@@ -2532,7 +2532,7 @@ impl Window {
         image_cache_chan: Sender<ImageCacheMsg>,
         image_cache: Arc<dyn ImageCache>,
         resource_threads: ResourceThreads,
-        bluetooth_thread:  GenericSender<BluetoothRequest>,
+        bluetooth_thread: GenericSender<BluetoothRequest>,
         mem_profiler_chan: MemProfilerChan,
         time_profiler_chan: TimeProfilerChan,
         devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -59,6 +59,7 @@ use script_traits::{
     ScriptToConstellationChan, ScrollState, StructuredSerializedData, TimerEventId,
     TimerSchedulerMsg, WindowSizeData, WindowSizeType,
 };
+use base::generic_channel::GenericSender;
 use selectors::attr::CaseSensitivity;
 use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
@@ -239,7 +240,7 @@ pub struct Window {
     /// A handle for communicating messages to the bluetooth thread.
     #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
-    bluetooth_thread: IpcSender<BluetoothRequest>,
+    bluetooth_thread:  GenericSender<BluetoothRequest>,
 
     bluetooth_extra_permission_data: BluetoothExtraPermissionData,
 
@@ -464,7 +465,7 @@ impl Window {
         })
     }
 
-    pub fn bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    pub fn bluetooth_thread(&self) ->  GenericSender<BluetoothRequest> {
         self.bluetooth_thread.clone()
     }
 
@@ -2531,7 +2532,7 @@ impl Window {
         image_cache_chan: Sender<ImageCacheMsg>,
         image_cache: Arc<dyn ImageCache>,
         resource_threads: ResourceThreads,
-        bluetooth_thread: IpcSender<BluetoothRequest>,
+        bluetooth_thread:  GenericSender<BluetoothRequest>,
         mem_profiler_chan: MemProfilerChan,
         time_profiler_chan: TimeProfilerChan,
         devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -46,6 +46,7 @@ use devtools_traits::{
     CSSError, DevtoolScriptControlMsg, DevtoolsPageInfo, NavigationState,
     ScriptToDevtoolsControlMsg, WorkerId,
 };
+use base::generic_channel::GenericSender;
 use embedder_traits::EmbedderMsg;
 use euclid::default::{Point2D, Rect};
 use fonts::FontCacheThread;
@@ -534,7 +535,7 @@ pub struct ScriptThread {
     resource_threads: ResourceThreads,
     /// A handle to the bluetooth thread.
     #[no_trace]
-    bluetooth_thread: IpcSender<BluetoothRequest>,
+    bluetooth_thread:  GenericSender<BluetoothRequest>,
 
     /// A queue of tasks to be executed in this script-thread.
     task_queue: TaskQueue<MainThreadScriptMsg>,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -34,6 +34,7 @@ use background_hang_monitor_api::{
     MonitoredComponentType, ScriptHangAnnotation,
 };
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSender;
 use base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, TopLevelBrowsingContextId,
 };
@@ -46,7 +47,6 @@ use devtools_traits::{
     CSSError, DevtoolScriptControlMsg, DevtoolsPageInfo, NavigationState,
     ScriptToDevtoolsControlMsg, WorkerId,
 };
-use base::generic_channel::GenericSender;
 use embedder_traits::EmbedderMsg;
 use euclid::default::{Point2D, Rect};
 use fonts::FontCacheThread;
@@ -535,7 +535,7 @@ pub struct ScriptThread {
     resource_threads: ResourceThreads,
     /// A handle to the bluetooth thread.
     #[no_trace]
-    bluetooth_thread:  GenericSender<BluetoothRequest>,
+    bluetooth_thread: GenericSender<BluetoothRequest>,
 
     /// A queue of tasks to be executed in this script-thread.
     task_queue: TaskQueue<MainThreadScriptMsg>,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1026,7 +1026,7 @@ fn create_constellation(
     // Global configuration options, parsed from the command line.
     let opts = opts::get();
 
-    let bluetooth_thread:  GenericSender<BluetoothRequest> =
+    let bluetooth_thread: GenericSender<BluetoothRequest> =
         BluetoothThreadFactory::new(embedder_proxy.clone());
 
     let (public_resource_threads, private_resource_threads) = new_resource_threads(

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -24,6 +24,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::vec::Drain;
 
+use base::generic_channel::GenericSender;
 pub use base::id::TopLevelBrowsingContextId;
 use base::id::{PipelineNamespace, PipelineNamespaceId};
 use bluetooth::BluetoothThreadFactory;
@@ -1025,7 +1026,7 @@ fn create_constellation(
     // Global configuration options, parsed from the command line.
     let opts = opts::get();
 
-    let bluetooth_thread: IpcSender<BluetoothRequest> =
+    let bluetooth_thread:  GenericSender<BluetoothRequest> =
         BluetoothThreadFactory::new(embedder_proxy.clone());
 
     let (public_resource_threads, private_resource_threads) = new_resource_threads(

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -4,7 +4,7 @@
 
 //! Enum wrappers to be able to select different channel implementations at runtime.
 
-use std::fmt;
+use std::fmt::{self, Display};
 
 use ipc_channel::router::ROUTER;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -64,6 +64,12 @@ impl<T: Serialize> GenericSender<T> {
 #[derive(Debug)]
 pub struct SendError;
 pub type SendResult = Result<(), SendError>;
+
+impl Display for SendError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Failed to send message")
+    }
+}
 
 #[derive(Debug)]
 pub struct ReceiveError;

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -6,6 +6,7 @@ pub mod resources;
 
 use std::fmt::{Debug, Error, Formatter};
 
+use base::generic_channel::GenericSender;
 use base::id::{PipelineId, TopLevelBrowsingContextId, WebViewId};
 use crossbeam_channel::{Receiver, Sender};
 use ipc_channel::ipc::IpcSender;
@@ -189,7 +190,7 @@ pub enum EmbedderMsg {
     /// A pipeline panicked. First string is the reason, second one is the backtrace.
     Panic(String, Option<String>),
     /// Open dialog to select bluetooth device.
-    GetSelectedBluetoothDevice(Vec<String>, IpcSender<Option<String>>),
+    GetSelectedBluetoothDevice(Vec<String>, GenericSender<Option<String>>),
     /// Open file dialog to select files. Set boolean flag to true allows to select multiple files.
     SelectFiles(Vec<FilterPattern>, bool, IpcSender<Option<Vec<String>>>),
     /// Open interface to request permission specified by prompt.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 
 use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSender;
 use base::id::{
     BlobId, BrowsingContextId, HistoryStateId, MessagePortId, PipelineId, PipelineNamespaceId,
     TopLevelBrowsingContextId,
@@ -29,7 +30,6 @@ use base::id::{
 use base::Epoch;
 use bitflags::bitflags;
 use bluetooth_traits::BluetoothRequest;
-use base::generic_channel::GenericSender;
 use canvas_traits::webgl::WebGLPipeline;
 use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
@@ -639,7 +639,7 @@ pub struct InitialScriptState {
     /// A channel to the resource manager thread.
     pub resource_threads: ResourceThreads,
     /// A channel to the bluetooth thread.
-    pub bluetooth_thread:  GenericSender<BluetoothRequest>,
+    pub bluetooth_thread: GenericSender<BluetoothRequest>,
     /// The image cache for this script thread.
     pub image_cache: Arc<dyn ImageCache>,
     /// A channel to the time profiler thread.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -29,6 +29,7 @@ use base::id::{
 use base::Epoch;
 use bitflags::bitflags;
 use bluetooth_traits::BluetoothRequest;
+use base::generic_channel::GenericSender;
 use canvas_traits::webgl::WebGLPipeline;
 use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
@@ -638,7 +639,7 @@ pub struct InitialScriptState {
     /// A channel to the resource manager thread.
     pub resource_threads: ResourceThreads,
     /// A channel to the bluetooth thread.
-    pub bluetooth_thread: IpcSender<BluetoothRequest>,
+    pub bluetooth_thread:  GenericSender<BluetoothRequest>,
     /// The image cache for this script thread.
     pub image_cache: Arc<dyn ImageCache>,
     /// A channel to the time profiler thread.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR replaces the IPC channel with `GenericChannel` in the Bluetooth component, as requested in issue #32411. 

---
Fixes #32411

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #32411

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they involve internal channel replacement and existing tests already cover the affected areas.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way. -->

