### PR TITLE
ohos: Add toast prompt

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -565,7 +565,7 @@ impl HostTrait for HostCallbacks {
     }
 
     fn on_load_ended(&self) {
-        warn!("on_load_ended not implemented")
+        self.prompt_alert("Page finished loading!".to_string(), true);
     }
 
     fn on_title_changed(&self, title: Option<String>) {

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -427,41 +427,44 @@ pub fn go_forward() {
 }
 
 #[napi(js_name = "registerURLcallback")]
-pub fn register_url_callback(cb: JsFunction) -> napi_ohos::Result<()> {
-    info!("register_url_callback called!");
-    let tsfn: ThreadsafeFunction<String, ErrorStrategy::Fatal> =
-        cb.create_threadsafe_function(1, |ctx| {
-            debug!(
-                "url callback argument transformer called with arg {}",
-                ctx.value
-            );
-            let s = ctx
-                .env
-                .create_string_from_std(ctx.value)
-                .inspect_err(|e| error!("Failed to create JsString: {e:?}"))?;
-            Ok(vec![s])
-        })?;
+pub fn register_url_callback(callback: JsFunction) -> napi_ohos::Result<()> {
+    // Currently we call the callback in a blocking fashion, always from the embedder thread,
+    // so a queue size of 1 is sufficient.
+    const UPDATE_URL_QUEUE_SIZE: usize = 1;
+    debug!("register_url_callback called!");
+    let function = callback.create_threadsafe_function(UPDATE_URL_QUEUE_SIZE, |ctx| {
+        Ok(vec![ctx
+            .env
+            .create_string_from_std(ctx.value)
+            .inspect_err(|e| {
+                error!("Failed to create JsString: {e:?}")
+            })?])
+    })?;
     // We ignore any error for now - but probably we should propagate it back to the TS layer.
     let _ = SET_URL_BAR_CB
-        .set(tsfn)
+        .set(function)
         .inspect_err(|_| warn!("Failed to set URL callback - register_url_callback called twice?"));
     Ok(())
 }
 
 #[napi]
-pub fn register_prompt_toast_callback(cb: JsFunction) -> napi_ohos::Result<()> {
+pub fn register_prompt_toast_callback(callback: JsFunction) -> napi_ohos::Result<()> {
+    // We can submit alerts in a non-blocking fashion, but alerts will always come from the
+    // embedder thread. Specifying 4 as a max queue size seems reasonable for now, and can
+    // be adjusted later.
+    const PROMPT_QUEUE_SIZE: usize = 4;
     debug!("register_prompt_toast_callback called!");
-    let tsfn: ThreadsafeFunction<String, ErrorStrategy::Fatal> =
-        cb.create_threadsafe_function(4, |ctx| {
-            let s = ctx
-                .env
-                .create_string_from_std(ctx.value)
-                .inspect_err(|e| error!("Failed to create JsString: {e:?}"))?;
-            Ok(vec![s])
-        })?;
+    let function = callback.create_threadsafe_function(PROMPT_QUEUE_SIZE, |ctx| {
+        Ok(vec![ctx
+            .env
+            .create_string_from_std(ctx.value)
+            .inspect_err(|e| {
+                error!("Failed to create JsString: {e:?}")
+            })?])
+    })?;
     // We ignore any error for now - but probably we should propagate it back to the TS layer.
     let _ = PROMPT_TOAST
-        .set(tsfn)
+        .set(function)
         .inspect_err(|_| error!("Failed to set prompt toast callback."));
     Ok(())
 }
@@ -533,11 +536,16 @@ impl HostCallbacks {
 #[allow(unused)]
 impl HostTrait for HostCallbacks {
     fn prompt_alert(&self, msg: String, _trusted: bool) {
-        debug!("prompt_alert: {}", &msg);
-        if let Some(prompt_fn) = PROMPT_TOAST.get() {
-            prompt_fn.call(msg, ThreadsafeFunctionCallMode::Blocking);
-        } else {
-            error!("PROMPT_TOAST not set. Dropping msg {msg}");
+        debug!("prompt_alert: {msg}");
+        match PROMPT_TOAST.get() {
+            Some(prompt_fn) => {
+                let status = prompt_fn.call(msg, ThreadsafeFunctionCallMode::NonBlocking);
+                if status != napi_ohos::Status::Ok {
+                    // Queue could be full.
+                    error!("prompt_alert failed with {status}");
+                }
+            },
+            None => error!("PROMPT_TOAST not set. Dropping msg {msg}"),
         }
     }
 
@@ -578,10 +586,14 @@ impl HostTrait for HostCallbacks {
 
     fn on_url_changed(&self, url: String) {
         debug!("Hosttrait `on_url_changed` called with new url: {url}");
-        if let Some(cb) = SET_URL_BAR_CB.get() {
-            cb.call(url, ThreadsafeFunctionCallMode::Blocking);
-        } else {
-            warn!("`on_url_changed` called without a registered callback")
+        match SET_URL_BAR_CB.get() {
+            Some(update_url_fn) => {
+                let status = update_url_fn.call(url, ThreadsafeFunctionCallMode::Blocking);
+                if status != napi_ohos::Status::Ok {
+                    error!("on_url_changed failed with {status}");
+                }
+            },
+            None => error!("`on_url_changed` called without a registered callback"),
         }
     }
 

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -1,12 +1,14 @@
 import { common } from '@kit.AbilityKit';
 import display from '@ohos.display';
 import deviceInfo from '@ohos.deviceInfo';
+import promptAction from '@ohos.promptAction';
 
 interface ServoXComponentInterface {
   loadURL(url: string): void;
   goBack(): void;
   goForward(): void;
   registerURLcallback(callback: (url: string) => void): void;
+  registerPromptToastCallback(callback: (msg: string) => void): void
   initServo(options: InitOpts): void;
 }
 
@@ -38,6 +40,13 @@ function get_device_type(): string {
     console.info("Device type is " + device_type)
   }
   return device_type;
+}
+
+function prompt_toast(msg: string) {
+    promptAction.showToast({
+      message: msg,
+      duration: 2000
+    });
 }
 
 // Use the getShared API to obtain the LocalStorage instance shared by stage.
@@ -107,6 +116,7 @@ struct Index {
             console.info('New URL from native: ', new_url)
             this.urlToLoad = new_url
           })
+          this.xComponentContext.registerPromptToastCallback(prompt_toast)
         })
     }
     .width('100%')


### PR DESCRIPTION
- Implement `prompt_alert()` Host callback
- show a toast on the panic callback
- show a toast when the page load has finished

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

