### PR TITLE
clippy: Fix too_many_arguments warnings in `script`, `layout`, and `webgpu`

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -102,6 +102,7 @@ impl FlexItemLayoutResult {
             .unwrap_or_else(|| item.synthesized_baseline_relative_to_margin_box(cross_size))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn collect_fragment(
         mut self,
         initial_flex_layout: &InitialFlexLineLayout,
@@ -2201,6 +2202,7 @@ impl FlexItemBox {
     }
 
     /// This is an implementation of <https://drafts.csswg.org/css-flexbox/#min-size-auto>.
+    #[allow(clippy::too_many_arguments)]
     fn automatic_min_size(
         &mut self,
         layout_context: &LayoutContext,
@@ -2307,6 +2309,7 @@ impl FlexItemBox {
     }
 
     /// <https://drafts.csswg.org/css-flexbox/#algo-main-item>
+    #[allow(clippy::too_many_arguments)]
     fn flex_base_size(
         &mut self,
         layout_context: &LayoutContext,
@@ -2457,6 +2460,7 @@ impl FlexItemBox {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_for_block_content_size(
         &mut self,
         flex_context: &FlexContext,

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -2043,6 +2043,7 @@ impl<'a> TableLayout<'a> {
         col_group.style.get_inherited_box().visibility == Visibility::Collapse
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn do_final_cell_layout(
         &mut self,
         row_index: usize,

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -552,6 +552,7 @@ impl LayoutThread {
         self.root_flow.borrow().clone()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         id: PipelineId,
         url: ServoUrl,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -494,6 +494,7 @@ impl Layout for LayoutThread {
 }
 
 impl LayoutThread {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         id: PipelineId,
         url: ServoUrl,
@@ -587,6 +588,7 @@ impl LayoutThread {
     }
 
     // Create a layout context for use in building display lists, hit testing, &c.
+    #[allow(clippy::too_many_arguments)]
     fn build_layout_context<'a>(
         &'a self,
         guards: StylesheetGuards<'a>,

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -120,6 +120,7 @@ fn create_svg_element(
 
 // https://dom.spec.whatwg.org/#concept-create-element
 #[allow(unsafe_code)]
+#[allow(clippy::too_many_arguments)]
 fn create_html_element(
     name: QualName,
     prefix: Option<Prefix>,

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -88,6 +88,7 @@ impl Gamepad {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         gamepad_id: u32,
@@ -115,6 +116,7 @@ impl Gamepad {
     /// The spec says UAs *may* do this for fingerprint mitigation, and it also
     /// happens to simplify implementation
     /// <https://www.w3.org/TR/gamepad/#fingerprinting-mitigation>
+    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         gamepad_id: u32,

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -107,6 +107,7 @@ impl GPUBuffer {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         global: &GlobalScope,
         channel: WebGPU,

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -548,6 +548,7 @@ impl crate::WGPU {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn update_wr_image(
     result: Result<(), BufferAccessError>,
     global: Arc<Global>,


### PR DESCRIPTION
Fixes `too_many_arguments` warnings in components as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
