### PR TITLE
Make ComputedValuesExt expose keywords for the sizing properties

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -936,10 +936,10 @@ impl FlexContainer {
             .padding_border_margin(containing_block_for_container);
         let max_box_size = self
             .style
-            .content_max_box_size(containing_block_for_container, &pbm);
+            .content_max_box_size_deprecated(containing_block_for_container, &pbm);
         let min_box_size = self
             .style
-            .content_min_box_size(containing_block_for_container, &pbm)
+            .content_min_box_size_deprecated(containing_block_for_container, &pbm)
             .auto_is(Au::zero);
 
         let max_box_size = self.config.flex_axis.vec2_to_flex_relative(max_box_size);
@@ -1012,15 +1012,15 @@ impl<'a> FlexItem<'a> {
         let pbm = box_.style().padding_border_margin(containing_block);
         let content_box_size = box_
             .style()
-            .content_box_size(containing_block, &pbm)
+            .content_box_size_deprecated(containing_block, &pbm)
             .map(|v| v.map(Au::from));
         let max_size = box_
             .style()
-            .content_max_box_size(containing_block, &pbm)
+            .content_max_box_size_deprecated(containing_block, &pbm)
             .map(|v| v.map(Au::from));
         let min_size = box_
             .style()
-            .content_min_box_size(containing_block, &pbm)
+            .content_min_box_size_deprecated(containing_block, &pbm)
             .map(|v| v.map(Au::from));
 
         let margin_auto_is_zero = flex_context.sides_to_flex_relative(pbm.margin.auto_is(Au::zero));
@@ -2005,7 +2005,7 @@ impl FlexItemBox {
             cross_axis_is_item_block_axis(container_is_horizontal, item_is_horizontal, flex_axis);
 
         let (content_box_size, content_min_size, content_max_size, pbm) =
-            style.content_box_sizes_and_padding_border_margin(containing_block);
+            style.content_box_sizes_and_padding_border_margin_deprecated(containing_block);
         let padding = main_start_cross_start.sides_to_flex_relative(pbm.padding);
         let border = main_start_cross_start.sides_to_flex_relative(pbm.border);
         let margin = main_start_cross_start.sides_to_flex_relative(pbm.margin);

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -915,13 +915,13 @@ impl FloatBox {
                         // https://drafts.csswg.org/css2/#float-width
                         let style = non_replaced.style.clone();
                         let box_size = style
-                            .content_box_size(containing_block, &pbm)
+                            .content_box_size_deprecated(containing_block, &pbm)
                             .map(|v| v.map(Au::from));
                         let max_box_size = style
-                            .content_max_box_size(containing_block, &pbm)
+                            .content_max_box_size_deprecated(containing_block, &pbm)
                             .map(|v| v.map(Au::from));
                         let min_box_size = style
-                            .content_min_box_size(containing_block, &pbm)
+                            .content_min_box_size_deprecated(containing_block, &pbm)
                             .map(|v| v.map(Au::from))
                             .auto_is(Au::zero);
 

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1929,15 +1929,15 @@ impl IndependentFormattingContext {
             IndependentFormattingContext::NonReplaced(non_replaced) => {
                 let box_size = non_replaced
                     .style
-                    .content_box_size(layout.containing_block, &pbm)
+                    .content_box_size_deprecated(layout.containing_block, &pbm)
                     .map(|v| v.map(Au::from));
                 let max_box_size = non_replaced
                     .style
-                    .content_max_box_size(layout.containing_block, &pbm)
+                    .content_max_box_size_deprecated(layout.containing_block, &pbm)
                     .map(|v| v.map(Au::from));
                 let min_box_size = non_replaced
                     .style
-                    .content_min_box_size(layout.containing_block, &pbm)
+                    .content_min_box_size_deprecated(layout.containing_block, &pbm)
                     .map(|v| v.map(Au::from))
                     .auto_is(Au::zero);
                 let block_size = box_size

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -135,10 +135,10 @@ impl BlockLevelBox {
         }
 
         let min_size = style
-            .content_min_box_size(containing_block, &pbm)
+            .content_min_box_size_deprecated(containing_block, &pbm)
             .auto_is(Au::zero);
-        let max_size = style.content_max_box_size(containing_block, &pbm);
-        let prefered_size = style.content_box_size(containing_block, &pbm);
+        let max_size = style.content_max_box_size_deprecated(containing_block, &pbm);
+        let prefered_size = style.content_box_size_deprecated(containing_block, &pbm);
         let inline_size = prefered_size
             .inline
             .auto_is(|| {
@@ -1048,11 +1048,15 @@ impl NonReplacedFormattingContext {
         sequential_layout_state: &mut SequentialLayoutState,
     ) -> BoxFragment {
         let pbm = self.style.padding_border_margin(containing_block);
-        let box_size = self.style.content_box_size(containing_block, &pbm);
-        let max_box_size = self.style.content_max_box_size(containing_block, &pbm);
+        let box_size = self
+            .style
+            .content_box_size_deprecated(containing_block, &pbm);
+        let max_box_size = self
+            .style
+            .content_max_box_size_deprecated(containing_block, &pbm);
         let min_box_size = self
             .style
-            .content_min_box_size(containing_block, &pbm)
+            .content_min_box_size_deprecated(containing_block, &pbm)
             .auto_is(Au::zero);
         let block_size = box_size.block.map(|block_size| {
             block_size.clamp_between_extremums(min_box_size.block, max_box_size.block)
@@ -1424,10 +1428,10 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
     style: &'a Arc<ComputedValues>,
 ) -> ContainingBlockPaddingAndBorder<'a> {
     let pbm = style.padding_border_margin(containing_block);
-    let box_size = style.content_box_size(containing_block, &pbm);
-    let max_box_size = style.content_max_box_size(containing_block, &pbm);
+    let box_size = style.content_box_size_deprecated(containing_block, &pbm);
+    let max_box_size = style.content_max_box_size_deprecated(containing_block, &pbm);
     let min_box_size = style
-        .content_min_box_size(containing_block, &pbm)
+        .content_min_box_size_deprecated(containing_block, &pbm)
         .auto_is(Au::zero);
 
     // https://drafts.csswg.org/css2/#the-width-property

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -66,7 +66,7 @@ impl<'a> IndefiniteContainingBlock<'a> {
         auto_minimum: &LogicalVec2<Au>,
     ) -> Self {
         let (content_box_size, content_min_size, content_max_size, _) =
-            style.content_box_sizes_and_padding_border_margin(self);
+            style.content_box_sizes_and_padding_border_margin_deprecated(self);
         let block_size = content_box_size.block.map(|v| {
             v.clamp_between_extremums(
                 content_min_size.block.auto_is(|| auto_minimum.block),

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -476,7 +476,7 @@ impl HoistedAbsolutelyPositionedBox {
             },
             IndependentFormattingContext::NonReplaced(non_replaced) => non_replaced
                 .style
-                .content_box_size(&indefinite_containing_block, &pbm),
+                .content_box_size_deprecated(&indefinite_containing_block, &pbm),
         };
 
         let shared_fragment = self.fragment.borrow();
@@ -561,10 +561,10 @@ impl HoistedAbsolutelyPositionedBox {
                     // https://drafts.csswg.org/css2/#min-max-heights
                     let min_size = non_replaced
                         .style
-                        .content_min_box_size(&indefinite_containing_block, &pbm)
+                        .content_min_box_size_deprecated(&indefinite_containing_block, &pbm)
                         .map(|t| t.map(Au::from).auto_is(Au::zero));
                     let max_size = style
-                        .content_max_box_size(&containing_block.into(), &pbm)
+                        .content_max_box_size_deprecated(&containing_block.into(), &pbm)
                         .map(|t| t.map(Au::from));
 
                     // https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -427,15 +427,15 @@ impl ReplacedContent {
         pbm: &PaddingBorderMargin,
     ) -> LogicalVec2<Au> {
         let box_size = style
-            .content_box_size(containing_block, pbm)
+            .content_box_size_deprecated(containing_block, pbm)
             // We need to clamp to zero here to obtain the proper aspect
             // ratio when box-sizing is border-box and the inner box size
             // would otherwise be negative.
             .map(|value| value.map(|value| value.max(Au::zero())));
         let min_box_size = style
-            .content_min_box_size(containing_block, pbm)
+            .content_min_box_size_deprecated(containing_block, pbm)
             .auto_is(Au::zero);
-        let max_box_size = style.content_max_box_size(containing_block, pbm);
+        let max_box_size = style.content_max_box_size_deprecated(containing_block, pbm);
         self.used_size_as_if_inline_element_from_content_box_sizes(
             containing_block,
             style,

--- a/components/layout_2020/sizing.rs
+++ b/components/layout_2020/sizing.rs
@@ -121,7 +121,7 @@ pub(crate) fn outer_inline(
     get_content_size: impl FnOnce(&IndefiniteContainingBlock) -> ContentSizes,
 ) -> ContentSizes {
     let (content_box_size, content_min_size, content_max_size, pbm) =
-        style.content_box_sizes_and_padding_border_margin(containing_block);
+        style.content_box_sizes_and_padding_border_margin_deprecated(containing_block);
     let content_min_size = LogicalVec2 {
         inline: content_min_size.inline.auto_is(|| auto_minimum.inline),
         block: content_min_size.block.auto_is(|| auto_minimum.block),

--- a/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
+++ b/tests/wpt/meta/css/css-tables/tentative/table-width-redistribution-fixed.html.ini
@@ -1,7 +1,4 @@
 [table-width-redistribution-fixed.html]
-  [table 3]
-    expected: FAIL
-
   [table 15]
     expected: FAIL
 

--- a/tests/wpt/tests/css/css-tables/fixed-layout-2.html
+++ b/tests/wpt/tests/css/css-tables/fixed-layout-2.html
@@ -1,84 +1,116 @@
-<!doctype html>
-<script src='/resources/testharness.js'></script>
-<script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='./support/base.css' />
+<!DOCTYPE html>
+<title>table-layout:fixed with various widths</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#in-fixed-mode">
-<main>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10937">
+<link rel="stylesheet" href="./support/base.css">
 
-    <h1>Fixed Layout</h1>
-    <p>Checks whether fixed layout is implemented properly (width is not definite)</p>
+<style>
+.wrapper {
+  width: 0;
+}
+x-table {
+  table-layout: fixed;
+  border-spacing: 0px;
+}
+x-td:first-child {
+  padding: 0;
+  background: cyan;
+  width: 50px;
+  height: 50px;
+}
+x-td + x-td {
+  padding: 0;
+  height: 50px;
+}
+x-td > div {
+  width: 100px;
+}
+</style>
 
-    <hr/>
-    <p>This should be a 100px-wide blue square:</p>
-    <p>Table-layout:fixed does not apply to width:auto tables</p>
-    <x-table style="table-layout: fixed; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 100px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0"></x-td>
-        </x-tr>
-    </x-table>
-
-    <hr/>
-    <p>This should be a 100px-wide blue square:</p>
-    <p>Table-layout:fixed does not apply to width:max-content tables</p>
-    <x-table style="table-layout: fixed; width: max-content; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 100px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0"></x-td>
-        </x-tr>
-    </x-table>
-
-    <hr/>
-    <p>This should be a 100px-wide blue square:</p>
-    <p>Table-layout:fixed does apply to width:min-content/fit-content tables</p>
-    <x-table style="table-layout: fixed; width: fit-content; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 50px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0"></x-td>
-        </x-tr>
-    </x-table>
-    <x-table style="table-layout: fixed; width: min-content; border-spacing: 0px">
-        <x-tr>
-            <x-td style="padding: 0; background: blue; height: 50px;width:100px;"><div style="width: 100px"></div></x-td>
-            <x-td style="padding: 0;height:50px"><div style="width: 100px"></div></x-td>
-        </x-tr>
-    </x-table>
-
+<main id="main">
+  <h1>Fixed Layout</h1>
+  <p>Checks whether fixed layout is implemented properly</p>
 </main>
 
+<template id="template">
+  <hr>
+  <p></p>
+  <p></p>
+  <div class="wrapper">
+    <x-table>
+      <x-tr>
+        <x-td>
+          <div></div>
+        </x-td>
+        <x-td></x-td>
+      </x-tr>
+    </x-table>
+  </div>
+</template>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script>
-    while(true) {
-        var xtd = document.querySelector('x-td[rowspan], x-td[colspan]'); if(!xtd) break;
-        var td = document.createElement('td'); for(var i = xtd.attributes.length; i--;) { td.setAttribute(xtd.attributes[i].name,xtd.attributes[i].value) }
-        xtd.parentNode.replaceChild(td,xtd);
+let sizeData = {
+  "10px": true,
+  "100%": true,
+  "calc(10px + 100%)": true,
+  "auto": false,
+  "min-content": true,
+  "max-content": false,
+  "fit-content": true,
+  "calc-size(any, 10px + 100%)": true,
+
+  // These expectations are tentative, see https://github.com/w3c/csswg-drafts/issues/10937
+  "fit-content(0)": true,
+  "stretch": true,
+
+  // These are non-standard, expect the most popular behavior among the supporting implementations.
+  "-moz-available": true,
+  "-webkit-fill-available": true,
+  "intrinsic": false,
+  "min-intrinsic": false,
+};
+
+function checkSize(size, allowsFixed) {
+  let fragment = template.content.cloneNode(true);
+  if (allowsFixed) {
+    fragment.querySelector("p").textContent = "This should be a 50x50 cyan square:";
+    fragment.querySelector("p + p").textContent = "Table-layout:fixed does apply to width:" + size + " tables";
+  } else {
+    fragment.querySelector("p").textContent = "This should be a 100x50 cyan rectangle:";
+    fragment.querySelector("p + p").textContent = "Table-layout:fixed does NOT apply to width:" + size + " tables";
+  }
+  let table = fragment.querySelector("x-table");
+  table.style.width = size;
+  table.querySelector("div").textContent = size;
+  main.appendChild(fragment);
+
+  test(() => {
+    assert_equals(
+      getComputedStyle(table).tableLayout,
+      "fixed",
+      "The computed value is 'fixed' regardless of whether it applies"
+    );
+    if (allowsFixed) {
+      assert_equals(table.offsetWidth, 50, "Table is in fixed mode");
+    } else {
+      assert_equals(table.offsetWidth, 100, "Table is NOT in fixed mode");
     }
+  }, size);
+}
 
-    generate_tests(assert_equals, [
-        [
-            "Table-layout:fixed is not applied when width is auto",
-            document.querySelector("x-table:nth-of-type(1) > x-tr:first-child > x-td:first-child").offsetWidth,
-            100
-        ],
-        [
-            "Table-layout:fixed reports fixed when width is auto",
-            getComputedStyle(document.querySelector("x-table:nth-of-type(1)")).tableLayout,
-            'fixed'
-        ],
-        [
-            "Table-layout:fixed is not applied when width is max-content",
-            document.querySelector("x-table:nth-of-type(2) > x-tr:first-child > x-td:first-child").offsetWidth,
-            100
-        ],
-        [
-            "Table-layout:fixed reports fixed when width is max-content",
-            getComputedStyle(document.querySelector("x-table:nth-of-type(2)")).tableLayout,
-            'fixed'
-        ],
-        [
-            "Table-layout:fixed is applied when width is min-content",
-            document.querySelector("x-table:nth-of-type(3) > x-tr:first-child > x-td:first-child").offsetWidth,
-            document.querySelector("x-table:nth-of-type(4) > x-tr:first-child > x-td:first-child").offsetWidth
-        ]
-    ])
+for (let [size, allowsFixed] of Object.entries(sizeData)) {
+  if (CSS.supports("width", size)) {
+    checkSize(size, allowsFixed);
 
+    // calc-size() should have the same behavior as its basis.
+    // https://drafts.csswg.org/css-values-5/#calc-size
+    let calcSize = "calc-size(" + size + ", size)";
+    if (CSS.supports("width", calcSize)) {
+      checkSize(calcSize, allowsFixed);
+    }
+  }
+}
 </script>


### PR DESCRIPTION
This will allow callers to start obeying `min-content`, `max-content`, `fit-content` and `stretch` in follow-up patches.
The old functionality is kept as deprecated methods that we should eventually remove.
This patch has very little impact on the existing behavior, just some very minimal implementation of the keywords for css tables.

This also overhauls fixed-layout-2.html since:
 - It had code that wasn't doing anything
 - It had wrong expecations in prose
 - The logic seemed broken in general
 - All browsers were failing one testcase

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #32853
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
