### PR TITLE
CI: increase self-hosted runner timeout from 30 to 120 seconds

### DIFF
--- a/.github/workflows/self-hosted-runner-timeout.yml
+++ b/.github/workflows/self-hosted-runner-timeout.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait a bit
-        run: sleep 30
+        run: sleep 120
 
       - name: Cancel if workload job is still queued
         run: |


### PR DESCRIPTION
When we run jobs on self-hosted runners, it’s up to GitHub to create the job, assign the runner, and start the job in a timely manner, as long as we reserve (label) the runner for it in advance.

Even when all GitHub-hosted runners are busy, self-hosted jobs should start immediately (confirmed experimentally). The self-hosted runner timeout job may get delayed, but that’s ok, because it just makes the timeout more lenient:

![image](https://github.com/user-attachments/assets/a96152c8-45a8-47c9-8804-05d302c5f421)

GitHub sometimes takes over a minute to assign and start jobs, for reasons that are not yet clear, so this patch increases the maximum time a self-hosted workload job can wait in `queued` state from 30 to 120 seconds. On our runner server, the maximum time a runner can be reserved but unused is [increased from 120 to 200 seconds](https://github.com/servo/ci-runners/commit/43d56bf194f81b3f88ab5d22b6339968411465a8).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes should fix #33533

<!-- Either: -->
- [x] Self-hosted runner test plan
  - [x] Before: builds that took too long to assign: [[1]](https://github.com/servo/servo/actions/runs/11011549294) [[2]](https://github.com/servo/servo/actions/runs/11012807997) [[3]](https://github.com/servo/servo/actions/runs/11025704608) [[4]](https://github.com/servo/servo/actions/runs/11026252579)
  - [x] After: [build whose Windows job was assigned in ~85 seconds](https://github.com/servo/servo/actions/runs/11026497530/job/30623144946#step:1:1) (ok; cancelled manually)
  - [x] After: builds that were assigned in under 10 seconds: [[1]](https://github.com/servo/servo/actions/runs/11117347715) [[2]](https://github.com/servo/servo/actions/runs/11117348713) (and many more in issue)