### PR TITLE
Let protocol handlers decide if they are fetchable

### DIFF
--- a/components/net/protocols/data.rs
+++ b/components/net/protocols/data.rs
@@ -54,4 +54,8 @@ impl ProtocolHandler for DataProtocolHander {
 
         Box::pin(std::future::ready(response))
     }
+
+    fn is_fetchable(&self) -> bool {
+        true
+    }
 }

--- a/ports/servoshell/desktop/protocols/urlinfo.rs
+++ b/ports/servoshell/desktop/protocols/urlinfo.rs
@@ -43,4 +43,8 @@ impl ProtocolHandler for UrlInfoProtocolHander {
 
         Box::pin(std::future::ready(response))
     }
+
+    fn is_fetchable(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
This adds a 'is_fetchable()' method on the ProtocolHandler trait that is then used in the fetch code. The 'data:' protocol handler is updated to return true instead of hardcoding the scheme comparison, as well as the 'urlinfo:' handler since it's just a testing one.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33564 (GitHub issue number if applicable)

