### PR TITLE
clippy: Fix several warnings in `components/script` and `components/webgpu`

### DIFF
--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
 
+#[allow(clippy::upper_case_acronyms)]
 pub type UUID = DOMString;
 pub type BluetoothServiceUUID = StringOrUnsignedLong;
 pub type BluetoothCharacteristicUUID = StringOrUnsignedLong;
@@ -19,7 +20,6 @@ pub type BluetoothDescriptorUUID = StringOrUnsignedLong;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothuuid
 #[dom_struct]
-#[allow(clippy::upper_case_acronyms)]
 pub struct BluetoothUUID {
     reflector_: Reflector,
 }

--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
 
-#[allow(clippy::upper_case_acronyms)]
 pub type UUID = DOMString;
 pub type BluetoothServiceUUID = StringOrUnsignedLong;
 pub type BluetoothCharacteristicUUID = StringOrUnsignedLong;
@@ -20,6 +19,7 @@ pub type BluetoothDescriptorUUID = StringOrUnsignedLong;
 
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetoothuuid
 #[dom_struct]
+#[allow(clippy::upper_case_acronyms)]
 pub struct BluetoothUUID {
     reflector_: Reflector,
 }

--- a/components/script/dom/bluetoothuuid.rs
+++ b/components/script/dom/bluetoothuuid.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::window::Window;
 
+#[allow(clippy::upper_case_acronyms)]
 pub type UUID = DOMString;
 pub type BluetoothServiceUUID = StringOrUnsignedLong;
 pub type BluetoothCharacteristicUUID = StringOrUnsignedLong;

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -19,6 +19,7 @@ use crate::dom::window::Window;
 use crate::dom::worklet::Worklet;
 
 #[dom_struct]
+#[allow(clippy::upper_case_acronyms)]
 pub struct CSS {
     reflector_: Reflector,
 }

--- a/components/script/dom/gpu.rs
+++ b/components/script/dom/gpu.rs
@@ -4,6 +4,7 @@
 
 use std::rc::Rc;
 
+#[allow(clippy::upper_case_acronyms)]
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;

--- a/components/script/dom/gpu.rs
+++ b/components/script/dom/gpu.rs
@@ -4,7 +4,6 @@
 
 use std::rc::Rc;
 
-#[allow(clippy::upper_case_acronyms)]
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -29,6 +28,7 @@ use crate::realms::InRealm;
 use crate::task_source::{TaskSource, TaskSourceName};
 
 #[dom_struct]
+#[allow(clippy::upper_case_acronyms)]
 pub struct GPU {
     reflector_: Reflector,
 }

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -398,7 +398,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         } else {
             // Step 3&4
             self.replace_drawing_buffer();
-            let current_texture = configuration.device.CreateTexture(&texture_descriptor)?;
+            let current_texture = configuration.device.CreateTexture(texture_descriptor)?;
             self.current_texture.set(Some(&current_texture));
             current_texture
         };

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -4,6 +4,7 @@
 
 use std::default::Default;
 
+#[allow(clippy::upper_case_acronyms)]
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use net_traits::blob_url_store::{get_blob_origin, parse_blob_url};

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -4,7 +4,6 @@
 
 use std::default::Default;
 
-#[allow(clippy::upper_case_acronyms)]
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use net_traits::blob_url_store::{get_blob_origin, parse_blob_url};
@@ -28,6 +27,7 @@ use crate::script_runtime::CanGc;
 
 /// <https://url.spec.whatwg.org/#url>
 #[dom_struct]
+#[allow(clippy::upper_case_acronyms)]
 pub struct URL {
     reflector_: Reflector,
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1678,6 +1678,7 @@ fn serialize_document(doc: &Document) -> Fallible<DOMString> {
 pub fn is_field_value(slice: &[u8]) -> bool {
     // Classifications of characters necessary for the [CRLF] (SP|HT) rule
     #[derive(PartialEq)]
+    #[allow(clippy::upper_case_acronyms)]
     enum PreviousCharacter {
         Other,
         CR,

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -139,7 +139,7 @@ impl WebGPUImageDescriptor {
     fn new(format: ImageFormat, size: DeviceIntSize, is_opaque: bool) -> Self {
         let stride = (((size.width * format.bytes_per_pixel()) |
             (wgt::COPY_BYTES_PER_ROW_ALIGNMENT as i32 - 1)) +
-            1) as i32;
+            1);
         Self(ImageDescriptor {
             format,
             size,

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -136,9 +136,9 @@ pub struct WebGPUImageDescriptor(pub ImageDescriptor);
 
 impl WebGPUImageDescriptor {
     fn new(format: ImageFormat, size: DeviceIntSize, is_opaque: bool) -> Self {
-        let stride = (((size.width * format.bytes_per_pixel()) |
+        let stride = ((size.width * format.bytes_per_pixel()) |
             (wgt::COPY_BYTES_PER_ROW_ALIGNMENT as i32 - 1)) +
-            1);
+            1;
         Self(ImageDescriptor {
             format,
             size,


### PR DESCRIPTION
Fixes several warnings in `components` as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
