### PR TITLE
Bump mozjs to 128.0-10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#d90edd169aae1e16c1ef8b7bd4b2e0d93dda8ba2"
+source = "git+https://github.com/servo/mozjs#2aa7659e6f481d4f11d9a4e67fbef9d5eeeb3f37"
 dependencies = [
  "bindgen",
  "cc",
@@ -4396,8 +4396,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.0-9"
-source = "git+https://github.com/servo/mozjs#d90edd169aae1e16c1ef8b7bd4b2e0d93dda8ba2"
+version = "0.128.0-10"
+source = "git+https://github.com/servo/mozjs#2aa7659e6f481d4f11d9a4e67fbef9d5eeeb3f37"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Changes:

-  Add prebuilt artifacts for OpenHarmony and test github attestions (https://github.com/servo/mozjs/pull/501)

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
