### PR TITLE
clippy: Fix let binding in components/fonts/font_context.rs

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -291,7 +291,7 @@ impl FontContext {
     }
 
     pub(crate) fn create_font_instance_key(&self, font: &Font) -> FontInstanceKey {
-        let result = match font.template.identifier() {
+        match font.template.identifier() {
             FontIdentifier::Local(_) | FontIdentifier::Mock(_) => {
                 self.system_font_service_proxy.get_system_font_instance(
                     font.template.identifier(),
@@ -305,8 +305,7 @@ impl FontContext {
                 font.descriptor.pt_size,
                 font.webrender_font_instance_flags(),
             ),
-        };
-        result
+        }
     }
 
     pub(crate) fn create_web_font_instance(

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -398,7 +398,7 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         } else {
             // Step 3&4
             self.replace_drawing_buffer();
-            let current_texture = configuration.device.CreateTexture(&texture_descriptor)?;
+            let current_texture = configuration.device.CreateTexture(texture_descriptor)?;
             self.current_texture.set(Some(&current_texture));
             current_texture
         };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed the variable declaration because the return value of function can be returned directly as adviced in [let_and_return](https://rust-lang.github.io/rust-clippy/master/index.html#/let_and_return)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #31500  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
