### PR TITLE
clippy: Fix warnings in components/devtools/actors/inspector

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -104,10 +104,10 @@ impl Actor for PageStyleActor {
     /// The page style actor can handle the following messages:
     ///
     /// - `getApplied`: Returns the applied styles for a node, they represent the explicit css
-    /// rules set for them, both in the style attribute and in stylesheets.
+    ///   rules set for them, both in the style attribute and in stylesheets.
     ///
     /// - `getComputed`: Returns the computed styles for a node, these include all of the supported
-    /// css properties calculated values.
+    ///   css properties calculated values.
     ///
     /// - `getLayout`: Returns the box layout properties for a node.
     ///

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -93,9 +93,9 @@ impl Actor for StyleRuleActor {
     /// The style rule configuration actor can handle the following messages:
     ///
     /// - `setRuleText`: Applies a set of modifications to the css rules that this actor manages.
-    /// There is also `modifyProperties`, which has a slightly different API to do the same, but
-    /// this is preferred. Which one the devtools client sends is decided by the `traits` defined
-    /// when returning the list of rules.
+    ///   There is also `modifyProperties`, which has a slightly different API to do the same, but
+    ///   this is preferred. Which one the devtools client sends is decided by the `traits` defined
+    ///   when returning the list of rules.
     fn handle_message(
         &self,
         registry: &ActorRegistry,


### PR DESCRIPTION
Fixes `doc_lazy_continuation` warnings in `components/devtools/actors/inspector` as a part of #31500


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 

<!-- Either: -->
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
