### PR TITLE
Fix table track constrainedness

### DIFF
--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -55,6 +55,15 @@ impl<T: fmt::Debug> fmt::Debug for LogicalVec2<T> {
     }
 }
 
+impl<T: Default> Default for LogicalVec2<T> {
+    fn default() -> Self {
+        Self {
+            inline: T::default(),
+            block: T::default(),
+        }
+    }
+}
+
 impl<T: Clone> LogicalVec2<T> {
     pub fn from_physical_size(physical_size: &PhysicalSize<T>, mode: WritingMode) -> Self {
         // https://drafts.csswg.org/css-writing-modes/#logical-to-physical

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -371,7 +371,7 @@ impl<'a> TableLayout<'a> {
         self.columns = vec![ColumnLayout::default(); self.table.size.width];
 
         let is_length = |size: &LengthPercentageOrAuto| {
-            size.non_auto().and_then(|size| size.to_length()).is_some()
+            size.non_auto().is_some_and(|size| !size.has_percentage())
         };
 
         for column_index in 0..self.table.size.width {

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -370,52 +370,50 @@ impl<'a> TableLayout<'a> {
         self.rows = vec![RowLayout::default(); self.table.size.height];
         self.columns = vec![ColumnLayout::default(); self.table.size.width];
 
+        let is_length = |size: &LengthPercentageOrAuto| {
+            size.non_auto().and_then(|size| size.to_length()).is_some()
+        };
+
         for column_index in 0..self.table.size.width {
             if let Some(column) = self.table.columns.get(column_index) {
-                if !column.style.box_size(writing_mode).inline.is_auto() {
+                if is_length(&column.style.box_size(writing_mode).inline) {
                     self.columns[column_index].constrained = true;
                     continue;
                 }
                 if let Some(column_group_index) = column.group_index {
                     let column_group = &self.table.column_groups[column_group_index];
-                    if !column_group.style.box_size(writing_mode).inline.is_auto() {
+                    if is_length(&column_group.style.box_size(writing_mode).inline) {
                         self.columns[column_index].constrained = true;
                         continue;
                     }
                 }
-                self.columns[column_index].constrained = false;
             }
         }
 
         for row_index in 0..self.table.size.height {
             if let Some(row) = self.table.rows.get(row_index) {
-                if !row.style.box_size(writing_mode).block.is_auto() {
+                if is_length(&row.style.box_size(writing_mode).block) {
                     self.rows[row_index].constrained = true;
                     continue;
                 }
                 if let Some(row_group_index) = row.group_index {
                     let row_group = &self.table.row_groups[row_group_index];
-                    if !row_group.style.box_size(writing_mode).block.is_auto() {
+                    if is_length(&row_group.style.box_size(writing_mode).block) {
                         self.rows[row_index].constrained = true;
                         continue;
                     }
                 }
             }
-            self.rows[row_index].constrained = false;
         }
 
         for column_index in 0..self.table.size.width {
             for row_index in 0..self.table.size.height {
                 let coords = TableSlotCoordinates::new(column_index, row_index);
                 let cell_constrained = match self.table.resolve_first_cell(coords) {
-                    Some(cell) if cell.colspan == 1 => cell
-                        .style
-                        .box_size(writing_mode)
-                        .inline
-                        .non_auto()
-                        .and_then(|length_percentage| length_percentage.to_length())
-                        .is_some(),
-                    _ => false,
+                    Some(cell) if cell.colspan == 1 => {
+                        cell.style.box_size(writing_mode).map(is_length)
+                    },
+                    _ => LogicalVec2::default(),
                 };
 
                 let rowspan_greater_than_1 = match self.table.slots[row_index][column_index] {
@@ -424,12 +422,12 @@ impl<'a> TableLayout<'a> {
                 };
 
                 self.rows[row_index].has_cell_with_span_greater_than_one |= rowspan_greater_than_1;
-                self.rows[row_index].constrained |= cell_constrained;
+                self.rows[row_index].constrained |= cell_constrained.block;
 
                 let has_originating_cell =
                     matches!(self.table.get_slot(coords), Some(TableSlot::Cell(_)));
                 self.columns[column_index].has_originating_cells |= has_originating_cell;
-                self.columns[column_index].constrained |= cell_constrained;
+                self.columns[column_index].constrained |= cell_constrained.inline;
             }
         }
     }

--- a/tests/wpt/meta/css/css-tables/auto-layout-calc-width-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/auto-layout-calc-width-001.html.ini
@@ -1,3 +1,0 @@
-[auto-layout-calc-width-001.html]
-  [#theTable 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/fixed-layout-calc-width-001.html.ini
+++ b/tests/wpt/meta/css/css-tables/fixed-layout-calc-width-001.html.ini
@@ -1,3 +1,0 @@
-[fixed-layout-calc-width-001.html]
-  [#theTable 1]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-tables/tentative/rowspan-height-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/rowspan-height-redistribution.html.ini
@@ -1,5 +1,5 @@
 [rowspan-height-redistribution.html]
-  [table 8]
+  [table 17]
     expected: FAIL
 
   [table 22]

--- a/tests/wpt/meta/css/css-tables/tentative/table-height-redistribution.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-height-redistribution.html.ini
@@ -8,21 +8,6 @@
   [table 17]
     expected: FAIL
 
-  [table 18]
-    expected: FAIL
-
-  [table 19]
-    expected: FAIL
-
-  [table 20]
-    expected: FAIL
-
-  [table 21]
-    expected: FAIL
-
-  [table 22]
-    expected: FAIL
-
   [table 25]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-tables/visibility-collapse-row-004.html.ini
+++ b/tests/wpt/meta/css/css-tables/visibility-collapse-row-004.html.ini
@@ -1,3 +1,0 @@
-[visibility-collapse-row-004.html]
-  [collapsed row shrinks table height]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-attribute.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/tables/table-attribute.html.ini
@@ -122,12 +122,6 @@
   [table th align attribute justify is correct]
     expected: FAIL
 
-  [td height attribute pixel is correct]
-    expected: FAIL
-
-  [th height attribute pixel is correct]
-    expected: FAIL
-
   [table_td height attribute percentage is correct]
     expected: FAIL
 
@@ -138,4 +132,7 @@
     expected: FAIL
 
   [table cellpadding attribute is correct]
+    expected: FAIL
+
+  [table_tr height attribute percentage is correct]
     expected: FAIL


### PR DESCRIPTION
Only as size that isn't `auto` and doesn't contain percentages can constrain a table track (https://drafts.csswg.org/css-tables/#constrainedness).

However, in a bunch of cases we were only checking for `auto`.

Also, we were allowing the inline-size of a cell to constrain both its column and row. Using the block-size of the row makes more sense. The spec doesn't define constrainedness for rows, though.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
