### PR TITLE
Fix typos on protocol handlers

### DIFF
--- a/ports/servoshell/desktop/embedder.rs
+++ b/ports/servoshell/desktop/embedder.rs
@@ -61,8 +61,8 @@ impl EmbedderMethods for EmbedderCallbacks {
     fn get_protocol_handlers(&self) -> ProtocolRegistry {
         let mut registry = ProtocolRegistry::default();
         registry.register("urlinfo", urlinfo::UrlInfoProtocolHander::default());
-        registry.register("servo", servo_handler::ServoProtocolHander::default());
-        registry.register("resource", resource::ResourceProtocolHander::default());
+        registry.register("servo", servo_handler::ServoProtocolHandler::default());
+        registry.register("resource", resource::ResourceProtocolHandler::default());
         registry
     }
 

--- a/ports/servoshell/desktop/protocols/resource.rs
+++ b/ports/servoshell/desktop/protocols/resource.rs
@@ -23,9 +23,9 @@ use net_traits::ResourceFetchTiming;
 use tokio::sync::mpsc::unbounded_channel;
 
 #[derive(Default)]
-pub struct ResourceProtocolHander {}
+pub struct ResourceProtocolHandler {}
 
-impl ResourceProtocolHander {
+impl ResourceProtocolHandler {
     pub fn response_for_path(
         request: &mut Request,
         done_chan: &mut DoneChannel,
@@ -91,7 +91,7 @@ impl ResourceProtocolHander {
     }
 }
 
-impl ProtocolHandler for ResourceProtocolHander {
+impl ProtocolHandler for ResourceProtocolHandler {
     fn load(
         &self,
         request: &mut Request,

--- a/ports/servoshell/desktop/protocols/servo.rs
+++ b/ports/servoshell/desktop/protocols/servo.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Loads resources using a mapping from well-known shortcuts to resource: urls.
-//! Recognized shorcuts:
+//! Recognized shortcuts:
 //! - servo:newtab
 
 use std::future::Future;
@@ -14,12 +14,12 @@ use net::protocols::ProtocolHandler;
 use net_traits::request::Request;
 use net_traits::response::Response;
 
-use crate::desktop::protocols::resource::ResourceProtocolHander;
+use crate::desktop::protocols::resource::ResourceProtocolHandler;
 
 #[derive(Default)]
-pub struct ServoProtocolHander {}
+pub struct ServoProtocolHandler {}
 
-impl ProtocolHandler for ServoProtocolHander {
+impl ProtocolHandler for ServoProtocolHandler {
     fn load(
         &self,
         request: &mut Request,
@@ -29,7 +29,7 @@ impl ProtocolHandler for ServoProtocolHander {
         let url = request.current_url();
 
         match url.path() {
-            "newtab" => ResourceProtocolHander::response_for_path(
+            "newtab" => ResourceProtocolHandler::response_for_path(
                 request,
                 done_chan,
                 context,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix typo `Hander` to `Handler`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because this PR only fixes some typos.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
