### PR TITLE
clippy: Fix `collapsible_match` warning in `components/shared/base`

### DIFF
--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -13,30 +13,30 @@ pub fn unicode_plane(codepoint: char) -> u32 {
 }
 
 pub fn is_cjk(codepoint: char) -> bool {
-    if let Some(block) = codepoint.block() {
-        match block {
-            UnicodeBlock::CJKRadicalsSupplement |
-            UnicodeBlock::KangxiRadicals |
-            UnicodeBlock::IdeographicDescriptionCharacters |
-            UnicodeBlock::CJKSymbolsandPunctuation |
-            UnicodeBlock::Hiragana |
-            UnicodeBlock::Katakana |
-            UnicodeBlock::Bopomofo |
-            UnicodeBlock::HangulCompatibilityJamo |
-            UnicodeBlock::Kanbun |
-            UnicodeBlock::BopomofoExtended |
-            UnicodeBlock::CJKStrokes |
-            UnicodeBlock::KatakanaPhoneticExtensions |
-            UnicodeBlock::EnclosedCJKLettersandMonths |
-            UnicodeBlock::CJKCompatibility |
-            UnicodeBlock::CJKUnifiedIdeographsExtensionA |
-            UnicodeBlock::YijingHexagramSymbols |
-            UnicodeBlock::CJKUnifiedIdeographs |
-            UnicodeBlock::CJKCompatibilityIdeographs |
-            UnicodeBlock::CJKCompatibilityForms |
-            UnicodeBlock::HalfwidthandFullwidthForms => return true,
-            _ => {},
-        }
+    if let Some(
+        UnicodeBlock::CJKRadicalsSupplement |
+        UnicodeBlock::KangxiRadicals |
+        UnicodeBlock::IdeographicDescriptionCharacters |
+        UnicodeBlock::CJKSymbolsandPunctuation |
+        UnicodeBlock::Hiragana |
+        UnicodeBlock::Katakana |
+        UnicodeBlock::Bopomofo |
+        UnicodeBlock::HangulCompatibilityJamo |
+        UnicodeBlock::Kanbun |
+        UnicodeBlock::BopomofoExtended |
+        UnicodeBlock::CJKStrokes |
+        UnicodeBlock::KatakanaPhoneticExtensions |
+        UnicodeBlock::EnclosedCJKLettersandMonths |
+        UnicodeBlock::CJKCompatibility |
+        UnicodeBlock::CJKUnifiedIdeographsExtensionA |
+        UnicodeBlock::YijingHexagramSymbols |
+        UnicodeBlock::CJKUnifiedIdeographs |
+        UnicodeBlock::CJKCompatibilityIdeographs |
+        UnicodeBlock::CJKCompatibilityForms |
+        UnicodeBlock::HalfwidthandFullwidthForms,
+    ) = codepoint.block()
+    {
+        return true;
     }
 
     // https://en.wikipedia.org/wiki/Plane_(Unicode)#Supplementary_Ideographic_Plane


### PR DESCRIPTION
Fixes `collapsible_match` warning in `components/shared` as a part of #31500 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes are a part of #31500 
- [X] These changes do not require tests because they do not modify functionality, they only fix lint errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
