### PR TITLE
webgpu: Introduce PresentationId to ensure updates with newer presentation

### DIFF
--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -382,7 +382,7 @@ impl crate::WGPU {
         let context_data = webgpu_contexts.get_mut(&context_id).unwrap();
 
         let presentation_id = context_data.next_presentation_id();
-        assert!(context_data.check_and_update_presentation_id(presentation_id));
+        context_data.check_and_update_presentation_id(presentation_id);
 
         // If configuration is not provided or presentation format is not valid
         // the context will be dummy until recreation


### PR DESCRIPTION
We index each (re)configuration and image with sequential number and so we only replace with images with newer data (bigger number).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33602
- [x] There are tests for these changes in WebGPU CTS

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
