### PR TITLE
fonts: Make `FontKey` and `FontInstanceKey` generation asynchronous

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -844,20 +844,20 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             },
 
             ForwardedToCompositorMsg::Layout(ScriptToCompositorMsg::AddFont(
+                font_key,
                 data,
                 index,
-                key_sender,
             )) => {
-                let _ = key_sender.send(self.add_font(index, data));
+                self.add_font(font_key, index, data);
             },
 
             ForwardedToCompositorMsg::Layout(ScriptToCompositorMsg::AddFontInstance(
+                font_instance_key,
                 font_key,
                 size,
                 flags,
-                sender,
             )) => {
-                let _ = sender.send(self.add_font_instance(font_key, size, flags));
+                self.add_font_instance(font_instance_key, font_key, size, flags);
             },
 
             ForwardedToCompositorMsg::Layout(ScriptToCompositorMsg::RemoveFonts(
@@ -884,33 +884,45 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
             },
 
+            ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::GenerateKeys(
+                number_of_font_keys,
+                number_of_font_instance_keys,
+                result_sender,
+            )) => {
+                let font_keys = (0..number_of_font_keys)
+                    .map(|_| self.webrender_api.generate_font_key())
+                    .collect();
+                let font_instance_keys = (0..number_of_font_instance_keys)
+                    .map(|_| self.webrender_api.generate_font_instance_key())
+                    .collect();
+                let _ = result_sender.send((font_keys, font_instance_keys));
+            },
+
             ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::AddFontInstance(
+                font_instance_key,
                 font_key,
                 size,
                 flags,
-                sender,
             )) => {
-                let _ = sender.send(self.add_font_instance(font_key, size, flags));
+                self.add_font_instance(font_instance_key, font_key, size, flags);
             },
 
             ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::AddFont(
-                key_sender,
+                font_key,
                 index,
                 data,
             )) => {
-                let _ = key_sender.send(self.add_font(index, data));
+                self.add_font(font_key, index, data);
             },
 
             ForwardedToCompositorMsg::SystemFontService(FontToCompositorMsg::AddSystemFont(
-                key_sender,
+                font_key,
                 native_handle,
             )) => {
-                let font_key = self.webrender_api.generate_font_key();
                 let mut transaction = Transaction::new();
                 transaction.add_native_font(font_key, native_handle);
                 self.webrender_api
                     .send_transaction(self.webrender_document, transaction);
-                let _ = key_sender.send(font_key);
             },
 
             ForwardedToCompositorMsg::Canvas(CanvasToCompositorMsg::GenerateKey(sender)) => {
@@ -955,26 +967,6 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 debug!("Compositor got pipeline exited: {:?}", pipeline_id);
                 self.remove_pipeline_root_layer(pipeline_id);
                 let _ = sender.send(());
-            },
-            CompositorMsg::Forwarded(ForwardedToCompositorMsg::SystemFontService(
-                FontToCompositorMsg::AddFontInstance(_, _, _, sender),
-            )) => {
-                let _ = sender.send(self.webrender_api.generate_font_instance_key());
-            },
-            CompositorMsg::Forwarded(ForwardedToCompositorMsg::Layout(
-                ScriptToCompositorMsg::AddFontInstance(_, _, _, sender),
-            )) => {
-                let _ = sender.send(self.webrender_api.generate_font_instance_key());
-            },
-            CompositorMsg::Forwarded(ForwardedToCompositorMsg::SystemFontService(
-                FontToCompositorMsg::AddFont(sender, _, _),
-            )) => {
-                let _ = sender.send(self.webrender_api.generate_font_key());
-            },
-            CompositorMsg::Forwarded(ForwardedToCompositorMsg::Layout(
-                ScriptToCompositorMsg::AddFont(_, _, sender),
-            )) => {
-                let _ = sender.send(self.webrender_api.generate_font_key());
             },
             CompositorMsg::Forwarded(ForwardedToCompositorMsg::Canvas(
                 CanvasToCompositorMsg::GenerateKey(sender),
@@ -2527,11 +2519,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
     fn add_font_instance(
         &mut self,
+        instance_key: FontInstanceKey,
         font_key: FontKey,
         size: f32,
         flags: FontInstanceFlags,
-    ) -> FontInstanceKey {
-        let instance_key = self.webrender_api.generate_font_instance_key();
+    ) {
         let mut transaction = Transaction::new();
 
         let font_instance_options = FontInstanceOptions {
@@ -2549,15 +2541,12 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
         self.webrender_api
             .send_transaction(self.webrender_document, transaction);
-        instance_key
     }
 
-    fn add_font(&mut self, index: u32, data: Arc<IpcSharedMemory>) -> FontKey {
-        let font_key = self.webrender_api.generate_font_key();
+    fn add_font(&mut self, font_key: FontKey, index: u32, data: Arc<IpcSharedMemory>) {
         let mut transaction = Transaction::new();
         transaction.add_raw_font(font_key, (**data).into(), index);
         self.webrender_api
             .send_transaction(self.webrender_document, transaction);
-        font_key
     }
 }

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -5,7 +5,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
-use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use ipc_channel::ipc::IpcSharedMemory;
 use log::warn;
@@ -13,13 +12,11 @@ use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use style::stylesheets::DocumentStyleSheet;
 use style::values::computed::{FontStyle, FontWeight};
-use webrender_api::{FontInstanceFlags, FontInstanceKey, FontKey};
 
 use crate::font::FontDescriptor;
 use crate::font_context::WebFontDownloadState;
 use crate::font_template::{FontTemplate, FontTemplateRef, FontTemplateRefMethods, IsOblique};
 use crate::system_font_service::{FontIdentifier, LowercaseFontFamilyName};
-use crate::FontContext;
 
 /// A data structure to store data for fonts. If sent across IPC channels and only a
 /// [`IpcSharedMemory`] handle is sent, avoiding the overhead of serialization and
@@ -183,84 +180,6 @@ impl FontStore {
     ) {
         self.font_data
             .retain(|font_identifier, _| identifiers.contains(font_identifier));
-    }
-}
-
-#[derive(Default)]
-pub struct WebRenderFontStore {
-    pub(crate) webrender_font_key_map: HashMap<FontIdentifier, FontKey>,
-    pub(crate) webrender_font_instance_map: HashMap<(FontKey, Au), FontInstanceKey>,
-}
-pub(crate) type CrossThreadWebRenderFontStore = Arc<RwLock<WebRenderFontStore>>;
-
-impl WebRenderFontStore {
-    pub(crate) fn get_font_instance(
-        &mut self,
-        font_context: &FontContext,
-        font_template: FontTemplateRef,
-        pt_size: Au,
-        flags: FontInstanceFlags,
-    ) -> FontInstanceKey {
-        let webrender_font_key_map = &mut self.webrender_font_key_map;
-        let identifier = font_template.identifier().clone();
-
-        let font_key = *webrender_font_key_map
-            .entry(identifier.clone())
-            .or_insert_with(|| {
-                let data = font_context.get_font_data(&identifier);
-                font_context.get_web_font(data, identifier.index())
-            });
-
-        *self
-            .webrender_font_instance_map
-            .entry((font_key, pt_size))
-            .or_insert_with(|| {
-                font_context.get_web_font_instance(font_key, pt_size.to_f32_px(), flags)
-            })
-    }
-
-    pub(crate) fn remove_all_fonts(&mut self) -> (Vec<FontKey>, Vec<FontInstanceKey>) {
-        (
-            self.webrender_font_key_map
-                .drain()
-                .map(|(_, key)| key)
-                .collect(),
-            self.webrender_font_instance_map
-                .drain()
-                .map(|(_, key)| key)
-                .collect(),
-        )
-    }
-
-    pub(crate) fn remove_all_fonts_for_identifiers(
-        &mut self,
-        identifiers: &HashSet<FontIdentifier>,
-    ) -> (Vec<FontKey>, Vec<FontInstanceKey>) {
-        let mut removed_keys: HashSet<FontKey> = HashSet::new();
-        self.webrender_font_key_map.retain(|identifier, font_key| {
-            if identifiers.contains(identifier) {
-                removed_keys.insert(*font_key);
-                false
-            } else {
-                true
-            }
-        });
-
-        let mut removed_instance_keys: HashSet<FontInstanceKey> = HashSet::new();
-        self.webrender_font_instance_map
-            .retain(|(font_key, _), instance_key| {
-                if removed_keys.contains(font_key) {
-                    removed_instance_keys.insert(*instance_key);
-                    false
-                } else {
-                    true
-                }
-            });
-
-        (
-            removed_keys.into_iter().collect(),
-            removed_instance_keys.into_iter().collect(),
-        )
     }
 }
 

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -32,7 +32,7 @@ use style::values::computed::font::{
 use style::values::computed::{FontLanguageOverride, XLang};
 use style::values::generics::font::LineHeight;
 use style::ArcSlice;
-use webrender_api::{FontInstanceKey, IdNamespace};
+use webrender_api::{FontInstanceKey, FontKey, IdNamespace};
 use webrender_traits::WebRenderScriptApi;
 
 struct TestContext {
@@ -125,8 +125,12 @@ impl MockSystemFontService {
                         template_data,
                     });
                 },
+                SystemFontServiceMessage::GetFontInstanceKey(result_sender) |
                 SystemFontServiceMessage::GetFontInstance(_, _, _, result_sender) => {
                     let _ = result_sender.send(FontInstanceKey(IdNamespace(0), 0));
+                },
+                SystemFontServiceMessage::GetFontKey(result_sender) => {
+                    let _ = result_sender.send(FontKey(IdNamespace(0), 0));
                 },
                 SystemFontServiceMessage::Exit(result_sender) => {
                     let _ = result_sender.send(());

--- a/components/layout/text.rs
+++ b/components/layout/text.rs
@@ -378,8 +378,10 @@ impl TextRunScanner {
                     },
                 };
 
+                let font_instance_key = font.key(font_context);
                 let (run, break_at_zero) = TextRun::new(
                     font,
+                    font_instance_key,
                     run_info.text,
                     &options,
                     run_info.bidi_level,

--- a/components/layout/text_run.rs
+++ b/components/layout/text_run.rs
@@ -160,6 +160,7 @@ impl<'a> TextRun {
     /// Constructs a new text run. Also returns if there is a line break at the beginning
     pub fn new(
         font: FontRef,
+        font_key: FontInstanceKey,
         text: String,
         options: &ShapingOptions,
         bidi_level: bidi::Level,
@@ -171,7 +172,7 @@ impl<'a> TextRun {
             TextRun {
                 text: Arc::new(text),
                 font_metrics: font.metrics.clone(),
-                font_key: font.font_key,
+                font_key,
                 pt_size: font.descriptor.pt_size,
                 glyphs: Arc::new(glyphs),
                 bidi_level,

--- a/components/layout_2020/flow/inline/mod.rs
+++ b/components/layout_2020/flow/inline/mod.rs
@@ -1528,8 +1528,11 @@ impl InlineFormattingContext {
                         &inline_box.style,
                         &layout_context.font_context,
                     ) {
-                        inline_box.default_font_index =
-                            Some(add_or_get_font(&font, &mut font_metrics));
+                        inline_box.default_font_index = Some(add_or_get_font(
+                            &font,
+                            &mut font_metrics,
+                            &layout_context.font_context,
+                        ));
                     }
                 },
                 InlineItem::Atomic(_, index_in_text, bidi_level) => {


### PR DESCRIPTION
Instead of a blocking a layout thread on the generation of WebRender
`FontKey`s and `FontInstanceKey`s, generate the keys ahead of time and
send the font data to WebRender asynchronously. This has the benefit of
allowing use of the font much more quickly in layout, though blocking
display list sending itself on the font data upload.

In order to make this work for web fonts, `FontContext` now asks the
`SystemFontService` for a `FontKey`s and `FontInstanceKey`s for new web
fonts. This should happen much more quickly as the `SystemFontService`
is only blocking in order to load system fonts into memory now. In
practice this still drops layout thread blocking to fractions of a
millisecond instead of multiple milliseconds as before.

In addition, ensure that we don't send font data or generate keys for
fonts that are used in layout but never added to display lists. This
should help to reduce memory usage and increase performance.

Performance of this change was verified by putting a microbenchmark
around `FontContext::create_font` which is what triggered font key
generation.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change functional behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
