### PR TITLE
Permitted functions in components/script/dom to have too many arguments.

### DIFF
--- a/components/script/dom/hashchangeevent.rs
+++ b/components/script/dom/hashchangeevent.rs
@@ -71,6 +71,7 @@ impl HashChangeEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/mediaquerylistevent.rs
+++ b/components/script/dom/mediaquerylistevent.rs
@@ -66,6 +66,7 @@ impl MediaQueryListEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -112,6 +112,7 @@ impl MessageEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_initialized(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -65,6 +65,7 @@ impl PromiseRejectionEvent {
     }
 
     #[allow(crown::unrooted_must_root)]
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -70,6 +70,7 @@ impl UIEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrinputsourceevent.rs
+++ b/components/script/dom/xrinputsourceevent.rs
@@ -59,6 +59,7 @@ impl XRInputSourceEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrreferencespaceevent.rs
+++ b/components/script/dom/xrreferencespaceevent.rs
@@ -62,6 +62,7 @@ impl XRReferenceSpaceEvent {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -78,6 +78,7 @@ impl XRWebGLLayer {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         global: &GlobalScope,
         proto: Option<HandleObject>,


### PR DESCRIPTION
This PR primarily permits functions with too many arguments in components/script/dom to not be detected by clippy

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are part of #31500 
- [X] These changes do not require tests because they do not touch functionality


