### PR TITLE
fonts: Simplify `FontContext` in two ways that affect the `FontContext` unit test

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -11,7 +11,7 @@ use euclid::default::{Box2D, Point2D, Rect, Size2D, Transform2D, Vector2D};
 use euclid::point2;
 use fonts::{
     ByteIndex, FontBaseline, FontContext, FontGroup, FontMetrics, FontRef, GlyphInfo, GlyphStore,
-    ShapingFlags, ShapingOptions, SystemFontServiceProxy, LAST_RESORT_GLYPH_ADVANCE,
+    ShapingFlags, ShapingOptions, LAST_RESORT_GLYPH_ADVANCE,
 };
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use log::{debug, warn};
@@ -434,7 +434,7 @@ pub struct CanvasData<'a> {
     old_image_key: Option<ImageKey>,
     /// An old webrender image key that can be deleted when the current epoch ends.
     very_old_image_key: Option<ImageKey>,
-    font_context: Arc<FontContext<SystemFontServiceProxy>>,
+    font_context: Arc<FontContext>,
 }
 
 fn create_backend() -> Box<dyn Backend> {
@@ -446,7 +446,7 @@ impl<'a> CanvasData<'a> {
         size: Size2D<u64>,
         webrender_api: Box<dyn WebrenderApi>,
         antialias: AntialiasMode,
-        font_context: Arc<FontContext<SystemFontServiceProxy>>,
+        font_context: Arc<FontContext>,
     ) -> CanvasData<'a> {
         let backend = create_backend();
         let draw_target = backend.create_drawtarget(size);

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -17,7 +17,7 @@ use ipc_channel::router::ROUTER;
 use log::warn;
 use net_traits::ResourceThreads;
 use webrender_api::ImageKey;
-use webrender_traits::ImageUpdate;
+use webrender_traits::{ImageUpdate, WebRenderScriptApi};
 
 use crate::canvas_data::*;
 
@@ -37,7 +37,7 @@ pub struct CanvasPaintThread<'a> {
     canvases: HashMap<CanvasId, CanvasData<'a>>,
     next_canvas_id: CanvasId,
     webrender_api: Box<dyn WebrenderApi>,
-    font_context: Arc<FontContext<SystemFontServiceProxy>>,
+    font_context: Arc<FontContext>,
 }
 
 impl<'a> CanvasPaintThread<'a> {
@@ -46,11 +46,18 @@ impl<'a> CanvasPaintThread<'a> {
         system_font_service: Arc<SystemFontServiceProxy>,
         resource_threads: ResourceThreads,
     ) -> CanvasPaintThread<'a> {
+        // This is only used for web fonts and currently canvas never uses web fonts.
+        let webrender_script_api = WebRenderScriptApi::dummy();
+
         CanvasPaintThread {
             canvases: HashMap::new(),
             next_canvas_id: CanvasId(0),
             webrender_api,
-            font_context: Arc::new(FontContext::new(system_font_service, resource_threads)),
+            font_context: Arc::new(FontContext::new(
+                system_font_service,
+                webrender_script_api,
+                resource_threads,
+            )),
         }
     }
 

--- a/components/fonts/font_template.rs
+++ b/components/fonts/font_template.rs
@@ -9,14 +9,12 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
-use servo_url::ServoUrl;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
 use style::stylesheets::DocumentStyleSheet;
 use style::values::computed::font::FontWeight;
 
 use crate::font::FontDescriptor;
-use crate::platform::font_list::LocalFontIdentifier;
 use crate::system_font_service::{
     CSSFontFaceDescriptors, ComputedFontStyleDescriptor, FontIdentifier,
 };
@@ -160,29 +158,17 @@ impl Debug for FontTemplate {
 /// is common, regardless of the number of instances of
 /// this font handle per thread.
 impl FontTemplate {
-    /// Create a new [`FontTemplate`] for a system font installed locally.
-    pub fn new_for_local_font(
-        identifier: LocalFontIdentifier,
-        descriptor: FontTemplateDescriptor,
-    ) -> FontTemplate {
-        FontTemplate {
-            identifier: FontIdentifier::Local(identifier),
-            descriptor,
-            stylesheet: None,
-        }
-    }
-
-    /// Create a new [`FontTemplate`] for a `@font-family` with a `url(...)` `src` font.
-    pub fn new_for_remote_web_font(
-        url: ServoUrl,
+    /// Create a new [`FontTemplate`].
+    pub fn new(
+        identifier: FontIdentifier,
         descriptor: FontTemplateDescriptor,
         stylesheet: Option<DocumentStyleSheet>,
-    ) -> Result<FontTemplate, &'static str> {
-        Ok(FontTemplate {
-            identifier: FontIdentifier::Web(url),
+    ) -> FontTemplate {
+        FontTemplate {
+            identifier,
             descriptor,
             stylesheet,
-        })
+        }
     }
 
     /// Create a new [`FontTemplate`] for a `@font-family` with a `local(...)` `src`. This takes in

--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -19,7 +19,8 @@ use style::Atom;
 
 use super::xml::{Attribute, Node};
 use crate::{
-    FallbackFontSelectionOptions, FontTemplate, FontTemplateDescriptor, LowercaseFontFamilyName,
+    FallbackFontSelectionOptions, FontIdentifier, FontTemplate, FontTemplateDescriptor,
+    LowercaseFontFamilyName,
 };
 
 static FONT_LIST: LazyLock<FontList> = LazyLock::new(|| FontList::new());
@@ -491,9 +492,10 @@ where
             None => StyleFontStyle::NORMAL,
         };
         let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
-        callback(FontTemplate::new_for_local_font(
-            local_font_identifier,
+        callback(FontTemplate::new(
+            FontIdentifier::Local(local_font_identifier),
             descriptor,
+            None,
         ));
     };
 

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -36,7 +36,10 @@ use super::c_str_to_string;
 use crate::font::map_platform_values_to_style_values;
 use crate::font_template::{FontTemplate, FontTemplateDescriptor};
 use crate::platform::add_noto_fallback_families;
-use crate::{EmojiPresentationPreference, FallbackFontSelectionOptions, LowercaseFontFamilyName};
+use crate::{
+    EmojiPresentationPreference, FallbackFontSelectionOptions, FontIdentifier,
+    LowercaseFontFamilyName,
+};
 
 /// An identifier for a local font on systems using Freetype.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
@@ -155,9 +158,10 @@ where
             };
             let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
 
-            callback(FontTemplate::new_for_local_font(
-                local_font_identifier,
+            callback(FontTemplate::new(
+                FontIdentifier::Local(local_font_identifier),
                 descriptor,
+                None,
             ))
         }
 

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -22,7 +22,7 @@ use style::Atom;
 use unicode_script::Script;
 
 use crate::{
-    EmojiPresentationPreference, FallbackFontSelectionOptions, FontTemplate,
+    EmojiPresentationPreference, FallbackFontSelectionOptions, FontIdentifier, FontTemplate,
     FontTemplateDescriptor, LowercaseFontFamilyName,
 };
 
@@ -492,9 +492,10 @@ where
             None => StyleFontStyle::NORMAL,
         };
         let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
-        callback(FontTemplate::new_for_local_font(
-            local_font_identifier,
+        callback(FontTemplate::new(
+            FontIdentifier::Local(local_font_identifier),
             descriptor,
+            None,
         ));
     };
 

--- a/components/fonts/platform/macos/core_text_font_cache.rs
+++ b/components/fonts/platform/macos/core_text_font_cache.rs
@@ -86,7 +86,7 @@ impl CoreTextFontCache {
 
                 core_text::font::new_from_descriptor(&descriptor, clamped_pt_size)
             },
-            FontIdentifier::Web(_) => {
+            FontIdentifier::Web(_) | FontIdentifier::Mock(_) => {
                 let provider = CGDataProvider::from_buffer(data);
                 let cgfont = CGFont::from_data_provider(provider).ok()?;
                 core_text::font::new_from_CGFont(&cgfont, clamped_pt_size)

--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -18,7 +18,7 @@ use webrender_api::NativeFontHandle;
 use crate::platform::add_noto_fallback_families;
 use crate::platform::font::CoreTextFontTraitsMapping;
 use crate::{
-    EmojiPresentationPreference, FallbackFontSelectionOptions, FontTemplate,
+    EmojiPresentationPreference, FallbackFontSelectionOptions, FontIdentifier, FontTemplate,
     FontTemplateDescriptor, LowercaseFontFamilyName,
 };
 
@@ -85,7 +85,11 @@ where
                     postscript_name: Atom::from(family_descriptor.font_name()),
                     path: Atom::from(path),
                 };
-                callback(FontTemplate::new_for_local_font(identifier, descriptor));
+                callback(FontTemplate::new(
+                    FontIdentifier::Local(identifier),
+                    descriptor,
+                    None,
+                ));
             }
         }
     }

--- a/components/fonts/platform/windows/font_list.rs
+++ b/components/fonts/platform/windows/font_list.rs
@@ -14,7 +14,7 @@ use style::values::computed::{FontStyle as StyleFontStyle, FontWeight as StyleFo
 use style::values::specified::font::FontStretchKeyword;
 
 use crate::{
-    EmojiPresentationPreference, FallbackFontSelectionOptions, FontTemplate,
+    EmojiPresentationPreference, FallbackFontSelectionOptions, FontIdentifier, FontTemplate,
     FontTemplateDescriptor, LowercaseFontFamilyName,
 };
 
@@ -78,9 +78,10 @@ where
             let local_font_identifier = LocalFontIdentifier {
                 font_descriptor: Arc::new(font.to_descriptor()),
             };
-            callback(FontTemplate::new_for_local_font(
-                local_font_identifier,
+            callback(FontTemplate::new(
+                FontIdentifier::Local(local_font_identifier),
                 template_descriptor,
+                None,
             ))
         }
     }

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -11,7 +11,7 @@ use std::thread;
 
 use base::id::PipelineId;
 use fnv::FnvHasher;
-use fonts::{FontContext, SystemFontServiceProxy};
+use fonts::FontContext;
 use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, UsePlaceholder,
 };
@@ -23,8 +23,6 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 use style::context::{RegisteredSpeculativePainter, SharedStyleContext};
 
 use crate::display_list::items::{OpaqueNode, WebRenderImageInfo};
-
-pub type LayoutFontContext = FontContext<SystemFontServiceProxy>;
 
 type WebrenderImageCache =
     HashMap<(ServoUrl, UsePlaceholder), WebRenderImageInfo, BuildHasherDefault<FnvHasher>>;
@@ -44,7 +42,7 @@ pub struct LayoutContext<'a> {
     pub image_cache: Arc<dyn ImageCache>,
 
     /// A FontContext to be used during layout.
-    pub font_context: Arc<FontContext<SystemFontServiceProxy>>,
+    pub font_context: Arc<FontContext>,
 
     /// A cache of WebRender image info.
     pub webrender_image_cache: Arc<RwLock<WebrenderImageCache>>,

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -11,7 +11,7 @@ use app_units::{Au, MIN_AU};
 use base::print_tree::PrintTree;
 use bitflags::bitflags;
 use euclid::default::{Point2D, Rect, Size2D};
-use fonts::FontMetrics;
+use fonts::{FontContext, FontMetrics};
 use log::debug;
 use range::{int_range_index, Range, RangeIndex};
 use script_layout_interface::wrapper_traits::PseudoElementType;
@@ -33,7 +33,7 @@ use style::values::specified::text::TextOverflowSide;
 use unicode_bidi as bidi;
 
 use crate::block::AbsoluteAssignBSizesTraversal;
-use crate::context::{LayoutContext, LayoutFontContext};
+use crate::context::LayoutContext;
 use crate::display_list::items::{DisplayListSection, OpaqueNode};
 use crate::display_list::{
     BorderPaintingMode, DisplayListBuildState, StackingContextCollectionState,
@@ -1239,7 +1239,7 @@ impl InlineFlow {
     /// `style` is the style of the block.
     pub fn minimum_line_metrics(
         &self,
-        font_context: &LayoutFontContext,
+        font_context: &FontContext,
         style: &ComputedValues,
     ) -> LineMetrics {
         InlineFlow::minimum_line_metrics_for_fragments(
@@ -1255,7 +1255,7 @@ impl InlineFlow {
     /// `style` is the style of the block that these fragments belong to.
     pub fn minimum_line_metrics_for_fragments(
         fragments: &[Fragment],
-        font_context: &LayoutFontContext,
+        font_context: &FontContext,
         style: &ComputedValues,
     ) -> LineMetrics {
         // As a special case, if this flow contains only hypothetical fragments, then the entire

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use app_units::Au;
 use base::text::is_bidi_control;
 use fonts::{
-    self, ByteIndex, FontIdentifier, FontMetrics, FontRef, RunMetrics, ShapingFlags,
+    self, ByteIndex, FontContext, FontIdentifier, FontMetrics, FontRef, RunMetrics, ShapingFlags,
     ShapingOptions, LAST_RESORT_GLYPH_ADVANCE,
 };
 use log::{debug, warn};
@@ -28,7 +28,6 @@ use unicode_bidi as bidi;
 use unicode_script::Script;
 use xi_unicode::LineBreakLeafIter;
 
-use crate::context::LayoutFontContext;
 use crate::fragment::{
     Fragment, ScannedTextFlags, ScannedTextFragmentInfo, SpecificFragmentInfo,
     UnscannedTextFragmentInfo,
@@ -71,7 +70,7 @@ impl TextRunScanner {
 
     pub fn scan_for_runs(
         &mut self,
-        font_context: &LayoutFontContext,
+        font_context: &FontContext,
         mut fragments: LinkedList<Fragment>,
     ) -> InlineFragments {
         debug!(
@@ -151,7 +150,7 @@ impl TextRunScanner {
     /// be adjusted.
     fn flush_clump_to_list(
         &mut self,
-        font_context: &LayoutFontContext,
+        font_context: &FontContext,
         out_fragments: &mut Vec<Fragment>,
         paragraph_bytes_processed: &mut usize,
         bidi_levels: Option<&[bidi::Level]>,
@@ -538,7 +537,7 @@ fn bounding_box_for_run_metrics(
 /// Panics if no font can be found for the given font style.
 #[inline]
 pub fn font_metrics_for_style(
-    font_context: &LayoutFontContext,
+    font_context: &FontContext,
     style: crate::ServoArc<FontStyleStruct>,
 ) -> FontMetrics {
     let font_group = font_context.font_group(style);

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use base::id::PipelineId;
 use fnv::FnvHashMap;
-use fonts::{FontContext, SystemFontServiceProxy};
+use fonts::FontContext;
 use net_traits::image_cache::{
     ImageCache, ImageCacheResult, ImageOrMetadataAvailable, UsePlaceholder,
 };
@@ -27,7 +27,7 @@ pub struct LayoutContext<'a> {
     pub style_context: SharedStyleContext<'a>,
 
     /// A FontContext to be used during layout.
-    pub font_context: Arc<FontContext<SystemFontServiceProxy>>,
+    pub font_context: Arc<FontContext>,
 
     /// Reference to the script thread image cache.
     pub image_cache: Arc<dyn ImageCache>,

--- a/components/layout_2020/flow/inline/text_run.rs
+++ b/components/layout_2020/flow/inline/text_run.rs
@@ -8,8 +8,7 @@ use std::ops::Range;
 use app_units::Au;
 use base::text::is_bidi_control;
 use fonts::{
-    FontContext, FontRef, GlyphRun, ShapingFlags, ShapingOptions, SystemFontServiceProxy,
-    LAST_RESORT_GLYPH_ADVANCE,
+    FontContext, FontRef, GlyphRun, ShapingFlags, ShapingOptions, LAST_RESORT_GLYPH_ADVANCE,
 };
 use fonts_traits::ByteIndex;
 use log::warn;
@@ -342,7 +341,7 @@ impl TextRun {
     pub(super) fn segment_and_shape(
         &mut self,
         formatting_context_text: &str,
-        font_context: &FontContext<SystemFontServiceProxy>,
+        font_context: &FontContext,
         linebreaker: &mut LineBreaker,
         font_cache: &mut Vec<FontKeyAndMetrics>,
         bidi_info: &BidiInfo,
@@ -410,7 +409,7 @@ impl TextRun {
     fn segment_text_by_font(
         &mut self,
         formatting_context_text: &str,
-        font_context: &FontContext<SystemFontServiceProxy>,
+        font_context: &FontContext,
         font_cache: &mut Vec<FontKeyAndMetrics>,
         bidi_info: &BidiInfo,
     ) -> Vec<(TextRunSegment, FontRef)> {
@@ -556,7 +555,7 @@ pub(super) fn add_or_get_font(font: &FontRef, ifc_fonts: &mut Vec<FontKeyAndMetr
 
 pub(super) fn get_font_for_first_font_for_style(
     style: &ComputedValues,
-    font_context: &FontContext<SystemFontServiceProxy>,
+    font_context: &FontContext,
 ) -> Option<FontRef> {
     let font = font_context
         .font_group(style.clone_font())

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -134,7 +134,7 @@ pub struct LayoutThread {
     image_cache: Arc<dyn ImageCache>,
 
     /// A per-layout FontContext managing font access.
-    font_context: Arc<FontContext<SystemFontServiceProxy>>,
+    font_context: Arc<FontContext>,
 
     /// Is this the first reflow in this layout?
     first_reflow: Cell<bool>,
@@ -577,7 +577,11 @@ impl LayoutThread {
             keyword_info: KeywordInfo::medium(),
         };
 
-        let font_context = Arc::new(FontContext::new(system_font_service, resource_threads));
+        let font_context = Arc::new(FontContext::new(
+            system_font_service,
+            webrender_api.clone(),
+            resource_threads,
+        ));
         let device = Device::new(
             MediaType::screen(),
             QuirksMode::NoQuirks,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -121,7 +121,7 @@ pub struct LayoutThread {
     image_cache: Arc<dyn ImageCache>,
 
     /// A FontContext to be used during layout.
-    font_context: Arc<FontContext<SystemFontServiceProxy>>,
+    font_context: Arc<FontContext>,
 
     /// Is this the first reflow in this LayoutThread?
     first_reflow: Cell<bool>,
@@ -521,7 +521,11 @@ impl LayoutThread {
 
         // The device pixel ratio is incorrect (it does not have the hidpi value),
         // but it will be set correctly when the initial reflow takes place.
-        let font_context = Arc::new(FontContext::new(system_font_service, resource_threads));
+        let font_context = Arc::new(FontContext::new(
+            system_font_service,
+            webrender_api_sender.clone(),
+            resource_threads,
+        ));
         let device = Device::new(
             MediaType::screen(),
             QuirksMode::NoQuirks,
@@ -1227,7 +1231,7 @@ impl RegisteredSpeculativePainters for RegisteredPaintersImpl {
     }
 }
 
-struct LayoutFontMetricsProvider(Arc<FontContext<SystemFontServiceProxy>>);
+struct LayoutFontMetricsProvider(Arc<FontContext>);
 
 impl FontMetricsProvider for LayoutFontMetricsProvider {
     fn query_font_metrics(

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1101,58 +1101,32 @@ impl WebRenderFontApi for WebRenderFontApiCompositorProxy {
         flags: FontInstanceFlags,
     ) -> FontInstanceKey {
         let (sender, receiver) = unbounded();
-        self.0
-            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddFontInstance(font_key, size, flags, sender),
-            )));
+        self.0.send(CompositorMsg::Forwarded(
+            ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::AddFontInstance(
+                font_key, size, flags, sender,
+            )),
+        ));
         receiver.recv().unwrap()
     }
 
     fn add_font(&self, data: Arc<IpcSharedMemory>, index: u32) -> FontKey {
         let (sender, receiver) = unbounded();
-        self.0
-            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddFont(sender, index, data),
-            )));
+        self.0.send(CompositorMsg::Forwarded(
+            ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::AddFont(
+                sender, index, data,
+            )),
+        ));
         receiver.recv().unwrap()
     }
 
     fn add_system_font(&self, handle: NativeFontHandle) -> FontKey {
         let (sender, receiver) = unbounded();
-        self.0
-            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddSystemFont(sender, handle),
-            )));
+        self.0.send(CompositorMsg::Forwarded(
+            ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::AddSystemFont(
+                sender, handle,
+            )),
+        ));
         receiver.recv().unwrap()
-    }
-
-    fn forward_add_font_message(
-        &self,
-        data: Arc<IpcSharedMemory>,
-        font_index: u32,
-        result_sender: IpcSender<FontKey>,
-    ) {
-        let (sender, receiver) = unbounded();
-        self.0
-            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddFont(sender, font_index, data),
-            )));
-        let _ = result_sender.send(receiver.recv().unwrap());
-    }
-
-    fn forward_add_font_instance_message(
-        &self,
-        font_key: FontKey,
-        size: f32,
-        flags: FontInstanceFlags,
-        result_sender: IpcSender<FontInstanceKey>,
-    ) {
-        let (sender, receiver) = unbounded();
-        self.0
-            .send(CompositorMsg::Forwarded(ForwardedToCompositorMsg::Font(
-                FontToCompositorMsg::AddFontInstance(font_key, size, flags, sender),
-            )));
-        let _ = result_sender.send(receiver.recv().unwrap());
     }
 }
 

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -141,7 +141,7 @@ pub struct CompositionPipeline {
 pub enum ForwardedToCompositorMsg {
     Layout(ScriptToCompositorMsg),
     Net(NetToCompositorMsg),
-    Font(FontToCompositorMsg),
+    SystemFontService(FontToCompositorMsg),
     Canvas(CanvasToCompositorMsg),
 }
 
@@ -150,7 +150,9 @@ impl Debug for ForwardedToCompositorMsg {
         match self {
             ForwardedToCompositorMsg::Layout(_) => write!(f, "Layout(ScriptToCompositorMsg)"),
             ForwardedToCompositorMsg::Net(_) => write!(f, "Net(NetToCompositorMsg)"),
-            ForwardedToCompositorMsg::Font(_) => write!(f, "Font(FontToCompositorMsg)"),
+            ForwardedToCompositorMsg::SystemFontService(_) => {
+                write!(f, "SystemFontService(FontToCompositorMsg)")
+            },
             ForwardedToCompositorMsg::Canvas(_) => write!(f, "Canvas(CanvasToCompositorMsg)"),
         }
     }


### PR DESCRIPTION
This is done by no longer forwarding compositor-bound messages through
SystemFontService and making `FontContext` non-generic:

- Messages from the `FontContext` to the `Compositor` no longer need to be
  forwarded through the `SystemFontService`. Instead send these messages
  directly through the script IPC channel to the `Compositor`.

- Instead of adding a mock `SystemFontServiceProxy`, simply implement a
  mock `SystemFontService` on the other side of an IPC channel in the
  `font_context` unit test. This allows making `FontContext`
  non-generic, greatly simplifying the code. The extra complexity moves
  into the unit test.

These changes necessitate adding a new kind of `FontIdentifier`,
`FontIdentifier::Mock` due to the fact that local fonts have
platform-specific identifiers. This avoids having to pretend like the
system font service can have web fonts -- which was always a bit of a
hack.

These two changes are combined into one PR because they both require
extensive and similar chages in the `FontContext` unit test which
depended on the details of both of them.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change observable behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
