### PR TITLE
Skip anonymous blocks for percentage resolution

### DIFF
--- a/tests/wpt/meta/css/CSS2/visuren/anonymous-boxes-001a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/anonymous-boxes-001a.xht.ini
@@ -1,2 +1,0 @@
-[anonymous-boxes-001a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/image-percentage-max-height-in-anonymous-block.html.ini
+++ b/tests/wpt/meta/css/css-sizing/image-percentage-max-height-in-anonymous-block.html.ini
@@ -1,2 +1,0 @@
-[image-percentage-max-height-in-anonymous-block.html]
-  expected: FAIL


### PR DESCRIPTION
Anonymous blocks have `height: auto`, so children with a percentage `height` were considered to have an indefinite height.

However, anonymous blocks need to be skipped for percentage resolution, so the percentages may actually be definite.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
