### PR TITLE
Avoid unnecessary recomputation of `inline-size` being `auto`

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -792,9 +792,8 @@ impl<'a> TableLayout<'a> {
                     block: padding.block_sum() + border.block_sum() + margin.block_sum(),
                 };
 
-                let (size, min_size, max_size, _) =
+                let (size, min_size, max_size, size_is_auto) =
                     get_outer_sizes_from_style(&context.style, writing_mode, &padding_border_sums);
-                let size_is_auto = context.style.box_size(writing_mode).inline.is_auto();
 
                 // If an inline size is defined it should serve as the upper limit and lower limit
                 // of the caption inline size.


### PR DESCRIPTION
This information is already provided by `get_outer_sizes_from_style()`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no change in behavior

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
