### PR TITLE
fix(pixels): make the unmultiply_inplace more performance

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -198,11 +198,16 @@ pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
 }
 
 pub fn unmultiply_inplace(pixels: &mut [u8]) {
-    for rgba in pixels.chunks_mut(4) {
-        let a = (rgba[3] as f32) / 255.0;
-        rgba[0] = (rgba[0] as f32 / a) as u8;
-        rgba[1] = (rgba[1] as f32 / a) as u8;
-        rgba[2] = (rgba[2] as f32 / a) as u8;
+    let mut iter = pixels.iter_mut();
+    while let Some(r) = iter.next() {
+        let g = iter.next().unwrap();
+        let b = iter.next().unwrap();
+        let a = iter.next().unwrap();
+        if *a > 0 {
+            *r = ((*r / *a) as u16 * 255) as u8;
+            *g = ((*g / *a) as u16 * 255) as u8;
+            *b = ((*b / *a) as u16 * 255) as u8;
+        }
     }
 }
 


### PR DESCRIPTION
change the chunks to iterator and change the f32 to u16

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #33552  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because the core functionality does not change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
