### PR TITLE
webgpu: destroy GPUTexture without erroring

### DIFF
--- a/components/webgpu/ipc_messages/recv.rs
+++ b/components/webgpu/ipc_messages/recv.rs
@@ -151,10 +151,7 @@ pub enum WebGPURequest {
     },
     DestroyBuffer(id::BufferId),
     DestroyDevice(id::DeviceId),
-    DestroyTexture {
-        device_id: id::DeviceId,
-        texture_id: id::TextureId,
-    },
+    DestroyTexture(id::TextureId),
     DestroySwapChain {
         context_id: WebGPUContextId,
         image_key: ImageKey,

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -567,13 +567,9 @@ impl WGPU {
                     } => {
                         self.destroy_swapchain(context_id, image_key);
                     },
-                    WebGPURequest::DestroyTexture {
-                        device_id,
-                        texture_id,
-                    } => {
+                    WebGPURequest::DestroyTexture(texture_id) => {
                         let global = &self.global;
-                        let result = global.texture_destroy(texture_id);
-                        self.maybe_dispatch_wgpu_error(device_id, result.err());
+                        let _ = global.texture_destroy(texture_id);
                     },
                     WebGPURequest::Exit(sender) => {
                         if let Err(e) = sender.send(()) {


### PR DESCRIPTION
This matches the spec: https://www.w3.org/TR/webgpu/#dom-gputexture-destroy

Splited from https://github.com/servo/servo/pull/33521 because there is a lot of new PASSes.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
