### PR TITLE
Bump sccache-action to v0.0.6

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install crown
         run: cargo install --path support/crown
       - name: Bootstrap Python

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2 # This is necessary for `test-tidy`.
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - uses: actions/setup-python@v5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -119,7 +119,7 @@ jobs:
       # Install missing tools in a GitHub-hosted runner.
       - name: Run sccache-cache
         if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         if: ${{ ! fromJSON(needs.runner-select.outputs.is-self-hosted) && !inputs.upload }} # not needed on ubuntu 20.04 used for nightly
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install crown
         run: cargo install --path support/crown
       - name: Bootstrap

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install crown
         run: cargo install --path support/crown
       - name: Bootstrap Python


### PR DESCRIPTION
Interesting changes since v0.0.4:

- fix: avoid downloading package when local cache exists in https://github.com/Mozilla-Actions/sccache-action/pull/123
- Output sccache stats as a notice and a summary table in https://github.com/Mozilla-Actions/sccache-action/pull/113

v0.0.6 changelog: https://github.com/Mozilla-Actions/sccache-action/releases/tag/v0.0.6

v0.0.5 changelog: https://github.com/Mozilla-Actions/sccache-action/releases/tag/v0.0.5

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

