### PR TITLE
Less `allow(crown::unrooted_must_root)` in bindings

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2694,7 +2694,7 @@ class CGAbstractMethod(CGThing):
     """
     def __init__(self, descriptor, name, returnType, args, inline=False,
                  alwaysInline=False, extern=False, unsafe=False, pub=False,
-                 templateArgs=None, docs=None, doesNotPanic=False, attrs=[]):
+                 templateArgs=None, docs=None, doesNotPanic=False, extra_decorators=[]):
         CGThing.__init__(self)
         self.descriptor = descriptor
         self.name = name
@@ -2707,7 +2707,7 @@ class CGAbstractMethod(CGThing):
         self.pub = pub
         self.docs = docs
         self.catchPanic = self.extern and not doesNotPanic
-        self.attrs = attrs
+        self.extra_decorators = extra_decorators
 
     def _argstring(self):
         return ', '.join([a.declare() for a in self.args])
@@ -2729,8 +2729,7 @@ class CGAbstractMethod(CGThing):
         if self.alwaysInline:
             decorators.append('#[inline]')
 
-        for attr in self.attrs:
-            decorators.append(attr)
+        decorators.extend(self.extra_decorators)
 
         if self.pub:
             decorators.append('pub')
@@ -2908,7 +2907,7 @@ class CGWrapMethod(CGAbstractMethod):
                 Argument('CanGc', '_can_gc')]
         retval = f'DomRoot<{descriptor.concreteType}>'
         CGAbstractMethod.__init__(self, descriptor, 'Wrap', retval, args,
-                                  pub=True, unsafe=True, attrs=['#[allow(crown::unrooted_must_root)]'])
+                                  pub=True, unsafe=True, extra_decorators=['#[allow(crown::unrooted_must_root)]'])
 
     def definition_body(self):
         unforgeable = CopyLegacyUnforgeablePropertiesToInstance(self.descriptor)
@@ -3000,7 +2999,7 @@ class CGWrapGlobalMethod(CGAbstractMethod):
                 Argument(f"Box<{descriptor.concreteType}>", 'object')]
         retval = f'DomRoot<{descriptor.concreteType}>'
         CGAbstractMethod.__init__(self, descriptor, 'Wrap', retval, args,
-                                  pub=True, unsafe=True, attrs=['#[allow(crown::unrooted_must_root)]'])
+                                  pub=True, unsafe=True, extra_decorators=['#[allow(crown::unrooted_must_root)]'])
         self.properties = properties
 
     def definition_body(self):

--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -169,7 +169,7 @@ pub mod xmlname;
 /// Generated JS-Rust bindings.
 #[allow(missing_docs, non_snake_case)]
 pub mod codegen {
-    #[allow(dead_code, crown::unrooted_must_root)]
+    #[allow(dead_code)]
     pub mod Bindings {
         include!(concat!(env!("OUT_DIR"), "/Bindings/mod.rs"));
     }


### PR DESCRIPTION
Currently we disabled unrooted_must_root lint in all bindings, now we just disable it where we absolutely need it.

This should help with crown problem in script-split: https://github.com/servo/servo/pull/33416#issuecomment-2390725477

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only limit scope of allowing lints

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
