### PR TITLE
DevTools: Fix console in Firefox 131

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -119,6 +119,12 @@ struct SetPreferencesReply {
     updated: Vec<String>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PageErrorWrapper {
+    page_error: PageError,
+}
+
 pub(crate) enum Root {
     BrowsingContext(String),
     DedicatedWorker(String),
@@ -255,7 +261,7 @@ impl ConsoleActor {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry
                     .find::<BrowsingContextActor>(bc)
-                    .page_error(page_error)
+                    .resource_available(PageErrorWrapper { page_error }, "error-message".into())
             };
         }
     }
@@ -297,7 +303,7 @@ impl ConsoleActor {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry
                     .find::<BrowsingContextActor>(bc)
-                    .console_message(console_api)
+                    .resource_available(console_api, "console-message".into())
             };
         }
     }

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -60,7 +60,7 @@ impl Actor for DeviceActor {
                         apptype: "servo".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                         appbuildid: BUILD_ID.to_string(),
-                        platformversion: "125.0".to_string(),
+                        platformversion: "130.0".to_string(),
                         brand_name: "Servo".to_string(),
                     },
                 };


### PR DESCRIPTION
This PR replaces the use of the deprecated `resource-available-form` with `resources-available-array`. This affects console messages, page errors and document events (though these last ones are a placeholder at the moment). It also adds a generic reply struct for all of the resource arrays which hopefully makes it easier to add new functionalities. Using generic messages may be helpful for cleaning up some repeated code on the codebase.

Though this fixes #33275 now that Firefox 131 is officially released, we should still think of a version targeting strategy for updating the browser support. @ochameau mentioned [this thread](https://bugzilla.mozilla.org/show_bug.cgi?id=1704796) in bugzilla which tracks the changes of each new release.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #33275
- [x] These changes do not require tests because there are no tests yet for DevTools