### PR TITLE
layout: Switch `.len()` comparison to `is_empty()` in `components/layout_2020/query.rs`.

### DIFF
--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -741,7 +741,7 @@ fn rendered_text_collection_steps<'dom>(
                     items.push(InnerOrOuterTextItem::Text(String::from(" ")));
                 };
 
-                if !transformed_text.is_empty(){
+                if !transformed_text.is_empty() {
                     // Here we decide whether to keep or truncate the final white
                     // space character, if there is one.
                     if is_final_character_whitespace && !is_preformatted_element {

--- a/components/layout_2020/query.rs
+++ b/components/layout_2020/query.rs
@@ -741,7 +741,7 @@ fn rendered_text_collection_steps<'dom>(
                     items.push(InnerOrOuterTextItem::Text(String::from(" ")));
                 };
 
-                if transformed_text.len() > 0 {
+                if !transformed_text.is_empty(){
                     // Here we decide whether to keep or truncate the final white
                     // space character, if there is one.
                     if is_final_character_whitespace && !is_preformatted_element {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because dont chenge app logic

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
