### PR TITLE
ohos: Allow passing arguments to servoshell

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -51,6 +51,7 @@ pub struct InitOpts {
     /// Path to application data bundled with the servo app, e.g. web-pages.
     pub resource_dir: String,
     pub display_density: f64,
+    pub commandline_args: String,
 }
 
 #[derive(Debug)]

--- a/support/openharmony/entry/src/main/cpp/CMakeLists.txt
+++ b/support/openharmony/entry/src/main/cpp/CMakeLists.txt
@@ -1,3 +1,3 @@
 # the minimum version of CMake.
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.16.0)
 project(servoshell)

--- a/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -5,8 +5,29 @@ import Want from '@ohos.app.ability.Want';
 import window from '@ohos.window';
 
 export default class EntryAbility extends UIAbility {
+  init_params: LocalStorage = new LocalStorage();
   onCreate(want: Want, launchParam: AbilityConstant.LaunchParam) {
-    hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onCreate');
+    let uri: string = want.uri || "https://servo.org"
+    let params: string[] = []
+    if (typeof want.parameters !== "undefined") {
+      Object.entries(want.parameters).forEach((entry) => {
+        let key = entry[0]
+        // Skip some default parameters, since servo is not interested in those
+        if (key.startsWith("ohos.")
+          || key.startsWith("component.")
+          || key === "isCallBySCB"
+          || key === "moduleName"
+        ) {
+          return
+        }
+        let value = entry[1]
+        params.push("--" + key + "=" + value.toString())
+      })
+    }
+    let servoshell_params = params.join("\u{001f}")
+    hilog.debug(0x0000, 'Servo EntryAbility', 'Servoshell parameters: %{public}s', servoshell_params);
+    this.init_params.setOrCreate('InitialURI', uri)
+    this.init_params.setOrCreate('CommandlineArgs', servoshell_params)
   }
 
   onDestroy() {
@@ -17,7 +38,7 @@ export default class EntryAbility extends UIAbility {
     // Main window is created, set main page for this ability
     hilog.info(0x0000, 'testTag', '%{public}s', 'Ability onWindowStageCreate');
 
-    windowStage.loadContent('pages/Index', (err, data) => {
+    windowStage.loadContent('pages/Index', this.init_params, (err, data) => {
       if (err.code) {
         hilog.error(0x0000, 'testTag', 'Failed to load the content. Cause: %{public}s', JSON.stringify(err) ?? '');
         return;

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -16,6 +16,7 @@ interface InitOpts {
   osFullName: string,
   resourceDir: string,
   displayDensity: number,
+  commandlineArgs: string,
 }
 
 function get_density(): number {
@@ -39,7 +40,10 @@ function get_device_type(): string {
   return device_type;
 }
 
-@Entry
+// Use the getShared API to obtain the LocalStorage instance shared by stage.
+let storage = LocalStorage.getShared()
+
+@Entry(storage)
 @Component
 struct Index {
   xComponentContext: ServoXComponentInterface | undefined = undefined;
@@ -48,8 +52,11 @@ struct Index {
     type: XComponentType.SURFACE,
     libraryname: 'servoshell',
   }
-  @State urlToLoad: string =  'https://servo.org'
+
   private context = getContext(this) as common.UIAbilityContext;
+  @LocalStorageProp('InitialURI') InitialURI: string = "unused"
+  @LocalStorageProp('CommandlineArgs') CommandlineArgs: string = ""
+  @State urlToLoad: string = this.InitialURI
 
   build() {
     Column() {
@@ -86,13 +93,14 @@ struct Index {
         .onLoad((xComponentContext) => {
           this.xComponentContext = xComponentContext as ServoXComponentInterface;
           let resource_dir: string = this.context.resourceDir;
-          console.debug("Resources are located at %s", resource_dir);
+          console.debug("Resources are located at %{public}s", resource_dir);
           let init_options: InitOpts = {
             url: this.urlToLoad,
             deviceType: get_device_type(),
             osFullName: deviceInfo.osFullName,
             displayDensity: get_density(),
             resourceDir: resource_dir,
+            commandlineArgs: this.CommandlineArgs
           }
           this.xComponentContext.initServo(init_options)
           this.xComponentContext.registerURLcallback((new_url) => {


### PR DESCRIPTION
Allows passing options passed via `wants` to the Ability through to servoshell.
This allows easier debugging, either by calling servoshell from a test app,
or from the commandline, e.g.
```
hdc shell aa start -a EntryAbility -b org.servo.servoshell -U "https://www.wikipedia.org" \
--pb dom.webgpu.enabled true \
--ps dom.webgpu.wgpu_backend "gl" \
--pi layout.threads 4
```

Note: While the OH `wants` API differentiates between boolean, string and integer values, we convert
everything back to strings, so we can reuse the same parsing code as the desktop servoshell.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
