### PR TITLE
Compositor: add document id to NewWebRenderFrame variant

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -610,7 +610,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(());
             },
 
-            CompositorMsg::NewWebRenderFrameReady(recomposite_needed) => {
+            CompositorMsg::NewWebRenderFrameReady(recomposite_needed, _document_id) => {
                 self.pending_frames -= 1;
 
                 if recomposite_needed {
@@ -999,7 +999,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     );
                 }
             },
-            CompositorMsg::NewWebRenderFrameReady(_) => {
+            CompositorMsg::NewWebRenderFrameReady(..) => {
                 // Subtract from the number of pending frames, but do not do any compositing.
                 self.pending_frames -= 1;
             },
@@ -2386,12 +2386,12 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         let mut found_recomposite_msg = false;
         while let Some(msg) = self.port.try_recv_compositor_msg() {
             match msg {
-                CompositorMsg::NewWebRenderFrameReady(_) if found_recomposite_msg => {
+                CompositorMsg::NewWebRenderFrameReady(..) if found_recomposite_msg => {
                     // Only take one of duplicate NewWebRendeFrameReady messages, but do subtract
                     // one frame from the pending frames.
                     self.pending_frames -= 1;
                 },
-                CompositorMsg::NewWebRenderFrameReady(_) => {
+                CompositorMsg::NewWebRenderFrameReady(..) => {
                     found_recomposite_msg = true;
                     compositor_messages.push(msg)
                 },
@@ -2445,7 +2445,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     pub fn repaint_synchronously(&mut self) {
         while self.shutdown_state != ShutdownState::ShuttingDown {
             let msg = self.port.recv_compositor_msg();
-            let need_recomposite = matches!(msg, CompositorMsg::NewWebRenderFrameReady(_));
+            let need_recomposite = matches!(msg, CompositorMsg::NewWebRenderFrameReady(..));
             let keep_going = self.handle_browser_message(msg);
             if need_recomposite {
                 self.composite();

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -610,7 +610,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 let _ = sender.send(());
             },
 
-            CompositorMsg::NewWebRenderFrameReady(recomposite_needed, _document_id) => {
+            CompositorMsg::NewWebRenderFrameReady(_document_id, recomposite_needed) => {
                 self.pending_frames -= 1;
 
                 if recomposite_needed {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -206,13 +206,16 @@ impl webrender_api::RenderNotifier for RenderNotifier {
 
     fn new_frame_ready(
         &self,
-        _document_id: DocumentId,
+        document_id: DocumentId,
         _scrolled: bool,
         composite_needed: bool,
         _frame_publish_id: FramePublishId,
     ) {
         self.compositor_proxy
-            .send(CompositorMsg::NewWebRenderFrameReady(composite_needed));
+            .send(CompositorMsg::NewWebRenderFrameReady(
+                composite_needed,
+                document_id,
+            ));
     }
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -213,8 +213,8 @@ impl webrender_api::RenderNotifier for RenderNotifier {
     ) {
         self.compositor_proxy
             .send(CompositorMsg::NewWebRenderFrameReady(
-                composite_needed,
                 document_id,
+                composite_needed,
             ));
     }
 }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -22,6 +22,7 @@ use script_traits::{
 };
 use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize, DeviceRect};
+use webrender_api::DocumentId;
 use webrender_traits::{
     CanvasToCompositorMsg, FontToCompositorMsg, NetToCompositorMsg, ScriptToCompositorMsg,
 };
@@ -93,8 +94,9 @@ pub enum CompositorMsg {
     /// Set whether to use less resources by stopping animations.
     SetThrottled(PipelineId, bool),
     /// WebRender has produced a new frame. This message informs the compositor that
-    /// the frame is ready, so that it may trigger a recomposite.
-    NewWebRenderFrameReady(bool /* composite_needed */),
+    /// the frame is ready. It contains a bool to indicate if it needs to composite and the document
+    /// ID related to this frame.
+    NewWebRenderFrameReady(bool /* composite_needed */, DocumentId),
     /// A pipeline was shut down.
     // This message acts as a synchronization point between the constellation,
     // when it shuts down a pipeline, to the compositor; when the compositor

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -94,9 +94,9 @@ pub enum CompositorMsg {
     /// Set whether to use less resources by stopping animations.
     SetThrottled(PipelineId, bool),
     /// WebRender has produced a new frame. This message informs the compositor that
-    /// the frame is ready. It contains a bool to indicate if it needs to composite and the document
-    /// ID related to this frame.
-    NewWebRenderFrameReady(bool /* composite_needed */, DocumentId),
+    /// the frame is ready. It contains a bool to indicate if it needs to composite and the
+    /// `DocumentId` of the new frame.
+    NewWebRenderFrameReady(DocumentId, bool),
     /// A pipeline was shut down.
     // This message acts as a synchronization point between the constellation,
     // when it shuts down a pipeline, to the compositor; when the compositor


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR makes compositor proxy send Document ID as well when it's called by `new_frame_ready`.
This won't affect anything at the moment, but can help us easier to improve [`CompositingReason`](https://github.com/servo/servo/blob/main/components/compositing/compositor.rs#L249).
I also opened a [upstream ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1921922) in hope for pushing multi-document rendering.
I hope we can know which frame belongs to which document precisely, so we have better understanding on why we need to composite when render method is called.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
