### PR TITLE
Optimized `unmultiply_inplace` by removing fp ops

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -199,10 +199,20 @@ pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
 
 pub fn unmultiply_inplace(pixels: &mut [u8]) {
     for rgba in pixels.chunks_mut(4) {
-        let a = (rgba[3] as f32) / 255.0;
-        rgba[0] = (rgba[0] as f32 / a) as u8;
-        rgba[1] = (rgba[1] as f32 / a) as u8;
-        rgba[2] = (rgba[2] as f32 / a) as u8;
+        let a = rgba[3] as u32;
+        let mut b = rgba[2] as u32;
+        let mut g = rgba[1] as u32;
+        let mut r = rgba[0] as u32;
+
+        if a > 0 {
+            r = r * 255 / a;
+            g = g * 255 / a;
+            b = b * 255 / a;
+
+            rgba[2] = b as u8;
+            rgba[1] = g as u8;
+            rgba[0] = r as u8;
+        }
     }
 }
 


### PR DESCRIPTION
Copied implementation from [wrench](https://github.com/servo/webrender/blob/bd7704a7091c51593cef9a3fe2ba86eb7e26359e/wrench/src/premultiply.rs#L21) which have no floating point operations, yielding performance improvement of 10%.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33552 

<!-- Either: -->
- [x] These changes do not require tests because functionality has not changed 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
