### PR TITLE
Fix mach run bustage

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -57,7 +57,7 @@ class MachCommands(CommandBase):
                      help='Print very verbose output')
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
-    @CommandBase.common_command_arguments(build_configuration=True, build_type=True)
+    @CommandBase.common_command_arguments(build_configuration=True, build_type=True, package_configuration=True)
     def build(self, build_type: BuildType, jobs=None, params=None, no_package=False,
               verbose=False, very_verbose=False, with_asan=False, flavor=None, **kwargs):
         opts = params or []

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -515,7 +515,11 @@ class CommandBase(object):
         return env
 
     @staticmethod
-    def common_command_arguments(build_configuration=False, build_type=False, binary_selection=False):
+    def common_command_arguments(build_configuration=False,
+                                 build_type=False,
+                                 binary_selection=False,
+                                 package_configuration=False
+                                 ):
         decorators = []
         if build_type or binary_selection:
             decorators += [
@@ -532,10 +536,6 @@ class CommandBase(object):
                 CommandArgument('--profile', group="Build Type",
                                 help='Build with custom Cargo profile'),
                 CommandArgument('--with-asan', action='store_true', help="Build with AddressSanitizer"),
-                CommandArgument(
-                    '--flavor', default=None, group="Build Type",
-                    help='Product flavor to be used when packaging with Gradle/Hvigor (android/ohos).'
-                ),
             ]
 
         if build_configuration:
@@ -593,6 +593,14 @@ class CommandBase(object):
                     action='store_true',
                     help="Enable Servo's `crown` linter tool"
                 )
+            ]
+        if package_configuration:
+            decorators += [
+                CommandArgumentGroup('Packaging options'),
+                CommandArgument(
+                    '--flavor', default=None, group="Packaging options",
+                    help='Product flavor to be used when packaging with Gradle/Hvigor (android/ohos).'
+                ),
             ]
 
         if binary_selection:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -132,7 +132,7 @@ class PackageCommands(CommandBase):
     @CommandArgument('--target', '-t',
                      default=None,
                      help='Package for given target platform')
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
+    @CommandBase.common_command_arguments(build_configuration=False, build_type=True, package_configuration=True)
     @CommandBase.allow_target_configuration
     def package(self, build_type: BuildType, flavor=None, with_asan=False):
         env = self.build_env()
@@ -420,7 +420,7 @@ class PackageCommands(CommandBase):
     @CommandArgument('--target', '-t',
                      default=None,
                      help='Install the given target platform')
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
+    @CommandBase.common_command_arguments(build_configuration=False, build_type=True, package_configuration=True)
     @CommandBase.allow_target_configuration
     def install(self, build_type: BuildType, emulator=False, usb=False, with_asan=False, flavor=None):
         env = self.build_env()
@@ -429,7 +429,7 @@ class PackageCommands(CommandBase):
         except BuildNotFound:
             print("Servo build not found. Building servo...")
             result = Registrar.dispatch(
-                "build", context=self.context, build_type=build_type
+                "build", context=self.context, build_type=build_type, flavor=flavor
             )
             if result:
                 return result


### PR DESCRIPTION
Move `--flavor` to a new "Packaging options" group, so that we can only apply the flavor option to the commands that support it.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33559

