### PR TITLE
clippy: Fix warnings in `components/script` & `components/webgpu`

### DIFF
--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -255,7 +255,7 @@ impl GPUCanvasContext {
             .send(WebGPURequest::UpdateContext {
                 context_id: self.context_id,
                 size: drawing_buffer.size,
-                configuration: drawing_buffer.config.clone(),
+                configuration: drawing_buffer.config,
             })
             .expect("Failed to update webgpu context");
     }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -534,8 +534,8 @@ impl HTMLElementMethods for HTMLElement {
         }
 
         // Step 8: If previous is a Text node, then merge with the next text node given previous.
-        if let Some(_previous) = previous {
-            Self::merge_with_the_next_text_node(_previous)
+        if let Some(previous) = previous {
+            Self::merge_with_the_next_text_node(previous)
         }
 
         Ok(())

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -534,7 +534,9 @@ impl HTMLElementMethods for HTMLElement {
         }
 
         // Step 8: If previous is a Text node, then merge with the next text node given previous.
-        previous.map(Self::merge_with_the_next_text_node);
+        if let Some(_previous) = previous {
+            Self::merge_with_the_next_text_node(_previous)
+        }
 
         Ok(())
     }

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -385,14 +385,11 @@ impl crate::WGPU {
 
         // If configuration is not provided or presentation format is not valid
         // the context will be dummy until recreation
-        let format = config
-            .as_ref()
-            .map(|config| match config.format {
-                wgt::TextureFormat::Rgba8Unorm => Some(ImageFormat::RGBA8),
-                wgt::TextureFormat::Bgra8Unorm => Some(ImageFormat::BGRA8),
-                _ => None,
-            })
-            .flatten();
+        let format = config.as_ref().and_then(|config| match config.format {
+            wgt::TextureFormat::Rgba8Unorm => Some(ImageFormat::RGBA8),
+            wgt::TextureFormat::Bgra8Unorm => Some(ImageFormat::BGRA8),
+            _ => None,
+        });
 
         let needs_image_update = if let Some(format) = format {
             let config = config.expect("Config should exist when valid format is available");


### PR DESCRIPTION
Fixes warnings in `components/script` & `components/webgpu` as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
