### PR TITLE
Assert that we don't get malformed ContentSizes in tables

### DIFF
--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -297,11 +297,10 @@ impl<'a> TableLayout<'a> {
                     };
                     inline_content_sizes.min_content += padding_border_sums.inline;
                     inline_content_sizes.max_content += padding_border_sums.inline;
-
-                    // TODO: the max-content size should never be smaller than the min-content size!
-                    inline_content_sizes.max_content = inline_content_sizes
-                        .max_content
-                        .max(inline_content_sizes.min_content);
+                    assert!(
+                        inline_content_sizes.max_content >= inline_content_sizes.min_content,
+                        "the max-content size should never be smaller than the min-content size"
+                    );
 
                     // These formulas differ from the spec, but seem to match Gecko and Blink.
                     let outer_min_content_width = if is_in_fixed_mode {


### PR DESCRIPTION
We have improved the logic for computing intrinsic sizes, and apparently we are no longer getting a `ContentSizes` whose `min_content` is greater than the `max_content`.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because there is no behavior change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
